### PR TITLE
Update to Gulp 4 allow it Ketcher build.

### DIFF
--- a/gulp/dev-script.js
+++ b/gulp/dev-script.js
@@ -33,9 +33,9 @@ module.exports = function (options, cb) {
 		}
 	}).on('exit', cb);
 
-	gulp.watch('src/style/**.less', ['style']);
-	gulp.watch('src/template/**', ['html']);
-	gulp.watch('doc/**', ['help']);
+	gulp.watch('src/style/**.less', gulp.series('style'));
+	gulp.watch('src/template/**', gulp.series('html'));
+	gulp.watch('doc/**', gulp.series('help'));
 	gulp.watch(['gulpfile.js', 'package.json'], function () {
 		server.close();
 		cp.spawn('gulp', process.argv.slice(2), {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,26 +53,32 @@ gulp.task('icons-svg', getTask('./gulp/style-html', {
 	dist: options.dist
 }));
 
-gulp.task('style', ['icons-svg'], getTask('./gulp/style-html', {
+gulp.task('style', gulp.series('icons-svg', getTask('./gulp/style-html', {
 	expName: 'style',
 	src: 'src/style/index.less',
 	pkg: pkg,
 	dist: options.dist
+})));
+
+/*== version ==*/
+gulp.task('patch-version', getTask('./gulp/utils', {
+	expName: 'version',
+	pkg: pkg
 }));
 
 /*== script ==*/
-gulp.task('script', ['patch-version'], getTask('./gulp/prod-script', Object.assign({
+gulp.task('script', gulp.series('patch-version', getTask('./gulp/prod-script', Object.assign({
 	expName: 'script',
 	pkg: pkg,
 	entry: 'src/script',
 	banner: 'src/script/util/banner.js'
-}, options)));
+}, options))));
 
-gulp.task('html', ['patch-version'], getTask('./gulp/style-html', Object.assign({
+gulp.task('html', gulp.series('patch-version', getTask('./gulp/style-html', Object.assign({
 	expName: 'html',
 	src: 'src/template/index.hbs',
 	pkg: pkg
-}, options)));
+}, options))));
 
 /*== assets ==*/
 gulp.task('doc', function () {
@@ -80,29 +86,23 @@ gulp.task('doc', function () {
 		.pipe(gulp.dest(options.dist + '/doc'));
 });
 
-gulp.task('help', ['doc'], getTask('./gulp/assets', {
+gulp.task('help', gulp.series('doc', getTask('./gulp/assets', {
 	expName: 'help',
 	src: 'doc/help.md',
 	dist: options.dist
-}));
+})));
 
 gulp.task('logo', function () {
 	return gulp.src('src/logo/*')
 		.pipe(gulp.dest(options.dist + '/logo'));
 });
 
-gulp.task('copy', ['logo'], getTask('./gulp/assets', {
+gulp.task('copy', gulp.series('logo', getTask('./gulp/assets', {
 	expName: 'copy',
 	dist: options.dist,
 	'miew-path': options['miew-path'],
 	distrib: ['LICENSE', 'src/template/demo.html', 'src/tmpl_data/library.sdf', 'src/tmpl_data/library.svg']
-}));
-
-/*== version ==*/
-gulp.task('patch-version', getTask('./gulp/utils', {
-	expName: 'version',
-	pkg: pkg
-}));
+})));
 
 /*== check ==*/
 gulp.task('lint', getTask('./gulp/check', {
@@ -124,19 +124,19 @@ gulp.task('clean', getTask('./gulp/clean', {
 	pkgName: pkg.name
 }));
 
-gulp.task('pre-commit', ['lint', 'check-epam-email', 'check-deps-exact']);
-gulp.task('assets', ['copy', 'help']);
-gulp.task('code', ['style', 'script', 'html']);
+gulp.task('pre-commit', gulp.series('lint', 'check-epam-email', 'check-deps-exact'));
+gulp.task('assets', gulp.series('copy', 'help'));
+gulp.task('code', gulp.series('style', 'script', 'html'));
 
 /*== dev ==*/
-gulp.task('serve', ['clean', 'style', 'html', 'assets'], getTask('./gulp/dev-script', Object.assign({
+gulp.task('serve', gulp.series('clean', 'style', 'html', 'assets', getTask('./gulp/dev-script', Object.assign({
 	entry: 'src/script',
 	pkg: pkg
-}, options)));
+}, options))));
 /*== production ==*/
-gulp.task('build', ['clean', 'code', 'assets']);
-gulp.task('archive', ['build'], getTask('./gulp/prod-script', {
+gulp.task('build', gulp.series('clean', 'code', 'assets'));
+gulp.task('archive', gulp.series('build', getTask('./gulp/prod-script', {
 	expName: 'archive',
 	pkg: pkg,
 	dist: options.dist
-}));
+})));

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.5.1",
     "exposify": "0.5.0",
-    "gulp": "3.9.1",
+    "gulp": "4.0.0",
     "gulp-autoprefixer": "4.0.0",
     "gulp-babel": "7.0.0",
     "gulp-clean-css": "3.1.1",


### PR DESCRIPTION
Ketcher will **not** build on newer versions of Node due to the now unsupported Gulp 3 (see below and [here](https://github.com/gulpjs/gulp/issues/2324)). This PR upgrades the **gulpfile.js** to Gulp 4 (see. [Gulp 3 to 4](https://www.sitepoint.com/how-to-migrate-to-gulp-4/)). There are some other things that could be optimised e.g. gulp-util is now [deprecated](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) but not essential and thought'd I see if this PR gets accepted first before suggesting making changes.

Here is the error:
```
[john@harbinger:ketcher]% npx gulp serve
fs.js:27
const { Math, Object } = primordials;
                         ^

ReferenceError: primordials is not defined
    at fs.js:27:26
    at req_ (/Users/john/Workspace/GitHub/ketcher/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/Users/john/Workspace/GitHub/ketcher/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/Users/john/Workspace/GitHub/ketcher/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
```