### PR TITLE
Remove titles for buttons on toolbar

### DIFF
--- a/src/script/ui/app/toolbar.jsx
+++ b/src/script/ui/app/toolbar.jsx
@@ -252,7 +252,7 @@ function TemplatesList({ active, onAction }) {
 							title={`${struct.name} (${shortcut})`}
 							onClick={() => onAction({ tool: 'template', opts: { struct } })}
 						>
-							<Icon name={`template-${i}`} />{struct.name}
+							<Icon name={`template-${i}`} />
 						</button>
 					</li>
 				))

--- a/src/script/ui/component/actionmenu.jsx
+++ b/src/script/ui/component/actionmenu.jsx
@@ -75,7 +75,7 @@ function ActionButton({ name, action, status = {}, onAction }) { // eslint-disab
 			}}
 			title={shortcut ? `${action.title} (${shortcut})` : action.title}
 		>
-			<Icon name={name} />{action.title}<kbd>{shortcut}</kbd>
+			<Icon name={name} /><kbd>{shortcut}</kbd>
 		</button>
 	);
 }


### PR DESCRIPTION
Fix #4 - "minimum font size" in Chromium