### PR TITLE
#159 'Template name' field does not contain grey 'tmpl' placeholder

### DIFF
--- a/src/script/ui/dialog/template/template-attach.jsx
+++ b/src/script/ui/dialog/template/template-attach.jsx
@@ -68,7 +68,7 @@ class Attach extends Component {
         params={prop}>
         <label>
           Template name:
-          <Input value={name} onChange={onNameEdit} />
+          <Input value={name} onChange={onNameEdit} placeholder="tmpl" />
         </label>
         <label>Choose attachment atom and bond:</label>
         <StructEditor


### PR DESCRIPTION
- add placeholder to 'Edit template' dialog