### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ketcher is an open-source web-based chemical structure editor incorporating high
 
 ## Installation and usage
 
-At this moment Ketcher library is delivered as an [react component library](https://www.npmjs.com/package/ketcher-react) and [zip archive](https://lifescience.opensource.epam.com/download/ketcher.html):
+At this moment Ketcher library is delivered as a [react component library](https://www.npmjs.com/package/ketcher-react) and [zip archive](https://lifescience.opensource.epam.com/download/ketcher.html):
 
 ### How to use react component library
 


### PR DESCRIPTION
- an => a
Not a problem, but it just little awkward to me.