### PR TITLE
add `DATIVE` to bondTypeMap

### DIFF
--- a/packages/ketcher-core/src/chemistry/serializers/mol/utils.js
+++ b/packages/ketcher-core/src/chemistry/serializers/mol/utils.js
@@ -71,6 +71,7 @@ var fmtInfo = {
     6: Bond.PATTERN.TYPE.SINGLE_OR_AROMATIC,
     7: Bond.PATTERN.TYPE.DOUBLE_OR_AROMATIC,
     8: Bond.PATTERN.TYPE.ANY,
+    9: Bond.PATTERN.TYPE.DATIVE, 
     10: Bond.PATTERN.TYPE.HYDROGEN
   },
   bondStereoMap: {


### PR DESCRIPTION
when open a molfile which contain a dative bond, ketcher will be crash