### PR TITLE
Export ketcher and buildKetcherAsync

### DIFF
--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -31,6 +31,7 @@
     "build": "cross-env NODE_ENV=production rollup -c -m true --silent",
     "start": "cross-env NODE_ENV=development rollup -c -m true -w",
     "test": "run-s test:unit test:lint prettier stylelint test:build",
+    "prepare": "npm run build",
     "test:build": "run-s build",
     "test:lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "test:unit": "cross-env CI=1 react-scripts test --env=jsdom",

--- a/packages/ketcher-react/src/index.tsx
+++ b/packages/ketcher-react/src/index.tsx
@@ -14,3 +14,5 @@
  * limitations under the License.
  ***************************************************************************/
 export * from './Editor'
+export * from './script'
+export * from './script/ketcher'

--- a/packages/ketcher-react/src/script/index.ts
+++ b/packages/ketcher-react/src/script/index.ts
@@ -23,7 +23,7 @@ interface Config {
   buttons?: ButtonsConfig
 }
 
-async function buildKetcherAsync({
+export async function buildKetcherAsync({
   element,
   staticResourcesUrl,
   structServiceProvider,


### PR DESCRIPTION
Exports `Ketcher` and `buildKetcherAsync` to allow for subscribing to editor changes.

Example

```tsx
const ref = useRef(null);
const [smiles, setSmiles] = useState("");

useEffect(() => {
  if (ref.current) {
    buildKetcherAsync({
      element: ref.current,
      staticResourcesUrl: process.env.PUBLIC_URL,
      structServiceProvider: structServiceProvider,
    }).then((k) => {
      k.editor.subscribe("change", () => {
        k.getSmilesAsync(false).then(setSmiles);
      });
    });
  }
}, []);
```