### PR TITLE
 #612 Left toolbar is not visible in firefox

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/toolbar.less
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/toolbar.less
@@ -47,6 +47,7 @@
   overflow-y: auto;
   flex-direction: column;
   -ms-overflow-style: none;
+  scrollbar-width: thin;
 
   .group {
     flex-direction: column;


### PR DESCRIPTION
 Reduce the width of the scrollbar in Firefox