### PR TITLE
#719 'R-Group Label Tool' and 'Shape Eclipse' buttons should not be expanded

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -1,16 +1,3 @@
-import React, { FC } from 'react'
-import {
-  ToolbarGroupItem,
-  ToolbarGroupItemCallProps,
-  ToolbarGroupItemProps
-} from '../ToolbarGroupItem'
-import { ToolbarItem, ToolbarItemVariant } from '../toolbar.types'
-
-import { Bond } from './Bond'
-import { RGroup } from './RGroup'
-import { Shape } from './Shape'
-import { Transform } from './Transform'
-import classes from './LeftToolbar.module.less'
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -26,9 +13,22 @@ import classes from './LeftToolbar.module.less'
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
+
+import React, { FC } from 'react'
+import {
+  ToolbarGroupItem,
+  ToolbarGroupItemCallProps,
+  ToolbarGroupItemProps
+} from '../ToolbarGroupItem'
+import { ToolbarItem, ToolbarItemVariant } from '../toolbar.types'
+
+import { Bond } from './Bond'
+import { RGroup } from './RGroup'
+import { Shape } from './Shape'
+import { Transform } from './Transform'
+import classes from './LeftToolbar.module.less'
 import clsx from 'clsx'
 import { makeItems } from '../ToolbarGroupItem/utils'
-import { mediaSizes } from '../mediaSizes'
 import { useResizeObserver } from '../../../../../hooks'
 
 const Group: FC<{ className?: string }> = ({ children, className }) => (
@@ -103,22 +103,21 @@ const LeftToolbar = (props: Props) => {
       <Group>
         <Transform {...rest} height={height} />
       </Group>
-
-      <Group
-        className={clsx({
-          [classes.borderOff]:
-            height && height < mediaSizes.reactionSeparatorShowingHeight
-        })}>
+      <Group>
         <Item id="sgroup" />
         <Item id="sgroup-data" />
+      </Group>
+      <Group>
         <Item id="reaction-plus" />
         <Item id="reaction-arrows" options={arrowsOptions} />
         <Item id="reaction-mapping-tools" options={mappingOptions} />
       </Group>
 
       <Group>
-        <RGroup {...rest} height={height} />
-        <Shape {...rest} height={height} />
+        <RGroup {...rest} />
+      </Group>
+      <Group>
+        <Shape {...rest} />
       </Group>
       <Group>
         <Item id="text" />

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/RGroup/RGroup.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/RGroup/RGroup.tsx
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import React from 'react'
-import { mediaSizes } from '../../mediaSizes'
+
 import {
   ToolbarGroupItem,
   ToolbarGroupItemCallProps,
   ToolbarGroupItemProps
 } from '../../ToolbarGroupItem'
+
+import React from 'react'
 import { makeItems } from '../../ToolbarGroupItem/utils'
 
 const rGroupOptions = makeItems([
@@ -36,20 +37,8 @@ interface RGroupCallProps extends ToolbarGroupItemCallProps {}
 type Props = RGroupProps & RGroupCallProps
 
 const RGroup = (props: Props) => {
-  const { height, ...rest } = props
-
-  if (height && height <= mediaSizes.rGroupCollapsableHeight) {
-    return (
-      <ToolbarGroupItem id="rgroup-label" options={rGroupOptions} {...rest} />
-    )
-  }
-
   return (
-    <>
-      <ToolbarGroupItem id="rgroup-label" {...rest} />
-      <ToolbarGroupItem id="rgroup-fragment" {...rest} />
-      <ToolbarGroupItem id="rgroup-attpoints" {...rest} />
-    </>
+    <ToolbarGroupItem id="rgroup-label" options={rGroupOptions} {...props} />
   )
 }
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/Shape/Shape.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/Shape/Shape.tsx
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import React from 'react'
-import { mediaSizes } from '../../mediaSizes'
+
 import {
   ToolbarGroupItem,
   ToolbarGroupItemCallProps,
   ToolbarGroupItemProps
 } from '../../ToolbarGroupItem'
+
+import React from 'react'
 import { makeItems } from '../../ToolbarGroupItem/utils'
 
 const shapeOptions = makeItems([
@@ -36,20 +37,8 @@ interface ShapeCallProps extends ToolbarGroupItemCallProps {}
 type Props = ShapeProps & ShapeCallProps
 
 const Shape = (props: Props) => {
-  const { height, ...rest } = props
-
-  if (height && height <= mediaSizes.shapeCollapsableHeight) {
-    return (
-      <ToolbarGroupItem id="shape-ellipse" options={shapeOptions} {...rest} />
-    )
-  }
-
   return (
-    <>
-      <ToolbarGroupItem id="shape-ellipse" {...rest} />
-      <ToolbarGroupItem id="shape-rectangle" {...rest} />
-      <ToolbarGroupItem id="shape-line" {...rest} />
-    </>
+    <ToolbarGroupItem id="shape-ellipse" options={shapeOptions} {...props} />
   )
 }
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/mediaSizes.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/mediaSizes.ts
@@ -18,7 +18,6 @@ const mediaSizes = {
   topSeparatorsShowingWidth: 1080,
   zoomShowingWidth: 780,
   infoShowingWidth: 790,
-  reactionSeparatorShowingHeight: 851,
   bondCollapsableHeight: 620,
   rGroupCollapsableHeight: 850,
   shapeCollapsableHeight: 850,


### PR DESCRIPTION
update LeftToolbar