### PR TITLE
#759 Fixed font size applying behavior

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/FontControl/FontControl.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/FontControl/FontControl.tsx
@@ -21,9 +21,9 @@ import classes from './FontControl.module.less'
 import { range } from 'lodash/fp'
 
 export const FontControl = ({ editorState, setEditorState, styles }) => {
-  const defultFontSize = 13
+  const defaultFontSize = '13px'
   const [isShowingFontSizeMenu, setIsShowingFontSizeMenu] = useState(false)
-  const [currentFontSize, setCurrentFontSize] = useState(`${defultFontSize}px`)
+  const [currentFontSize, setCurrentFontSize] = useState(defaultFontSize)
 
   const setFontSize = (e, value) => {
     e.preventDefault()
@@ -33,11 +33,11 @@ export const FontControl = ({ editorState, setEditorState, styles }) => {
     setIsShowingFontSizeMenu(false)
   }
 
-  const currentStyle = styles.fontSize.current(editorState) || currentFontSize
+  const currentStyle = styles.fontSize.current(editorState)
 
   useEffect(() => {
-    setCurrentFontSize(currentStyle)
-  })
+    setCurrentFontSize(currentStyle || defaultFontSize)
+  }, [currentStyle])
 
   const MIN_FONT_SIZE = 4
   const MAX_FONT_SIZE = 144


### PR DESCRIPTION
**Now font size applying works the same way as for font styles: all settings resets to default if are chosen before clicking on text field**

![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/89648393/133559646-e70d57c2-c3ef-4c01-950a-d0a495d04cc9.gif)
