### PR TITLE
#849 Сhanges in the 'Rotation Step' setting are not tightened when working with structures on canvas

### DIFF
--- a/packages/ketcher-core/src/application/editor/index.ts
+++ b/packages/ketcher-core/src/application/editor/index.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
+
+import utils from './shared/utils'
+
+// TODO: delete it
+export const fracAngle = utils.fracAngle
 export * from './operations'
 export * from './actions'
 export * from './shared/constants'

--- a/packages/ketcher-core/src/application/render/options.js
+++ b/packages/ketcher-core/src/application/render/options.js
@@ -15,12 +15,12 @@
  ***************************************************************************/
 
 import { Vec2 } from 'domain/entities'
+import utils from '../editor/shared/utils'
 
 function defaultOptions(opt) {
   const scaleFactor = opt.scale || 100
 
-  // TODO: test if rotation step is working now
-  // if (opt.rotationStep) utils.setFracAngle(opt.rotationStep)
+  if (opt.rotationStep) utils.setFracAngle(opt.rotationStep)
 
   const labelFontSize = Math.ceil(1.9 * (scaleFactor / 6))
   const subFontSize = Math.ceil(0.7 * labelFontSize)

--- a/packages/ketcher-react/src/script/editor/shared/utils.js
+++ b/packages/ketcher-react/src/script/editor/shared/utils.js
@@ -14,23 +14,13 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Vec2 } from 'ketcher-core'
+import { Vec2, fracAngle } from 'ketcher-core'
+
 import { inRange } from 'lodash'
-
-let FRAC = Math.PI / 12 // '15º'
-
-function setFracAngle(angle) {
-  FRAC = (Math.PI / 180) * angle
-}
 
 function calcAngle(pos0, pos1) {
   const v = Vec2.diff(pos1, pos0)
   return Math.atan2(v.y, v.x)
-}
-
-function fracAngle(angle, angle2) {
-  if (angle2) angle = calcAngle(angle, angle2)
-  return Math.round(angle / FRAC) * FRAC
 }
 
 function calcNewAtomPos(pos0, pos1, ctrlKey) {
@@ -74,6 +64,5 @@ export default {
   fracAngle,
   calcNewAtomPos,
   degrees,
-  setFracAngle,
   mergeBondsParams
 }


### PR DESCRIPTION
re-export fracAngle function