### PR TITLE
#900 Structure previews display hydrogen if settings specify it

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/structrender.jsx
+++ b/packages/ketcher-react/src/script/ui/component/structrender.jsx
@@ -24,6 +24,9 @@ function renderStruct(el, struct, options = {}) {
       el.innerHTML = struct.prerender
     } else if (struct) {
       console.info('render!', el.clientWidth, el.clientWidth)
+      struct.initHalfBonds()
+      struct.initNeighbors()
+      struct.setImplicitHydrogen()
       const rnd = new Render(el, {
         autoScale: true,
         ...options


### PR DESCRIPTION
Fixes issue #900 

This is a patch, further refactoring may be required. This branch adds 3 lines of code that calculate implicit H for a structure right before it is rendered to the table with previews.

It's probably not the best way to fix it, because these same calculations are performed again right after rendering (because we call force update on it):
https://github.com/epam/ketcher/blob/bb1efd45119e13a923d7e0d3b6855a45399264c7/packages/ketcher-react/src/script/ui/component/structrender.jsx#L31-L32

, but the component does not catch this update after mounting.