### PR TITLE
#900 Template editor respects global display settings

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/template-attach.jsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/template-attach.jsx
@@ -62,7 +62,9 @@ class Attach extends Component {
       struct.atoms.get(this.props.atomid) && struct.bonds.get(this.props.bondid)
         ? this.props
         : this.tmpl.props
-    const options = Object.assign(EDITOR_STYLES, { scale: getScale(struct) })
+    const options = Object.assign(EDITOR_STYLES, this.props.globalSettings, {
+      scale: getScale(struct)
+    })
 
     return (
       <Dialog
@@ -107,7 +109,8 @@ export default connect(
   store => ({
     ...store.templates.attach,
     templateLib: store.templates.lib,
-    formState: store.modal.form
+    formState: store.modal.form,
+    globalSettings: store.options.settings
   }),
   dispatch => ({
     onInit: (name, ap) => dispatch(initAttach(name, ap)),


### PR DESCRIPTION
Subscribing template edit modal component to global display settings to pass them with other options down to structure editor.