### PR TITLE
#1109 FG correctly detected by doubleclick on atom or bond with Select tool

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -404,7 +404,7 @@ class SelectTool {
       )
       const atomFromStruct = atomId !== null && struct.atoms.get(atomId)?.a
       if (
-        atomId &&
+        atomId !== null &&
         !FunctionalGroup.isBondInContractedFunctionalGroup(
           atomFromStruct,
           sgroups,
@@ -422,7 +422,7 @@ class SelectTool {
       )
       const bondFromStruct = bondId !== null && struct.bonds.get(bondId)?.b
       if (
-        bondId &&
+        bondId !== null &&
         !FunctionalGroup.isBondInContractedFunctionalGroup(
           bondFromStruct,
           sgroups,


### PR DESCRIPTION
Fixes issue #1109 

The problem is with type coercion, atom or bond with id of `0` are coerced to `false` in a logical expression, thus not being considered as non-null.