### PR TITLE
#1108 functional groups are not aromatized

### DIFF
--- a/packages/ketcher-core/src/application/ketcherBuilder.ts
+++ b/packages/ketcher-core/src/application/ketcherBuilder.ts
@@ -29,7 +29,8 @@ const DefaultStructServiceOptions = {
   'smart-layout': true,
   'ignore-stereochemistry-errors': true,
   'mass-skip-error-on-pseudoatoms': false,
-  'gross-formula-add-rsites': true
+  'gross-formula-add-rsites': true,
+  'aromatize-skip-super-atoms': true
 }
 
 export class KetcherBuilder {

--- a/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
+++ b/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
@@ -45,7 +45,8 @@ class KetcherBuilder {
       'smart-layout': true,
       'ignore-stereochemistry-errors': true,
       'mass-skip-error-on-pseudoatoms': false,
-      'gross-formula-add-rsites': true
+      'gross-formula-add-rsites': true,
+      'aromatize-skip-super-atoms': true
     })
   }
 


### PR DESCRIPTION
Fixes #1108 , making use of `aromatize-skip-super-atoms` flag implemented in Indigo, [issue 506](https://github.com/epam/Indigo/issues/506).