### PR TITLE
#1137 Allow empty ket file

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/schema.json
+++ b/packages/ketcher-core/src/domain/serializers/ket/schema.json
@@ -11,7 +11,7 @@
       "properties": {
         "nodes": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 0,
           "items": {
             "oneOf": [
               {


### PR DESCRIPTION
This prevents throwing a validation error when empty `*.ket` file is opened, as described in issue #1137 

However, modal window is not closed if the structure is empty:
https://github.com/epam/ketcher/blob/ab62ab034b444164e30845701aeccf40815ef36f/packages/ketcher-react/src/script/ui/state/shared.js#L133-L143

Please let me know if we _should_ close the modal and maybe treat empty structure as a new structure.

Also worth noting: as of now it is not possible to test this with potential empty struct response from Indigo.