### PR TITLE
#1137 Close modal on empty file load

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/shared.js
+++ b/packages/ketcher-react/src/script/ui/state/shared.js
@@ -23,6 +23,7 @@ import {
 } from 'ketcher-core'
 
 import { supportedSGroupTypes } from './constants'
+import tools from '../action/tools'
 
 export function onAction(action) {
   if (action && action.dialog) {
@@ -131,11 +132,12 @@ export function load(struct, options) {
 
           struct.markFragments()
 
-          if (struct.isBlank()) {
-            return
-          }
           if (fragment) {
-            dispatch(onAction({ tool: 'paste', opts: struct }))
+            if (struct.isBlank()) {
+              dispatch({ type: 'ACTION', action: tools['select-lasso'].action })
+            } else {
+              dispatch(onAction({ tool: 'paste', opts: struct }))
+            }
           } else {
             editor.struct(struct)
           }


### PR DESCRIPTION
This branch updates behaviour of Open structure modal window when empty structure is loaded.

Now, if user wants:
- to load empty structure as fragment, then modal is closed and Select tool is selected (like after paste).
- to load empty structure as new canvas, then canvas with empty structure is loaded.