### PR TITLE
#1163 Stereocenter labels color gradient works in FF

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -343,7 +343,7 @@ class ReAtom extends ReObject {
         const color = getStereoAtomColor(render.options, stereoLabel)
         aamPath.node.childNodes[0].setAttribute('fill', color)
         const opacity = getStereoAtomOpacity(render.options, stereoLabel)
-        aamPath.node.childNodes[0].setAttribute('opacity', opacity)
+        aamPath.node.childNodes[0].setAttribute('fill-opacity', opacity)
       }
       const aamBox = util.relBox(aamPath.getBBox())
       draw.recenterText(aamPath, aamBox)


### PR DESCRIPTION
Using `fill-opacity` attribute, as FireFox doesn't seem to work with `opacity` for `<tspan>`. Fixes #1163 