### PR TITLE
#1291 Prevent Check Structure modal from updating its state after being closed

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/modal/index.js
+++ b/packages/ketcher-react/src/script/ui/state/modal/index.js
@@ -37,6 +37,8 @@ function modalReducer(state = null, action) {
 
   if (type === 'UPDATE_FORM') {
     // Don't update if modal has already been closed
+    // TODO: refactor actions and server functions in /src/script/ui/state/server/index.js to
+    // not send 'UPDATE_FORM' action to a closed modal in the first place
     if (!state) {
       return null
     }

--- a/packages/ketcher-react/src/script/ui/state/modal/index.js
+++ b/packages/ketcher-react/src/script/ui/state/modal/index.js
@@ -36,6 +36,11 @@ function modalReducer(state = null, action) {
   const { type, data } = action
 
   if (type === 'UPDATE_FORM') {
+    // Don't update if modal has already been closed
+    if (!state) {
+      return null
+    }
+
     const formState = formReducer(state.form, action, state.name)
     return { ...state, form: formState }
   }


### PR DESCRIPTION
Updated modalReducer to check whether modal is closed upon receiving `UPDATE_FORM` action. 