### PR TITLE
#1312 extra scrollbar in data s-group modal when field name contains long string

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.module.less
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.module.less
@@ -41,6 +41,11 @@
   fieldset {
     border: 0;
     padding: 0;
+
+    // stylelint-disable selector-pseudo-class-no-unknown
+    :global(.MuiSelect-select) {
+      max-width: 230px;
+    }
   }
 
   fieldset[class='radio'] {


### PR DESCRIPTION
Scrollbar appears because of fixed standard width of dialog and select width that depends on option string length

Set max width for the select itself, options in dropdown can have bigger width, like this (there's a single edge case):
![closed](https://user-images.githubusercontent.com/77681522/157829160-f28927c2-e990-401f-874d-7bda16874059.PNG)
![open](https://user-images.githubusercontent.com/77681522/157829163-4a93dc4c-1795-4344-a4a2-24239ae0869c.png)

Another option:
- set bigger (not standard) width for data s-group modal (inconsistency with other modals)