### PR TITLE
#1325 button group is not presented if ketcher is in a drawer

### DIFF
--- a/packages/ketcher-react/src/script/ui/Portal/Portal.tsx
+++ b/packages/ketcher-react/src/script/ui/Portal/Portal.tsx
@@ -81,12 +81,12 @@ class Portal extends Component<Props> {
   }
 
   private addElementInDOM() {
-    document.querySelector('body')?.appendChild(this.element)
+    document.querySelector('.Ketcher-root')?.appendChild(this.element)
     this.isElementInDom = true
   }
 
   private removeElementFromDOM() {
-    document.querySelector('body')?.removeChild(this.element)
+    document.querySelector('.Ketcher-root')?.removeChild(this.element)
     this.isElementInDom = false
   }
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalStyle.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalStyle.ts
@@ -26,13 +26,15 @@ function usePortalStyle([ref, isOpen]: HookParams): [CSSProperties] {
       return
     }
 
-    const rect = ref.current.getBoundingClientRect()
-    // if content is bigger than page height and user scrolled document, we should correct portal position
-    const scrollOffset = document.scrollingElement?.scrollTop || 0
-    const top = rect.top + scrollOffset
+    const editorRect = document
+      .querySelector('.Ketcher-root')
+      ?.getBoundingClientRect() || { top: 0, left: 0 }
+    const menuItemRect = ref.current.getBoundingClientRect()
 
+    const top = menuItemRect.top - editorRect.top
     const spaceBetween = 4
-    const left = rect.left + rect.width + spaceBetween
+    const left =
+      menuItemRect.left - editorRect.left + menuItemRect.width + spaceBetween
 
     setPortalStyle({ top: `${top}px`, left: `${left}px` })
   }, [ref, isOpen])


### PR DESCRIPTION
- fix portal container
- fix portal position
![ketcher-in-drawer](https://user-images.githubusercontent.com/77681522/158539132-7e322a2e-345d-4269-9d8d-79b5ed396361.png)

