### PR TITLE
#1472 blur structure in the preview tab when saved in pdf

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.module.less
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.module.less
@@ -144,8 +144,8 @@
     
       img {
         background-color: @color-background-primary;
-        height: 220px;
-        width: 220px;
+        max-height: 220px;
+        max-width: 428px;
       }
     }
 


### PR DESCRIPTION
- fix incorrect ratio in preview
- blur is caused by external issues 