### PR TITLE
#1154 The 'Apply' button in the 'Template edit' window is enabled

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/template-attach.jsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/template-attach.jsx
@@ -150,6 +150,11 @@ const SaveButton = styled(Button)`
     background-color: #43b5c0;
     box-shadow: none;
   }
+
+  &:disabled {
+    background-color: #e1e5ea;
+    color: #333333;
+  }
 `
 
 const CancelButton = styled(Button)`
@@ -261,6 +266,7 @@ class Attach extends Component {
               <SaveButton
                 variant="contained"
                 onClick={() => this.props.onOk(this.onResult())}
+                disabled={!name}
               >
                 Apply
               </SaveButton>


### PR DESCRIPTION
[Issue](https://github.com/epam/ketcher/issues/1554)

Fix: disabled button if name-field is empty, add styles fo disabled button