### PR TITLE
Add recognize method to ketcher API

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -164,6 +164,10 @@ export class Ketcher {
     throw Error('not implemented yet')
   }
 
+  recognize(image: Blob, version?: string): Promise<Struct> {
+    return this.#indigo.recognize(image, { version: version })
+  }
+
   async generateImage(
     data: string,
     options: GenerateImageOptions = { outputFormat: 'png' }


### PR DESCRIPTION
To check the operation of the recognize method:
have a saved molecule in .png format
convert image to base64 (for example [here](https://www.base64-image.de/))
   1. Open ketcher in remote mode
   2. Through the browser console, create a blob-object from the image code and make sure that it was created correctly (you can create a Blob URL to check)
  3. use ketcher.recognize( blob, ?imago version)

The structure should be returned as an object