### PR TITLE
fix bug: new bond on single atom

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -61,11 +61,13 @@ export function atomForNewBond(restruct, id, bond?) {
   // eslint-disable-line max-statements
   const neighbours: Array<any> = []
   const pos = atomGetPos(restruct, id)
-  const prevBondId = restruct.molecule.findBondId(
-    id,
-    restruct.molecule.atomGetNeighbors(id)[0].aid
-  )
-  const prevBondType = restruct.molecule.bonds.get(prevBondId).type
+  const atomNeighbors = restruct.molecule.atomGetNeighbors(id)
+   const prevBondId = atomNeighbors.length
+    ? restruct.molecule.findBondId(id, atomNeighbors[0].aid)
+    : null
+  const prevBondType = prevBondId
+    ? restruct.molecule.bonds.get(prevBondId).type
+    : null
 
   restruct.molecule.atomGetNeighbors(id).forEach((nei) => {
     const neiPos = atomGetPos(restruct, nei.aid)


### PR DESCRIPTION
single atom has no atomNeighbors, so when new bond on single atom, `atomNeighbors[0]` is out of range