### PR TITLE
Fix TopToolbar's dynamic styles respond to its width

### DIFF
--- a/packages/ketcher-react/.babelrc
+++ b/packages/ketcher-react/.babelrc
@@ -4,5 +4,5 @@
     ["@babel/react", { "runtime": "automatic" }],
     "@babel/typescript"
   ],
-  "plugins": ["@babel/plugin-transform-runtime"]
+  "plugins": ["@emotion", "@babel/plugin-transform-runtime"]
 }

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -86,6 +86,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
+    "@emotion/babel-plugin": "^11.10.2",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/IconButton.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/IconButton.tsx
@@ -19,7 +19,7 @@ import styled from '@emotion/styled'
 
 import Icon from 'src/script/ui/component/view/icon'
 
-const Button = styled(MuiButton)`
+export const Button = styled(MuiButton)`
   display: block;
   color: #333;
   border: 0;
@@ -61,18 +61,6 @@ const Button = styled(MuiButton)`
     background-color: initial;
     color: #333;
     pointer-events: auto;
-  }
-
-  @media only screen and (min-width: 1024px) {
-    height: 32px;
-    width: 32px;
-    padding: 4px;
-  }
-
-  @media only screen and (min-width: 1920px) {
-    height: 40px;
-    width: 40px;
-    padding: 5px;
   }
 `
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
@@ -23,7 +23,7 @@ import { UndoRedo } from './UndoRedo'
 import { ZoomControls } from './ZoomControls'
 
 import { SystemControls } from './SystemControls'
-import { IconButton } from './IconButton'
+import { IconButton, Button } from './IconButton'
 import { ExternalFuncControls } from './ExternalFuncControls'
 import { Divider } from './Divider'
 
@@ -65,15 +65,20 @@ export interface PanelProps {
   onHelp: VoidFunction
 }
 
-const collapseLimit = 650
+interface ControlsPanelProps {
+  width: number
+}
 
-const ControlsPanel = styled('div')`
+const collapseLimit = 650
+const panelPadding = 8
+
+const ControlsPanel = styled('div')<ControlsPanelProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 0px;
   height: 36px;
-  padding: 0px 8px;
+  padding: 0px ${panelPadding}px;
 
   .group {
     display: flex;
@@ -85,18 +90,43 @@ const ControlsPanel = styled('div')`
     box-sizing: border-box;
   }
 
-  @media only screen and (min-width: 1024px) {
-    height: 40px;
-    gap: 4px;
-
-    .group {
-      gap: 4px;
+  ${(props) => {
+    let ResponsiveStyles = {}
+    if (props.width >= 1920 - 2 * panelPadding) {
+      ResponsiveStyles = {
+        height: 64,
+        gap: 12
+      }
+    } else if (props.width >= 1024 - 2 * panelPadding) {
+      ResponsiveStyles = {
+        height: 40,
+        gap: 4,
+        '.group': {
+          gap: 4
+        }
+      }
     }
-  }
+    return ResponsiveStyles
+  }};
 
-  @media only screen and (min-width: 1920px) {
-    height: 64px;
-    gap: 12px;
+  ${Button} {
+    ${(props) => {
+      let ResponsiveStyles = {}
+      if (props.width >= 1920 - 2 * panelPadding) {
+        ResponsiveStyles = {
+          height: 40,
+          width: 40,
+          padding: 5
+        }
+      } else if (props.width >= 1024 - 2 * panelPadding) {
+        ResponsiveStyles = {
+          height: 32,
+          width: 32,
+          padding: 4
+        }
+      }
+      return ResponsiveStyles
+    }};
   }
 `
 
@@ -138,7 +168,7 @@ export const TopToolbar = ({
   const { ref: resizeRef, width = 50 } = useResizeObserver<HTMLDivElement>()
 
   return (
-    <ControlsPanel className={className} ref={resizeRef}>
+    <ControlsPanel className={className} ref={resizeRef} width={width}>
       <IconButton
         title="Clear Canvas"
         onClick={onClear}

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-plugin-utils@npm:^7.18.6":
+  version: 7.19.0
+  resolution: "@babel/helper-plugin-utils@npm:7.19.0"
+  checksum: eedc996c633c8c207921c26ec2989eae0976336ecd9b9f1ac526498f52b5d136f7cd03c32b6fdf8d46a426f907c142de28592f383c42e5fba1e904cbffa05345
+  languageName: node
+  linkType: hard
+
 "@babel/helper-remap-async-to-generator@npm:^7.16.8":
   version: 7.16.8
   resolution: "@babel/helper-remap-async-to-generator@npm:7.16.8"
@@ -785,6 +792,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: cd9b0e53c50e8ddb0afaf0f42e0b221a94e4f59aee32a591364266a31195c48cac5fef288d02c1c935686bda982d2e0f1ed61cceb995fc9f6fb09ef5ebecdd2b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.17.12":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6d37ea972970195f1ffe1a54745ce2ae456e0ac6145fae9aa1480f297248b262ea6ebb93010eddb86ebfacb94f57c05a1fc5d232b9a67325b09060299d515c67
   languageName: node
   linkType: hard
 
@@ -1522,6 +1540,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.18.3":
+  version: 7.19.0
+  resolution: "@babel/runtime@npm:7.19.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
@@ -1696,6 +1723,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/babel-plugin@npm:^11.10.2":
+  version: 11.10.2
+  resolution: "@emotion/babel-plugin@npm:11.10.2"
+  dependencies:
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/plugin-syntax-jsx": ^7.17.12
+    "@babel/runtime": ^7.18.3
+    "@emotion/hash": ^0.9.0
+    "@emotion/memoize": ^0.8.0
+    "@emotion/serialize": ^1.1.0
+    babel-plugin-macros: ^3.1.0
+    convert-source-map: ^1.5.0
+    escape-string-regexp: ^4.0.0
+    find-root: ^1.1.0
+    source-map: ^0.5.7
+    stylis: 4.0.13
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 7f9e84b3c00b4db5a829c6880549c6a816b3defcaf828cb37808737f3c17b22a45a06e48334f38f5729b218812252857ced27d3a12dd8ca1e260e4b1d0045dfd
+  languageName: node
+  linkType: hard
+
 "@emotion/babel-plugin@npm:^11.7.1, @emotion/babel-plugin@npm:^11.7.2":
   version: 11.7.2
   resolution: "@emotion/babel-plugin@npm:11.7.2"
@@ -1738,6 +1787,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/hash@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@emotion/hash@npm:0.9.0"
+  checksum: b63428f7c8186607acdca5d003700cecf0ded519d0b5c5cc3b3154eafcad6ff433f8361bd2bac8882715b557e6f06945694aeb6ba8b25c6095d7a88570e2e0bb
+  languageName: node
+  linkType: hard
+
 "@emotion/is-prop-valid@npm:^1.1.2":
   version: 1.1.2
   resolution: "@emotion/is-prop-valid@npm:1.1.2"
@@ -1751,6 +1807,13 @@ __metadata:
   version: 0.7.5
   resolution: "@emotion/memoize@npm:0.7.5"
   checksum: 83da8d4a7649a92c72f960817692bc6be13cc13e107b9f7e878d63766525ed4402881bfeb3cda61145c050281e7e260f114a0a2870515527346f2ef896b915b3
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@emotion/memoize@npm:0.8.0"
+  checksum: c87bb110b829edd8e1c13b90a6bc37cebc39af29c7599a1e66a48e06f9bec43e8e53495ba86278cc52e7589549492c8dfdc81d19f4fdec0cee6ba13d2ad2c928
   languageName: node
   linkType: hard
 
@@ -1790,6 +1853,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/serialize@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@emotion/serialize@npm:1.1.0"
+  dependencies:
+    "@emotion/hash": ^0.9.0
+    "@emotion/memoize": ^0.8.0
+    "@emotion/unitless": ^0.8.0
+    "@emotion/utils": ^1.2.0
+    csstype: ^3.0.2
+  checksum: 8f22f83194ad76cb3bbee481daa57fdc65ca3078a5db9e219c04151341ef93af80c7057aea17b64446682d275918f7ecc0c20e977c1af153c79a1485503fe717
+  languageName: node
+  linkType: hard
+
 "@emotion/sheet@npm:^1.1.0":
   version: 1.1.0
   resolution: "@emotion/sheet@npm:1.1.0"
@@ -1826,10 +1902,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/unitless@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@emotion/unitless@npm:0.8.0"
+  checksum: 176141117ed23c0eb6e53a054a69c63e17ae532ec4210907a20b2208f91771821835f1c63dd2ec63e30e22fcc984026d7f933773ee6526dd038e0850919fae7a
+  languageName: node
+  linkType: hard
+
 "@emotion/utils@npm:^1.0.0, @emotion/utils@npm:^1.1.0":
   version: 1.1.0
   resolution: "@emotion/utils@npm:1.1.0"
   checksum: d3b681ca3a23b07033ac6c6937e71010a5549ac8ccec325eb6c91a7e48d9a73db83fa5dadc58be981bb125d7c00fedca868ea4362b1da9e02866615f96be4df1
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@emotion/utils@npm:1.2.0"
+  checksum: 55457a49ddd4db6a014ea0454dc09eaa23eedfb837095c8ff90470cb26a303f7ceb5fcc1e2190ef64683e64cfd33d3ba3ca3109cd87d12bc9e379e4195c9a4dd
   languageName: node
   linkType: hard
 
@@ -11297,6 +11387,7 @@ __metadata:
     "@babel/preset-react": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
     "@babel/runtime": ^7.17.9
+    "@emotion/babel-plugin": ^11.10.2
     "@emotion/react": ^11.7.1
     "@emotion/styled": ^11.6.0
     "@mui/material": ^5.2.4


### PR DESCRIPTION
Some styles, like `height`, of TopToolbar was responsive to the screen width. That caused issues when Kether was not fullscreen.

Replace the media query with changing styles based on props. Add new dev dependency `@emotion/babel-plugin` for targeting the child component in emotion.

Resolves: #1678