### PR TITLE
#1723 convert Daylight SMILES using indigo api

### DIFF
--- a/packages/ketcher-core/src/application/formatters/formatterFactory.ts
+++ b/packages/ketcher-core/src/application/formatters/formatterFactory.ts
@@ -22,8 +22,7 @@ import {
 import {
   KetSerializer,
   MolSerializer,
-  MolSerializerOptions,
-  SmiSerializer
+  MolSerializerOptions
 } from 'domain/serializers'
 import { StructService, StructServiceOptions } from 'domain/services'
 
@@ -31,7 +30,6 @@ import { KetFormatter } from './ketFormatter'
 import { MolfileV2000Formatter } from './molfileV2000Formatter'
 import { RxnFormatter } from './rxnFormatter'
 import { ServerFormatter } from './serverFormatter'
-import { SmilesFormatter } from './smilesFormatter'
 
 export class FormatterFactory {
   #structService: StructService
@@ -85,24 +83,12 @@ export class FormatterFactory {
         formatter = new RxnFormatter(new MolSerializer(molSerializerOptions))
         break
 
-      case 'smiles':
-        formatter = new SmilesFormatter(
-          new SmiSerializer(),
-
-          // only for ServerFormatter, because 'getStructureFromStringAsync' is delegated to it
-
-          this.#structService,
-          new KetSerializer(),
-          format,
-          structServiceOptions
-        )
-        break
-
       case 'cml':
       case 'inChIAuxInfo':
       case 'inChI':
       case 'molV3000':
       case 'rxnV3000':
+      case 'smiles':
       case 'smilesExt':
       case 'smarts':
       case 'cdxml':


### PR DESCRIPTION
Ketcher started using API call /convert to convert ket format to Daylight SMILES because Indigo supports reagents