### PR TITLE
fix: Add missing peer dependencies

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -46,5 +46,9 @@
   },
   "devDependencies": {
     "serve": "^13.0.2"
+  },
+  "peerDependencies": {
+    "immutable": "^3.x",
+    "prop-types": "^15.0.0"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -64,6 +64,10 @@
     "typescript": "^4.5.2",
     "webpack-bundle-analyzer": "^3.9.0"
   },
+  "peerDependencies": {
+    "immutable": "^3.x",
+    "prop-types": "^15.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "22.0.0"
   },
+  "peerDependencies": {
+    "immutable": "^3.x",
+    "prop-types": "^15.0.0"
+  },
   "resolutions": {
     "react-error-overlay": "6.0.9"
   },

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -41,6 +41,8 @@
     "stylelint:fix": "stylelint \"./**/*.{css,less}\" --formatter verbose --fix"
   },
   "peerDependencies": {
+    "immutable": "^3.x",
+    "prop-types": "^15.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6651,6 +6651,9 @@ __metadata:
     serve: ^13.0.2
     typescript: ^4.5.5
     web-vitals: ^2.1.4
+  peerDependencies:
+    immutable: ^3.x
+    prop-types: ^15.0.0
   languageName: unknown
   linkType: soft
 
@@ -11334,6 +11337,9 @@ __metadata:
     stylelint: 13.13.1
     typescript: ^4.5.2
     webpack-bundle-analyzer: ^3.9.0
+  peerDependencies:
+    immutable: ^3.x
+    prop-types: ^15.0.0
   languageName: unknown
   linkType: soft
 
@@ -11424,6 +11430,8 @@ __metadata:
     w3c-keyname: ^2.2.4
     whatwg-fetch: ^3.4.1
   peerDependencies:
+    immutable: ^3.x
+    prop-types: ^15.0.0
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -15800,6 +15808,9 @@ __metadata:
     stylelint: 13.13.1
     stylelint-config-prettier: ^9.0.3
     stylelint-config-standard: 22.0.0
+  peerDependencies:
+    immutable: ^3.x
+    prop-types: ^15.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Adds missing peer dependencies for immutable and prop-types to fix yarn install error messages.