### PR TITLE
Fix local `input` styles overriding other styles

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/input.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/input.jsx
@@ -34,7 +34,7 @@ export function GenericInput({
         value={value}
         onInput={onChange}
         onChange={onChange}
-        className={classes.input}
+        className={clsx(classes.input, classes.genericInput)}
         {...props}
       />
       {type === 'checkbox' && <span className={classes.checkbox} />}
@@ -68,6 +68,7 @@ function CheckBox({ schema, value = '', onChange, ...rest }) {
         checked={value}
         onClick={onChange}
         onChange={onChange}
+        className={classes.input}
         {...rest}
       />
       <span className={classes.checkbox} />
@@ -94,8 +95,7 @@ function Select({
       value={value}
       name={name}
       multiple={multiple}
-      className={clsx(classes.select, className)}
-    >
+      className={clsx(classes.select, className)}>
       {enumSchema(schema, (title, val) => (
         <option key={val} value={val}>
           {title}
@@ -136,6 +136,7 @@ function FieldSet({
                 type === 'radio' ? selected(val, checked) : selected(val, value)
               }
               value={typeof val !== 'object' && val}
+              className={classes.input}
               {...rest}
             />
             {type === 'checkbox' && <span className={classes.checkbox} />}

--- a/packages/ketcher-react/src/script/ui/component/form/input.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/input.jsx
@@ -95,7 +95,8 @@ function Select({
       value={value}
       name={name}
       multiple={multiple}
-      className={clsx(classes.select, className)}>
+      className={clsx(classes.select, className)}
+    >
       {enumSchema(schema, (title, val) => (
         <option key={val} value={val}>
           {title}

--- a/packages/ketcher-react/src/script/ui/component/form/input.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/input.jsx
@@ -96,7 +96,7 @@ function Select({
       name={name}
       multiple={multiple}
       className={clsx(classes.select, className)}
-      >
+    >
       {enumSchema(schema, (title, val) => (
         <option key={val} value={val}>
           {title}

--- a/packages/ketcher-react/src/script/ui/component/form/input.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/input.jsx
@@ -96,7 +96,7 @@ function Select({
       name={name}
       multiple={multiple}
       className={clsx(classes.select, className)}
-    >
+      >
       {enumSchema(schema, (title, val) => (
         <option key={val} value={val}>
           {title}
@@ -127,7 +127,7 @@ function FieldSet({
   ...rest
 }) {
   return (
-    <fieldset onClick={onSelect} className="radio">
+    <fieldset onClick={onSelect}>
       {enumSchema(schema, (title, val) => (
         <li key={title} className={classes.fieldSetItem}>
           <label className={classes.fieldSetLabel}>

--- a/packages/ketcher-react/src/script/ui/component/form/input.module.less
+++ b/packages/ketcher-react/src/script/ui/component/form/input.module.less
@@ -1,60 +1,60 @@
 @import '../../../../style/variables';
 
-  .fieldSetLabel {
-    position: relative;
-  }
+.fieldSetLabel {
+  position: relative;
+}
 
-  input[type='radio'],
-  input[type='checkbox'] {
-    position: absolute;
-    opacity: 0;
-  }
+.input[type='radio'],
+.input[type='checkbox'] {
+  position: absolute;
+  opacity: 0;
+}
 
-  input[type='checkbox'] + .checkbox {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    vertical-align: middle;
-    margin-right: 6px;
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='15' height='15' rx='3.5' fill='white' stroke='%23B4B9D6'/%3E%3C/svg%3E%0A");
-    background-repeat: no-repeat;
-    background-size: 100%;
-  }
+.input[type='checkbox'] + .checkbox {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  margin-right: 6px;
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.5' y='0.5' width='15' height='15' rx='3.5' fill='white' stroke='%23B4B9D6'/%3E%3C/svg%3E%0A");
+  background-repeat: no-repeat;
+  background-size: 100%;
+}
 
-  input[type='checkbox']:hover + .checkbox {
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.75' y='0.75' width='14.5' height='14.5' rx='3.25' fill='white' stroke='%2343B5C0' stroke-width='1.5'/%3E%3C/svg%3E%0A");
-  }
+.input[type='checkbox']:hover + .checkbox {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0.75' y='0.75' width='14.5' height='14.5' rx='3.25' fill='white' stroke='%2343B5C0' stroke-width='1.5'/%3E%3C/svg%3E%0A");
+}
 
-  input[type='checkbox']:checked + .checkbox {
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='16' height='16' rx='4' fill='%23167782'/%3E%3Cpath d='M6.33711 11.8079L2.42578 7.63124L3.39911 6.71991L6.36845 9.89124L12.6171 3.64258L13.5598 4.58524L6.33711 11.8079Z' fill='white'/%3E%3C/svg%3E%0A");
-  }
+.input[type='checkbox']:checked + .checkbox {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='16' height='16' rx='4' fill='%23167782'/%3E%3Cpath d='M6.33711 11.8079L2.42578 7.63124L3.39911 6.71991L6.36845 9.89124L12.6171 3.64258L13.5598 4.58524L6.33711 11.8079Z' fill='white'/%3E%3C/svg%3E%0A");
+}
 
-  input[type='radio'] + .radioButton {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    vertical-align: middle;
-    margin-right: 8px;
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-default}' stroke-width='2'/%3E%3C/svg%3E%0A");
-    background-repeat: no-repeat;
-    background-size: 100%;
-  }
+.input[type='radio'] + .radioButton {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  margin-right: 8px;
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-default}' stroke-width='2'/%3E%3C/svg%3E%0A");
+  background-repeat: no-repeat;
+  background-size: 100%;
+}
 
-  input[type='radio']:hover + .radioButton {
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-hover-svg}' stroke-width='2'/%3E%3C/svg%3E%0A");
-  }
+.input[type='radio']:hover + .radioButton {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-hover-svg}' stroke-width='2'/%3E%3C/svg%3E%0A");
+}
 
-  input[type='radio']:checked + .radioButton {
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='@{color-input}' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input}' stroke-width='2'/%3E%3Ccircle cx='8' cy='8' r='4' fill='@{color-input}'/%3E%3C/svg%3E%0A");
-  }
+.input[type='radio']:checked + .radioButton {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='@{color-input}' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input}' stroke-width='2'/%3E%3Ccircle cx='8' cy='8' r='4' fill='@{color-input}'/%3E%3C/svg%3E%0A");
+}
 
-  input[type='radio']:disabled + .radioButton {
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-default}' stroke-width='2' /%3E%3C/svg%3E%0A");
-  }
+.input[type='radio']:disabled + .radioButton {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-default}' stroke-width='2' /%3E%3C/svg%3E%0A");
+}
 
-  input[type='radio']:checked:disabled + .radioButton {
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='@{color-input-default}' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-default}' stroke-width='2'/%3E%3Ccircle cx='8' cy='8' r='4' fill='@{color-input-default}'/%3E%3C/svg%3E%0A");
-  }
+.input[type='radio']:checked:disabled + .radioButton {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='@{color-input-default}' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='7' stroke='@{color-input-default}' stroke-width='2'/%3E%3Ccircle cx='8' cy='8' r='4' fill='@{color-input-default}'/%3E%3C/svg%3E%0A");
+}
 
 .slider.slider {
   position: relative;
@@ -107,7 +107,7 @@
 }
 
 .select,
-.input {
+.genericInput {
   color: @color-text-primary;
 }
 


### PR DESCRIPTION
There were `input` selectors lying in the outer-most layer of a `.less` file, which led to overriding other styles when importing the `less` file.

After going through all `.less` files, I found just one file having that problem. I changed the tag selector to its corresponding class selector. I've checked styles that may be affected by my changes to make sure everything works fine.

* Update selector `input` to `.input`

Resolves: #1694