### PR TITLE
Get rid of percentages from css opacity

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/OpenOptions.module.less
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/OpenOptions.module.less
@@ -73,7 +73,7 @@
 
   .textLabel {
     color: @color-text-primary;
-    opacity: 50%;
+    opacity: 0.5;
     font-weight: 400;
   }
 


### PR DESCRIPTION
Old versions of cssnano (css minimiser) can't minimise opacity with percentages and it cause a bug:
![Screenshot from 2022-10-06 15-45-39](https://user-images.githubusercontent.com/10114517/196142299-75dacbac-85ef-449a-9ffa-45a3d5d4d9d5.png)

![Screenshot from 2022-10-17 12-31-27](https://user-images.githubusercontent.com/10114517/196142841-3a98759a-4a18-4c63-9317-bfae3637181e.png)

How it should look:
![Screenshot from 2022-10-06 15-46-02](https://user-images.githubusercontent.com/10114517/196143115-fc2e7c8f-5f39-4513-b400-d53c67ad9624.png)

Although it's a bug in cssnano for opacity in css better to use just float number in any cases.

Related: [opacity percentage changed to 1% · Issue #118 · NMFR/optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/118)

[Resolve Opacity Bug by genemecija · Pull Request #881 · cssnano/cssnano](https://github.com/cssnano/cssnano/pull/881#issuecomment-627420821)