### PR TITLE
fix: add className 'selected' for styledAtom

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/AtomsList/AtomsList.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/AtomsList/AtomsList.tsx
@@ -79,6 +79,9 @@ const AtomsList = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
             key={label}
             el={element}
             shortcut={shortcut}
+            className={
+              isAtom && active && active.opts.label === label ? 'selected' : ''
+            }
             selected={isAtom && active && active.opts.label === label}
             onClick={() => onAction({ tool: 'atom', opts: { label } })}
           />


### PR DESCRIPTION
Styles for selected state already exist (attached to class 'selected'), but class itself wasn't added to an element.