### PR TITLE
added autofocus attribute for texarea

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/Open.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/Open.tsx
@@ -158,6 +158,7 @@ const Open: FC<Props> = (props) => {
         isRecognizeDisabled={isRecognizeDisabled}
         structStr={structStr}
         inputHandler={setStructStr}
+        autoFocus
       />
     </Dialog>
   )

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/TextEditor.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/TextEditor.tsx
@@ -19,15 +19,21 @@ import classes from '../Open.module.less'
 export type TextEditorProps = {
   structStr: string
   inputHandler: (str: string) => void
+  autoFocus?: boolean
 }
 
-export const TextEditor = ({ structStr, inputHandler }: TextEditorProps) => {
+export const TextEditor = ({
+  structStr,
+  inputHandler,
+  autoFocus = false
+}: TextEditorProps) => {
   return (
     <>
       <textarea
         className={classes.textareaEditor}
         value={structStr}
         onChange={(event) => inputHandler(event.target.value)}
+        autoFocus={autoFocus}
       />
     </>
   )


### PR DESCRIPTION
Added optional attribute `autofocus` for textarea. Added this new attribute in `Open` modal, making text editor focused by default.