### PR TITLE
#1802 fix set scroll to the top after reloading the page

### DIFF
--- a/packages/ketcher-react/src/script/ui/App/App.tsx
+++ b/packages/ketcher-react/src/script/ui/App/App.tsx
@@ -57,6 +57,7 @@ const App = (props: Props) => {
   useEffect(() => {
     checkServer()
     dispatch(initFGTemplates(staticResourcesUrl))
+    window.scrollTo(0, 0)
   }, [])
 
   return (


### PR DESCRIPTION
Fix bug #1802: [Refresh the interface when the scroll axis appears again, it will automatically scroll to the bottom ](https://github.com/epam/ketcher/issues/1802)