### PR TITLE
#1894 – added support for extra spaces and alias in mol v2000 files

### DIFF
--- a/packages/ketcher-core/src/domain/entities/atom.ts
+++ b/packages/ketcher-core/src/domain/entities/atom.ts
@@ -24,13 +24,14 @@ function getValueOrDefault<T>(value: T | undefined, defaultValue: T): T {
   return typeof value !== 'undefined' ? value : defaultValue
 }
 
+function isCorrectPseudo(label) {
+  return (
+    !Elements.get(label) && label !== 'L' && label !== 'L#' && label !== 'R#'
+  )
+}
+
 function getPseudo(label: string) {
-  return !Elements.get(label) &&
-    label !== 'L' &&
-    label !== 'L#' &&
-    label !== 'R#'
-    ? label
-    : ''
+  return isCorrectPseudo(label) ? label : ''
 }
 
 export function radicalElectrons(radical: any) {
@@ -213,6 +214,11 @@ export class Atom {
       enumerable: true,
       get: function () {
         return getPseudo(this.label)
+      },
+      set: function (value) {
+        if (isCorrectPseudo(value)) {
+          this.label = value
+        }
       }
     })
   }

--- a/packages/ketcher-core/src/domain/serializers/mol/common.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/common.js
@@ -43,10 +43,14 @@ function parseCTab(/* string */ ctabLines) /* Struct */ {
   )
   const version = countsSplit[11].trim()
   ctabLines = ctabLines.slice(1)
-  if (version === 'V2000') return v2000.parseCTabV2000(ctabLines, countsSplit)
-  else if (version === 'V3000') {
+  if (version === 'V2000') {
+    return v2000.parseCTabV2000(ctabLines, countsSplit)
+  }
+  if (version === 'V3000') {
     return v3000.parseCTabV3000(ctabLines, !loadRGroupFragments)
-  } else throw new Error('Molfile version unknown: ' + version) // eslint-disable-line no-else-return
+  } else {
+    throw new Error('Molfile version unknown: ' + version)
+  }
 }
 
 /* Parse Rxn */

--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.js
@@ -136,17 +136,20 @@ function parsePropertyLines(ctab, ctabLines, shift, end, sGroups, rLogic) {
   while (shift < end) {
     const line = ctabLines[shift]
     if (line.charAt(0) === 'A') {
-      let propValue = ctabLines[++shift]
+      const propValue = ctabLines[++shift]
       // TODO: Atom entity only have pseudo getter. Check during refactoring
       // this type of pseudo labeling is not used in current BIOVIA products. See ctab documentation 2020
       // https://discover.3ds.com/sites/default/files/2020-08/biovia_ctfileformats_2020.pdf (page 47)
       const isPseudo = /'.+'/.test(propValue)
-      if (isPseudo && !props.get('pseudo')) props.set('pseudo', new Pool())
-      if (!isPseudo && !props.get('alias')) props.set('alias', new Pool())
-      if (isPseudo) propValue = propValue.replace(/'/g, '')
+      if (isPseudo && !props.get('pseudo')) {
+        props.set('pseudo', new Pool())
+      }
+      if (!isPseudo && !props.get('alias')) {
+        props.set('alias', new Pool())
+      }
       props
         .get(isPseudo ? 'pseudo' : 'alias')
-        .set(utils.parseDecimalInt(line.slice(3, 6)) - 1, propValue)
+        .set(utils.parseDecimalInt(line.slice(3)) - 1, propValue)
     } else if (line.charAt(0) === 'M') {
       const type = line.slice(3, 6)
       let propertyData = line.slice(6)


### PR DESCRIPTION
When Atom has alias with single quotes, it is parsed as "pseudo". This "pseudo" didn't have corresponding setter, that's why error was shown.
resolves #1894 