### PR TITLE
#1827: fix hover icon

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -134,6 +134,14 @@ class AtomTool {
     }
   }
 
+  mouseleave() {
+    this.editor.hoverIcon.hide()
+  }
+
+  mouseover() {
+    this.editor.hoverIcon.show()
+  }
+
   mousemove(event) {
     const rnd = this.editor.render
     const { layerX, layerY } = event


### PR DESCRIPTION
Now atom tool hover Icon disappears if cursor isn't over canvas
fixes #1908 