### PR TITLE
#1920 Salts and Solvents tab: Abbreviation is expanded after adding to the canvas

### DIFF
--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -46,9 +46,13 @@ export class FunctionalGroup {
   static isFunctionalGroup(sgroup): boolean {
     const provider = FunctionalGroupsProvider.getInstance()
     const types = provider.getFunctionalGroupsList()
+    const {
+      data: { name },
+      type
+    } = sgroup
     return (
-      types.some((type) => type.name === sgroup.data.name) &&
-      sgroup.type === 'SUP'
+      type === 'SUP' &&
+      (types.some((type) => type.name === name) || SGroup.isSaltOrSolvent(name))
     )
   }
 

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -220,7 +220,10 @@ export class SGroup {
   static isSaltOrSolvent(moleculeName: string): boolean {
     const saltsAndSolventsProvider = SaltsAndSolventsProvider.getInstance()
     const saltsAndSolvents = saltsAndSolventsProvider.getSaltsAndSolventsList()
-    return saltsAndSolvents.some(({ name }) => name === moleculeName)
+    return saltsAndSolvents.some(
+      ({ name, abbreviation }) =>
+        name === moleculeName || moleculeName === abbreviation
+    )
   }
 
   static isAtomInSaltOrSolvent(

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -60,6 +60,7 @@ export class Struct {
   frags: Pool<Fragment | null>
   rgroups: Pool<RGroup>
   name: string
+  abbreviation?: string
   sGroupForest: SGroupForest
   simpleObjects: Pool<SimpleObject>
   texts: Pool<Text>
@@ -78,6 +79,7 @@ export class Struct {
     this.frags = new Pool<Fragment>()
     this.rgroups = new Pool<RGroup>()
     this.name = ''
+    this.abbreviation = ''
     this.sGroupForest = new SGroupForest()
     this.simpleObjects = new Pool<SimpleObject>()
     this.texts = new Pool<Text>()

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -237,7 +237,7 @@ class BondTool {
           }
         }
         // don't rotate the bond if the distance between the start and end point is too small
-        if (dist > 0.3)
+        if (dist > 0.3) {
           dragCtx.action = fromBondAddition(
             rnd.ctab,
             this.bondProps,
@@ -246,7 +246,9 @@ class BondTool {
             beginPos,
             endPos
           )[0]
-        else delete dragCtx.action
+        } else {
+          delete dragCtx.action
+        }
         this.editor.update(dragCtx.action, true)
         return true
       }

--- a/packages/ketcher-react/src/script/ui/state/saltsAndSolvents/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/saltsAndSolvents/index.ts
@@ -63,7 +63,10 @@ export function initSaltsAndSolventsTemplates(baseUrl: string) {
     const text = await prefetchStatic(url)
     const templates = sdfSerializer.deserialize(text)
     const saltsAndSolvents = templates.reduce(
-      (acc: Struct[], { struct }) => [...acc, struct],
+      (acc: Struct[], { struct, props }) => {
+        acc.push({ ...struct, abbreviation: props.abbreviation } as Struct)
+        return acc
+      },
       []
     )
     saltsAndSolventsProvider.setSaltsAndSolventsList(saltsAndSolvents)


### PR DESCRIPTION
Fixed `isSaltOrSolvent` by also considering an abbreviation of structure.
`Struct` now also has `abbreviation` property.