### PR TITLE
#1914 Data S-Group: In the window 'S-Group Properties' the names of the radio buttons are displayed without separation

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sdata.jsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sdata.jsx
@@ -75,7 +75,7 @@ function SData({
         init={init}
         {...formState}
       >
-        <fieldset>
+        <fieldset className="sdata">
           <Field
             name="context"
             options={getSelectOptionsFromSchema(formSchema.properties.context)}

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.module.less
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.module.less
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-@import "src/style/variables";
-@import "src/style/mixins";
+@import 'src/style/variables';
+@import 'src/style/mixins';
+
 // stylelint-disable selector-pseudo-class-no-unknown
 // stylelint-disable no-descending-specificity
 .sgroup {
   width: @width-small;
   border-radius: 6px;
   background-color: @color-background-primary;
-
 
   label {
     display: flex;
@@ -32,7 +32,8 @@
       width: inherit;
     }
 
-    :global(.MuiOutlinedInput-root), input[type='text'] {
+    :global(.MuiOutlinedInput-root),
+    input[type='text'] {
       max-width: 236px;
       margin-top: 4px;
     }
@@ -43,22 +44,24 @@
     padding: 0;
   }
 
-  fieldset[class='radio'] {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 24px;
-    width: 100%;
-
-    & label {
+  fieldset[class='sdata'] {
+    fieldset {
       display: flex;
-      flex-direction: row;
-      line-height: 16px;
+      justify-content: space-between;
+      margin-top: 24px;
+      width: 100%;
+
+      & label {
+        display: flex;
+        flex-direction: row;
+        line-height: 16px;
+      }
     }
   }
 
   form {
     margin: 12px 12px 4px;
-    
+
     label {
       text-align: left;
       font-size: 12px;
@@ -67,7 +70,7 @@
         width: 100%;
       }
 
-      fieldset { 
+      fieldset {
         label {
           display: flex;
           flex-direction: row;


### PR DESCRIPTION
fix #1914
![image](https://user-images.githubusercontent.com/56927722/207940600-a15bb59c-8de1-442e-b768-b2d740c2b6cc.png)
