### PR TITLE
Backmerge: #1640 add cdx support (#1650)

### DIFF
--- a/packages/ketcher-core/src/application/formatters/formatProperties.ts
+++ b/packages/ketcher-core/src/application/formatters/formatProperties.ts
@@ -94,6 +94,12 @@ const formatProperties: FormatPropertiesMap = {
     ChemicalMimeType.CDXML,
     ['.cdxml'],
     true
+  ),
+  cdx: new SupportedFormatProperties(
+    'Base64 CDX',
+    ChemicalMimeType.CDX,
+    ['.cdx'],
+    true
   )
 }
 

--- a/packages/ketcher-core/src/application/formatters/formatterFactory.ts
+++ b/packages/ketcher-core/src/application/formatters/formatterFactory.ts
@@ -91,6 +91,7 @@ export class FormatterFactory {
       case SupportedFormat.smilesExt:
       case SupportedFormat.smarts:
       case SupportedFormat.cdxml:
+      case SupportedFormat.cdx:
       default:
         formatter = new ServerFormatter(
           this.#structService,

--- a/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
+++ b/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
@@ -47,6 +47,7 @@ export function identifyStructFormat(
       return SupportedFormat.mol
     }
   }
+
   if (
     sanitizedString[0] === '<' &&
     sanitizedString.indexOf('<molecule') !== -1
@@ -54,11 +55,24 @@ export function identifyStructFormat(
     return SupportedFormat.cml
   }
 
+  const clearStr = sanitizedString.replace(/\s/g, '')
+  const anyLetterAnyDigitContainsSlashesEndsWithEqualSign =
+    /^[a-zA-Z0-9+/]*={0,2}$/
+  if (
+    anyLetterAnyDigitContainsSlashesEndsWithEqualSign.test(clearStr) &&
+    clearStr.length % 4 === 0
+  ) {
+    return SupportedFormat.cdx
+  }
+
   if (sanitizedString.slice(0, 5) === 'InChI') {
     return SupportedFormat.inChI
   }
 
-  if (sanitizedString.indexOf('\n') === -1) {
+  if (
+    sanitizedString.indexOf('\n') === -1 &&
+    sanitizedString === sanitizedString.toUpperCase()
+  ) {
     // TODO: smiles regexp
     return SupportedFormat.smiles
   }

--- a/packages/ketcher-core/src/application/formatters/structFormatter.types.ts
+++ b/packages/ketcher-core/src/application/formatters/structFormatter.types.ts
@@ -36,7 +36,8 @@ export enum SupportedFormat {
   inChIAuxInfo = 'inChIAuxInfo',
   cml = 'cml',
   ket = 'ket',
-  cdxml = 'cdxml'
+  cdxml = 'cdxml',
+  cdx = 'cdx'
 }
 
 export type FormatterFactoryOptions = Partial<

--- a/packages/ketcher-core/src/domain/services/struct/structService.types.ts
+++ b/packages/ketcher-core/src/domain/services/struct/structService.types.ts
@@ -22,6 +22,7 @@ export enum ChemicalMimeType {
   DaylightSmarts = 'chemical/x-daylight-smarts',
   InChI = 'chemical/x-inchi',
   InChIAuxInfo = 'chemical/x-inchi-aux',
+  CDX = 'chemical/x-cdx',
   CDXML = 'chemical/x-cdxml',
   CML = 'chemical/x-cml',
   KET = 'chemical/x-indigo-ket'

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -20,7 +20,8 @@ import {
   SGroup,
   getStereoAtomsMap,
   identifyStructFormat,
-  Struct
+  Struct,
+  SupportedFormat
 } from 'ketcher-core'
 
 import { supportedSGroupTypes } from './constants'
@@ -51,12 +52,19 @@ export function loadStruct(struct) {
   }
 }
 
-function parseStruct(struct: Struct, server, options?): Promise<Struct> {
+function parseStruct(
+  struct: string | Struct,
+  server,
+  options?
+): Promise<Struct> {
   if (typeof struct === 'string') {
     options = options || {}
     const { rescale, fragment, ...formatterOptions } = options
 
     const format = identifyStructFormat(struct)
+    if (format === SupportedFormat.cdx) {
+      struct = `base64::${struct.replace(/\s/g, '')}`
+    }
     const factory = new FormatterFactory(server)
 
     const service = factory.create(format, formatterOptions)

--- a/packages/ketcher-react/src/script/ui/utils/fileOpener.js
+++ b/packages/ketcher-react/src/script/ui/utils/fileOpener.js
@@ -40,11 +40,12 @@ export function fileOpener(server) {
 }
 
 function throughFileReader(file) {
+  const isCDX = file.name.endsWith('cdx')
   return new Promise((resolve, reject) => {
     const rd = new FileReader() // eslint-disable-line no-undef
 
     rd.onload = () => {
-      const content = rd.result
+      const content = isCDX ? rd.result.slice(37) : rd.result
       if (file.msClose) file.msClose()
       resolve(content)
     }
@@ -52,8 +53,7 @@ function throughFileReader(file) {
     rd.onerror = (event) => {
       reject(event)
     }
-
-    rd.readAsText(file, 'UTF-8')
+    isCDX ? rd.readAsDataURL(file) : rd.readAsText(file, 'UTF-8')
   })
 }
 

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
@@ -88,6 +88,7 @@ class SaveDialog extends Component {
         'svg',
         'png',
         'cdxml'
+        // 'cdx' TO DO: Uncomment, when export will be ready on Indigo side
       )
 
     this.saveSchema = saveSchema

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.types.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.types.ts
@@ -53,6 +53,7 @@ export enum SupportedFormat {
   InChI = 'inchi',
   InChIAuxInfo = 'inchi-aux',
   Ket = 'ket',
+  CDX = 'cdx',
   CDXML = 'cdxml'
 }
 

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -112,6 +112,10 @@ function convertMimeTypeToOutputFormat(
       format = SupportedFormat.CDXML
       break
     }
+    case ChemicalMimeType.CDX: {
+      format = SupportedFormat.CDX
+      break
+    }
     default: {
       throw new Error('Unsupported chemical mime type')
     }


### PR DESCRIPTION
* add cdx format to types

* add check for cdx format

* add magic word for cdx for recognizing on server

* delete magik number

* fix format check

* update indigo to 1.7.3

* fix format check

* clear string from unnecessary info

* clear string from \n symbols from clipboard

* update indigo version

Co-authored-by: Nikita_Vozisov <Nikita_Vozisov@epam.com>