### PR TITLE
Backmerge:  #1958 Improve performance, when opening Salts and Solvents tab

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -284,7 +284,7 @@ class BondTool {
 
         this.editor.update(bondAddition[0])
       } else if (dragCtx.item.map === 'atoms') {
-        // when does it hapend?
+        // click on atom
         this.editor.update(
           fromBondAddition(
             rnd.ctab,

--- a/packages/ketcher-react/src/script/ui/component/structrender.tsx
+++ b/packages/ketcher-react/src/script/ui/component/structrender.tsx
@@ -15,54 +15,8 @@
  ***************************************************************************/
 
 import { Component, ComponentType, createRef } from 'react'
-import { MolSerializer, Render, Struct } from 'ketcher-core'
-
-/**
- * for S-Groups we want to show expanded structure
- * without brackets
- */
-function prepareStruct(struct: Struct) {
-  if (struct.sgroups.size > 0) {
-    const newStruct = struct.clone()
-    newStruct.sgroups.delete(0)
-    return newStruct
-  }
-  return struct
-}
-
-/**
- * Is used to improve search and opening tab performance in Template Dialog
- * Rendering a lot of structures causes great delay
- */
-const renderCache = new Map()
-
-function renderStruct(
-  el: HTMLElement | null,
-  struct: Struct | null,
-  options: any = {}
-) {
-  if (el && struct) {
-    const { cachePrefix = '' } = options
-    const cacheKey = `${cachePrefix}${struct.name}`
-    if (renderCache.has(cacheKey)) {
-      el.innerHTML = renderCache.get(cacheKey)
-      return
-    }
-    const preparedStruct = prepareStruct(struct)
-    preparedStruct.initHalfBonds()
-    preparedStruct.initNeighbors()
-    preparedStruct.setImplicitHydrogen()
-    preparedStruct.markFragments()
-    const rnd = new Render(el, {
-      autoScale: true,
-      ...options
-    })
-    rnd.setMolecule(preparedStruct)
-    rnd.update(true, options.viewSz)
-    renderCache.set(cacheKey, rnd.clientArea.innerHTML)
-  }
-}
-
+import { MolSerializer, Struct } from 'ketcher-core'
+import { RenderStruct } from '../utils'
 interface StructRenderProps {
   struct: Struct
   options: any
@@ -100,7 +54,7 @@ class StructRender extends Component<StructRenderProps> {
     el?.childNodes.forEach((node) => {
       node.remove()
     })
-    renderStruct(el, parsedStruct, options)
+    RenderStruct.render(el, parsedStruct, options)
   }
 
   componentDidMount() {

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -44,6 +44,7 @@ import EmptySearchResult from '../../../ui/dialog/template/EmptySearchResult'
 
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
+import useSaltsAndSolvents from './useSaltsAndSolvets'
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props
@@ -104,7 +105,6 @@ const filterLibSelector = createSelector(
 )
 
 const FUNCTIONAL_GROUPS = 'Functional Groups'
-const SALTS_AND_SOLVENTS = 'Salts and Solvents'
 
 const HeaderContent = () => (
   <div className={classes.dialogHeader}>
@@ -161,11 +161,9 @@ const TemplateDialog: FC<Props> = (props) => {
   const [expandedAccordions, setExpandedAccordions] = useState<string[]>([
     props.group
   ])
+  const filteredSaltsAndSolvents = useSaltsAndSolvents(saltsAndSolvents, filter)
   const [filteredFG, setFilteredFG] = useState(
     functionalGroups[FUNCTIONAL_GROUPS]
-  )
-  const [filteredSaltsAndSolvents, setFilteredSaltsAndSolvents] = useState(
-    saltsAndSolvents[SALTS_AND_SOLVENTS]
   )
 
   const filteredTemplateLib = filterLibSelector(props)
@@ -173,12 +171,6 @@ const TemplateDialog: FC<Props> = (props) => {
   useEffect(() => {
     setFilteredFG(filterFGLib(functionalGroups, filter)[FUNCTIONAL_GROUPS])
   }, [functionalGroups, filter])
-
-  useEffect(() => {
-    setFilteredSaltsAndSolvents(
-      filterFGLib(saltsAndSolvents, filter)[SALTS_AND_SOLVENTS]
-    )
-  }, [saltsAndSolvents, filter])
 
   const handleTabChange = (_, tab) => {
     setTab(tab)

--- a/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
+++ b/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { filterFGLib } from '../../utils'
+import { Template } from './TemplateTable'
+
+const SALTS_AND_SOLVENTS = 'Salts and Solvents'
+const batchDelay = 300
+
+export default function useSaltsAndSolvents(
+  saltsAndSolvents: Template[],
+  filter: string
+) {
+  const [isFirstRender, setIsFirstRender] = useState(true)
+  const timerId = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const [filteredSaltsAndSolvents, setFilteredSaltsAndSolvents] = useState(
+    saltsAndSolvents[SALTS_AND_SOLVENTS]
+  )
+
+  const addToSaSWithBatches = useCallback((fullFilteredArray) => {
+    const batchSize = 16
+    setFilteredSaltsAndSolvents((filteredSaltsAndSolvents) => [
+      ...(filteredSaltsAndSolvents ?? []),
+      ...fullFilteredArray.splice(0, batchSize)
+    ])
+    if (fullFilteredArray.length > 0) {
+      timerId.current = setTimeout(
+        () => addToSaSWithBatches(fullFilteredArray),
+        batchDelay
+      )
+    }
+  }, [])
+
+  useEffect(() => {
+    const filteredSaS = filterFGLib(saltsAndSolvents, filter)[
+      SALTS_AND_SOLVENTS
+    ]
+    addToSaSWithBatches(filteredSaS)
+  }, [saltsAndSolvents, addToSaSWithBatches])
+
+  useEffect(() => {
+    if (isFirstRender) {
+      setIsFirstRender(false)
+      return
+    }
+    clearTimeout(timerId.current as unknown as number)
+    const filteredSaS = filterFGLib(saltsAndSolvents, filter)[
+      SALTS_AND_SOLVENTS
+    ]
+    setFilteredSaltsAndSolvents(filteredSaS)
+  }, [saltsAndSolvents, filter])
+
+  return filteredSaltsAndSolvents
+}

--- a/packages/ketcher-react/src/script/ui/state/saltsAndSolvents/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/saltsAndSolvents/index.ts
@@ -24,6 +24,7 @@ import {
   Struct
 } from 'ketcher-core'
 import { prefetchStatic } from '../templates/init-lib'
+import { RenderStruct } from '../../utils'
 
 interface SaltsAndSolventsState {
   lib: []
@@ -53,9 +54,24 @@ const initSaltsAndSolvents = (lib: SdfItem[]) => ({
   payload: { lib }
 })
 
+// This prerender adds part of structures to cache to speed up loading of Salts and Solvents tab
+const prerenderPartOfStructures = (saltsAndSolvents: Struct[], settings) => {
+  const part = saltsAndSolvents.slice(0, 50)
+  part.forEach((struct) => {
+    const div = document.createElement('div')
+    div.style.width = '100px'
+    div.style.height = '100px'
+    div.style.display = 'none'
+    document.body.appendChild(div)
+    RenderStruct.render(div, struct, { ...settings, autoScaleMargin: 15 })
+    div.remove()
+  })
+}
+
 export function initSaltsAndSolventsTemplates(baseUrl: string) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     const fileName = 'salts-and-solvents.sdf'
+    const { settings } = getState().options
     const url = `${baseUrl}/templates/${fileName}`
     const saltsAndSolventsProvider = SaltsAndSolventsProvider.getInstance()
     const functionalGroupsProvider = FunctionalGroupsProvider.getInstance()
@@ -70,6 +86,7 @@ export function initSaltsAndSolventsTemplates(baseUrl: string) {
       },
       []
     )
+    prerenderPartOfStructures(saltsAndSolvents, settings)
     saltsAndSolventsProvider.setSaltsAndSolventsList(saltsAndSolvents)
     functionalGroupsProvider.addToFunctionalGroupsList(saltsAndSolvents)
     dispatch(initSaltsAndSolvents(templates))

--- a/packages/ketcher-react/src/script/ui/utils/index.ts
+++ b/packages/ketcher-react/src/script/ui/utils/index.ts
@@ -75,8 +75,6 @@ export function filterFGLib(lib, filter) {
   )(lib)
 }
 
-export { fileOpener } from './fileOpener'
-
 export const getSelectOptionsFromSchema = (schema): Array<Option> => {
   return schema.enum.reduce((options, value, index) => {
     options.push({
@@ -87,3 +85,6 @@ export const getSelectOptionsFromSchema = (schema): Array<Option> => {
     return options
   }, [])
 }
+
+export { RenderStruct } from './renderStruct'
+export { fileOpener } from './fileOpener'

--- a/packages/ketcher-react/src/script/ui/utils/renderStruct.ts
+++ b/packages/ketcher-react/src/script/ui/utils/renderStruct.ts
@@ -1,0 +1,49 @@
+import { Render, Struct } from 'ketcher-core'
+
+/**
+ * Is used to improve search and opening tab performance in Template Dialog
+ * Rendering a lot of structures causes great delay
+ */
+const renderCache = new Map()
+
+export class RenderStruct {
+  /**
+   * for S-Groups we want to show expanded structure
+   * without brackets
+   */
+  static prepareStruct(struct: Struct) {
+    if (struct.sgroups.size > 0) {
+      const newStruct = struct.clone()
+      newStruct.sgroups.delete(0)
+      return newStruct
+    }
+    return struct
+  }
+
+  static render(
+    el: HTMLElement | null,
+    struct: Struct | null,
+    options: any = {}
+  ) {
+    if (el && struct) {
+      const { cachePrefix = '' } = options
+      const cacheKey = `${cachePrefix}${struct.name}`
+      if (renderCache.has(cacheKey)) {
+        el.innerHTML = renderCache.get(cacheKey)
+        return
+      }
+      const preparedStruct = this.prepareStruct(struct)
+      preparedStruct.initHalfBonds()
+      preparedStruct.initNeighbors()
+      preparedStruct.setImplicitHydrogen()
+      preparedStruct.markFragments()
+      const rnd = new Render(el, {
+        autoScale: true,
+        ...options
+      })
+      rnd.setMolecule(preparedStruct)
+      rnd.update(true, options.viewSz)
+      renderCache.set(cacheKey, rnd.clientArea.innerHTML)
+    }
+  }
+}


### PR DESCRIPTION
Improve performance, when opening Salts and Solvents tab (#1960)

* #1958 Salts And Solvents performance improved: added batches, caching and prerendering

* #1958 – moved salts and solvents logic to hook