### PR TITLE
#1963 Custom Templates: When switching between tabs, the focus is not active on the search bar

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/input.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/input.jsx
@@ -26,12 +26,15 @@ export function GenericInput({
   onChange,
   type = 'text',
   isFocused = false,
+  searchFocusBack = false,
   ...props
 }) {
   const inputRef = useRef(null)
   useEffect(() => {
-    if (inputRef.current && isFocused) inputRef.current.focus()
-  }, [inputRef, isFocused])
+    if (inputRef.current && isFocused) {
+      inputRef.current.focus()
+    }
+  }, [inputRef, isFocused, searchFocusBack])
 
   return (
     <>
@@ -306,6 +309,7 @@ function shallowCompare(a, b) {
 export default class Input extends Component {
   shouldComponentUpdate({ children, onChange, style, ...nextProps }) {
     const oldProps = omit(this.props, ['children', 'onChange', 'style'])
+
     return shallowCompare(oldProps, nextProps)
   }
 

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -157,6 +157,10 @@ const TemplateDialog: FC<Props> = (props) => {
     ...rest
   } = props
 
+  // For search input in custom templates dialog - to set focus back to input
+  // after tab change
+  const [searchFocusBack, setSearchFocusBack] = useState(false)
+
   const [tab, setTab] = useState(initialTab ?? TemplateTabs.TemplateLibrary)
   const [expandedAccordions, setExpandedAccordions] = useState<string[]>([
     props.group
@@ -182,6 +186,7 @@ const TemplateDialog: FC<Props> = (props) => {
 
   const handleTabChange = (_, tab) => {
     setTab(tab)
+    setSearchFocusBack((prevState) => !prevState)
     props.onSelect(null)
   }
 
@@ -225,6 +230,7 @@ const TemplateDialog: FC<Props> = (props) => {
           onChange={(value) => onFilter(value)}
           placeholder="Search by elements..."
           isFocused={true}
+          searchFocusBack={searchFocusBack}
         />
         <Icon name="search" className={classes.searchIcon} />
       </div>


### PR DESCRIPTION
Create an additional state member in TemplateDialog, which is changing after tab changed, and pass it as a param to input, and then - as a dependency to useEffect, setting focus.