### PR TITLE
#1973 – App crashes when template dialog is closed and there is text in the search filter

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
+++ b/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
@@ -30,9 +30,8 @@ export default function useSaltsAndSolvents(
   }, [])
 
   useEffect(() => {
-    const filteredSaS = filterFGLib(saltsAndSolvents, filter)[
-      SALTS_AND_SOLVENTS
-    ]
+    const filteredSaS =
+      filterFGLib(saltsAndSolvents, filter)[SALTS_AND_SOLVENTS] ?? []
     addToSaSWithBatches(filteredSaS)
   }, [saltsAndSolvents, addToSaSWithBatches])
 


### PR DESCRIPTION
When nothing is found, then empty object is returned. Then 'Salts and Solvents' property is accessed in this empty object. So that's why application was failing.
closes #1973 