### PR TITLE
#1986 – SMILES: Pasting structure with small letters throw an error

### DIFF
--- a/packages/ketcher-core/src/application/formatters/formatProperties.ts
+++ b/packages/ketcher-core/src/application/formatters/formatProperties.ts
@@ -100,6 +100,12 @@ const formatProperties: FormatPropertiesMap = {
     ChemicalMimeType.CDX,
     ['.cdx'],
     true
+  ),
+  unknown: new SupportedFormatProperties(
+    'Unknown',
+    ChemicalMimeType.UNKNOWN,
+    ['.'],
+    true
   )
 }
 

--- a/packages/ketcher-core/src/application/formatters/formatterFactory.ts
+++ b/packages/ketcher-core/src/application/formatters/formatterFactory.ts
@@ -92,6 +92,7 @@ export class FormatterFactory {
       case SupportedFormat.smarts:
       case SupportedFormat.cdxml:
       case SupportedFormat.cdx:
+      case SupportedFormat.unknown:
       default:
         formatter = new ServerFormatter(
           this.#structService,

--- a/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
+++ b/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
@@ -32,6 +32,10 @@ export function identifyStructFormat(
     return SupportedFormat.rxn
   }
 
+  if (sanitizedString.indexOf('V2000') !== -1) {
+    return SupportedFormat.mol
+  }
+
   if (sanitizedString.indexOf('V3000') !== -1) {
     return SupportedFormat.molV3000
   }
@@ -55,12 +59,16 @@ export function identifyStructFormat(
     return SupportedFormat.cml
   }
 
-  const clearStr = sanitizedString.replace(/\s/g, '')
-  const anyLetterAnyDigitContainsSlashesEndsWithEqualSign =
-    /^[a-zA-Z0-9+/]*={0,2}$/
+  const clearStr = sanitizedString
+    .replace(/\s/g, '')
+    .replace(/(\\r)|(\\n)/g, '')
+  const isBase64String =
+    /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/
+  const cdxHeader = 'VjCD0100'
   if (
-    anyLetterAnyDigitContainsSlashesEndsWithEqualSign.test(clearStr) &&
-    clearStr.length % 4 === 0
+    clearStr.length % 4 === 0 &&
+    isBase64String.test(clearStr) &&
+    window.atob(clearStr).startsWith(cdxHeader)
   ) {
     return SupportedFormat.cdx
   }
@@ -69,10 +77,7 @@ export function identifyStructFormat(
     return SupportedFormat.inChI
   }
 
-  if (
-    sanitizedString.indexOf('\n') === -1 &&
-    sanitizedString === sanitizedString.toUpperCase()
-  ) {
+  if (sanitizedString.indexOf('\n') === -1) {
     // TODO: smiles regexp
     return SupportedFormat.smiles
   }
@@ -80,6 +85,6 @@ export function identifyStructFormat(
   if (sanitizedString.indexOf('<CDXML') !== -1) {
     return SupportedFormat.cdxml
   }
-  // Molfile by default as Indigo does
-  return SupportedFormat.mol
+
+  return SupportedFormat.unknown
 }

--- a/packages/ketcher-core/src/application/formatters/structFormatter.types.ts
+++ b/packages/ketcher-core/src/application/formatters/structFormatter.types.ts
@@ -37,7 +37,8 @@ export enum SupportedFormat {
   cml = 'cml',
   ket = 'ket',
   cdxml = 'cdxml',
-  cdx = 'cdx'
+  cdx = 'cdx',
+  unknown = 'unknown'
 }
 
 export type FormatterFactoryOptions = Partial<

--- a/packages/ketcher-core/src/domain/services/struct/structService.types.ts
+++ b/packages/ketcher-core/src/domain/services/struct/structService.types.ts
@@ -25,7 +25,8 @@ export enum ChemicalMimeType {
   CDX = 'chemical/x-cdx',
   CDXML = 'chemical/x-cdxml',
   CML = 'chemical/x-cml',
-  KET = 'chemical/x-indigo-ket'
+  KET = 'chemical/x-indigo-ket',
+  UNKNOWN = 'chemical/x-unknown'
 }
 
 export interface WithStruct {

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -116,6 +116,7 @@ function convertMimeTypeToOutputFormat(
       format = SupportedFormat.CDX
       break
     }
+    case ChemicalMimeType.UNKNOWN:
     default: {
       throw new Error('Unsupported chemical mime type')
     }


### PR DESCRIPTION
– Added check for molV2000 format
– CDX format is recognised by header "VjCD0100"
– If no format is recognised, then new "unknown" format is returned
closes #1986 