### PR TITLE
#1955 – Selection tool: The highlight of structure, abbreviation is not reset when clicking on the canvas

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -605,9 +605,13 @@ class ReStruct {
             item.selected = sGroupAtoms.length > 0 && sGroupAtoms[0].selected
           }
 
-          const selected = selection?.[map]
+          let selected = selection?.[map]
             ? selection[map].indexOf(id) > -1
             : item.selected
+
+          if (selection === null) {
+            selected = false
+          }
 
           this.showItemSelection(item, selected)
         })

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -606,6 +606,10 @@ function domEventSetup(editor: Editor, clientArea) {
       editor.lastEvent = event
       if (EditorTool && eventName in EditorTool) {
         EditorTool[eventName](event)
+        return true
+      }
+      if (eventName === 'mouseup') {
+        editor.selection(null)
       }
       return true
     }, -1)

--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -193,6 +193,7 @@ class SelectTool {
     if (event.shiftKey) {
       this.editor.selection(selMerge(sel, selection, true))
     } else {
+      this.editor.selection(null)
       this.editor.selection(isSelected(selection, ci) ? selection : sel)
     }
     return true


### PR DESCRIPTION
Added selection removal on mouseup.
When passing `null` to `editor.selection` it just left the previous selection and didn't actually reset selection.

closes #1955 