### PR TITLE
#1984: Hot key: If a 'Hand tool' is selected, then when you press any hot key (e.g. 'C','S','O','N') Ketcher crashes

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -200,6 +200,8 @@ class StructEditor extends Component {
       ...props
     } = this.props
 
+    const { clientX = 0, clientY = 0 } = this.state
+
     return (
       <Tag
         className={clsx(classes.canvas, className)}
@@ -232,7 +234,13 @@ class StructEditor extends Component {
             </div>
           )}
         </ContextMenuTrigger>
-        <InfoPanel {...this.state} {...this.props} />
+        <InfoPanel
+          clientX={clientX}
+          clientY={clientY}
+          render={this.props.render}
+          groupStruct={this.props.groupStruct}
+          sGroup={this.props.sGroup}
+        />
         <FGContextMenu />
       </Tag>
     )


### PR DESCRIPTION
… hot key (e.g. 'C','S','O','N') Ketcher crashes

Closes #1984 