### PR TITLE
#2015: Migrate to Indigo v1.9.0-rc.2 in-browser module

### DIFF
--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "indigo-ketcher": "1.9.0-rc.1",
+    "indigo-ketcher": "1.9.0-rc.2",
     "ketcher-core": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9265,10 +9265,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"indigo-ketcher@npm:1.9.0-rc.1":
-  version: 1.9.0-rc.1
-  resolution: "indigo-ketcher@npm:1.9.0-rc.1"
-  checksum: 6f9cefd7389caa357b353e1ff984f2f0b49eef4849c9f886deb7c5141ced84f35a10bb1e4030607da270e96ee5d529bb7dc7a45357f9aef5022191797ab687b6
+"indigo-ketcher@npm:1.9.0-rc.2":
+  version: 1.9.0-rc.2
+  resolution: "indigo-ketcher@npm:1.9.0-rc.2"
+  checksum: 67a211510467b12274c9c2e6d58ec1d61823eae227cf34bbff3de7e8d3aa7a90be3988642439a57b70828f58981bb83028cd97eedb20dc37d50338a282a72770
   languageName: node
   linkType: hard
 
@@ -11449,7 +11449,7 @@ __metadata:
     cross-env: ^7.0.3
     eslint: ^8.4.1
     eslint-plugin-jest: ^25.3.0
-    indigo-ketcher: 1.9.0-rc.1
+    indigo-ketcher: 1.9.0-rc.2
     jest: 26.6.0
     ketcher-core: "workspace:*"
     npm-run-all: ^4.1.5


### PR DESCRIPTION
Closes #2015 