### PR TITLE
#1942 Automatically reset the search filter when the 'Custom Templates' window is closed

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -325,9 +325,15 @@ const TemplateDialog: FC<Props> = (props) => {
 const selectTemplate = (template, props, dispatch) => {
   dispatch(selectTmpl(null))
   if (!template) return
+  dispatch(changeFilter(''))
   dispatch(selectTmpl(template))
   dispatch(onAction({ tool: 'template', opts: template }))
   props.onOk(template)
+}
+
+const exit = (props, dispatch) => {
+  dispatch(changeFilter(''))
+  props.onCancel()
 }
 
 export default connect(
@@ -342,6 +348,7 @@ export default connect(
     onSelect: (tmpl) => selectTemplate(tmpl, props, dispatch),
     onChangeGroup: (group) => dispatch(changeGroup(group)),
     onAttach: (tmpl) => dispatch(editTmpl(tmpl)),
+    onCancel: () => exit(props, dispatch),
     onDelete: (tmpl) => dispatch(deleteTmpl(tmpl))
   })
 )(TemplateDialog)

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -88,7 +88,7 @@ interface TemplateLibCallProps {
   onFilter: (filter: string) => void
   onOk: (res: any) => void
   onSelect: (res: any) => void
-  onTab: (tab: number) => void
+  onTabChange: (tab: number) => void
   functionalGroups: Template[]
 }
 
@@ -150,7 +150,7 @@ const TemplateDialog: FC<Props> = (props) => {
   const {
     filter,
     onFilter,
-    onTab,
+    onTabChange,
     onChangeGroup,
     mode,
     tab,
@@ -180,7 +180,7 @@ const TemplateDialog: FC<Props> = (props) => {
 
   useEffect(() => {
     props.onSelect(null)
-  }, [props])
+  }, [tab])
 
   const handleAccordionChange = (accordion) => (_, isExpanded) => {
     setExpandedAccordions(
@@ -227,7 +227,7 @@ const TemplateDialog: FC<Props> = (props) => {
       </div>
       <Tabs
         value={tab}
-        onChange={(_, value) => onTab(value)}
+        onChange={(_, value) => onTabChange(value)}
         className={classes.tabs}
       >
         <Tab
@@ -340,7 +340,7 @@ const selectTemplate = (template, props, dispatch) => {
   props.onOk(template)
 }
 
-const exit = (props, dispatch) => {
+const onModalClose = (props, dispatch) => {
   dispatch(changeFilter(''))
   props.onCancel()
 }
@@ -354,11 +354,11 @@ export default connect(
   }),
   (dispatch: Dispatch<any>, props: Props) => ({
     onFilter: (filter) => dispatch(changeFilter(filter)),
-    onTab: (tab) => dispatch(changeTab(tab)),
+    onTabChange: (tab) => dispatch(changeTab(tab)),
     onSelect: (tmpl) => selectTemplate(tmpl, props, dispatch),
     onChangeGroup: (group) => dispatch(changeGroup(group)),
     onAttach: (tmpl) => dispatch(editTmpl(tmpl)),
-    onCancel: () => exit(props, dispatch),
+    onCancel: () => onModalClose(props, dispatch),
     onDelete: (tmpl) => dispatch(deleteTmpl(tmpl))
   })
 )(TemplateDialog)

--- a/packages/ketcher-react/src/script/ui/dialog/template/template-lib.module.less
+++ b/packages/ketcher-react/src/script/ui/dialog/template/template-lib.module.less
@@ -57,11 +57,16 @@
   }
 
   & > footer {
+    min-height: 24px;
     box-shadow: 0 -6px 6px 0 @color-accordion-shadow;
     z-index: 10;
 
     & > input {
       min-width: 110px !important;
+    }
+
+    & > span {
+      line-height: 24px;
     }
   }
 
@@ -81,7 +86,7 @@
       }
     }
 
-    .searchIcon { 
+    .searchIcon {
       width: 28px;
       height: 28px;
       position: absolute;
@@ -95,7 +100,7 @@
     flex-direction: row-reverse;
     font-size: 14px;
   }
-  
+
   .groupIcon {
     margin-left: 15px;
     margin-right: 8px;
@@ -104,13 +109,13 @@
   .expandIcon {
     width: 20px;
   }
-  
+
   .tabsContent {
     height: 50vh;
     background-color: @color-primary-light;
     overflow-y: auto;
     overflow-x: hidden;
-    
+
     .scrollbar();
   }
 
@@ -147,7 +152,7 @@
   :global(.MuiPaper-root.MuiAccordion-root) {
     box-shadow: none;
   }
-  
+
   :global(.MuiPaper-root.MuiAccordion-root::before),
   :global(.MuiPaper-root.MuiAccordion-root.Mui-expanded::before) {
     opacity: 0;
@@ -155,16 +160,16 @@
 
   :global(.MuiPaper-root) {
     &:not(:last-child)::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    height: 1px;
-    width: 424px;
-    margin: 0 auto;
-    background-color: @color-grey-5;
-    opacity: 1;
+      content: '';
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      height: 1px;
+      width: 424px;
+      margin: 0 auto;
+      background-color: @color-grey-5;
+      opacity: 1;
     }
   }
 
@@ -182,7 +187,7 @@
 
   .tabs {
     box-shadow: 0 6px 6px 0 @color-accordion-shadow;
-    z-index: 10;  
+    z-index: 10;
   }
 
   :global(.MuiButtonBase-root.MuiTab-root) {

--- a/packages/ketcher-react/src/script/ui/state/templates/index.js
+++ b/packages/ketcher-react/src/script/ui/state/templates/index.js
@@ -45,6 +45,13 @@ export function changeFilter(filter) {
   }
 }
 
+export function changeTab(tab) {
+  return {
+    type: 'TMPL_CHANGE_TAB',
+    data: { tab }
+  }
+}
+
 /* TEMPLATE-ATTACH-EDIT */
 export function initAttach(name, attach) {
   return {
@@ -148,14 +155,16 @@ export const initTmplsState = {
   filter: '',
   group: null,
   attach: {},
-  mode: 'classic'
+  mode: 'classic',
+  tab: 0
 }
 
 const tmplActions = [
   'TMPL_INIT',
   'TMPL_SELECT',
   'TMPL_CHANGE_GROUP',
-  'TMPL_CHANGE_FILTER'
+  'TMPL_CHANGE_FILTER',
+  'TMPL_CHANGE_TAB'
 ]
 
 const attachActions = ['INIT_ATTACH', 'SET_ATTACH_POINTS', 'SET_TMPL_NAME']


### PR DESCRIPTION
Closes #1942
1. The search filter reset when the 'Custom Templates' window is closed.
2. The last opened tab shown when you re-open the modal window.
3. Fixed styles for 3th tab