### PR TITLE
Backmerge: #2020: When hovering over a functional group for the first time a lot of errors are generated in console

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -133,7 +133,6 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
       >
         <StructRender
           struct={molecule}
-          {...props}
           id={groupName}
           ref={childRef}
           options={{


### PR DESCRIPTION
… time a lot of errors are generated in console