### PR TITLE
Backmerge: #1998: Functional Groups: The abbreviation and hovering preview 'Boc' is displayed as 'Bn'

### DIFF
--- a/packages/ketcher-react/src/templates/fg.sdf
+++ b/packages/ketcher-react/src/templates/fg.sdf
@@ -76,7 +76,7 @@ G    1  0
 M  STY  1   1 SUP
 M  SLB  1   1   1
 M  SAL   1  7   1   2   3   4   5   6   7
-M  SMT   1 Bn
+M  SMT   1 Boc
 M  END
 
 >  <group>


### PR DESCRIPTION
…eview 'Boc' is displayed as 'Bn'