### PR TITLE
hotfix: #1942 Automatically reset the search filter when the 'Custom Templates' window is closed

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -175,10 +175,6 @@ const TemplateDialog: FC<Props> = (props) => {
   }, [functionalGroups, filter])
 
   useEffect(() => {
-    setFilteredFG(filterFGLib(functionalGroups, filter)[FUNCTIONAL_GROUPS])
-  }, [functionalGroups, filter])
-
-  useEffect(() => {
     props.onSelect(null)
   }, [tab])
 


### PR DESCRIPTION
clean code