### PR TITLE
#1999 S-group: hover over the s group displays always acetaldehyde

### DIFF
--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -60,9 +60,14 @@ export class FunctionalGroup {
   static getFunctionalGroupByName(searchName: string): Struct | null {
     const provider = FunctionalGroupsProvider.getInstance()
     const functionalGroups = provider.getFunctionalGroupsList()
-    const foundGroup = functionalGroups.find(({ name, abbreviation }) => {
-      return name === searchName || abbreviation === searchName
-    })
+
+    let foundGroup
+    if (searchName) {
+      foundGroup = functionalGroups.find(({ name, abbreviation }) => {
+        return name === searchName || abbreviation === searchName
+      })
+    }
+
     return foundGroup || null
   }
 

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -102,8 +102,17 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
     sGroup
   } = props
   const [molecule, setMolecule] = useState<Struct | null>(null)
+  const [sGroupData, setSGroupData] = useState<string | null>(null)
   const childRef = useRef(null)
   const groupName = sGroup?.data?.name
+
+  useEffect(() => {
+    if (!groupStruct && sGroup && sGroup.type === 'DAT') {
+      setSGroupData(`${sGroup.data?.fieldName}=${sGroup.data?.fieldValue}`)
+    } else {
+      setSGroupData(null)
+    }
+  }, [groupStruct, sGroup])
 
   useEffect(() => {
     let timer
@@ -122,34 +131,47 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
   const width = size.x
   const height = size.y
 
-  return (
-    molecule && (
-      <div
-        style={{
-          left: x + 'px',
-          top: y + 'px'
+  if (!molecule && !sGroupData) {
+    return null
+  }
+
+  return molecule ? (
+    <div
+      style={{
+        left: x + 'px',
+        top: y + 'px'
+      }}
+      className={clsx(classes.infoPanel, className)}
+    >
+      <StructRender
+        struct={molecule}
+        id={groupName}
+        ref={childRef}
+        options={{
+          ...render.options,
+          autoScale: true,
+          autoScaleMargin: 0,
+          rescaleAmount: 1,
+          cachePrefix: 'infoPanel',
+          viewSz: new Vec2(width, height),
+          width: width,
+          height: height
         }}
-        className={clsx(classes.infoPanel, className)}
-      >
-        <StructRender
-          struct={molecule}
-          id={groupName}
-          ref={childRef}
-          options={{
-            ...render.options,
-            autoScale: true,
-            autoScaleMargin: 0,
-            rescaleAmount: 1,
-            cachePrefix: 'infoPanel',
-            viewSz: new Vec2(width, height),
-            width: width,
-            height: height
-          }}
-        />
-      </div>
-    )
+      />
+    </div>
+  ) : (
+    <div
+      style={{
+        left: x + 'px',
+        top: y + 'px'
+      }}
+      className={clsx(classes.infoPanel, className)}
+    >
+      {sGroupData}
+    </div>
   )
 }
+
 export default connect((store: any) => ({
   clientX: functionGroupInfoSelector(store)?.event?.clientX || 0,
   clientY: functionGroupInfoSelector(store)?.event?.clientY || 0,

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -104,9 +104,9 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
   const [molecule, setMolecule] = useState<Struct | null>(null)
   const childRef = useRef(null)
   const groupName = sGroup?.data?.name
-  let timer: ReturnType<typeof setTimeout>
 
   useEffect(() => {
+    let timer
     if (groupStruct) {
       timer = setTimeout(() => {
         setMolecule(groupStruct.clone())
@@ -115,7 +115,7 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
       setMolecule(null)
     }
     return () => clearTimeout(timer)
-  }, [groupName])
+  }, [groupName, groupStruct])
 
   const [position, size] = getPanelPosition(clientX, clientY, render, sGroup)
   const { x, y } = position

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -107,7 +107,7 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
   const groupName = sGroup?.data?.name
 
   useEffect(() => {
-    if (!groupStruct && sGroup && sGroup.type === 'DAT') {
+    if (!groupStruct && sGroup?.type === 'DAT') {
       setSGroupData(`${sGroup.data?.fieldName}=${sGroup.data?.fieldValue}`)
     } else {
       setSGroupData(null)


### PR DESCRIPTION
Fix getFunctionalGroupByName - so that it doesn't return first functionalGroup for empty searchName;

Show name=value pair on hover for 'DAT' sGroup (and nothing - for other sGroup types):
inside InfoPanel - check if groupStruct is null and there is sGroup and sGroup.type is 'DAT' - render div with sGroup name and value.