### PR TITLE
#2035 Changing the logic of interaction with the 'Selection tool' hotkey

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverAtom.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverAtom.ts
@@ -32,8 +32,6 @@ export async function handleHotkeyOverAtom({
     bond: () => handleBondTool({ hoveredItemId, newAction, render, editor }),
     eraser: () =>
       handleEraserTool({ hoveredItemId, newAction, render, editor }),
-    select: () =>
-      handleSelectionTool({ hoveredItemId, newAction, render, editor }),
     charge: () =>
       handleChargeTool({ hoveredItemId, newAction, render, editor }),
     rgroupatom: () =>
@@ -49,8 +47,7 @@ export async function handleHotkeyOverAtom({
       )
   }
   const toolHandler = toolsMapping[newAction.tool]
-  const isChangeStructureTool =
-    newAction.tool !== 'hand' || newAction.tool !== 'select'
+  const isChangeStructureTool = newAction.tool !== 'hand'
   if (toolHandler) {
     const isFunctionalGroupChange = await isChangingFunctionalGroup({
       hoveredItemId,
@@ -102,12 +99,6 @@ function handleEraserTool({
   editor
 }: hotkeyOverAtomHandler) {
   editor.update(fromOneAtomDeletion(render.ctab, hoveredItemId))
-}
-
-function handleSelectionTool({ hoveredItemId, editor }: hotkeyOverAtomHandler) {
-  editor.selection({
-    atoms: [hoveredItemId]
-  })
 }
 
 function handleChargeTool({

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -76,7 +76,7 @@ function keyHandle(dispatch, state, hotKeys, event) {
       const newAction = actions[actName].action
       const hoveredItemId = getHoveredAtomId(render.ctab.atoms)
       const isHoveringOverAtom = hoveredItemId !== null
-      if (isHoveringOverAtom) {
+      if (isHoveringOverAtom && newAction.tool !== 'select') {
         // check if atom is currently hovered over
         // in this case we do not want to activate the corresponding tool
         // and just insert the atom directly


### PR DESCRIPTION
Changed behaviour of "Select" tool hotkey: now it ignores hovering status and acts consistently in all cases.
Solves #2035 