### PR TITLE
#2057 Move enhanced stereochemistry icon to left toolbar

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
@@ -143,7 +143,8 @@ const EnhancedStereo: FC<Props> = (props) => {
               name="type"
               labelPos={false}
               type="radio"
-              value={`&${maxAnd + 1}`}
+              value={`${StereoLabel.And}${maxAnd + 1}`}
+              checked={result.type === `${StereoLabel.And}${maxAnd + 1}`}
             />
             Create new AND Group
           </label>
@@ -152,7 +153,8 @@ const EnhancedStereo: FC<Props> = (props) => {
               name="type"
               labelPos={false}
               type="radio"
-              value={`or${maxOr + 1}`}
+              value={`${StereoLabel.Or}${maxOr + 1}`}
+              checked={result.type === `${StereoLabel.Or}${maxOr + 1}`}
             />
             Create new OR Group
           </label>

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -148,6 +148,11 @@ const LeftToolbar = (props: Props) => {
 
         <Group
           className={classes.groupItem}
+          items={[{ id: 'enhanced-stereo' }]}
+        />
+
+        <Group
+          className={classes.groupItem}
           items={[{ id: 'charge-plus' }, { id: 'charge-minus' }]}
         />
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/ExternalFuncControls.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/ExternalFuncControls.tsx
@@ -26,7 +26,6 @@ interface ExternalFuncProps {
   onCalculate: () => void
   onCheck: () => void
   onAnalyse: () => void
-  onStereo: () => void
   onMiew: () => void
   disabledButtons: string[]
   hiddenButtons: string[]
@@ -43,7 +42,6 @@ export const ExternalFuncControls = ({
   onCalculate,
   onCheck,
   onAnalyse,
-  onStereo,
   onMiew,
   disabledButtons,
   indigoVerification,
@@ -85,11 +83,6 @@ export const ExternalFuncControls = ({
       name: 'analyse',
       title: 'Calculated Values',
       handler: onAnalyse
-    },
-    {
-      name: 'enhanced-stereo',
-      title: 'Stereochemistry',
-      handler: onStereo
     },
     {
       name: 'miew',

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
@@ -102,7 +102,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
     onCalculate: () => dispatchAction('cip'),
     onCheck: () => dispatchAction('check'),
     onAnalyse: () => dispatchAction('analyse'),
-    onStereo: () => dispatchAction('enhanced-stereo'),
     onMiew: () => dispatchAction('miew'),
     onAction: (action) => dispatch(onAction(action)),
     onOpen: (menuName, isSelected) =>

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
@@ -58,7 +58,6 @@ export interface PanelProps {
   onCalculate: VoidFunction
   onCheck: VoidFunction
   onAnalyse: VoidFunction
-  onStereo: VoidFunction
   onMiew: VoidFunction
   onFullscreen: VoidFunction
   onAbout: VoidFunction
@@ -129,7 +128,6 @@ export const TopToolbar = ({
   onCalculate,
   onCheck,
   onAnalyse,
-  onStereo,
   onMiew,
   onFullscreen,
   onAbout,
@@ -178,7 +176,6 @@ export const TopToolbar = ({
         onCalculate={onCalculate}
         onCheck={onCheck}
         onAnalyse={onAnalyse}
-        onStereo={onStereo}
         onMiew={onMiew}
         disabledButtons={disabledButtons}
         hiddenButtons={hiddenButtons}


### PR DESCRIPTION
- Moved enhanced stereochemistry icon to left toolbar
- Fixed enhanced stereochemistry dialog radio buttons not activating properly
Resolves #2057 