### PR TITLE
#2028 Hotkey: Atom symbols are not displayed under mouse cursor while mouse hovers over the canvas

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -47,6 +47,7 @@ class AtomTool {
       .show()
       .attr('text', `${atomProps.label}`)
       .attr('fill', `${ElementColor[atomProps.label]}`)
+    this.editor.updateHoverIconPosition()
 
     if (editor.selection()) {
       if (editor.selection()?.atoms) {
@@ -140,6 +141,7 @@ class AtomTool {
 
   mouseover() {
     this.editor.hoverIcon.show()
+    this.editor.updateHoverIconPosition()
   }
 
   mousemove(event) {


### PR DESCRIPTION
When clearing canvas `Visel`s (Visual Elements) are cleared. Because of this, DOM representation of hoverIcon was removed, despite having a reference. Fix – after clearing canvas this icon is recreated.
In addition, last cursor position is saved. This is done due to inability to get mouse cursor position at random time (only in mouse-event handlers). Previous behaviour led to showing a part of atom at top-left corner ((0,0) coordinates) and atom wasn't shown immediately at mouse cursor.
Now, last cursor position is used, when we use a shortcut for atoms.
closes #2028 