### PR TITLE
#2003 MDL Molfile v2000: Incorrect padding for M ALS

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
@@ -406,6 +406,7 @@ export class Molfile {
           this.writeWhiteSpace()
           this.writePadded(labelList[k], 3)
         }
+        this.writeWhiteSpace()
         this.writeCR()
       }
     }


### PR DESCRIPTION
According to the specification in the CTFileformats, p.46, the atom symbol of the list entry should be in the field of width 4.
![width 4](https://user-images.githubusercontent.com/43993423/211049268-8a8af044-b31c-488a-8f18-62f9d423f138.png)

So, if an atom's symbol consists of one letter, it should have three spaces after it.
If an atom's symbol consists of two letters, it should have three spaces after if.

Steps to verify:

1. Click the PT button under the atom's panel on the right
2. In the opened Periodic Table modal select 'List' radio button at bottom
3. Select any atoms
4. Click 'Add'
5. Click on the canvas to place the atom
6. Click the 'Save' icon on the instrument panel at the top of the page
7. In the opened 'Save Structure' modal inspect the line after the letters 'M  ALS'
8. If an atom's symbol consists of 1 letter, it should have 3 spaces after it, if an atom's symbol consists of 2 letters, it should have 2 spaces after it

![padding fixed](https://user-images.githubusercontent.com/43993423/211049600-3d5caf60-20d0-4776-bc47-c6c2d90e9818.png)
