### PR TITLE
#1954 draw selected structure at mouse cursor after closing templates window

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -130,6 +130,7 @@ class Editor implements KetcherEditor {
     confirm: PipelineSubscription
     showInfo: PipelineSubscription
     cursor: Subscription
+    cursorFollowingChange: PipelineSubscription
   }
 
   lastEvent: any
@@ -178,7 +179,8 @@ class Editor implements KetcherEditor {
       enhancedStereoEdit: new PipelineSubscription(),
       confirm: new PipelineSubscription(),
       cursor: new PipelineSubscription(),
-      showInfo: new PipelineSubscription()
+      showInfo: new PipelineSubscription(),
+      cursorFollowingChange: new PipelineSubscription()
     }
 
     domEventSetup(this, clientArea)

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -236,6 +236,8 @@ class TemplateTool {
   }
 
   mousemove(event) {
+    showCursorFollowingTemplate(this.editor, event)
+
     const restruct = this.editor.render.ctab
 
     if (!this.dragCtx) {
@@ -500,7 +502,12 @@ class TemplateTool {
     this.mouseup(e)
   }
 
+  mouseover(e) {
+    showCursorFollowingTemplate(this.editor, e)
+  }
+
   mouseleave(e) {
+    hideCursorFollowingTemplate(this.editor)
     this.mouseup(e)
   }
 }
@@ -535,6 +542,32 @@ function getSign(molecule, bond, v) {
   }
 
   return 0
+}
+
+export type CursorFollowingSubscriberPayload = {
+  disabled: boolean
+  offsetX: number
+  offsetY: number
+}
+
+function showCursorFollowingTemplate(editor: Editor, event: MouseEvent) {
+  const payload: CursorFollowingSubscriberPayload = {
+    disabled: false,
+    offsetX: event.offsetX,
+    offsetY: event.offsetY
+  }
+
+  editor.event.cursorFollowingChange.dispatch(payload)
+}
+
+function hideCursorFollowingTemplate(editor: Editor) {
+  const payload: CursorFollowingSubscriberPayload = {
+    disabled: true,
+    offsetX: 0,
+    offsetY: 0
+  }
+
+  editor.event.cursorFollowingChange.dispatch(payload)
 }
 
 export default TemplateTool

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.module.less
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.module.less
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * Copyright 2023 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+.wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0.3;
+
+  // The element is never the target of pointer events
+  // see: https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events
+  pointer-events: none;
+
+  .text {
+    font-weight: 700;
+    position: relative;
+    transform: translate(-50%, -50%);
+  }
+
+  svg {
+    transform: translate(-50%, -50%);
+  }
+}

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.module.less
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.module.less
@@ -19,6 +19,7 @@
   top: 0;
   left: 0;
   opacity: 0.3;
+  transform-origin: left top;
 
   // The element is never the target of pointer events
   // see: https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.tsx
@@ -14,13 +14,17 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { connect } from 'react-redux'
 import Editor from 'src/script/editor'
 import { CursorFollowingSubscriberPayload } from 'src/script/editor/tool/template'
 import StructRender from 'src/script/ui/component/structrender'
 import { Template } from 'src/script/ui/dialog/template/TemplateTable'
 import classes from './CursorFollowing.module.less'
+
+const stereoStructOffset = {
+  transform: `translate(14px, -22px)`
+}
 
 interface CursorFollowingProps {
   selectedTemplate?: Template
@@ -35,6 +39,12 @@ const CursorFollowing: React.FC<CursorFollowingProps> = ({
   const [dynamicStyles, setDynamicStyles] = useState({
     transform: 'none'
   })
+
+  const hasStereoAtom = useMemo<boolean | undefined>(
+    () =>
+      selectedTemplate?.struct.atoms.some((atom) => atom.stereoLabel !== null),
+    [selectedTemplate?.struct.atoms]
+  )
 
   const updatePosition = useCallback(
     (offsetX: number, offsetY: number) => {
@@ -86,18 +96,19 @@ const CursorFollowing: React.FC<CursorFollowingProps> = ({
           {isFunctionalGroupOrSaltOrSolvent ? (
             <div className={classes.text}>{selectedTemplate.struct.name}</div>
           ) : (
-            // todo @yulei the center not overlapped when stereotype
-            <StructRender
-              id={selectedTemplate.struct?.name}
-              struct={selectedTemplate.struct}
-              options={{
-                ...editor?.render.options,
-                cachePrefix: 'cursorFollowing',
-                autoScale: true,
-                autoScaleMargin: 0,
-                rescaleAmount: 1
-              }}
-            />
+            <div style={hasStereoAtom ? stereoStructOffset : undefined}>
+              <StructRender
+                id={selectedTemplate.struct?.name}
+                struct={selectedTemplate.struct}
+                options={{
+                  ...editor?.render.options,
+                  cachePrefix: 'cursorFollowing',
+                  autoScale: true,
+                  autoScaleMargin: 0,
+                  rescaleAmount: 1
+                }}
+              />
+            </div>
           )}
         </div>
       ) : null}

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.tsx
@@ -45,8 +45,10 @@ const CursorFollowing: React.FC<CursorFollowingProps> = ({
       const x = offsetX - scrollLeft
       const y = offsetY - scrollTop
 
+      const scale = editor.render.options.zoom
+
       setDynamicStyles({
-        transform: `translate(${x}px, ${y}px)`
+        transform: `translate(${x}px, ${y}px) scale(${scale})`
       })
     },
     [editor]

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/CursorFollowing.tsx
@@ -1,0 +1,124 @@
+/****************************************************************************
+ * Copyright 2023 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { throttle } from 'lodash/fp'
+import { useCallback, useEffect, useState } from 'react'
+import { connect } from 'react-redux'
+import Editor from 'src/script/editor'
+import { CursorFollowingSubscriberPayload } from 'src/script/editor/tool/template'
+import StructRender from 'src/script/ui/component/structrender'
+import { Template } from 'src/script/ui/dialog/template/TemplateTable'
+import classes from './CursorFollowing.module.less'
+
+const setTransform = throttle(100, (x, y) => `translate(${x}px, ${y}px)`)
+
+// TODO: @yulei use requestAnimationFrame to optimize the animation
+// const setTransform = requestAnimationFrame((x, y) => {})
+
+interface CursorFollowingProps {
+  selectedTemplate?: Template
+  editor?: Editor
+}
+
+const CursorFollowing: React.FC<CursorFollowingProps> = ({
+  selectedTemplate,
+  editor
+}) => {
+  const [disabled, setDisabled] = useState(true)
+  const [offsetXY, setOffsetXY] = useState({
+    x: 0,
+    y: 0
+  })
+  const [dynamicStyles, setDynamicStyles] = useState({
+    transform: 'none'
+  })
+
+  useEffect(() => {
+    if (!editor) return
+
+    const scrollTop = editor.render.clientArea?.scrollTop || 0
+    const scrollLeft = editor.render.clientArea?.scrollLeft || 0
+
+    setDynamicStyles((styles) => ({
+      transform:
+        setTransform(offsetXY.x - scrollLeft, offsetXY.y - scrollTop) ||
+        styles.transform
+    }))
+  }, [editor, offsetXY.x, offsetXY.y])
+
+  const subscriber = useCallback(
+    (payload: CursorFollowingSubscriberPayload) => {
+      if (disabled !== payload.disabled) setDisabled(payload.disabled)
+      setOffsetXY({
+        x: payload.offsetX,
+        y: payload.offsetY
+      })
+    },
+    [disabled]
+  )
+
+  useEffect(() => {
+    editor?.event.cursorFollowingChange.add(subscriber)
+    return () => {
+      editor?.event.cursorFollowingChange.remove(subscriber)
+    }
+  }, [editor, subscriber])
+
+  const templateGroup = selectedTemplate?.props?.group
+  // Custom template means the template in the modal other than on the bottom toolbar
+  const isCustomTemplate = templateGroup !== undefined
+  const isFunctionalGroupOrSaltOrSolvent =
+    templateGroup === 'Functional Groups' ||
+    templateGroup === 'Salts and Solvents'
+
+  return (
+    <>
+      {!disabled && isCustomTemplate && selectedTemplate ? (
+        <div className={classes.wrapper} style={dynamicStyles}>
+          {isFunctionalGroupOrSaltOrSolvent ? (
+            <div className={classes.text}>{selectedTemplate.struct.name}</div>
+          ) : (
+            // todo @yulei the center not overlapped when stereotype
+            <StructRender
+              id={selectedTemplate.struct?.name}
+              struct={selectedTemplate.struct}
+              options={{
+                ...editor?.render.options,
+                cachePrefix: 'cursorFollowing',
+                autoScale: true,
+                autoScaleMargin: 0,
+                rescaleAmount: 1
+              }}
+            />
+          )}
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+const mapStateToProps = (state) => {
+  const activeTool = state.actionState?.activeTool?.tool
+  const selectedTemplate =
+    activeTool === 'template' ? state.actionState?.activeTool?.opts : undefined
+
+  return {
+    selectedTemplate,
+    editor: state.editor
+  }
+}
+
+export default connect(mapStateToProps)(CursorFollowing)

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -32,6 +32,7 @@ import Cursor from '../Cursor'
 import { ContextMenu, ContextMenuTrigger } from '../ContextMenu'
 
 import InfoPanel from './InfoPanel'
+import CursorFollowing from './CursorFollowing'
 
 // TODO: need to update component after making refactoring of store
 function setupEditor(editor, props, oldProps = {}) {
@@ -232,6 +233,7 @@ class StructEditor extends Component {
               PressedIcon={compressedHandIcon}
               enableHandTool={this.state.enableCursor}
             />
+            <CursorFollowing />
             <div className={classes.measureLog} ref={this.logRef} />
             {indigoVerification && (
               <div className={classes.spinnerOverlay}>


### PR DESCRIPTION
Resolves: #1954 

## Showcases

### When selecting structures from the Template Library

![ketcher-01-template-library](https://user-images.githubusercontent.com/27288153/211280140-1f04817b-8dfc-45cc-b690-21c5d878b986.gif)


### When selecting from the Functional Groups or Salts and Solvents

![ketcher-02-fg-and-ss](https://user-images.githubusercontent.com/27288153/211280344-795887d9-3db7-48eb-ac86-20f46d4b4236.gif)

### When zooming out/in

![ketcher-03-zoom](https://user-images.githubusercontent.com/27288153/211280477-11a8d002-f568-4a10-b68a-e7dfb3395873.gif)



