### PR TITLE
#2047: Templates: When the structure is pasted or dragged on each other, carbon atoms are highlighted

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -211,7 +211,6 @@ export function fromAtomMerge(restruct, srcId, dstId) {
   if (sgChanged) removeSgroupIfNeeded(action, restruct, [srcId])
 
   action.addOp(new AtomDelete(srcId))
-  action.addOp(new CalcImplicitH([dstId]))
   const dstAtomNeighbors = restruct.molecule.atomGetNeighbors(dstId)
   const bond = restruct.molecule.bonds.get(
     dstAtomNeighbors[0]?.bid || atomNeighbors[0]?.bid
@@ -269,4 +268,14 @@ export function mergeSgroups(action, restruct, srcAtoms, dstAtom) {
       action.addOp(new SGroupAtomAdd(sid, aid).perform(restruct))
     )
   })
+}
+
+export function checkAtomValence(restruct, atomId) {
+  const action = new Action()
+
+  if (!restruct.atoms.has(atomId)) return action
+
+  action.addOp(new CalcImplicitH([atomId]))
+
+  return action.perform(restruct)
 }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -542,7 +542,7 @@ class Editor implements KetcherEditor {
     if (res.atoms && res.bonds) {
       struct.bonds.forEach((bond, bid) => {
         if (
-          res.bonds.indexOf(bid) >= 0 &&
+          res.bonds.indexOf(bid) < 0 &&
           res.atoms.indexOf(bond.begin) >= 0 &&
           res.atoms.indexOf(bond.end) >= 0
         ) {


### PR DESCRIPTION
Fixes a big issue with valence validation upon merging structures.
Previously validation was performed atom by atom alongside other modifications, which resulted in miscalculations when taking into account atoms that were queued for deletion.
Now it is performed separately, after all merges complete, and takes into account all connected atoms in case structure is changed.

Resolves #2047 