### PR TITLE
#1995 bond context menu move non query bonds to 1st level add dots to edit item & #2083 Error when deleting stereo bond via context-menu

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
@@ -17,17 +17,10 @@
 import { Menu } from 'react-contexify'
 import 'react-contexify/ReactContexify.css'
 import styles from './ContextMenu.module.less'
-import {
-  AtomBatchEdit,
-  AtomStereoBatchEdit,
-  AtomBatchDelete
-} from './items/AtomBatchOperations'
+import { AtomBatchEdit, AtomStereoBatchEdit } from './items/AtomBatchOperations'
 import AtomSingleOperations from './items/AtomSingleOperations'
-import {
-  BondBatchEdit,
-  BondTypeBatchChange,
-  BondBatchDelete
-} from './items/BondBatchOperations'
+import { BatchDelete } from './items/BatchDelete'
+import { BondBatchEdit, BondTypeBatchChange } from './items/BondBatchOperations'
 import BondSingleOperations from './items/BondSingleOperations'
 
 export const CONTEXT_MENU_ID = 'ketcherBondAndAtomContextMenu'
@@ -42,8 +35,7 @@ const ContextMenu: React.FC = () => {
       <AtomBatchEdit />
       <BondTypeBatchChange />
       <AtomStereoBatchEdit />
-      <BondBatchDelete />
-      <AtomBatchDelete />
+      <BatchDelete />
     </Menu>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/AtomBatchOperations.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/AtomBatchOperations.tsx
@@ -103,7 +103,7 @@ export const AtomBatchEdit: React.FC<CustomItemProps> = (props) => {
       disabled={isDisabled}
       onClick={handleClick}
     >
-      Edit selected atom(s)
+      Edit selected atom(s)...
     </Item>
   )
 }
@@ -165,7 +165,7 @@ export const AtomStereoBatchEdit: React.FC<CustomItemProps> = (props) => {
       disabled={isStereoDisabled}
       onClick={handleClick}
     >
-      Enhanced stereochemistry
+      Enhanced stereochemistry...
     </Item>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/AtomBatchOperations.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/AtomBatchOperations.tsx
@@ -14,12 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import {
-  Action,
-  findStereoAtoms,
-  fromAtomsAttrs,
-  fromOneAtomDeletion
-} from 'ketcher-core'
+import { findStereoAtoms, fromAtomsAttrs } from 'ketcher-core'
 import { useCallback, useRef } from 'react'
 import type { PredicateParams } from 'react-contexify'
 import { Item } from 'react-contexify'
@@ -33,10 +28,7 @@ import type {
   ContextMenuShowProps,
   CustomItemProps
 } from '../contextMenu.types'
-import { noOperation } from './utils'
-
-const isHidden = ({ props }: PredicateParams<ContextMenuShowProps, ItemData>) =>
-  !props?.selected
+import { noOperation, isBatchOperationHidden } from './utils'
 
 const useDisabled = () => {
   const { getKetcherInstance } = useAppContext()
@@ -46,7 +38,7 @@ const useDisabled = () => {
       props,
       triggerEvent
     }: PredicateParams<ContextMenuShowProps, ItemData>) => {
-      if (isHidden({ props, triggerEvent })) {
+      if (isBatchOperationHidden({ props, triggerEvent })) {
         return true
       }
 
@@ -99,7 +91,7 @@ export const AtomBatchEdit: React.FC<CustomItemProps> = (props) => {
   return (
     <Item
       {...props}
-      hidden={isHidden}
+      hidden={isBatchOperationHidden}
       disabled={isDisabled}
       onClick={handleClick}
     >
@@ -161,39 +153,11 @@ export const AtomStereoBatchEdit: React.FC<CustomItemProps> = (props) => {
   return (
     <Item
       {...props}
-      hidden={isHidden}
+      hidden={isBatchOperationHidden}
       disabled={isStereoDisabled}
       onClick={handleClick}
     >
       Enhanced stereochemistry...
-    </Item>
-  )
-}
-
-export const AtomBatchDelete: React.FC<CustomItemProps> = (props) => {
-  const { getKetcherInstance } = useAppContext()
-  const isDisabled = useDisabled()
-
-  const handleClick = useCallback(() => {
-    const editor = getKetcherInstance().editor as Editor
-    const action = new Action()
-    const selectedAtomIds = editor.selection()?.atoms
-
-    selectedAtomIds?.forEach((atomId) => {
-      action.mergeWith(fromOneAtomDeletion(editor.render.ctab, atomId))
-    })
-
-    editor.update(action)
-  }, [getKetcherInstance])
-
-  return (
-    <Item
-      {...props}
-      hidden={isHidden}
-      disabled={isDisabled}
-      onClick={handleClick}
-    >
-      Delete selected atom(s)
     </Item>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/AtomSingleOperations.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/AtomSingleOperations.tsx
@@ -115,7 +115,7 @@ const AtomSingleOperations: React.FC = (props) => {
   return (
     <>
       <Item {...props} hidden={isHidden} onClick={handleEdit}>
-        Edit
+        Edit...
       </Item>
 
       <Item
@@ -124,7 +124,7 @@ const AtomSingleOperations: React.FC = (props) => {
         disabled={isStereoDisabled}
         onClick={handleStereoEdit}
       >
-        Enhanced stereochemistry
+        Enhanced stereochemistry...
       </Item>
 
       <Item {...props} hidden={isHidden} onClick={handleDelete}>

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BatchDelete.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BatchDelete.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+import { Item } from 'react-contexify'
+import { useAppContext } from 'src/hooks'
+import Editor from 'src/script/editor'
+import EraserTool from 'src/script/editor/tool/eraser'
+import { CustomItemProps } from '../contextMenu.types'
+import { isBatchOperationHidden } from './utils'
+
+export const BatchDelete: React.FC<CustomItemProps> = (props) => {
+  const { getKetcherInstance } = useAppContext()
+
+  const handleClick = useCallback(() => {
+    const editor = getKetcherInstance().editor as Editor
+
+    // eslint-disable-next-line no-new
+    new EraserTool(editor, 0)
+  }, [getKetcherInstance])
+
+  return (
+    <Item {...props} hidden={isBatchOperationHidden} onClick={handleClick}>
+      Delete
+    </Item>
+  )
+}

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BondBatchOperations.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BondBatchOperations.tsx
@@ -93,7 +93,7 @@ export const BondBatchEdit: React.FC<CustomItemProps> = (props) => {
       disabled={isDisabled}
       onClick={handleClick}
     >
-      Edit selected bond(s)
+      Edit selected bond(s)...
     </Item>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BondBatchOperations.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BondBatchOperations.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Action, fromBondsAttrs, fromOneBondDeletion } from 'ketcher-core'
+import { fromBondsAttrs } from 'ketcher-core'
 import { useCallback } from 'react'
 import type { ItemParams, PredicateParams } from 'react-contexify'
 import { Item, Submenu } from 'react-contexify'
@@ -31,12 +31,14 @@ import type {
   CustomItemProps,
   CustomSubMenuProps
 } from '../contextMenu.types'
-import { formatTitle, getBondNames, noOperation } from './utils'
+import {
+  formatTitle,
+  getBondNames,
+  noOperation,
+  isBatchOperationHidden
+} from './utils'
 
 const bondNames = getBondNames(tools)
-
-const isHidden = ({ props }: PredicateParams<ContextMenuShowProps, ItemData>) =>
-  !props?.selected
 
 const useDisabled = () => {
   const { getKetcherInstance } = useAppContext()
@@ -46,7 +48,7 @@ const useDisabled = () => {
       props,
       triggerEvent
     }: PredicateParams<ContextMenuShowProps, ItemData>) => {
-      if (isHidden({ props, triggerEvent })) {
+      if (isBatchOperationHidden({ props, triggerEvent })) {
         return true
       }
 
@@ -89,7 +91,7 @@ export const BondBatchEdit: React.FC<CustomItemProps> = (props) => {
   return (
     <Item
       {...props}
-      hidden={isHidden}
+      hidden={isBatchOperationHidden}
       disabled={isDisabled}
       onClick={handleClick}
     >
@@ -120,7 +122,7 @@ export const BondTypeBatchChange: React.FC<CustomSubMenuProps> = (props) => {
     <Submenu
       {...props}
       label="Bond type"
-      hidden={isHidden}
+      hidden={isBatchOperationHidden}
       disabled={isDisabled}
       className={styles.subMenu}
     >
@@ -131,33 +133,5 @@ export const BondTypeBatchChange: React.FC<CustomSubMenuProps> = (props) => {
         </Item>
       ))}
     </Submenu>
-  )
-}
-
-export const BondBatchDelete: React.FC<CustomItemProps> = (props) => {
-  const { getKetcherInstance } = useAppContext()
-  const isDisabled = useDisabled()
-
-  const handleClick = useCallback(() => {
-    const editor = getKetcherInstance().editor as Editor
-    const action = new Action()
-    const selectedBonds = editor.selection()?.bonds
-
-    selectedBonds?.forEach((bondId) => {
-      action.mergeWith(fromOneBondDeletion(editor.render.ctab, bondId))
-    })
-
-    editor.update(action)
-  }, [getKetcherInstance])
-
-  return (
-    <Item
-      {...props}
-      hidden={isHidden}
-      disabled={isDisabled}
-      onClick={handleClick}
-    >
-      Delete selected bond(s)
-    </Item>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BondSingleOperations.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/BondSingleOperations.tsx
@@ -25,9 +25,14 @@ import tools from 'src/script/ui/action/tools'
 import Icon from 'src/script/ui/component/view/icon'
 import styles from '../ContextMenu.module.less'
 import type { ItemData, ContextMenuShowProps } from '../contextMenu.types'
-import { formatTitle, getBondNames, noOperation } from './utils'
+import {
+  formatTitle,
+  getNonQueryBondNames,
+  noOperation,
+  queryBondNames
+} from './utils'
 
-const bondNames = getBondNames(tools)
+const nonQueryBondNames = getNonQueryBondNames(tools)
 
 const BondSingleOperations: React.FC = (props) => {
   const { getKetcherInstance } = useAppContext()
@@ -78,16 +83,29 @@ const BondSingleOperations: React.FC = (props) => {
   return (
     <>
       <Item {...props} hidden={isHidden} onClick={handleEdit}>
-        Edit
+        Edit...
       </Item>
+
+      {nonQueryBondNames.map((name) => (
+        <Item
+          {...props}
+          hidden={isHidden}
+          id={name}
+          onClick={handleTypeChange}
+          key={name}
+        >
+          <Icon name={name} className={styles.icon} />
+          <span>{formatTitle(tools[name].title)}</span>
+        </Item>
+      ))}
 
       <Submenu
         {...props}
-        label="Bond type"
+        label="Query bonds"
         hidden={isHidden}
         className={styles.subMenu}
       >
-        {bondNames.map((name) => (
+        {queryBondNames.map((name) => (
           <Item id={name} onClick={handleTypeChange} key={name}>
             <Icon name={name} className={styles.icon} />
             <span>{formatTitle(tools[name].title)}</span>

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/utils.ts
@@ -1,4 +1,6 @@
 import { difference } from 'lodash'
+import { PredicateParams } from 'react-contexify'
+import { ContextMenuShowProps, ItemData } from '../contextMenu.types'
 
 /**
  * Remove the word `bond` out of the title
@@ -41,3 +43,7 @@ export const getNonQueryBondNames = (tools) => {
 }
 
 export const noOperation = () => null
+
+export const isBatchOperationHidden = ({
+  props
+}: PredicateParams<ContextMenuShowProps, ItemData>) => !props?.selected

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/items/utils.ts
@@ -1,3 +1,5 @@
+import { difference } from 'lodash'
+
 /**
  * Remove the word `bond` out of the title
  *
@@ -17,6 +19,25 @@ export const formatTitle = (title: string) => {
  */
 export const getBondNames = (tools) => {
   return Object.keys(tools).filter((key) => key.startsWith('bond-'))
+}
+
+export const queryBondNames = [
+  'bond-any',
+  'bond-aromatic',
+  'bond-singledouble',
+  'bond-singlearomatic',
+  'bond-doublearomatic'
+]
+
+/**
+ * Get bond names except for query bonds
+ *
+ * @returns `['bond-single', 'bond-up', 'bond-down', 'bond-updown', 'bond-double',
+ * 'bond-crossed', 'bond-triple', 'bond-aromatic', 'bond-hydrogen', 'bond-dative']`
+ */
+export const getNonQueryBondNames = (tools) => {
+  const allBondNames = getBondNames(tools)
+  return difference(allBondNames, queryBondNames)
 }
 
 export const noOperation = () => null


### PR DESCRIPTION
Resolves #1995 #2083 

### Changes

1. Context menu for one bond (looks a bit weird, seems we need to add icons for _Edit_, _Query bonds_ and _Delete_)
![Untitled-2023-01-13-2115](https://user-images.githubusercontent.com/27288153/212329058-b7ce8757-0b7b-4a77-b8e0-15f426aa1cbe.png)

2. Context menu for one atom
![Untitled-2023-01-13-2119](https://user-images.githubusercontent.com/27288153/212329465-6c436493-39cb-4cae-a880-013eb3eaeb1b.png)

3. Context menu for selection
![image](https://user-images.githubusercontent.com/27288153/212693275-668a5653-1c91-4a65-a679-6b0ec65c5f1d.png)

