### PR TITLE
#2045: Functional Groups: The functional group is not added to one of the H3C

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -433,7 +433,7 @@ class TemplateTool {
           // on chain end
           const atom = struct.atoms.get(ci.id)
           const neiId = atom && struct.halfBonds.get(atom.neighbors[0])?.end
-          const nei: any = neiId && struct.atoms.get(neiId)
+          const nei: any = (neiId || neiId === 0) && struct.atoms.get(neiId)
 
           angle = event.ctrlKey
             ? utils.calcAngle(nei?.pp, atom?.pp)


### PR DESCRIPTION
- Fixed wrong false check on template insertion.
- Resolves #2045 