### PR TITLE
#2084: When we double click on the selected atom we get error in console

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/input.tsx
@@ -90,7 +90,7 @@ function TextArea({ schema, value, onChange, ...rest }) {
 
 TextArea.val = (ev) => ev.target.value
 
-function CheckBox({ schema, value = '', onChange, ...rest }) {
+function CheckBox({ schema, value = '', onChange, innerRef, ...rest }) {
   return (
     <div className={classes.fieldSetItem}>
       <input


### PR DESCRIPTION
Removed `innerRef` from checkbox input element.
Resolves #2084 