### PR TITLE
#2026 - Erase tool: Hotkey (Del) can't delete arrows and plus sign

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -17,21 +17,21 @@ type TNewAction = {
   opts?: any
 }
 
-type hotkeyOverItemHandlerProps = {
+type HandlersProps = {
   hoveredItemId: number
   newAction: TNewAction
   editor: Editor
   dispatch: Dispatch
 }
 
-type handleHotkeyOverItemProps = {
+type HandleHotkeyOverItemProps = {
   hoveredItem: Record<string, number>
   newAction: TNewAction
   editor: Editor
   dispatch: Dispatch
 }
 
-export function handleHotkeyOverItems(props: handleHotkeyOverItemProps) {
+export function handleHotkeyOverItem(props: HandleHotkeyOverItemProps) {
   if (props.newAction.tool === 'eraser') {
     handleEraser(props)
   } else {
@@ -39,7 +39,7 @@ export function handleHotkeyOverItems(props: handleHotkeyOverItemProps) {
   }
 }
 
-function handleEraser({ editor, hoveredItem }: handleHotkeyOverItemProps) {
+function handleEraser({ editor, hoveredItem }: HandleHotkeyOverItemProps) {
   const action = fromFragmentDeletion(
     editor.render.ctab,
     mapItemsToArrays(hoveredItem)
@@ -53,14 +53,14 @@ function handleTool({
   newAction,
   editor,
   dispatch
-}: handleHotkeyOverItemProps) {
+}: HandleHotkeyOverItemProps) {
   for (const item in hoveredItem) {
     const toolHandler = getToolHandler(item, newAction.tool)
     const isChangeStructureTool = newAction.tool !== 'hand'
     const hoveredItemId = hoveredItem[item]
 
     if (toolHandler) {
-      const props: hotkeyOverItemHandlerProps = {
+      const props: HandlersProps = {
         hoveredItemId,
         editor,
         newAction,
@@ -73,24 +73,21 @@ function handleTool({
     }
   }
 }
-async function isFunctionalGroupChange(
-  props: hotkeyOverItemHandlerProps
-): Promise<boolean> {
+async function isFunctionalGroupChange(props: HandlersProps): Promise<boolean> {
   return await isChangingFunctionalGroup(props)
 }
 
 function getToolHandler(itemType: string, toolName: string) {
   const items = {
     atoms: {
-      atom: (props: hotkeyOverItemHandlerProps) => handleAtomTool(props),
-      bond: (props: hotkeyOverItemHandlerProps) => handleBondTool(props),
-      charge: (props: hotkeyOverItemHandlerProps) => handleChargeTool(props),
-      rgroupatom: (props: hotkeyOverItemHandlerProps) =>
-        handleRGroupAtomTool(props),
-      sgroup: ({ editor, hoveredItemId }: hotkeyOverItemHandlerProps) => {
+      atom: (props: HandlersProps) => handleAtomTool(props),
+      bond: (props: HandlersProps) => handleBondTool(props),
+      charge: (props: HandlersProps) => handleChargeTool(props),
+      rgroupatom: (props: HandlersProps) => handleRGroupAtomTool(props),
+      sgroup: ({ editor, hoveredItemId }: HandlersProps) => {
         Tools.sgroup.sgroupDialog(editor, hoveredItemId, null)
       },
-      hand: ({ dispatch }: hotkeyOverItemHandlerProps) =>
+      hand: ({ dispatch }: HandlersProps) =>
         dispatch(onAction({ tool: 'hand' }))
     },
     _default: {}
@@ -102,11 +99,7 @@ function getToolHandler(itemType: string, toolName: string) {
   return items._default[toolName]
 }
 
-function handleAtomTool({
-  hoveredItemId,
-  newAction,
-  editor
-}: hotkeyOverItemHandlerProps) {
+function handleAtomTool({ hoveredItemId, newAction, editor }: HandlersProps) {
   const atomProps = { ...newAction.opts }
   const updatedAtoms = fromAtomsAttrs(
     editor.render.ctab,
@@ -117,11 +110,7 @@ function handleAtomTool({
   editor.update(updatedAtoms)
 }
 
-function handleBondTool({
-  hoveredItemId,
-  newAction,
-  editor
-}: hotkeyOverItemHandlerProps) {
+function handleBondTool({ hoveredItemId, newAction, editor }: HandlersProps) {
   const newBond = fromBondAddition(
     editor.render.ctab,
     newAction.opts,
@@ -131,11 +120,7 @@ function handleBondTool({
   editor.update(newBond)
 }
 
-function handleChargeTool({
-  hoveredItemId,
-  newAction,
-  editor
-}: hotkeyOverItemHandlerProps) {
+function handleChargeTool({ hoveredItemId, newAction, editor }: HandlersProps) {
   const existingAtom = editor.render.ctab.atoms.get(hoveredItemId)?.a
   if (existingAtom) {
     const updatedAtom = fromAtomsAttrs(
@@ -160,10 +145,7 @@ function mapItemsToArrays(
   return mappedItems
 }
 
-async function handleRGroupAtomTool({
-  hoveredItemId,
-  editor
-}: hotkeyOverItemHandlerProps) {
+async function handleRGroupAtomTool({ hoveredItemId, editor }: HandlersProps) {
   const struct = editor.render.ctab.molecule
   const atom =
     hoveredItemId || hoveredItemId === 0
@@ -197,7 +179,7 @@ async function handleRGroupAtomTool({
 async function isChangingFunctionalGroup({
   hoveredItemId,
   editor
-}: hotkeyOverItemHandlerProps) {
+}: HandlersProps) {
   const atomResult: number[] = []
   const result: number[] = []
   const atom = editor.render.ctab.atoms.get(hoveredItemId)?.a

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -91,11 +91,10 @@ function keyHandle(dispatch, state, hotKeys, event) {
     if (clipArea.actions.indexOf(actName) === -1) {
       let newAction = actions[actName].action
       const hoveredItem = getHoveredItem(render.ctab)
-      const isHoveringOverItem = Object.keys(hoveredItem).length
       // check if atom is currently hovered over
       // in this case we do not want to activate the corresponding tool
       // and just insert the atom directly
-      if (isHoveringOverItem && newAction.tool !== 'select') {
+      if (hoveredItem && newAction.tool !== 'select') {
         newAction = getCurrentAction(group[index]) || newAction
         handleHotkeyOverItem({
           hoveredItem,
@@ -120,17 +119,17 @@ function getCurrentAction(prevActName) {
 
 function getHoveredItem(
   ctab: Record<string, Map<number, Record<string, unknown>>>
-): Record<string, number> {
-  const hoveredItems = {}
+): Record<string, number> | null {
+  const hoveredItem = {}
 
   for (const ctabItem in ctab) {
     if (!(ctab[ctabItem] instanceof Map)) continue
     ctab[ctabItem].forEach((item, id) => {
-      if (item.hover) hoveredItems[ctabItem] = id
+      if (item.hover) hoveredItem[ctabItem] = id
     })
   }
 
-  return hoveredItems
+  return Object.keys(hoveredItem).length ? hoveredItem : null
 }
 
 function setHotKey(key, actName, hotKeys) {

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -123,9 +123,18 @@ function getHoveredItem(
   const hoveredItem = {}
 
   for (const ctabItem in ctab) {
-    if (!(ctab[ctabItem] instanceof Map)) continue
+    if (Object.keys(hoveredItem).length) {
+      break
+    }
+
+    if (!(ctab[ctabItem] instanceof Map)) {
+      continue
+    }
+
     ctab[ctabItem].forEach((item, id) => {
-      if (item.hover) hoveredItem[ctabItem] = id
+      if (item.hover) {
+        hoveredItem[ctabItem] = id
+      }
     })
   }
 

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -30,7 +30,7 @@ import tools from '../action/tools'
 import keyNorm from '../data/convert/keynorm'
 import { openDialog } from './modal'
 import { isIE } from 'react-device-detect'
-import { handleHotkeyOverItems } from './handleHotkeysOverAtom'
+import { handleHotkeyOverItem } from './handleHotkeysOverItem'
 import { SettingsManager } from '../utils/settingsManager'
 
 export function initKeydownListener(element) {
@@ -97,7 +97,7 @@ function keyHandle(dispatch, state, hotKeys, event) {
       // and just insert the atom directly
       if (isHoveringOverItem && newAction.tool !== 'select') {
         newAction = getCurrentAction(group[index]) || newAction
-        handleHotkeyOverItems({
+        handleHotkeyOverItem({
           hoveredItem,
           newAction,
           editor,


### PR DESCRIPTION
- Revamped hotkey tool handler on hover.
- Resolves #2026 