### PR TITLE
#2104: JS error is thrown, when clicking on a canvas after right click on a bond with "Data S-Group" tool selected

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -442,7 +442,7 @@ class SGroupTool {
     }
 
     // TODO: handle click on an existing group?
-    if (id !== null || (selection && selection.atoms)) {
+    if (id !== null || selection?.atoms?.length) {
       this.editor.selection(selection)
       SGroupTool.sgroupDialog(this.editor, id, this.type)
     }


### PR DESCRIPTION
- Fixed the check if atoms are selected
- Resolves #2104 