### PR TITLE
#2055 Hand tool: Unable to scroll canvas down and to the right

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/hand.ts
+++ b/packages/ketcher-react/src/script/editor/tool/hand.ts
@@ -52,7 +52,6 @@ class HandTool {
     this.begPos = this.endPos
 
     rnd.ctab.translate(diff)
-    rnd.options.offset = rnd.options.offset.add(diff)
     rnd.update(false)
   }
 


### PR DESCRIPTION
closes: #2055 

WIP

TODO:

- [ ] Fix 'Unable to scroll canvas down and to the right'

- [ ] restrict the user from endless scrolling the canvas. The restriction must take effect when the last pixel of the structure disappears from the visibility area. Now it is implemented so that you can scroll endlessly and then the user can hardly find his structures on the canvas.