### PR TITLE
#1889 – Add ability to flip a part of structure

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/rotate.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rotate.ts
@@ -23,7 +23,11 @@ import {
   SGroupDataMove
 } from '../operations'
 import { Bond, Fragment, Pile, Vec2 } from 'domain/entities'
-import { getRelSgroupsBySelection, structSelection } from './utils'
+import {
+  getRelSgroupsBySelection,
+  structSelection,
+  isAttachmentBond
+} from './utils'
 
 import { Action } from './action'
 import utils from '../shared/utils'
@@ -86,20 +90,10 @@ export function fromFlip(restruct, selection, dir, center) {
 
 function getRotationPoint(struct, selection) {
   const { bonds } = struct
-  const isAttachmentBond = ({ begin, end }) => {
-    const isBondStartsInSelectionAndEndsOutside =
-      selection.atoms.includes(begin) && !selection.atoms.includes(end)
-    const isBondEndsInSelectionAndStartsOutside =
-      selection.atoms.includes(end) && !selection.atoms.includes(begin)
-    return (
-      isBondStartsInSelectionAndEndsOutside ||
-      isBondEndsInSelectionAndStartsOutside
-    )
-  }
   const isSelectedAtom = (atomId) => selection.atoms.includes(atomId)
   const getAttachmentBond = () => {
     for (const [bondId, bond] of bonds.entries()) {
-      if (isAttachmentBond(bond)) {
+      if (isAttachmentBond(bond, selection)) {
         return [bondId, bond]
       }
     }

--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -184,3 +184,17 @@ export function getRelSgroupsBySelection(restruct, selectedAtoms) {
       difference(sg.atoms, selectedAtoms).length === 0
   )
 }
+
+export function isAttachmentBond({ begin, end }: Bond, selection): boolean {
+  if (!selection.atoms) {
+    return false
+  }
+  const isBondStartsInSelectionAndEndsOutside =
+    selection.atoms.includes(begin) && !selection.atoms.includes(end)
+  const isBondEndsInSelectionAndStartsOutside =
+    selection.atoms.includes(end) && !selection.atoms.includes(begin)
+  return (
+    isBondStartsInSelectionAndEndsOutside ||
+    isBondEndsInSelectionAndStartsOutside
+  )
+}

--- a/packages/ketcher-react/src/script/ui/action/flips.ts
+++ b/packages/ketcher-react/src/script/ui/action/flips.ts
@@ -1,4 +1,4 @@
-import { Bond, ReBond, ReStruct } from 'ketcher-core'
+import { ReBond, ReStruct, isAttachmentBond } from 'ketcher-core'
 
 export function isFlipDisabled(editor): boolean {
   const selection: { atoms: number[]; bonds: number[] } = editor.selection()
@@ -9,9 +9,6 @@ export function isFlipDisabled(editor): boolean {
   }
 
   const { bonds = [], atoms = [] } = selection
-  const isAttachmentBond = ({ begin, end }: Bond): boolean =>
-    (selection.atoms.includes(begin) && !selection.atoms.includes(end)) ||
-    (selection.atoms.includes(end) && !selection.atoms.includes(begin))
   const getBondIdsForAtom = (atomId: number) => {
     const result: number[] = []
     for (const [bondId, bond] of restruct.bonds.entries()) {
@@ -27,7 +24,7 @@ export function isFlipDisabled(editor): boolean {
       const atomBondIds = getBondIdsForAtom(atomId)
       for (const atomBondId of atomBondIds) {
         const bond: ReBond | undefined = restruct.bonds.get(atomBondId)
-        if (bond && isAttachmentBond(bond.b)) {
+        if (bond && isAttachmentBond(bond.b, selection)) {
           result.push(atomBondId)
         }
       }
@@ -39,7 +36,7 @@ export function isFlipDisabled(editor): boolean {
     const totalBondIds = new Set([...bonds, ...getBondIdsForAttachmentAtoms()])
     for (const bondId of totalBondIds) {
       const bond: ReBond | undefined = restruct.bonds.get(bondId)
-      if (bond && isAttachmentBond(bond.b)) {
+      if (bond && isAttachmentBond(bond.b, selection)) {
         amountOfAttachmentBonds++
       }
     }


### PR DESCRIPTION
Fixes a case, when only bonds are selected.

closes #1889 