### PR TITLE
#2130: Custom Templates: When drag an abbreviation preview is not hide

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -239,6 +239,9 @@ class SelectTool {
         editor.update(dragCtx.action, true)
         return true
       }
+      if (dragCtx.item.map === 'functionalGroups' && !dragCtx.action) {
+        editor.event.showInfo.dispatch(null)
+      }
       if (dragCtx.item.map === 'rxnArrows' && dragCtx.item.ref) {
         if (dragCtx?.action) dragCtx.action.perform(rnd.ctab)
         const current = rnd.page2obj(event)

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -206,7 +206,7 @@ export default function initEditor(dispatch, getState) {
         const { groupStruct, event, sGroup } = payload
         highlightFG(dispatch, { groupStruct, event, sGroup })
       } else {
-        highlightFG(dispatch, { groupStruct: null, event: null, sGroup: null })
+        highlightFG(dispatch, { groupStruct: null, sGroup: null })
       }
     }
   }


### PR DESCRIPTION
Closes #2130 