### PR TITLE
#2146: Migrate to Indigo v1.10.0-rc.2 in-browser module

### DIFF
--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "indigo-ketcher": "1.10.0-rc.1",
+    "indigo-ketcher": "1.10.0-rc.2",
     "ketcher-core": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9385,12 +9385,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"indigo-ketcher@npm:1.10.0-rc.1":
-  version: 1.10.0-rc.1
-  resolution: "indigo-ketcher@npm:1.10.0-rc.1"
+"indigo-ketcher@npm:1.10.0-rc.2":
+  version: 1.10.0-rc.2
+  resolution: "indigo-ketcher@npm:1.10.0-rc.2"
   dependencies:
     looks-same: ^8.1.0
-  checksum: 1ab47c0674fc4449247ecedd850786d3c3091194a2c0176b73ff2f264f6f525dcbafd7c58cebe0c077c5f0c08fbd0b253bb54f66857ed17608cf0b2cdbf2cc93
+  checksum: 2625c64d81b452308e68fe1e578bdd68d1b306e7d37bd35f669f89a546a31a2ceab8f510c27181e2a51b68968745b9bb20600a1cd6d6f79099a37e4b6ab7ff1a
   languageName: node
   linkType: hard
 
@@ -11588,7 +11588,7 @@ __metadata:
     cross-env: ^7.0.3
     eslint: ^8.4.1
     eslint-plugin-jest: ^25.3.0
-    indigo-ketcher: 1.10.0-rc.1
+    indigo-ketcher: 1.10.0-rc.2
     jest: 26.6.0
     ketcher-core: "workspace:*"
     npm-run-all: ^4.1.5


### PR DESCRIPTION
Closes #2146 