### PR TITLE
#2123: Hover effect doesn't appear after clicking on bonds or atoms

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -241,6 +241,11 @@ class AtomTool {
     this.editor.event.message.dispatch({
       info: false
     })
+    this.editor.hover(
+      this.editor.findItem(event, ['atoms', 'functionalGroups']),
+      null,
+      event
+    )
   }
 }
 

--- a/packages/ketcher-react/src/script/editor/tool/attach.ts
+++ b/packages/ketcher-react/src/script/editor/tool/attach.ts
@@ -43,9 +43,11 @@ class AttachTool {
       ((ci.map === 'atoms' &&
         Elements.get(struct.atoms.get(ci.id)?.label as string)) ||
         ci.map === 'bonds')
-    )
+    ) {
       this.editor.hover(ci)
-    else this.editor.hover(null)
+    } else {
+      this.editor.hover(null)
+    }
     return true
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -332,6 +332,11 @@ class BondTool {
     this.editor.event.message.dispatch({
       info: false
     })
+    this.editor.hover(
+      this.editor.findItem(event, ['atoms', 'bonds']),
+      null,
+      event
+    )
     return true
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/charge.ts
+++ b/packages/ketcher-react/src/script/editor/tool/charge.ts
@@ -84,7 +84,7 @@ class ChargeTool {
       ci.map === 'atoms' &&
       Elements.get(molecule.atoms.get(ci.id)?.label as string | number)
     ) {
-      this.editor.hover(null)
+      this.editor.hover(ci)
       this.editor.update(
         fromAtomsAttrs(
           rnd.ctab,

--- a/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
@@ -142,7 +142,7 @@ class ReactionMapTool {
       this.updateLine(null, null)
       delete this.dragCtx
     }
-    this.editor.hover(null)
+    this.editor.hover(this.editor.findItem(event, ['atoms']), null, event)
   }
 }
 

--- a/packages/ketcher-react/src/script/editor/tool/reactionunmap.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionunmap.ts
@@ -55,7 +55,7 @@ class ReactionUnmapTool {
       })
       this.editor.update(action)
     }
-    this.editor.hover(null)
+    this.editor.hover(this.editor.findItem(event, ['atoms']), null, event)
   }
 }
 

--- a/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
@@ -84,9 +84,9 @@ class RGroupAtomTool {
       propsDialog(this.editor, null, rnd.page2obj(event))
       return true
     } else if (ci.map === 'atoms') {
-      this.editor.hover(null)
       const struct = this.editor.render.ctab.molecule
       const atom = struct.atoms.get(ci.id)
+      this.editor.hover(this.editor.findItem(event, ['atoms']), null, event)
 
       if (atom?.attpnt !== null) return
 

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -186,7 +186,6 @@ class RotateTool {
     delete this.dragCtx
 
     this.editor.update(action)
-    this.editor.hover(null)
 
     if (dragCtx.mergeItems) {
       this.editor.selection(null)

--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -419,11 +419,12 @@ class SGroupTool {
           : this.lassoHelper.end(event)
       this.editor.selection(selection)
     } else {
-      if (!ci)
+      if (!ci) {
         // ci.type == 'Canvas'
         return
-      this.editor.hover(null)
+      }
 
+      this.editor.hover(this.editor.findItem(event, searchMaps), null, event)
       if (ci.map === 'atoms') {
         // if we click the SGroup tool on a single atom or bond, make a group out of those
         selection = { atoms: [ci.id] }


### PR DESCRIPTION
This PR resolves #2123 
Fixed by removing hover reset call from click handlers