### PR TITLE
#2142 S-Groups get lost when saving as ket file

### DIFF
--- a/packages/ketcher-core/__tests__/domain/serializers/ket/KetSerializer.test.ts
+++ b/packages/ketcher-core/__tests__/domain/serializers/ket/KetSerializer.test.ts
@@ -205,6 +205,20 @@ describe('serialize (ToKet)', () => {
     const plusKet = parsedPrepareContent.root.nodes[3]
     expect(structPlus).toEqual(plusKet)
   })
+  it('correct work with sgroups', () => {
+    const parsedSgroupStruct = JSON.parse(ket.serialize(moleculeSgroupStruct))
+    expect(parsedSgroupStruct.root.nodes[6].data.type).toEqual('GEN')
+    expect(parsedSgroupStruct.root.nodes[7].data.type).toEqual('MUL')
+    expect(parsedSgroupStruct.root.nodes[7].data.mul).toEqual(1)
+    expect(parsedSgroupStruct.root.nodes[8].data.type).toEqual('SRU')
+    expect(parsedSgroupStruct.root.nodes[8].data.subscript).toEqual('n')
+    expect(parsedSgroupStruct.root.nodes[8].data.connectivity).toEqual('HT')
+    expect(parsedSgroupStruct.root.nodes[9].data.type).toEqual('MUL')
+    expect(parsedSgroupStruct.root.nodes[9].data.mul).toEqual(1)
+    expect(parsedSgroupStruct.root.nodes[10].data.type).toEqual('SUP')
+    expect(parsedSgroupStruct.root.nodes[11].data.subscript).toEqual('n')
+    expect(parsedSgroupStruct.root.nodes[11].data.connectivity).toEqual('HT')
+  })
   it('moleculeToKet', () => {
     const spy = jest.spyOn(moleculeToKet, 'moleculeToKet')
     ket.serialize(moleculeContentStruct)
@@ -230,19 +244,6 @@ describe('serialize (ToKet)', () => {
     expect(
       spy.mock.results[1].value.bonds.filter((bond) => bond.type === 2).length
     ).toEqual(3)
-    // sgroups
-    ket.serialize(moleculeSgroupStruct)
-    expect(spy.mock.results[2].value.sgroups[0].type).toEqual('GEN')
-    expect(spy.mock.results[2].value.sgroups[1].type).toEqual('MUL')
-    expect(spy.mock.results[2].value.sgroups[1].mul).toEqual(1)
-    expect(spy.mock.results[2].value.sgroups[2].type).toEqual('SRU')
-    expect(spy.mock.results[2].value.sgroups[2].subscript).toEqual('n')
-    expect(spy.mock.results[2].value.sgroups[2].connectivity).toEqual('HT')
-    expect(spy.mock.results[2].value.sgroups[3].type).toEqual('MUL')
-    expect(spy.mock.results[2].value.sgroups[3].mul).toEqual(1)
-    expect(spy.mock.results[2].value.sgroups[4].type).toEqual('SUP')
-    expect(spy.mock.results[2].value.sgroups[5].subscript).toEqual('n')
-    expect(spy.mock.results[2].value.sgroups[5].connectivity).toEqual('HT')
   })
   it('rgroupToKet', () => {
     const spy = jest.spyOn(rgroupToKet, 'rgroupToKet')

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
@@ -49,7 +49,6 @@ export function moleculeToStruct(ketItem: any): Struct {
   struct.initHalfBonds()
   struct.initNeighbors()
   struct.markFragments()
-  struct.bindSGroupsToFunctionalGroups()
 
   return struct
 }

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -85,6 +85,7 @@ export class KetSerializer implements Serializer<Struct> {
       else if (nodes[i].$ref) parseNode(ket[nodes[i].$ref], resultingStruct)
     })
     resultingStruct.name = ket.header ? ket.header.moleculeName : null
+    resultingStruct.bindSGroupsToFunctionalGroups()
 
     return resultingStruct
   }

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -19,8 +19,8 @@ import { arrowToKet, plusToKet } from './toKet/rxnToKet'
 
 import { Serializer } from '../serializers.types'
 import { headerToKet } from './toKet/headerToKet'
-import { moleculeToKet } from './toKet/moleculeToKet'
-import { moleculeToStruct } from './fromKet/moleculeToStruct'
+import { moleculeToKet, sgroupToKet } from './toKet/moleculeToKet'
+import { moleculeToStruct, sgroupToStruct } from './fromKet/moleculeToStruct'
 import { prepareStructForKet } from './toKet/prepare'
 import { rgroupToKet } from './toKet/rgroupToKet'
 import { rgroupToStruct } from './fromKet/rgroupToStruct'
@@ -62,6 +62,10 @@ function parseNode(node: any, struct: any) {
     }
     case 'text': {
       textToStruct(node, struct)
+      break
+    }
+    case 'sgroup': {
+      struct.sgroups.add(sgroupToStruct(node.data))
       break
     }
     default:
@@ -127,6 +131,13 @@ export class KetSerializer implements Serializer<Struct> {
         }
         case 'text': {
           result.root.nodes.push(textToKet(item))
+          break
+        }
+        case 'sgroup': {
+          result.root.nodes.push({
+            type: item.type,
+            data: sgroupToKet(struct, item.data)
+          })
           break
         }
         default:

--- a/packages/ketcher-core/src/domain/serializers/ket/schema.json
+++ b/packages/ketcher-core/src/domain/serializers/ket/schema.json
@@ -27,6 +27,9 @@
                 "$ref": "#/definitions/plus"
               },
               {
+                "$ref": "#/definitions/sgroup"
+              },
+              {
                 "type": "object",
                 "required": ["$ref"],
                 "properties": {
@@ -379,117 +382,132 @@
         ]
       }
     },
-    "sgroups": {
-      "type": "array",
-      "items": {
-        "required": ["atoms", "type"],
-        "type": "object",
+    "sgroupData": {
+      "type": "object",
+      "required": ["atoms", "type"],
+      "properties": {
+        "atoms": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": ["GEN", "MUL", "SRU", "SUP", "DAT"]
+        }
+      },
+      "if": {
         "properties": {
-          "atoms": {
+          "type": {
+            "const": "MUL"
+          }
+        }
+      },
+      "then": {
+        "required": ["mul"],
+        "properties": {
+          "mul": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "SRU"
+          }
+        }
+      },
+      "then": {
+        "required": ["subscript", "connectivity"],
+        "properties": {
+          "subscript": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]$"
+          },
+          "connectivity": {
+            "type": "string",
+            "enum": ["HT", "HH", "EU"]
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "SUP"
+          }
+        }
+      },
+      "then": {
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expanded": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "number"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "DAT"
+          }
+        }
+      },
+      "then": {
+        "required": ["fieldName"],
+        "properties": {
+          "context": {
+            "enum": ["Fragment", "Multifragment", "Bond", "Atom", "Group"]
+          },
+          "fieldName": {
+            "type": "string"
+          },
+          "fieldValue": {
+            "type": "string",
+            "minLength": 1
+          },
+          "display": {
+            "type": "boolean"
+          },
+          "placement": {
+            "type": "boolean"
+          },
+          "bonds": {
             "type": "array",
             "items": {
               "type": "integer",
               "minimum": 0
             }
-          },
-          "type": {
-            "type": "string",
-            "enum": ["GEN", "MUL", "SRU", "SUP", "DAT"]
           }
+        }
+      }
+    },
+    "sgroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/sgroupData"
+      }
+    },
+    "sgroup": {
+      "type": "object",
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "const": "sgroup"
         },
-        "if": {
-          "properties": {
-            "type": {
-              "const": "MUL"
-            }
-          }
-        },
-        "then": {
-          "required": ["mul"],
-          "properties": {
-            "mul": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 1000
-            }
-          }
-        },
-        "if": {
-          "properties": {
-            "type": {
-              "const": "SRU"
-            }
-          }
-        },
-        "then": {
-          "required": ["subscript", "connectivity"],
-          "properties": {
-            "subscript": {
-              "type": "string",
-              "pattern": "^[a-zA-Z]$"
-            },
-            "connectivity": {
-              "type": "string",
-              "enum": ["HT", "HH", "EU"]
-            }
-          }
-        },
-        "if": {
-          "properties": {
-            "type": {
-              "const": "SUP"
-            }
-          }
-        },
-        "then": {
-          "required": ["type"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "minLength": 1
-            },
-            "expanded": {
-              "type": "boolean"
-            },
-            "id": {
-              "type": "number"
-            }
-          }
-        },
-        "if": {
-          "properties": {
-            "type": {
-              "const": "DAT"
-            }
-          }
-        },
-        "then": {
-          "required": ["fieldName"],
-          "properties": {
-            "context": {
-              "enum": ["Fragment", "Multifragment", "Bond", "Atom", "Group"]
-            },
-            "fieldName": {
-              "type": "string"
-            },
-            "fieldValue": {
-              "type": "string",
-              "minLength": 1
-            },
-            "display": {
-              "type": "boolean"
-            },
-            "placement": {
-              "type": "boolean"
-            },
-            "bonds": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "minimum": 0
-              }
-            }
-          }
+        "data": {
+          "$ref": "#/definitions/sgroupData"
         }
       }
     },

--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
@@ -124,7 +124,7 @@ function bondToKet(source) {
   return result
 }
 
-function sgroupToKet(struct, source) {
+export function sgroupToKet(struct, source) {
   const result = {}
 
   ifDef(result, 'type', source.type)

--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
@@ -44,12 +44,6 @@ export function moleculeToKet(struct: Struct): any {
     body.bonds = Array.from(struct.bonds.values()).map(bondToKet)
   }
 
-  if (struct.sgroups.size !== 0) {
-    body.sgroups = Array.from(struct.sgroups.values()).map((sGroup) =>
-      sgroupToKet(struct, sGroup)
-    )
-  }
-
   const fragment = struct.frags.get(0)
   if (fragment) {
     ifDef(body, 'stereoFlagPosition', fragment.stereoFlagPosition, null)

--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/prepare.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/prepare.ts
@@ -17,6 +17,7 @@ import { Pile, SGroup, Struct, Vec2 } from 'domain/entities'
 
 export function prepareStructForKet(struct: Struct) {
   const ketNodes: any = []
+  const atomIdMap: Map<number, number> = initAtomIdMap(struct)
 
   const rgFrags = new Set() // skip this when writing molecules
   for (const [rgnumber, rgroup] of struct.rgroups.entries()) {
@@ -90,6 +91,13 @@ export function prepareStructForKet(struct: Struct) {
     })
   })
 
+  struct.sgroups.forEach((sgroup) => {
+    ketNodes.push({
+      type: 'sgroup',
+      data: SGroup.clone(sgroup, atomIdMap)
+    })
+  })
+
   ketNodes.forEach((ketNode) => {
     if (ketNode.fragment) {
       const sgroups: SGroup[] = Array.from(ketNode.fragment.sgroups.values())
@@ -112,4 +120,16 @@ export function prepareStructForKet(struct: Struct) {
 function getFragmentCenter(struct, atomSet) {
   const bb = struct.getCoordBoundingBox(atomSet)
   return Vec2.centre(bb.min, bb.max)
+}
+
+function initAtomIdMap(struct: Struct): Map<number, number> {
+  const atomIdMap = new Map()
+
+  let index = 0
+  struct.atoms.forEach((_value, key) => {
+    atomIdMap.set(key, index)
+    index++
+  })
+
+  return atomIdMap
 }


### PR DESCRIPTION
Resolves: #2142 

Now in a ket file, all S-Groups either exist on the top layer (new version) or in the molecules (old version but compatible), which means there's no chance that some S-Groups exist on the top layer and some exist in the molecules.

More details: https://excalidraw.com/#json=EBblE5uf7cDbf7WO5-iSU,aqAVNKUKnIKF3EZUtjXVsA