### PR TITLE
#2143: Opening file with a superatom label saved in RXN v3000 format removes a custom s-group

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -138,7 +138,7 @@ export class KetSerializer implements Serializer<Struct> {
         case 'sgroup': {
           const sgroup: any = sgroupToKet(struct, item.data)
           sgroup.id = sgroupId++
-          sgroup.atoms.forEach((atomId) => {
+          sgroup.atoms?.forEach((atomId) => {
             const key = `mol${atomId}`
             if (!result[key]) return
             if (!result[key].sgroups) result[key].sgroups = []

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -103,6 +103,7 @@ export class KetSerializer implements Serializer<Struct> {
     const ketNodes = prepareStructForKet(struct)
 
     let moleculeId = 0
+    let sgroupId = 0
     ketNodes.forEach((item) => {
       switch (item.type) {
         case 'molecule': {
@@ -135,9 +136,17 @@ export class KetSerializer implements Serializer<Struct> {
           break
         }
         case 'sgroup': {
+          const sgroup: any = sgroupToKet(struct, item.data)
+          sgroup.id = sgroupId++
+          sgroup.atoms.forEach((atomId) => {
+            const key = `mol${atomId}`
+            if (!result[key]) return
+            if (!result[key].sgroups) result[key].sgroups = []
+            result[key].sgroups.push(sgroup)
+          })
           result.root.nodes.push({
             type: item.type,
-            data: sgroupToKet(struct, item.data)
+            data: sgroup
           })
           break
         }

--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
@@ -44,6 +44,12 @@ export function moleculeToKet(struct: Struct): any {
     body.bonds = Array.from(struct.bonds.values()).map(bondToKet)
   }
 
+  if (struct.sgroups.size !== 0) {
+    body.sgroups = Array.from(struct.sgroups.values()).map((sGroup) =>
+      sgroupToKet(struct, sGroup)
+    )
+  }
+
   const fragment = struct.frags.get(0)
   if (fragment) {
     ifDef(body, 'stereoFlagPosition', fragment.stereoFlagPosition, null)


### PR DESCRIPTION
Closes #2143 