### PR TITLE
#1996 Bond context menu add ability to attach or edit s group & #2180 When selected S-Group/Data S-Group right click on an atom or bond opens S-Group Properties window

### DIFF
--- a/packages/ketcher-core/src/domain/entities/atom.ts
+++ b/packages/ketcher-core/src/domain/entities/atom.ts
@@ -134,7 +134,7 @@ export class Atom {
   implicitH: number
   pp: Vec2
   neighbors: Array<number>
-  sgs: Pile<any>
+  sgs: Pile<number>
   badConn: boolean
   alias: string | null
   rglabel: string | null

--- a/packages/ketcher-core/src/domain/entities/bond.ts
+++ b/packages/ketcher-core/src/domain/entities/bond.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
+import { Pile } from './pile'
+import { Struct } from './struct'
 import { Vec2 } from './vec2'
 
 export interface BondAttributes {
@@ -149,5 +151,11 @@ export class Bond {
       cp.end = aidMap.get(cp.end)!
     }
     return cp
+  }
+
+  getAttachedSGroups(struct: Struct) {
+    const sGroupsWithBeginAtom = struct.atoms.get(this.begin)?.sgs || new Pile()
+    const sGroupsWithEndAtom = struct.atoms.get(this.end)?.sgs || new Pile()
+    return sGroupsWithBeginAtom?.intersection(sGroupsWithEndAtom)
   }
 }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -591,10 +591,12 @@ class Editor implements KetcherEditor {
   }
 }
 
-function isMouseRight(event) {
-  return (
-    (event.which && event.which === 3) || (event.button && event.button === 2)
-  )
+/**
+ * Main button pressed, usually the left button or the un-initialized state
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+ */
+function isMouseMainButtonPressed(event: MouseEvent) {
+  return event.button === 0
 }
 
 function resetSelectionOnCanvasClick(
@@ -667,13 +669,17 @@ function domEventSetup(editor: Editor, clientArea: HTMLElement) {
 
     subs.add((event) => {
       updateLastCursorPosition(editor, event)
+
+      if (
+        ['mouseup', 'mousedown', 'click', 'dbclick'].includes(event.type) &&
+        !isMouseMainButtonPressed(event)
+      ) {
+        return true
+      }
+
       if (eventName !== 'mouseup' && eventName !== 'mouseleave') {
         // to complete drag actions
-        if (
-          isMouseRight(event) ||
-          !event.target ||
-          event.target.nodeName === 'DIV'
-        ) {
+        if (!event.target || event.target.nodeName === 'DIV') {
           // click on scroll
           editor.hover(null)
           return true

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -139,12 +139,14 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
             const functionalGroup = FunctionalGroup.findFunctionalGroupBySGroup(
               struct.functionalGroups,
               sGroup
-            ) as FunctionalGroup
+            )
 
-            showProps = {
-              id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-              functionalGroups: [functionalGroup]
-            }
+            showProps = functionalGroup
+              ? {
+                  id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+                  functionalGroups: [functionalGroup]
+                }
+              : null
             break
           }
         }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondSGroupAttach.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondSGroupAttach.ts
@@ -1,0 +1,50 @@
+import { ReStruct } from 'ketcher-core'
+import { useCallback } from 'react'
+import { useAppContext } from 'src/hooks'
+import Editor from 'src/script/editor'
+import SGroupTool from 'src/script/editor/tool/sgroup'
+import { ItemEventParams } from '../contextMenu.types'
+
+const useBondSGroupAttach = () => {
+  const { getKetcherInstance } = useAppContext()
+
+  const handler = useCallback(
+    ({ props }: ItemEventParams) => {
+      const editor = getKetcherInstance().editor as Editor
+      const struct: ReStruct = editor.render.ctab
+      const bondId = props!.bondIds![0]
+      const bond = struct.bonds.get(bondId)!
+
+      const selection = {
+        atoms: [bond?.b.begin, bond?.b.end],
+        bonds: [bondId]
+      }
+
+      editor.selection(selection)
+      SGroupTool.sgroupDialog(editor, null)
+    },
+    [getKetcherInstance]
+  )
+
+  const hidden = useCallback(
+    ({ props }: ItemEventParams) => {
+      const editor = getKetcherInstance().editor as Editor
+      const struct: ReStruct = editor.render.ctab
+      const bondIds = props!.bondIds!
+
+      if (bondIds.length > 1) {
+        return true
+      }
+
+      const bond = struct.bonds.get(bondIds[0])!
+      const attachedSGroups = bond.b.getAttachedSGroups(struct.molecule)
+
+      return attachedSGroups.size > 0
+    },
+    [getKetcherInstance]
+  )
+
+  return [handler, hidden] as const
+}
+
+export default useBondSGroupAttach

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondSGroupEdit.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondSGroupEdit.ts
@@ -1,0 +1,44 @@
+import { Pile, ReStruct } from 'ketcher-core'
+import { useCallback, useRef } from 'react'
+import { useAppContext } from 'src/hooks'
+import Editor from 'src/script/editor'
+import SGroupTool from 'src/script/editor/tool/sgroup'
+import { ItemEventParams } from '../contextMenu.types'
+
+const useBondSGroupEdit = () => {
+  const { getKetcherInstance } = useAppContext()
+  const sGroupsRef = useRef(new Pile<number>())
+
+  const handler = useCallback(() => {
+    const editor = getKetcherInstance().editor as Editor
+    const sGroups = Array.from(sGroupsRef.current)
+    SGroupTool.sgroupDialog(editor, sGroups[0])
+  }, [getKetcherInstance])
+
+  // In react-contexify, `disabled` is executed before `hidden`
+  const disabled = useCallback(
+    ({ props }: ItemEventParams) => {
+      const editor = getKetcherInstance().editor as Editor
+      const struct: ReStruct = editor.render.ctab
+      const bondIds = props!.bondIds!
+
+      if (bondIds.length > 1) {
+        return true
+      }
+
+      const bond = struct.bonds.get(bondIds[0])!
+      sGroupsRef.current = bond.b.getAttachedSGroups(struct.molecule)
+
+      return sGroupsRef.current.size > 1
+    },
+    [getKetcherInstance]
+  )
+
+  const hidden = useCallback(() => {
+    return sGroupsRef.current.size === 0
+  }, [])
+
+  return [handler, disabled, hidden] as const
+}
+
+export default useBondSGroupEdit

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useFunctionalGroupEoc.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useFunctionalGroupEoc.ts
@@ -34,7 +34,7 @@ const useFunctionalGroupEoc = () => {
     [dispatch, getKetcherInstance]
   )
 
-  const disabled = useCallback(
+  const hidden = useCallback(
     ({ props }: ItemEventParams, toExpand: boolean) => {
       return Boolean(
         props?.functionalGroups?.every((functionalGroup) =>
@@ -45,7 +45,7 @@ const useFunctionalGroupEoc = () => {
     []
   )
 
-  return [handler, disabled] as const
+  return [handler, hidden] as const
 }
 
 export default useFunctionalGroupEoc

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -3,6 +3,8 @@ import tools from 'src/script/ui/action/tools'
 import Icon from 'src/script/ui/component/view/icon'
 import styles from '../ContextMenu.module.less'
 import useBondEdit from '../hooks/useBondEdit'
+import useBondSGroupAttach from '../hooks/useBondSGroupAttach'
+import useBondSGroupEdit from '../hooks/useBondSGroupEdit'
 import useBondTypeChange from '../hooks/useBondTypeChange'
 import useDelete from '../hooks/useDelete'
 import { formatTitle, getNonQueryBondNames, queryBondNames } from '../utils'
@@ -12,6 +14,9 @@ const nonQueryBondNames = getNonQueryBondNames(tools)
 const BondMenuItems: React.FC = (props) => {
   const [handleEdit] = useBondEdit()
   const [handleTypeChange] = useBondTypeChange()
+  const [handleSGroupAttach, sGroupAttachHidden] = useBondSGroupAttach()
+  const [handleSGroupEdit, sGroupEditDisabled, sGroupEditHidden] =
+    useBondSGroupEdit()
   const handleDelete = useDelete()
 
   return (
@@ -35,6 +40,19 @@ const BondMenuItems: React.FC = (props) => {
           </Item>
         ))}
       </Submenu>
+
+      <Item {...props} hidden={sGroupAttachHidden} onClick={handleSGroupAttach}>
+        Attach S-Group...
+      </Item>
+
+      <Item
+        {...props}
+        hidden={sGroupEditHidden}
+        disabled={sGroupEditDisabled}
+        onClick={handleSGroupEdit}
+      >
+        Edit S-Group...
+      </Item>
 
       <Item {...props} onClick={handleDelete}>
         Delete


### PR DESCRIPTION
Resolves: #1996 #2180 


https://user-images.githubusercontent.com/27288153/220265571-915a23e1-4368-496a-a269-e0dde7b806a8.mp4

