### PR TITLE
#2210 – label does not appear when hovering on created S-Group

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/apoint.ts
+++ b/packages/ketcher-react/src/script/editor/tool/apoint.ts
@@ -31,7 +31,7 @@ class APointTool {
     if (closestItem) {
       const atom = struct.atoms.get(closestItem.id)
       if (atom?.label !== 'R#' && atom?.rglabel === null)
-        this.editor.hover(closestItem)
+        this.editor.hover(closestItem, null, event)
     } else {
       this.editor.hover(null)
     }

--- a/packages/ketcher-react/src/script/editor/tool/eraser.ts
+++ b/packages/ketcher-react/src/script/editor/tool/eraser.ts
@@ -76,7 +76,7 @@ class EraserTool {
     if (this.lassoHelper.running()) {
       this.editor.selection(this.lassoHelper.addPoint(event))
     } else {
-      this.editor.hover(this.editor.findItem(event, this.maps))
+      this.editor.hover(this.editor.findItem(event, this.maps), null, event)
     }
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/hand.ts
+++ b/packages/ketcher-react/src/script/editor/tool/hand.ts
@@ -41,7 +41,15 @@ class HandTool {
 
   mousemove(event) {
     this.editor.event.cursor.dispatch({ status: 'move' })
-    if (this.begPos == null) return
+    this.editor.hover(
+      this.editor.findItem(event, ['atoms', 'bonds'], null),
+      null,
+      event
+    )
+
+    if (this.begPos == null) {
+      return
+    }
     const { clientX, clientY } = event
     this.endPos = new Vec2(clientX, clientY)
 

--- a/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
@@ -69,7 +69,7 @@ class ReactionMapTool {
         )
       }
     } else {
-      editor.hover(editor.findItem(event, ['atoms']))
+      editor.hover(editor.findItem(event, ['atoms']), null, event)
     }
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
@@ -53,7 +53,7 @@ class ReactionPlusTool {
       )
       editor.update(this.dragCtx.action, true)
     } else {
-      editor.hover(editor.findItem(event, ['rxnPluses']))
+      editor.hover(editor.findItem(event, ['rxnPluses']), null, event)
     }
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/reactionunmap.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionunmap.ts
@@ -30,7 +30,9 @@ class ReactionUnmapTool {
 
     if (ci && ci.map === 'atoms') {
       this.editor.hover(
-        this.editor.render.ctab.molecule.atoms.get(ci.id)?.aam ? ci : null
+        this.editor.render.ctab.molecule.atoms.get(ci.id)?.aam ? ci : null,
+        null,
+        event
       )
     } else {
       this.editor.hover(null)

--- a/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
@@ -37,7 +37,7 @@ class RGroupAtomTool {
 
     if (ci) {
       const atom = struct.atoms.get(ci.id)
-      if (atom?.attpnt === null) this.editor.hover(ci)
+      if (atom?.attpnt === null) this.editor.hover(ci, null, event)
     } else {
       this.editor.hover(null)
     }

--- a/packages/ketcher-react/src/script/editor/tool/rgroupfragment.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rgroupfragment.ts
@@ -33,7 +33,11 @@ class RGroupFragmentTool {
   }
 
   mousemove(event) {
-    this.editor.hover(this.editor.findItem(event, ['frags', 'rgroups']))
+    this.editor.hover(
+      this.editor.findItem(event, ['frags', 'rgroups']),
+      null,
+      event
+    )
   }
 
   click(event) {

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -130,6 +130,7 @@ class RotateTool {
 
   mousemove(event) {
     if (!this.dragCtx) {
+      this.editor.hover(null, null, event)
       return true
     }
 
@@ -165,7 +166,7 @@ class RotateTool {
 
     const expSel = this.editor.explicitSelected()
     dragCtx.mergeItems = getItemsToFuse(this.editor, expSel)
-    this.editor.hover(getHoverToFuse(dragCtx.mergeItems))
+    this.editor.hover(getHoverToFuse(dragCtx.mergeItems), null, event)
 
     this.editor.update(dragCtx.action, true)
     return true

--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -249,7 +249,7 @@ class SGroupTool {
     if (this.lassoHelper.running(event)) {
       this.editor.selection(this.lassoHelper.addPoint(event))
     } else {
-      this.editor.hover(this.editor.findItem(event, searchMaps))
+      this.editor.hover(this.editor.findItem(event, searchMaps), null, event)
     }
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/simpleobject.ts
+++ b/packages/ketcher-react/src/script/editor/tool/simpleobject.ts
@@ -109,7 +109,7 @@ class SimpleObjectTool {
       }
     } else {
       const items = this.editor.findItem(event, ['simpleObjects'])
-      this.editor.hover(items)
+      this.editor.hover(items, null, event)
     }
   }
 


### PR DESCRIPTION
Event wasn't passed for `editor.hover` everywhere. Without an event it is not possible to determine coordinates of mouse and show a tooltip at correct position.
closes #2210