### PR TITLE
Backmerge: #2228 – There are freezes in application when Chrome DevTools are opened (#2232)

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/functionalGroups/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/functionalGroups/index.ts
@@ -23,6 +23,7 @@ import {
   Struct
 } from 'ketcher-core'
 import templatesRawData from '../../../../templates/fg.sdf'
+import _ from 'lodash'
 
 interface FGState {
   lib: []
@@ -58,9 +59,11 @@ const highlightFGroup = (group: any) => ({
   payload: group
 })
 
-export function highlightFG(dispatch, group: any) {
+function notDebouncedHighlightFG(dispatch, group: any) {
   dispatch(highlightFGroup(group))
 }
+
+export const highlightFG = _.debounce(notDebouncedHighlightFG, 200)
 
 export function initFGTemplates() {
   return async (dispatch) => {


### PR DESCRIPTION
* #2228 – There are freezes in application when Chrome DevTools are opened

* #2228 – changed throttle to debounce; fixed issue of InfoPanel appearing at (0;0) coordinates

closes #2228 