### PR TITLE
#2227: Click and drag rotation is not working for Templates toolbar structures

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -342,7 +342,17 @@ class TemplateTool {
     let action = null
     let pasteItems
 
-    if (ci?.map === 'atoms') {
+    if (!ci) {
+      const isAddingFunctionalGroup = this.template?.molecule?.sgroups.size
+      // skip, b/c we dont want to do any additional actions (e.g. rotating for s-groups)
+      if (isAddingFunctionalGroup) return true
+      ;[action, pasteItems] = fromTemplateOnCanvas(
+        restruct,
+        this.template,
+        targetPos,
+        angle
+      )
+    } else if (ci?.map === 'atoms') {
       ;[action, pasteItems] = fromTemplateOnAtom(
         restruct,
         this.template,

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -344,8 +344,10 @@ class TemplateTool {
 
     if (!ci) {
       const isAddingFunctionalGroup = this.template?.molecule?.sgroups.size
-      // skip, b/c we dont want to do any additional actions (e.g. rotating for s-groups)
-      if (isAddingFunctionalGroup) return true
+      if (isAddingFunctionalGroup) {
+        // skip, b/c we dont want to do any additional actions (e.g. rotating for s-groups)
+        return true
+      }
       ;[action, pasteItems] = fromTemplateOnCanvas(
         restruct,
         this.template,


### PR DESCRIPTION
Closes #2227 