### PR TITLE
Backmerge: #2264: Template menu tab and content differs

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -257,7 +257,10 @@ const TemplateDialog: FC<Props> = (props) => {
         />
       </Tabs>
       <div className={classes.tabsContent}>
-        <TabPanel value={tab} index={TemplateTabs.TemplateLibrary}>
+        <TabPanel
+          value={thisInitialTab !== null ? initialTab : tab}
+          index={TemplateTabs.TemplateLibrary}
+        >
           <div>
             {Object.keys(filteredTemplateLib).length ? (
               Object.keys(filteredTemplateLib).map((groupName) => {


### PR DESCRIPTION
Hotfix for https://github.com/epam/ketcher/issues/2241
Resolves #2264 