### PR TITLE
Backmerge: #1953 The bond between two Functional Group abbreviations disappears

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -67,8 +67,7 @@ class ReBond extends ReObject {
       FunctionalGroup.isBondInContractedFunctionalGroup(
         bond,
         sgroups,
-        functionalGroups,
-        true
+        functionalGroups
       )
     ) {
       return null
@@ -89,8 +88,7 @@ class ReBond extends ReObject {
       FunctionalGroup.isBondInContractedFunctionalGroup(
         bond,
         sgroups,
-        functionalGroups,
-        true
+        functionalGroups
       )
     ) {
       return null
@@ -109,15 +107,13 @@ class ReBond extends ReObject {
     const bond = restruct.molecule.bonds.get(bid)
     const sgroups = restruct.molecule.sgroups
     const functionalGroups = restruct.molecule.functionalGroups
-    const sgroupsIds = struct.getGroupsIdsFromBondId(bid)
     if (
+      bond &&
       FunctionalGroup.isBondInContractedFunctionalGroup(
         bond,
         sgroups,
-        functionalGroups,
-        false
-      ) &&
-      sgroupsIds.length < 2
+        functionalGroups
+      )
     ) {
       return
     }

--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
+import { ReSGroup } from 'application/render'
 import assert from 'assert'
 import { FunctionalGroupsProvider } from '../helpers'
+import { Bond } from './bond'
 import { Pool } from './pool'
 import { SGroup } from './sgroup'
 import { Struct } from './struct'
@@ -259,36 +261,23 @@ export class FunctionalGroup {
   }
 
   static isBondInContractedFunctionalGroup(
-    bond,
-    sgroups,
-    functionalGroups,
-    sgroupsFromReStruct: boolean
-  ): boolean {
-    const contractedFunctionalGroupsAtoms: number[] = []
-    if (sgroupsFromReStruct) {
-      sgroups.forEach((sg) => {
-        if (
-          FunctionalGroup.isContractedFunctionalGroup(
-            sg.item.id,
-            functionalGroups
-          )
-        ) {
-          contractedFunctionalGroupsAtoms.push(...sg.item.atoms)
-        }
-      })
-    } else {
-      sgroups.forEach((sg) => {
-        if (
-          FunctionalGroup.isContractedFunctionalGroup(sg.id, functionalGroups)
-        ) {
-          contractedFunctionalGroupsAtoms.push(...sg.atoms)
-        }
-      })
-    }
-    return (
-      contractedFunctionalGroupsAtoms.includes(bond.begin) &&
-      contractedFunctionalGroupsAtoms.includes(bond.end)
-    )
+    bond: Bond,
+    sGroups: Map<number, ReSGroup> | Pool<SGroup>,
+    functionalGroups: Pool<FunctionalGroup>
+  ) {
+    return [...sGroups.values()].some((sGroup) => {
+      const sGroupId = 'item' in sGroup ? sGroup.item.id : sGroup.id
+      const atomsInSGroup = 'item' in sGroup ? sGroup.item.atoms : sGroup.atoms
+      const isContracted = FunctionalGroup.isContractedFunctionalGroup(
+        sGroupId,
+        functionalGroups
+      )
+      return (
+        isContracted &&
+        atomsInSGroup.includes(bond.begin) &&
+        atomsInSGroup.includes(bond.end)
+      )
+    })
   }
 
   static isContractedFunctionalGroup(sgroupId, functionalGroups): boolean {

--- a/packages/ketcher-react/src/script/editor/shared/closest.js
+++ b/packages/ketcher-react/src/script/editor/shared/closest.js
@@ -181,8 +181,7 @@ function findClosestBond(restruct, pos, skip, minDist, scale) {
       FunctionalGroup.isBondInContractedFunctionalGroup(
         bond.b,
         sGroups,
-        functionalGroups,
-        true
+        functionalGroups
       )
     )
       return null
@@ -202,8 +201,7 @@ function findClosestBond(restruct, pos, skip, minDist, scale) {
       FunctionalGroup.isBondInContractedFunctionalGroup(
         bond.b,
         sGroups,
-        functionalGroups,
-        true
+        functionalGroups
       )
     )
       return null

--- a/packages/ketcher-react/src/script/editor/tool/eraser.ts
+++ b/packages/ketcher-react/src/script/editor/tool/eraser.ts
@@ -154,8 +154,7 @@ class EraserTool {
           !FunctionalGroup.isBondInContractedFunctionalGroup(
             bondFromStruct,
             sgroups,
-            functionalGroups,
-            true
+            functionalGroups
           )
         ) {
           bondsResult.push(bondId)
@@ -269,8 +268,7 @@ class EraserTool {
         !FunctionalGroup.isBondInContractedFunctionalGroup(
           bondFromStruct,
           sgroups,
-          functionalGroups,
-          true
+          functionalGroups
         )
       ) {
         bondResult.push(bondId)

--- a/packages/ketcher-react/src/script/editor/tool/helper/locate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/locate.ts
@@ -42,8 +42,7 @@ function getElementsInRectangle(restruct, p0, p1) {
       !FunctionalGroup.isBondInContractedFunctionalGroup(
         bond.b,
         sGroups,
-        functionalGroups,
-        true
+        functionalGroups
       )
     ) {
       bondList.push(bid)
@@ -177,8 +176,7 @@ function getElementsInPolygon(restruct, rr) {
       !FunctionalGroup.isBondInContractedFunctionalGroup(
         bond.b,
         sGroups,
-        functionalGroups,
-        true
+        functionalGroups
       )
     ) {
       bondList.push(bid)

--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -318,13 +318,12 @@ class SelectTool {
       )
       const bondFromStruct = bondId !== null && struct.bonds.get(bondId)?.b
       if (
-        bondId !== null &&
+        bondFromStruct &&
         !FunctionalGroup.isBondInContractedFunctionalGroup(
           // TODO: examine if this code is really needed, seems like its a hack
           bondFromStruct,
           sgroups,
-          functionalGroups,
-          true
+          functionalGroups
         )
       )
         bondResult.push(bondId)

--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -189,8 +189,7 @@ class SGroupTool {
         !FunctionalGroup.isBondInContractedFunctionalGroup(
           bondFromStruct,
           sgroups,
-          functionalGroups,
-          true
+          functionalGroups
         )
       ) {
         bondResult.push(bondId)


### PR DESCRIPTION
Resolves: #1953 


