### PR TITLE
#2216 S-Group pop-up tool tip is positioned so that it overlaps structure

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -18,7 +18,7 @@ import { useState, useEffect, useRef, FC } from 'react'
 import { Scale, Vec2, Render, Struct, SGroup } from 'ketcher-core'
 
 import StructRender from '../../../component/structrender'
-import WrapperPositionedRelativeToRectangle from './WrapperPositionedRelativeToRectangle'
+import SGroupDataRender from './SGroupDataRender'
 import { calculateScrollOffsetX, calculateScrollOffsetY } from './helpers'
 import { functionGroupInfoSelector } from '../../../state/functionalGroups/selectors'
 import { connect } from 'react-redux'
@@ -145,7 +145,7 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
       />
     </div>
   ) : (
-    <WrapperPositionedRelativeToRectangle
+    <SGroupDataRender
       clientX={clientX}
       clientY={clientY}
       render={render}

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -18,6 +18,8 @@ import { useState, useEffect, useRef, FC } from 'react'
 import { Scale, Vec2, Render, Struct, SGroup } from 'ketcher-core'
 
 import StructRender from '../../../component/structrender'
+import WrapperPositionedRelativeToRectangle from './WrapperPositionedRelativeToRectangle'
+import { calculateScrollOffsetX, calculateScrollOffsetY } from './helpers'
 import { functionGroupInfoSelector } from '../../../state/functionalGroups/selectors'
 import { connect } from 'react-redux'
 import clsx from 'clsx'
@@ -71,17 +73,12 @@ function getPanelPosition(
       y = panelPosition.y - height - HOVER_PANEL_PADDING * 3
     }
     // adjust position to current scroll offset
-    const scrollOffsetX =
-      render?.options.offset?.x - render?.clientArea?.scrollLeft
-    const scrollOffsetY =
-      render?.options?.offset?.y - render?.clientArea?.scrollTop
-    x += scrollOffsetX
-    y += scrollOffsetY
+    x += calculateScrollOffsetX(render)
+    y += calculateScrollOffsetY(render)
   }
 
   return [new Vec2(x, y), new Vec2(width, height)]
 }
-
 interface InfoPanelProps {
   clientX: number | undefined
   clientY: number | undefined
@@ -148,15 +145,15 @@ const InfoPanel: FC<InfoPanelProps> = (props) => {
       />
     </div>
   ) : (
-    <div
-      style={{
-        left: x + 'px',
-        top: y + 'px'
-      }}
-      className={clsx(classes.infoPanel, className)}
-    >
-      {sGroupData}
-    </div>
+    <WrapperPositionedRelativeToRectangle
+      clientX={clientX}
+      clientY={clientY}
+      render={render}
+      groupStruct={groupStruct}
+      sGroup={sGroup}
+      sGroupData={sGroupData}
+      className={className}
+    />
   )
 }
 

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
@@ -25,42 +25,42 @@ function getPanelPositionRelativeToRect(
   const viewportRightLimit =
     render?.clientArea?.clientWidth - BAR_PANEL_SIZE - width
 
-  // We need to remove first element of the path. Example of the path => ['M', 23, 43]
+  // [['M', 23, 43], ['L', 23, 24]] we should remove first elements => [[23,43], [23,24]]
   const rectCoords: Array<Array<number>> = sGroup.hovering.attrs?.path?.map(
     (line) => line.slice(1)
   )
 
-  const [mLeftSide, mBottomSide, mRightSide, mTopSide] =
+  const [middleLeftSide, middleBottomSide, middleRightSide, middleTopSide] =
     calculateMiddleCoordsForRect(rectCoords)
 
   if (
-    !mBottomSide?.x ||
-    !mBottomSide?.y ||
-    !mTopSide?.y ||
-    !mLeftSide?.x ||
-    !mLeftSide?.y ||
-    !mRightSide?.x ||
-    !mRightSide?.y
+    !middleBottomSide?.x ||
+    !middleBottomSide?.y ||
+    !middleTopSide?.y ||
+    !middleLeftSide?.x ||
+    !middleLeftSide?.y ||
+    !middleRightSide?.x ||
+    !middleRightSide?.y
   ) {
     return null
   }
 
   // Default position for panel is in the bottom;
-  let x = mBottomSide.x - width / 2
-  let y = mBottomSide.y
+  let x = middleBottomSide.x - width / 2
+  let y = middleBottomSide.y
 
   if (clientY > viewportBottomLimit) {
-    y = mTopSide.y - height
+    y = middleTopSide.y - height
   }
 
   if (clientX > viewportRightLimit) {
-    x = mLeftSide.x - width
-    y = mLeftSide.y - height / 2
+    x = middleLeftSide.x - width
+    y = middleLeftSide.y - height / 2
   }
 
   if (clientX < viewportLeftLimit) {
-    x = mRightSide.x
-    y = mRightSide.y - height / 2
+    x = middleRightSide.x
+    y = middleRightSide.y - height / 2
   }
 
   x += calculateScrollOffsetX(render)
@@ -69,7 +69,7 @@ function getPanelPositionRelativeToRect(
   return new Vec2(x, y)
 }
 
-interface WrapperPositionedRelativeToRectangleProps {
+interface SGroupDataRenderProps {
   clientX: number
   clientY: number
   render: Render
@@ -79,9 +79,7 @@ interface WrapperPositionedRelativeToRectangleProps {
   className?: string
 }
 
-const WrapperPositionedRelativeToRectangle: FC<
-  WrapperPositionedRelativeToRectangleProps
-> = (props) => {
+const SGroupDataRender: FC<SGroupDataRenderProps> = (props) => {
   const { clientX, clientY, render, className, sGroup, sGroupData } = props
   const [wrapperHeight, setWrapperHeight] = useState(0)
   const [wrapperWidth, setWrapperWidth] = useState(0)
@@ -114,4 +112,4 @@ const WrapperPositionedRelativeToRectangle: FC<
   ) : null
 }
 
-export default WrapperPositionedRelativeToRectangle
+export default SGroupDataRender

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/WrapperPositionedRelativeToRectangle.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/WrapperPositionedRelativeToRectangle.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState, FC } from 'react'
+import { Vec2, Render, SGroup, Struct } from 'ketcher-core'
+import clsx from 'clsx'
+import classes from './InfoPanel.module.less'
+import {
+  calculateMiddleCoordsForRect,
+  calculateScrollOffsetX,
+  calculateScrollOffsetY
+} from './helpers'
+
+/* eslint-disable-line camelcase */
+const BAR_PANEl_SIZE = 32
+const LEFT_PADDING_MULTIPLIER = 3
+
+function getPanelPositionRelativeToRect(
+  clientX: number,
+  clientY: number,
+  sGroup: SGroup,
+  render: Render,
+  width: number,
+  height: number
+): Array<Vec2> {
+  const viewportLeftLimit = BAR_PANEl_SIZE * LEFT_PADDING_MULTIPLIER + width
+  const viewportBottomLimit =
+    render?.clientArea?.clientHeight - BAR_PANEl_SIZE - height
+  const viewportRightLimit =
+    render?.clientArea?.clientWidth - BAR_PANEl_SIZE - width
+
+  // We need to remove first element of the path. Example of the path => ['M', 23, 43]
+  const rectCoords: Array<Array<number>> = sGroup.hovering.attrs?.path?.map(
+    (line) => line.slice(1)
+  )
+
+  const [mLeftSide, mBottomSide, mRightSide, mTopSide] =
+    calculateMiddleCoordsForRect(rectCoords)
+
+  // Default position for panel is in the bottom;
+  let x = mBottomSide.x - width / 2
+  let y = mBottomSide.y
+
+  if (clientY > viewportBottomLimit) {
+    y = mTopSide.y - height
+  }
+
+  if (clientX > viewportRightLimit) {
+    x = mLeftSide.x - width
+    y = mLeftSide.y - height / 2
+  }
+
+  if (clientX < viewportLeftLimit) {
+    x = mRightSide.x
+    y = mRightSide.y - height / 2
+  }
+
+  x += calculateScrollOffsetX(render)
+  y += calculateScrollOffsetY(render)
+
+  return [new Vec2(x, y)]
+}
+
+interface WrapperPositionedRelativeToRectangleProps {
+  clientX: number
+  clientY: number
+  render: Render
+  groupStruct: Struct
+  sGroup: SGroup
+  sGroupData: string | null
+  className?: string
+}
+
+const WrapperPositionedRelativeToRectangle: FC<
+  WrapperPositionedRelativeToRectangleProps
+> = (props) => {
+  const { clientX, clientY, render, className, sGroup, sGroupData } = props
+  const [wrapperHeight, setWrapperHeight] = useState(0)
+  const [wrapperWidth, setWrapperWidth] = useState(0)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      setWrapperHeight(wrapperRef.current.clientHeight)
+      setWrapperWidth(wrapperRef.current.clientWidth)
+    }
+  })
+
+  const [coords] = getPanelPositionRelativeToRect(
+    clientX,
+    clientY,
+    sGroup,
+    render,
+    wrapperWidth,
+    wrapperHeight
+  )
+
+  const { x, y } = coords
+
+  const style = { left: x + 'px', top: y + 'px' }
+
+  return (
+    <div
+      ref={wrapperRef}
+      style={style}
+      className={clsx(classes.infoPanel, className)}
+    >
+      {sGroupData}
+    </div>
+  )
+}
+
+export default WrapperPositionedRelativeToRectangle

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/WrapperPositionedRelativeToRectangle.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/WrapperPositionedRelativeToRectangle.tsx
@@ -19,7 +19,7 @@ function getPanelPositionRelativeToRect(
   render: Render,
   width: number,
   height: number
-): Array<Vec2> {
+): Vec2 | null {
   const viewportLeftLimit = BAR_PANEl_SIZE * LEFT_PADDING_MULTIPLIER + width
   const viewportBottomLimit =
     render?.clientArea?.clientHeight - BAR_PANEl_SIZE - height
@@ -33,6 +33,18 @@ function getPanelPositionRelativeToRect(
 
   const [mLeftSide, mBottomSide, mRightSide, mTopSide] =
     calculateMiddleCoordsForRect(rectCoords)
+
+  if (
+    !mBottomSide?.x ||
+    !mBottomSide?.y ||
+    !mTopSide?.y ||
+    !mLeftSide?.x ||
+    !mLeftSide?.y ||
+    !mRightSide?.x ||
+    !mRightSide?.y
+  ) {
+    return null
+  }
 
   // Default position for panel is in the bottom;
   let x = mBottomSide.x - width / 2
@@ -55,7 +67,7 @@ function getPanelPositionRelativeToRect(
   x += calculateScrollOffsetX(render)
   y += calculateScrollOffsetY(render)
 
-  return [new Vec2(x, y)]
+  return new Vec2(x, y)
 }
 
 interface WrapperPositionedRelativeToRectangleProps {
@@ -83,7 +95,7 @@ const WrapperPositionedRelativeToRectangle: FC<
     }
   })
 
-  const [coords] = getPanelPositionRelativeToRect(
+  const panelCoordinate = getPanelPositionRelativeToRect(
     clientX,
     clientY,
     sGroup,
@@ -92,19 +104,15 @@ const WrapperPositionedRelativeToRectangle: FC<
     wrapperHeight
   )
 
-  const { x, y } = coords
-
-  const style = { left: x + 'px', top: y + 'px' }
-
-  return (
+  return panelCoordinate ? (
     <div
       ref={wrapperRef}
-      style={style}
+      style={{ left: panelCoordinate.x + 'px', top: panelCoordinate.y + 'px' }}
       className={clsx(classes.infoPanel, className)}
     >
       {sGroupData}
     </div>
-  )
+  ) : null
 }
 
 export default WrapperPositionedRelativeToRectangle

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/WrapperPositionedRelativeToRectangle.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/WrapperPositionedRelativeToRectangle.tsx
@@ -8,8 +8,7 @@ import {
   calculateScrollOffsetY
 } from './helpers'
 
-/* eslint-disable-line camelcase */
-const BAR_PANEl_SIZE = 32
+const BAR_PANEL_SIZE = 32
 const LEFT_PADDING_MULTIPLIER = 3
 
 function getPanelPositionRelativeToRect(
@@ -20,11 +19,11 @@ function getPanelPositionRelativeToRect(
   width: number,
   height: number
 ): Vec2 | null {
-  const viewportLeftLimit = BAR_PANEl_SIZE * LEFT_PADDING_MULTIPLIER + width
+  const viewportLeftLimit = BAR_PANEL_SIZE * LEFT_PADDING_MULTIPLIER + width
   const viewportBottomLimit =
-    render?.clientArea?.clientHeight - BAR_PANEl_SIZE - height
+    render?.clientArea?.clientHeight - BAR_PANEL_SIZE - height
   const viewportRightLimit =
-    render?.clientArea?.clientWidth - BAR_PANEl_SIZE - width
+    render?.clientArea?.clientWidth - BAR_PANEL_SIZE - width
 
   // We need to remove first element of the path. Example of the path => ['M', 23, 43]
   const rectCoords: Array<Array<number>> = sGroup.hovering.attrs?.path?.map(

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/helpers.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/helpers.ts
@@ -1,23 +1,27 @@
-import { Render } from 'ketcher-core'
+import { Render, Point } from 'ketcher-core'
 
 const X_COORD_INDEX = 0
 const Y_COORD_INDEX = 1
 
 export const calculateMiddleCoordsForRect = (
   rectCoords: Array<Array<number>>
-): Array<{ x: number; y: number }> | [] => {
+): Array<Point> | [] => {
   if (!rectCoords) {
     return []
   }
 
-  const middleCoordForRectangleSides: Array<{ x: number; y: number }> = []
+  const middleCoordForRectangleSides: Array<Point> = []
 
-  const previousPoint: { x: number; y: number } = {
+  const previousPoint: Point = {
     x: rectCoords[0][X_COORD_INDEX],
     y: rectCoords[0][Y_COORD_INDEX]
   }
 
   for (let i = 1; i < rectCoords.length; i++) {
+    if (!previousPoint.x || !previousPoint.y) {
+      return []
+    }
+
     const middleX = (previousPoint.x + rectCoords[i][X_COORD_INDEX]) / 2
     const middleY = (previousPoint.y + rectCoords[i][Y_COORD_INDEX]) / 2
     middleCoordForRectangleSides.push({ x: middleX, y: middleY })

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/helpers.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/helpers.ts
@@ -1,0 +1,37 @@
+import { Render } from 'ketcher-core'
+
+const X_COORD_INDEX = 0
+const Y_COORD_INDEX = 1
+
+export const calculateMiddleCoordsForRect = (
+  rectCoords: Array<Array<number>>
+): Array<{ x: number; y: number }> | [] => {
+  if (!rectCoords) {
+    return []
+  }
+
+  const middleCoordForRectangleSides: Array<{ x: number; y: number }> = []
+
+  const previousPoint: { x: number; y: number } = {
+    x: rectCoords[0][X_COORD_INDEX],
+    y: rectCoords[0][Y_COORD_INDEX]
+  }
+
+  for (let i = 1; i < rectCoords.length; i++) {
+    const middleX = (previousPoint.x + rectCoords[i][X_COORD_INDEX]) / 2
+    const middleY = (previousPoint.y + rectCoords[i][Y_COORD_INDEX]) / 2
+    middleCoordForRectangleSides.push({ x: middleX, y: middleY })
+    previousPoint.x = rectCoords[i][X_COORD_INDEX]
+    previousPoint.y = rectCoords[i][Y_COORD_INDEX]
+  }
+
+  return middleCoordForRectangleSides
+}
+
+export const calculateScrollOffsetX = (render: Render) => {
+  return render?.options.offset?.x - render?.clientArea?.scrollLeft
+}
+
+export const calculateScrollOffsetY = (render: Render) => {
+  return render?.options?.offset?.y - render?.clientArea?.scrollTop
+}


### PR DESCRIPTION
**What was done?**

For now it calculates according to the green rectangle that appears when user hovering over the element. Function calculateMiddleCoordsForRect calculate middle coord for each side of the rect. After that panel appears relativly to the middle point of side.

Panel info is always in the bottom if it is center of the page.

![image](https://user-images.githubusercontent.com/29872339/222155728-6790e7da-efc1-407a-b497-2d8292594ee2.png)
![image](https://user-images.githubusercontent.com/29872339/222155767-f4e999d2-f0b8-4714-bb0a-0872d61476b6.png)

Close to borders
![image](https://user-images.githubusercontent.com/29872339/222156009-c01f629e-f69a-42ea-a38f-61a879574a0d.png)
![image](https://user-images.githubusercontent.com/29872339/222156159-8af937a9-a7cd-48e3-a6dc-571794ac78b1.png)
![image](https://user-images.githubusercontent.com/29872339/222156261-0b691305-b3fc-4985-ba81-f7b6f38ea8b2.png)




- created WrapperPositionedRelativeToRectangle component.
- moved calculateScrollOffsetX , calculateScrollOffsetY into helpers.ts to reduce code duplication
- created calculateMiddleCoordsForRect accepts array of arrays [[1,2], [3,4], [3,4]] => [{ x: 2, y: 3 }, { x: 3, y: 4}]
- added wrapperRef on div to get dinamically changed width / height of the element

Please, review and add to the q