### PR TITLE
Backmerge: #2330 – Atom editing via right click menu not applied (#2333)

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -367,7 +367,7 @@ class SelectTool {
       const atoms = getSelectedAtoms(selection, molecule)
       const changeAtomPromise = editor.event.elementEdit.dispatch(atoms)
       updateSelectedAtoms({
-        selection,
+        atoms: selection?.atoms || [],
         editor,
         changeAtomPromise
       })

--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -102,7 +102,7 @@ function handleAtomPropsDialog({
     const changeAtomPromise = editor.event.elementEdit.dispatch(atoms)
 
     updateSelectedAtoms({
-      selection,
+      atoms: selection.atoms || [],
       editor,
       changeAtomPromise
     })

--- a/packages/ketcher-react/src/script/ui/state/modal/atoms.ts
+++ b/packages/ketcher-react/src/script/ui/state/modal/atoms.ts
@@ -66,17 +66,24 @@ export function updateOnlyChangedProperties(atomId, userChangedAtom, molecule) {
   )
 }
 
-export function updateSelectedAtoms({ selection, changeAtomPromise, editor }) {
+export function updateSelectedAtoms({
+  atoms,
+  changeAtomPromise,
+  editor
+}: {
+  atoms: number[]
+  editor
+  changeAtomPromise: Promise<Atom>
+}) {
   const action = new Action()
   const struct = editor.render.ctab
   const { molecule } = struct
-  if (selection?.atoms) {
-    const selectionAtoms = selection.atoms
+  if (atoms) {
     Promise.resolve(changeAtomPromise)
       .then((userChangedAtom) => {
         // TODO: deep compare to not produce dummy, e.g.
         // atom.label != attrs.label || !atom.atomList.equals(attrs.atomList)
-        selectionAtoms.forEach((atomId) => {
+        atoms.forEach((atomId) => {
           const atomWithChangedProperties = updateOnlyChangedProperties(
             atomId,
             userChangedAtom,

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useAtomEdit.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useAtomEdit.ts
@@ -18,7 +18,7 @@ const useAtomEdit = () => {
       const newAtom = editor.event.elementEdit.dispatch(atoms)
 
       updateSelectedAtoms({
-        selection: { atoms },
+        atoms: atomIds,
         changeAtomPromise: newAtom,
         editor
       })


### PR DESCRIPTION
closes #2330