### PR TITLE
#2295 – Atom under mouse cursor does not disappear when cursor crosses bottom and right boundaries of canvas

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -135,7 +135,7 @@ class AtomTool {
     }
   }
 
-  mouseleave() {
+  mouseLeaveClientArea() {
     this.editor.hoverIcon.hide()
   }
 


### PR DESCRIPTION
closes #2295 