### PR TITLE
Backmerge: #2325 – When user hovers cursor with any template selected near the border of the canvas scrollbars appear (#2346)

### DIFF
--- a/packages/ketcher-core/src/application/render/raphaelRender.js
+++ b/packages/ketcher-core/src/application/render/raphaelRender.js
@@ -190,7 +190,13 @@ Render.prototype.setMolecule = function (ctab) {
   this.update(false)
 }
 
-Render.prototype.update = function (force = false, viewSz = null) {
+Render.prototype.update = function (
+  force = false,
+  viewSz = null,
+  options = {
+    extendCanvas: true
+  }
+) {
   // eslint-disable-line max-statements
   viewSz =
     viewSz ||
@@ -226,12 +232,15 @@ Render.prototype.update = function (force = false, viewSz = null) {
       const sz = cb.sz().floor()
       const delta = this.oldCb.p0.sub(cb.p0).ceil()
       this.oldBb = bb
-      if (!this.sz || sz.x !== this.sz.x || sz.y !== this.sz.y) {
+      if (
+        (!this.sz || sz.x !== this.sz.x || sz.y !== this.sz.y) &&
+        options.extendCanvas
+      ) {
         this.setPaperSize(sz)
       }
 
       this.options.offset = this.options.offset || new Vec2()
-      if (delta.x !== 0 || delta.y !== 0) {
+      if ((delta.x !== 0 || delta.y !== 0) && options.extendCanvas) {
         this.setOffset(this.options.offset.add(delta))
         this.ctab.translate(delta)
       }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -394,9 +394,13 @@ class Editor implements KetcherEditor {
     showFunctionalGroupsTooltip(this)
   }
 
-  update(action: Action | true, ignoreHistory?: boolean) {
+  update(
+    action: Action | true,
+    ignoreHistory?: boolean,
+    options = { extendCanvas: true }
+  ) {
     if (action === true) {
-      this.render.update(true) // force
+      this.render.update(true, null, options) // force
     } else {
       if (!ignoreHistory && !action.isDummy()) {
         this.historyStack.splice(this.historyPtr, HISTORY_SIZE + 1, action)
@@ -406,7 +410,7 @@ class Editor implements KetcherEditor {
         this.historyPtr = this.historyStack.length
         this.event.change.dispatch(action) // TODO: stoppable here
       }
-      this.render.update()
+      this.render.update(false, null, options)
     }
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -163,7 +163,7 @@ class PasteTool {
         this.editor.render.page2obj(event)
       )
       this.action = action
-      this.editor.update(this.action, true)
+      this.editor.update(this.action, true, { extendCanvas: false })
 
       this.mergeItems = getMergeItems(this.editor, pasteItems)
       this.editor.hover(getHoverToFuse(this.mergeItems))

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -210,7 +210,7 @@ class TemplateTool {
       )
 
       this.followAction = followAction
-      this.editor.update(followAction, true)
+      this.editor.update(followAction, true, { extendCanvas: false })
 
       if (this.mode === 'fg') {
         const skip = getIgnoredGroupItem(this.editor.struct(), pasteItems)


### PR DESCRIPTION
closes #2325
closes #2114