### PR TITLE
Backmerge: #2353 – CTRL+SHIFT+0 hotkey not working for 'Zoom 100%' (#2364)

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/zoom.js
+++ b/packages/ketcher-react/src/script/ui/action/zoom.js
@@ -24,7 +24,7 @@ export const zoomList = [
 
 export default {
   zoom: {
-    shortcut: ['Ctrl+Shift+0'],
+    shortcut: ['Mod+Shift+0'],
     selected: (editor) => editor.zoom(),
     action: (editor) => editor.zoom(1),
     hidden: (options) => isHidden(options, 'zoom')


### PR DESCRIPTION
closes #2353 