### PR TITLE
Backmerge: #2368 When you select Stereo flag label and make right click application crashes

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -35,7 +35,11 @@ export function atomGetPos(restruct, id) {
   return restruct.molecule.atoms.get(id).pp
 }
 
-export function findStereoAtoms(struct, aids) {
+export function findStereoAtoms(struct, aids: number[] | undefined): number[] {
+  if (!aids) {
+    return [] as number[]
+  }
+
   return aids.filter((aid) => struct.atoms.get(aid).stereoLabel !== null)
 }
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -61,6 +61,10 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
 
       let showProps: ContextMenuShowProps = null
 
+      if (selection && !selection.bonds && !selection.atoms) {
+        return
+      }
+
       if (selection) {
         if (functionalGroupsInSelection.size > 0) {
           const functionalGroups = Array.from(

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useAtomStereo.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useAtomStereo.ts
@@ -35,7 +35,7 @@ const useAtomStereo = () => {
   const disabled = useCallback(
     ({ props }: ItemEventParams) => {
       const editor = getKetcherInstance().editor as Editor
-      const stereoAtomIds: undefined | number[] = findStereoAtoms(
+      const stereoAtomIds: number[] = findStereoAtoms(
         editor.struct(),
         props?.atomIds
       )


### PR DESCRIPTION
**Ticket**
https://github.com/epam/ketcher/issues/2368

**What was done?**

- changed logic findStereoAtoms function to prevent crash of the application
- prevent to show ContextMenu in case if we do not have atoms and bonds

Please, review and add to the q