### PR TITLE
Backmerge: #2326 - Functional Groups forms a bond instead of a replacement (#2363)

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -470,7 +470,7 @@ class TemplateTool {
           this.template,
           ci.id,
           angle,
-          this.mode === 'fg'
+          false
         )
         if (functionalGroupRemoveAction) {
           action = functionalGroupRemoveAction.mergeWith(action)


### PR DESCRIPTION
Closes #2326 