### PR TITLE
#2267- Using Template Tool, Salts and Solvents should replace Atoms, Functional Groups, and Salts and Solvents & #1994 - Salts and Solvents: Edit notification appears instead of replacing new Salt or Solvent

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -32,6 +32,10 @@ import { Action } from './action'
 import { Vec2 } from 'domain/entities'
 import { fromSgroupAddition } from './sgroup'
 
+export type PasteItems = {
+  atoms: number[]
+  bonds: number[]
+}
 export function fromPaste(restruct, pstruct, point, angle = 0) {
   const xy0 = getStructCenter(pstruct)
   const offset = Vec2.diff(point, xy0)
@@ -41,7 +45,7 @@ export function fromPaste(restruct, pstruct, point, angle = 0) {
   const aidMap = new Map()
   const fridMap = new Map()
 
-  const pasteItems: any = {
+  const pasteItems: PasteItems = {
     // only atoms and bonds now
     atoms: [],
     bonds: []
@@ -158,7 +162,7 @@ export function fromPaste(restruct, pstruct, point, angle = 0) {
   })
 
   action.operations.reverse()
-  return [action, pasteItems]
+  return [action, pasteItems] as const
 }
 
 function getStructCenter(struct) {

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -37,7 +37,7 @@ export function fromTemplateOnCanvas(restruct, template, pos, angle) {
 
   action.addOp(new CalcImplicitH(pasteItems.atoms).perform(restruct))
 
-  return [action, pasteItems]
+  return [action, pasteItems] as const
 }
 
 function extraBondAction(restruct, aid, angle) {

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -39,6 +39,38 @@ import { getMergeItems } from './helper/getMergeItems'
 
 type MergeItems = Record<string, Map<unknown, unknown>> | null
 
+/**
+ * @prop `atomid`: Attachment atom ID
+ * @prop `bondid`: Attachment bond ID
+ * @prop `group`: For the Complex Template, it's folder name.
+ *                For the Functional Group, the value is `"Functional Groups"`.
+ *                For the Salt or Solvent, the value is `"Salts and Solvents"`
+ * @prop `prerender`: Only for Complex Templates
+ */
+type TemplateToolOptionProps = {
+  atomid?: string
+  bondid?: string
+  group: string
+  prerender?: string
+  name?: string // deprecated
+  abbreviation?: string // deprecated
+}
+
+/**
+ * @prop `props`: Simple Templates don't have it
+ */
+type TemplateToolOptions = {
+  struct: Struct
+  props?: TemplateToolOptionProps
+}
+
+/**
+ * Template Catagories:
+ * 1. Simple Templates, e.g. Benzene
+ * 2. Complex Templates (which in Template Library), e.g. alpha-D-Allopyranose
+ * 3. Functional Groups, e.g. Bn
+ * 4. Salts and Solvents, e.g formic acid
+ */
 class TemplateTool {
   editor: Editor
   mode: any
@@ -50,36 +82,40 @@ class TemplateTool {
   isSaltOrSolvent: boolean
   followAction: any
 
-  constructor(editor, tmpl) {
+  constructor(editor: Editor, options: TemplateToolOptions) {
     this.editor = editor
-    this.mode = getTemplateMode(tmpl)
+    this.mode = getTemplateMode(options)
     this.editor.selection(null)
-    this.isSaltOrSolvent = SGroup.isSaltOrSolvent(tmpl.struct.name)
+    this.isSaltOrSolvent = SGroup.isSaltOrSolvent(options.struct.name)
 
     this.template = {
-      aid: parseInt(tmpl.aid) || 0,
-      bid: parseInt(tmpl.bid) || 0
+      attachmentAtomId: options.props?.atomid
+        ? parseInt(options.props.atomid)
+        : 0,
+      attachmentBondId: options.props?.bondid
+        ? parseInt(options.props.bondid)
+        : 0
     }
 
-    const frag = tmpl.struct
+    const frag = options.struct
     frag.rescale()
 
     const xy0 = new Vec2()
     frag.atoms.forEach((atom) => {
-      xy0.add_(atom.pp) // eslint-disable-line no-underscore-dangle
+      xy0.add_(atom.pp)
     })
 
     this.template.molecule = frag // preloaded struct
     this.findItems = []
     this.template.xy0 = xy0.scaled(1 / (frag.atoms.size || 1)) // template center
 
-    const atom = frag.atoms.get(this.template.aid)
+    const atom = frag.atoms.get(this.template.attachmentAtomId)
     if (atom) {
       this.template.angle0 = utils.calcAngle(atom.pp, this.template.xy0) // center tilt
       this.findItems.push('atoms')
     }
 
-    const bond = frag.bonds.get(this.template.bid)
+    const bond = frag.bonds.get(this.template.attachmentBondId)
     if (bond && this.mode !== 'fg') {
       // template location sign against attachment bond
       this.template.sign = getSign(frag, bond, this.template.xy0)
@@ -93,19 +129,98 @@ class TemplateTool {
   }
 
   mousedown(event) {
-    if (this.followAction) {
-      this.followAction.perform(this.editor.render.ctab)
-      delete this.followAction
+    this.undoFollowAction()
+    this.mouseDownFunctionalGroups(event)
+
+    const dragCtxItem = getDragCtxItem(
+      this.editor,
+      event,
+      this.mode,
+      this.mergeItems,
+      this.findItems
+    )
+
+    this.dragCtx = {
+      xy0: this.editor.render.page2obj(event),
+      item: dragCtxItem
     }
 
+    this.editor.hover(null)
+
+    // const dragCtx = this.dragCtx
+    // const ci = dragCtx.item
+
+    // if (!ci) {
+    //   //  ci.type == 'Canvas'
+    //   delete dragCtx.item
+    //   return
+    // }
+
+    if (this.mode !== 'fg' && dragCtxItem?.map === 'bonds') {
+      this.mouseDownBond()
+    }
+  }
+
+  private mouseDownBond() {
+    const closestItem = this.dragCtx.item
+    const struct = this.editor.struct()
+
+    // calculate fragment center
+    const xy0 = new Vec2()
+    const bond = struct.bonds.get(closestItem.id)
+    const frid = struct.atoms.get(bond?.begin as number)?.fragment
+    const frIds = struct.getFragmentIds(frid as number)
+    let count = 0
+
+    let loop = struct.halfBonds.get(bond?.hb1 as number)?.loop
+
+    if (loop && loop < 0) {
+      loop = struct.halfBonds.get(bond?.hb2 as number)?.loop
+    }
+
+    if (loop && loop >= 0) {
+      const loopHbs = struct.loops.get(loop)?.hbs
+      loopHbs?.forEach((hb) => {
+        const halfBondBegin = struct.halfBonds.get(hb)?.begin
+
+        if (halfBondBegin) {
+          const hbbAtom = struct.atoms.get(halfBondBegin)
+
+          if (hbbAtom) {
+            xy0.add_(hbbAtom.pp) // eslint-disable-line no-underscore-dangle, max-len
+            count++
+          }
+        }
+      })
+    } else {
+      frIds.forEach((id) => {
+        const atomById = struct.atoms.get(id)
+
+        if (atomById) {
+          xy0.add_(atomById.pp) // eslint-disable-line no-underscore-dangle
+          count++
+        }
+      })
+    }
+
+    this.dragCtx.v0 = xy0.scaled(1 / count)
+
+    const sign = getSign(struct, bond, this.dragCtx.v0)
+
+    // calculate default template flip
+    this.dragCtx.sign1 = sign || 1
+    this.dragCtx.sign2 = this.template.sign
+  }
+
+  private mouseDownFunctionalGroups(event) {
     const closestItem = this.editor.findItem(event, [
       'atoms',
       'bonds',
       'sgroups',
       'functionalGroups'
     ])
-    const ctab = this.editor.render.ctab
-    const struct = ctab.molecule
+
+    const struct = this.editor.struct()
 
     if (struct.functionalGroups.size) {
       this.targetGroupsIds = getGroupIdsFromItemArrays(struct, {
@@ -123,159 +238,130 @@ class TemplateTool {
         this.targetGroupsIds.push(closestItem.id)
       }
     }
-
-    this.editor.hover(null)
-
-    const dragCtxItem = getDragCtxItem(
-      this.editor,
-      event,
-      this.mode,
-      this.mergeItems,
-      this.findItems
-    )
-
-    this.dragCtx = {
-      xy0: this.editor.render.page2obj(event),
-      item: dragCtxItem
-    }
-
-    const dragCtx = this.dragCtx
-    const ci = dragCtx.item
-
-    if (!ci) {
-      //  ci.type == 'Canvas'
-      delete dragCtx.item
-      return
-    }
-
-    if (ci.map === 'bonds' && this.mode !== 'fg') {
-      // calculate fragment center
-      const xy0 = new Vec2()
-      const bond = struct.bonds.get(ci.id)
-      const frid = struct.atoms.get(bond?.begin as number)?.fragment
-      const frIds = struct.getFragmentIds(frid as number)
-      let count = 0
-
-      let loop = struct.halfBonds.get(bond?.hb1 as number)?.loop
-
-      if (loop && loop < 0) {
-        loop = struct.halfBonds.get(bond?.hb2 as number)?.loop
-      }
-
-      if (loop && loop >= 0) {
-        const loopHbs = struct.loops.get(loop)?.hbs
-        loopHbs?.forEach((hb) => {
-          const halfBondBegin = struct.halfBonds.get(hb)?.begin
-
-          if (halfBondBegin) {
-            const hbbAtom = struct.atoms.get(halfBondBegin)
-
-            if (hbbAtom) {
-              xy0.add_(hbbAtom.pp) // eslint-disable-line no-underscore-dangle, max-len
-              count++
-            }
-          }
-        })
-      } else {
-        frIds.forEach((id) => {
-          const atomById = struct.atoms.get(id)
-
-          if (atomById) {
-            xy0.add_(atomById.pp) // eslint-disable-line no-underscore-dangle
-            count++
-          }
-        })
-      }
-
-      dragCtx.v0 = xy0.scaled(1 / count)
-
-      const sign = getSign(struct, bond, dragCtx.v0)
-
-      // calculate default template flip
-      dragCtx.sign1 = sign || 1
-      dragCtx.sign2 = this.template.sign
-    }
   }
 
   mousemove(event) {
     if (!this.dragCtx) {
-      if (this.followAction) {
-        this.followAction.perform(this.editor.render.ctab)
-      }
-
-      const [followAction, pasteItems] = fromPaste(
-        this.editor.render.ctab,
-        this.template.molecule,
-        this.editor.render.page2obj(event)
-      )
-
-      this.followAction = followAction
-      this.editor.update(followAction, true, { extendCanvas: false })
-
-      if (this.mode === 'fg') {
-        const skip = getIgnoredGroupItem(this.editor.struct(), pasteItems)
-        const ci = this.editor.findItem(event, this.findItems, skip)
-
-        this.editor.hover(ci ?? null, null, event)
-      } else {
-        this.mergeItems = getMergeItems(this.editor, pasteItems)
-        this.editor.hover(getHoverToFuse(this.mergeItems))
-      }
-
+      this.mouseHover(event)
       return
     }
-
-    const dragCtx = this.dragCtx
 
     if (this.isSaltOrSolvent) {
-      delete dragCtx.item
+      delete this.dragCtx.item
       return
     }
 
-    const ci = dragCtx.item
-    let targetPos: Vec2 | null | undefined = null
-    const eventPos = this.editor.render.page2obj(event)
-    const struct = this.editor.render.ctab.molecule
-
-    /* moving when attached to bond */
-    if (ci && ci.map === 'bonds' && this.mode !== 'fg') {
-      const bond = struct.bonds.get(ci.id)
-      let sign = getSign(struct, bond, eventPos)
-
-      if (dragCtx.sign1 * this.template.sign > 0) {
-        sign = -sign
-      }
-
-      if (sign !== dragCtx.sign2 || !dragCtx.action) {
-        if (dragCtx.action) {
-          dragCtx.action.perform(this.editor.render.ctab)
-        } // undo previous action
-
-        dragCtx.sign2 = sign
-        const [action, pasteItems] = fromTemplateOnBondAction(
-          this.editor.render.ctab,
-          this.template,
-          ci.id,
-          this.editor.event,
-          dragCtx.sign1 * dragCtx.sign2 > 0,
-          false
-        ) as Array<any>
-
-        dragCtx.action = action
-        this.editor.update(dragCtx.action, true)
-
-        dragCtx.mergeItems = getItemsToFuse(this.editor, pasteItems)
-        this.editor.hover(getHoverToFuse(dragCtx.mergeItems))
-      }
+    const ci = this.dragCtx.item
+    if (this.mode !== 'fg' && ci?.map === 'bonds') {
+      this.mouseMoveBond()
       return true
     }
-    /* end */
 
+    const isNothingChanged = this.calculateMouseMovePosition(event)
+    if (isNothingChanged === true) {
+      return true
+    }
+    const positionData = isNothingChanged
+    const [targetPos, extraBond, angle, degrees] = positionData
+
+    // undo previous action
+    if (this.dragCtx.action) {
+      this.dragCtx.action.perform(this.editor.render.ctab)
+    }
+
+    // create new action
+    this.dragCtx.angle = degrees
+    let action = null
+    let pasteItems
+    const struct = this.editor.struct()
+
+    if (!ci) {
+      const isAddingFunctionalGroup = this.template?.molecule?.sgroups.size
+      if (isAddingFunctionalGroup) {
+        // skip, b/c we dont want to do any additional actions (e.g. rotating for s-groups)
+        return true
+      }
+      ;[action, pasteItems] = fromTemplateOnCanvas(
+        this.editor.render.ctab,
+        this.template,
+        targetPos,
+        angle
+      )
+    } else if (ci?.map === 'atoms' || ci?.map === 'functionalGroups') {
+      const atomId = getTargetAtomId(struct, ci)
+      ;[action, pasteItems] = fromTemplateOnAtom(
+        this.editor.render.ctab,
+        this.template,
+        atomId,
+        angle,
+        extraBond
+      )
+      this.dragCtx.extra_bond = extraBond
+    }
+    this.dragCtx.action = action
+
+    this.editor.update(this.dragCtx.action, true)
+
+    if (this.mode !== 'fg') {
+      this.dragCtx.mergeItems = getItemsToFuse(this.editor, pasteItems)
+      this.editor.hover(getHoverToFuse(this.dragCtx.mergeItems))
+    }
+
+    // TODO: refactor after #2195 comes into effect
+    if (this.targetGroupsIds.length) this.targetGroupsIds.length = 0
+
+    return true
+  }
+
+  private mouseMoveBond() {
+    const closest = this.dragCtx.item
+    const struct = this.editor.struct()
+    const eventPos = this.editor.render.page2obj(event)
+
+    const bond = struct.bonds.get(closest.id)
+    let sign = getSign(struct, bond, eventPos)
+
+    if (this.dragCtx.sign1 * this.template.sign > 0) {
+      sign = -sign
+    }
+
+    if (sign !== this.dragCtx.sign2 || !this.dragCtx.action) {
+      if (this.dragCtx.action) {
+        this.dragCtx.action.perform(this.editor.render.ctab)
+      } // undo previous action
+
+      this.dragCtx.sign2 = sign
+      const [action, pasteItems] = fromTemplateOnBondAction(
+        this.editor.render.ctab,
+        this.template,
+        closest.id,
+        this.editor.event,
+        this.dragCtx.sign1 * this.dragCtx.sign2 > 0,
+        false
+      ) as Array<any>
+
+      this.dragCtx.action = action
+      this.editor.update(this.dragCtx.action, true)
+
+      this.dragCtx.mergeItems = getItemsToFuse(this.editor, pasteItems)
+      this.editor.hover(getHoverToFuse(this.dragCtx.mergeItems))
+    }
+  }
+
+  /**
+   * @returns `true`: no `targetPos` or nothing changed
+   */
+  private calculateMouseMovePosition(event) {
     let extraBond: boolean | null = null
+    let targetPos: Vec2 | null | undefined = null
+    const ci = this.dragCtx.item
+    const struct = this.editor.struct()
+    const eventPos = this.editor.render.page2obj(event)
+
     // calc initial pos and is extra bond needed
     if (!ci) {
       //  ci.type == 'Canvas'
-      targetPos = dragCtx.xy0
+      targetPos = this.dragCtx.xy0
     } else if (ci.map === 'atoms' || ci.map === 'functionalGroups') {
       const atomId = getTargetAtomId(struct, ci)
 
@@ -307,131 +393,82 @@ class TemplateTool {
     // check if anything changed since last time
     if (
       // eslint-disable-next-line no-prototype-builtins
-      dragCtx.hasOwnProperty('angle') &&
-      dragCtx.angle === degrees &&
+      this.dragCtx.hasOwnProperty('angle') &&
+      this.dragCtx.angle === degrees &&
       // eslint-disable-next-line no-prototype-builtins
-      (!dragCtx.hasOwnProperty('extra_bond') ||
-        dragCtx.extra_bond === extraBond)
+      (!this.dragCtx.hasOwnProperty('extra_bond') ||
+        this.dragCtx.extra_bond === extraBond)
     ) {
       return true
     }
 
-    // undo previous action
-    if (dragCtx.action) {
-      dragCtx.action.perform(this.editor.render.ctab)
+    return [targetPos, extraBond, angle, degrees] as const
+  }
+
+  private mouseHover(event: any) {
+    if (this.followAction) {
+      this.followAction.perform(this.editor.render.ctab)
     }
 
-    // create new action
-    dragCtx.angle = degrees
-    let action = null
-    let pasteItems
+    const [followAction, pasteItems] = fromPaste(
+      this.editor.render.ctab,
+      this.template.molecule,
+      this.editor.render.page2obj(event)
+    )
 
-    if (!ci) {
-      const isAddingFunctionalGroup = this.template?.molecule?.sgroups.size
-      if (isAddingFunctionalGroup) {
-        // skip, b/c we dont want to do any additional actions (e.g. rotating for s-groups)
-        return true
-      }
-      ;[action, pasteItems] = fromTemplateOnCanvas(
-        this.editor.render.ctab,
-        this.template,
-        targetPos,
-        angle
-      )
-    } else if (ci?.map === 'atoms' || ci?.map === 'functionalGroups') {
-      const atomId = getTargetAtomId(struct, ci)
-      ;[action, pasteItems] = fromTemplateOnAtom(
-        this.editor.render.ctab,
-        this.template,
-        atomId,
-        angle,
-        extraBond
-      )
-      dragCtx.extra_bond = extraBond
+    this.followAction = followAction
+    this.editor.update(followAction, true, { extendCanvas: false })
+
+    if (this.mode === 'fg') {
+      const skip = getIgnoredGroupItem(this.editor.struct(), pasteItems)
+      const ci = this.editor.findItem(event, this.findItems, skip)
+
+      this.editor.hover(ci ?? null, null, event)
+    } else {
+      this.mergeItems = getMergeItems(this.editor, pasteItems)
+      this.editor.hover(getHoverToFuse(this.mergeItems))
     }
-    dragCtx.action = action
-
-    this.editor.update(dragCtx.action, true)
-
-    if (this.mode !== 'fg') {
-      dragCtx.mergeItems = getItemsToFuse(this.editor, pasteItems)
-      this.editor.hover(getHoverToFuse(dragCtx.mergeItems))
-    }
-
-    // TODO: refactor after #2195 comes into effect
-    if (this.targetGroupsIds.length) this.targetGroupsIds.length = 0
-
-    return true
   }
 
   mouseup(event) {
-    const dragCtx = this.dragCtx
-
     if (this.targetGroupsIds.length && this.mode !== 'fg') {
       this.editor.event.removeFG.dispatch({ fgIds: this.targetGroupsIds })
       return
     }
 
-    if (!dragCtx) {
+    if (!this.dragCtx) {
       return true
     }
 
+    const dragCtx = this.dragCtx
     delete this.dragCtx
 
     const restruct = this.editor.render.ctab
-    const struct = restruct.molecule
+    // const struct = restruct.molecule
     let ci = dragCtx.item
-    const functionalGroups = struct.functionalGroups
+    // const functionalGroups = struct.functionalGroups
 
     /* after moving around bond */
-    if (dragCtx.action && ci && ci.map === 'bonds' && this.mode !== 'fg') {
+    if (dragCtx.action && ci?.map === 'bonds' && this.mode !== 'fg') {
       dragCtx.action.perform(restruct) // revert drag action
-
-      const promise = fromTemplateOnBondAction(
-        restruct,
-        this.template,
-        ci.id,
-        this.editor.event,
-        dragCtx.sign1 * dragCtx.sign2 > 0,
-        true
-      ) as Promise<any>
-
-      promise.then(([action, pasteItems]) => {
-        const mergeItems = getItemsToFuse(this.editor, pasteItems)
-        action = fromItemsFuse(restruct, mergeItems).mergeWith(action)
-        this.editor.update(action)
-      })
+      this.mouseUpBond(dragCtx)
       return true
     }
     /* end */
 
-    let action, functionalGroupRemoveAction
-    let pasteItems = null
+    // let action
+    // let pasteItems = null
 
-    if (
-      ci?.map === 'functionalGroups' &&
-      FunctionalGroup.isContractedFunctionalGroup(ci.id, functionalGroups) &&
-      this.mode === 'fg' &&
-      this.targetGroupsIds.length
-    ) {
-      functionalGroupRemoveAction = new Action()
-      const struct = this.editor.struct()
-      const restruct = this.editor.render.ctab
-      const functionalGroupToReplace = struct.sgroups.get(ci.id)!
-      const attachmentAtomId = functionalGroupToReplace.getAttAtomId(struct)
-      const atomsWithoutAttachmentAtom = SGroup.getAtoms(
-        struct,
-        functionalGroupToReplace
-      ).filter((id) => id !== attachmentAtomId)
-
-      functionalGroupRemoveAction.mergeWith(fromSgroupDeletion(restruct, ci.id))
-      functionalGroupRemoveAction.mergeWith(
-        fromFragmentDeletion(restruct, { atoms: atomsWithoutAttachmentAtom })
-      )
-
-      ci = { map: 'atoms', id: attachmentAtomId }
+    const isSaltAdded = this.mouseUpFunctionalGroup(ci, dragCtx)
+    if (isSaltAdded === true) {
+      return
     }
+    const functionalGroupRemoveAction = isSaltAdded?.functionalGroupRemoveAction
+    ci = isSaltAdded?.ci || ci
 
+    const struct = restruct.molecule
+    let action
+    let pasteItems = null
     if (!dragCtx.action) {
       if (!ci) {
         //  ci.type == 'Canvas'
@@ -455,23 +492,7 @@ class TemplateTool {
           return true
         }
 
-        let angle
-        if (degree && degree > 1) {
-          // common case
-          angle = null
-        } else if (degree === 1) {
-          // on chain end
-          const atom = struct.atoms.get(ci.id)
-          const neiId = atom && struct.halfBonds.get(atom.neighbors[0])?.end
-          const nei: any = (neiId || neiId === 0) && struct.atoms.get(neiId)
-
-          angle = event.ctrlKey
-            ? utils.calcAngle(nei?.pp, atom?.pp)
-            : utils.fracAngle(utils.calcAngle(nei.pp, atom?.pp), null)
-        } else {
-          // on single atom
-          angle = 0
-        }
+        const angle = this.calculateMouseUpAngle(degree, struct, ci, event)
 
         ;[action, pasteItems] = fromTemplateOnAtom(
           restruct,
@@ -480,28 +501,14 @@ class TemplateTool {
           angle,
           false
         )
+
         if (functionalGroupRemoveAction) {
           action = functionalGroupRemoveAction.mergeWith(action)
         }
+
         dragCtx.action = action
       } else if (ci.map === 'bonds' && this.mode !== 'fg') {
-        const promise = fromTemplateOnBondAction(
-          restruct,
-          this.template,
-          ci.id,
-          this.editor.event,
-          dragCtx.sign1 * dragCtx.sign2 > 0,
-          true
-        ) as Promise<any>
-
-        promise.then(([action, pasteItems]) => {
-          if (this.mode !== 'fg') {
-            const mergeItems = getItemsToFuse(this.editor, pasteItems)
-            action = fromItemsFuse(restruct, mergeItems).mergeWith(action)
-            this.editor.update(action)
-          }
-        })
-
+        this.mouseUpBond(dragCtx)
         return true
       }
     }
@@ -526,13 +533,107 @@ class TemplateTool {
     return true
   }
 
+  private calculateMouseUpAngle(degree: any, struct: any, ci: any, event: any) {
+    let angle
+    if (degree && degree > 1) {
+      // common case
+      angle = null
+    } else if (degree === 1) {
+      // on chain end
+      const atom = struct.atoms.get(ci.id)
+      const neiId = atom && struct.halfBonds.get(atom.neighbors[0])?.end
+      const nei: any = (neiId || neiId === 0) && struct.atoms.get(neiId)
+
+      angle = event.ctrlKey
+        ? utils.calcAngle(nei?.pp, atom?.pp)
+        : utils.fracAngle(utils.calcAngle(nei.pp, atom?.pp), null)
+    } else {
+      // on single atom
+      angle = 0
+    }
+    return angle
+  }
+
+  /**
+   * @returns `true`: salt or solvent is added without merge
+   */
+  private mouseUpFunctionalGroup(ci: any, dragCtx: any) {
+    const struct = this.editor.struct()
+    const functionalGroups = struct.functionalGroups
+
+    if (
+      ci?.map === 'functionalGroups' &&
+      FunctionalGroup.isContractedFunctionalGroup(ci.id, functionalGroups) &&
+      this.mode === 'fg' &&
+      this.targetGroupsIds.length
+    ) {
+      const restruct = this.editor.render.ctab
+      const functionalGroupToReplace = struct.sgroups.get(ci.id)!
+
+      if (
+        this.isSaltOrSolvent &&
+        functionalGroupToReplace.isGroupAttached(struct)
+      ) {
+        addSaltsAndSolventsOnCanvasWithoutMerge(
+          restruct,
+          this.template,
+          dragCtx,
+          this.editor
+        )
+        return true
+      }
+
+      const attachmentAtomId = functionalGroupToReplace.getAttAtomId(struct)
+      const atomsWithoutAttachmentAtom = SGroup.getAtoms(
+        struct,
+        functionalGroupToReplace
+      ).filter((id) => id !== attachmentAtomId)
+
+      const functionalGroupRemoveAction = new Action()
+      functionalGroupRemoveAction.mergeWith(fromSgroupDeletion(restruct, ci.id))
+      functionalGroupRemoveAction.mergeWith(
+        fromFragmentDeletion(restruct, { atoms: atomsWithoutAttachmentAtom })
+      )
+
+      return {
+        ci: { map: 'atoms', id: attachmentAtomId },
+        functionalGroupRemoveAction
+      }
+    }
+
+    return undefined
+  }
+
+  private mouseUpBond(dragCtx: any) {
+    const restruct = this.editor.render.ctab
+    const ci = dragCtx.item
+
+    const promise = fromTemplateOnBondAction(
+      restruct,
+      this.template,
+      ci.id,
+      this.editor.event,
+      dragCtx.sign1 * dragCtx.sign2 > 0,
+      true
+    ) as Promise<any>
+
+    promise.then(([action, pasteItems]) => {
+      const mergeItems = getItemsToFuse(this.editor, pasteItems)
+      action = fromItemsFuse(restruct, mergeItems).mergeWith(action)
+      this.editor.update(action)
+    })
+  }
+
   cancel(e) {
+    this.undoFollowAction()
+    this.mouseup(e)
+  }
+
+  private undoFollowAction() {
     if (this.followAction) {
       this.followAction.perform(this.editor.render.ctab)
       delete this.followAction
     }
-
-    this.mouseup(e)
   }
 
   mouseleave(e) {
@@ -555,9 +656,11 @@ function addSaltsAndSolventsOnCanvasWithoutMerge(
   })
 }
 
-function getTemplateMode(tmpl) {
-  if (tmpl.mode) return tmpl.mode
-  if (['Functional Groups', 'Salts and Solvents'].includes(tmpl.props?.group))
+function getTemplateMode(options: any) {
+  if (options.mode) return options.mode
+  if (
+    ['Functional Groups', 'Salts and Solvents'].includes(options.props?.group)
+  )
     return 'fg'
   return null
 }

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -75,10 +75,6 @@ type TemplateCategory =
   | 'Functional Groups'
   | 'Salts and Solvents'
 
-/**
- * - COMPLETE_STRUCT: current template is one of `'Simple Templates'` and `'Complex Templates'`
- * - ABBREVIATION: current template is one of `'Functional Groups'` and `'Salts and Solvents'`
- */
 enum MODE {
   /** In this mode, current template is one of `'Simple Templates'` and `'Complex Templates'`.
    * (See type `TemplateCategory` for more details) */

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -142,7 +142,7 @@ class TemplateTool {
     const dragCtx = this.dragCtx
     const ci = dragCtx.item
 
-    if (!ci || this.isSaltOrSolvent) {
+    if (!ci) {
       //  ci.type == 'Canvas'
       delete dragCtx.item
       return
@@ -226,6 +226,12 @@ class TemplateTool {
     }
 
     const dragCtx = this.dragCtx
+
+    if (this.isSaltOrSolvent) {
+      delete dragCtx.item
+      return
+    }
+
     const ci = dragCtx.item
     let targetPos: Vec2 | null | undefined = null
     const eventPos = this.editor.render.page2obj(event)
@@ -402,15 +408,7 @@ class TemplateTool {
     let action, functionalGroupRemoveAction
     let pasteItems = null
 
-    if (this.isSaltOrSolvent) {
-      addSaltsAndSolventsOnCanvasWithoutMerge(
-        restruct,
-        this.template,
-        dragCtx,
-        this.editor
-      )
-      return true
-    } else if (
+    if (
       ci?.map === 'functionalGroups' &&
       FunctionalGroup.isContractedFunctionalGroup(ci.id, functionalGroups) &&
       this.mode === 'fg' &&
@@ -446,8 +444,18 @@ class TemplateTool {
         dragCtx.action = action
       } else if (ci.map === 'atoms') {
         const degree = restruct.atoms.get(ci.id)?.a.neighbors.length
-        let angle
 
+        if (degree && degree >= 1 && this.isSaltOrSolvent) {
+          addSaltsAndSolventsOnCanvasWithoutMerge(
+            restruct,
+            this.template,
+            dragCtx,
+            this.editor
+          )
+          return true
+        }
+
+        let angle
         if (degree && degree > 1) {
           // common case
           angle = null


### PR DESCRIPTION
Closes #2267
Closes #1994 
Refactors `TemplateTool`: extracts code for specific function to method, adds types to member variables.