### PR TITLE
#2362 Remove appearance of a tooltip under mouse cursor for Functional Groups/Salts and Solvents abbreviations 

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -409,6 +409,11 @@ class TemplateTool {
         dragCtx,
         this.editor
       )
+      this.editor.hover(
+        this.editor.findItem(event, this.findItems),
+        null,
+        event
+      )
       return true
     } else if (
       ci?.map === 'functionalGroups' &&

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -26,7 +26,7 @@ export function showFunctionalGroupsTooltip(editor) {
   )
   if (closestCollapsibleStructures) {
     const sGroup = editor.struct()?.sgroups.get(closestCollapsibleStructures.id)
-    if (sGroup && !sGroup.data.expanded) {
+    if (sGroup && !sGroup.data.expanded && sGroup.hovering) {
       const groupName = sGroup.data.name
       const groupStruct = FunctionalGroup.getFunctionalGroupByName(groupName)
       infoPanelData = {


### PR DESCRIPTION
closes #2362 

1) Added condition group.hovering. It triggers and becomes active when you hover over an element. Condition solves the problem, that tooltip is visible when the cursor moves. (Remove appearance of a tooltip under mouse cursor) 
Now tooltip is visible when you hover the element. 

2) Added hover method in case Salt Or Solvent . It helps to show the tooltip when event "mouse up" appears