### PR TITLE
Backmerge: #2390 – Selected atom is not displayed under cursor during structure loading (#2406)

### DIFF
--- a/packages/ketcher-core/src/domain/constants/elementColor.ts
+++ b/packages/ketcher-core/src/domain/constants/elementColor.ts
@@ -141,3 +141,6 @@ export const ElementColor: ElementColorType = {
   Ts: '#000000',
   Og: '#000000'
 } as const
+
+type Keys = keyof typeof ElementColor
+export type AtomColor = typeof ElementColor[Keys]

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -37,10 +37,10 @@ import toolMap from './tool'
 import { Highlighter } from './highlighter'
 import { showFunctionalGroupsTooltip } from './utils/functionalGroupsTooltip'
 import { contextMenuInfo } from '../ui/views/components/ContextMenu/contextMenu.types'
+import { HoverIcon } from './HoverIcon'
 
 const SCALE = 40
 const HISTORY_SIZE = 32 // put me to options
-const HOVER_ICON_OPACITY = 0.7
 
 const structObjects = [
   'atoms',
@@ -112,7 +112,7 @@ class Editor implements KetcherEditor {
   historyPtr: any
   errorHandler: ((message: string) => void) | null
   highlights: Highlighter
-  hoverIcon: any
+  hoverIcon: HoverIcon
   lastCursorPosition: { x: number; y: number }
   contextMenu: contextMenuInfo
   event: {
@@ -163,7 +163,8 @@ class Editor implements KetcherEditor {
       x: 0,
       y: 0
     }
-    this.createHoverIcon()
+    this.hoverIcon = new HoverIcon(this)
+    this.hoverIcon.updatePosition()
     this.contextMenu = {}
 
     this.event = {
@@ -231,24 +232,6 @@ class Editor implements KetcherEditor {
     /* eslint-enable no-underscore-dangle */
   }
 
-  updateHoverIconPosition() {
-    const { x, y } = this.lastCursorPosition
-    const { height, width } = this.hoverIcon.getBBox()
-    this.hoverIcon.attr({
-      x: x - width / 2,
-      y: y - height / 2
-    })
-  }
-
-  createHoverIcon() {
-    this.hoverIcon = this.render.paper
-      .text(0, 0, '')
-      .attr('font-size', this.options().fontsz)
-      .attr('opacity', HOVER_ICON_OPACITY)
-
-    this.updateHoverIconPosition()
-  }
-
   clear() {
     this.struct(undefined)
   }
@@ -272,7 +255,7 @@ class Editor implements KetcherEditor {
 
     const molecule = this.renderAndRecoordinateStruct(struct)
 
-    this.createHoverIcon()
+    this.hoverIcon.create()
     return molecule
   }
 

--- a/packages/ketcher-react/src/script/editor/HoverIcon.ts
+++ b/packages/ketcher-react/src/script/editor/HoverIcon.ts
@@ -1,0 +1,126 @@
+import type { ElementLabel, AtomColor } from 'ketcher-core'
+import Editor from './Editor'
+
+const HOVER_ICON_OPACITY = 0.7
+
+export class HoverIcon {
+  element: any
+  _fill: AtomColor | ''
+  _label: ElementLabel | ''
+  isShown: boolean
+  /**
+   Is required for the case, when mouse moved outside the canvas, then loading of structure
+   happens and icon needs to be shown above loader.
+  */
+  shouldBeShownWhenMouseBack: boolean
+  editor: Editor
+
+  constructor(editor: Editor) {
+    this.editor = editor
+
+    const icon = this.initialize()
+    this.element = icon.element
+    this._fill = icon.fill
+    this._label = icon.label
+    this.isShown = true
+    this.shouldBeShownWhenMouseBack = false
+    this.updatePosition()
+
+    const clientArea = this.editor.render.clientArea
+    this.onMouseMove = this.onMouseMove.bind(this)
+    this.onMouseLeave = this.onMouseLeave.bind(this)
+
+    document.addEventListener('mousemove', this.onMouseMove)
+    clientArea.addEventListener('mouseover', this.onMouseMove)
+    clientArea.addEventListener('mouseleave', this.onMouseLeave)
+  }
+
+  set fill(fillColor: AtomColor | '') {
+    this._fill = fillColor
+    this.element.attr('fill', fillColor)
+  }
+
+  get fill() {
+    return this._fill
+  }
+
+  set label(label: ElementLabel | '') {
+    this._label = label
+    this.element.attr('text', label)
+  }
+
+  get label() {
+    return this._label
+  }
+
+  isOverLoader(event: MouseEvent) {
+    const target = <HTMLDivElement>event?.relatedTarget || event.target
+    return target?.classList.contains('loading-spinner')
+  }
+
+  onMouseMove(event: MouseEvent) {
+    if (
+      this.isShown ||
+      (this.isOverLoader(event) && this.shouldBeShownWhenMouseBack)
+    ) {
+      this.show()
+      this.updatePosition()
+    }
+  }
+
+  onMouseLeave(event: MouseEvent) {
+    if (!this.isOverLoader(event)) {
+      this.shouldBeShownWhenMouseBack = true
+      this.hide()
+    }
+  }
+
+  updatePosition() {
+    const { x, y } = this.editor.lastCursorPosition
+    const { height, width } = this.element.getBBox()
+    this.element.attr({
+      x: x - width / 2,
+      y: y - height / 2
+    })
+  }
+
+  show() {
+    this.element.show()
+    this.isShown = true
+    this.shouldBeShownWhenMouseBack = false
+  }
+
+  hide() {
+    this.element.hide()
+    this.isShown = false
+  }
+
+  initialize(): {
+    element: any
+    fill: AtomColor | ''
+    label: ElementLabel | ''
+  } {
+    const render = this.editor.render
+    const fillColor = this.fill ?? '#000000'
+    const element = render.paper.text(0, 0, this.label || '')
+    element.attr('fill', fillColor)
+    element.attr('font-size', this.editor.options().fontsz)
+    element.attr('opacity', HOVER_ICON_OPACITY)
+
+    return {
+      element: element,
+      fill: fillColor,
+      label: this?.label || ''
+    }
+  }
+
+  create() {
+    const icon = this.initialize()
+    this.element = icon.element
+    this._fill = icon.fill
+    this._label = icon.label
+    this.isShown = true
+    this.shouldBeShownWhenMouseBack = false
+    this.updatePosition()
+  }
+}

--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -43,11 +43,10 @@ class AtomTool {
     this.atomProps = atomProps
     this.#bondProps = { type: 1, stereo: Bond.PATTERN.STEREO.NONE }
 
-    this.editor.hoverIcon
-      .show()
-      .attr('text', `${atomProps.label}`)
-      .attr('fill', `${ElementColor[atomProps.label]}`)
-    this.editor.updateHoverIconPosition()
+    this.editor.hoverIcon.show()
+    this.editor.hoverIcon.label = atomProps.label
+    this.editor.hoverIcon.fill = ElementColor[atomProps.label] ?? '#000000'
+    this.editor.hoverIcon.updatePosition()
 
     if (editor.selection()) {
       if (editor.selection()?.atoms) {
@@ -135,27 +134,13 @@ class AtomTool {
     }
   }
 
-  mouseLeaveClientArea() {
-    this.editor.hoverIcon.hide()
-  }
-
-  mouseover() {
-    this.editor.hoverIcon.show()
-    this.editor.updateHoverIconPosition()
-  }
-
   mousemove(event) {
     this.editor.hoverIcon.show()
     const rnd = this.editor.render
-    const { layerX, layerY } = event
 
     if (!this.dragCtx || !this.dragCtx.item) {
-      const { height, width } = this.editor.hoverIcon.getBBox()
+      this.editor.hoverIcon.updatePosition()
 
-      this.editor.hoverIcon.attr({
-        x: layerX - width / 2,
-        y: layerY - height / 2
-      })
       this.editor.hover(
         this.editor.findItem(event, ['atoms', 'functionalGroups']),
         null,

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -221,7 +221,7 @@ class StructEditor extends Component {
         <div className={classes.measureLog} ref={this.logRef} />
 
         {indigoVerification && (
-          <div className={classes.spinnerOverlay}>
+          <div className={`${classes.spinnerOverlay} loading-spinner`}>
             <LoadingCircles />
           </div>
         )}


### PR DESCRIPTION
closes #2390 