### PR TITLE
Backmerge: #2446 – Structures are drawn outside the viewbox, when changing rendering options (#2448)

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -285,7 +285,7 @@ class Editor implements KetcherEditor {
       this.render.clientArea,
       Object.assign({ scale: SCALE }, value)
     )
-    this.render.setMolecule(struct) // TODO: reuse this.struct here?
+    this.struct(struct)
     this.render.setZoom(zoom)
     this.render.update()
     return this.render.options

--- a/packages/ketcher-react/src/script/editor/utils/canvasExtension.ts
+++ b/packages/ketcher-react/src/script/editor/utils/canvasExtension.ts
@@ -1,5 +1,4 @@
 import { Vec2 } from 'ketcher-core'
-import _ from 'lodash'
 
 const edgeOffset = 150
 


### PR DESCRIPTION
closes #2446 