### PR TITLE
#2353 CTRL+SHIFT+0 hotkey not working for 'Zoom 100%'

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/zoom.js
+++ b/packages/ketcher-react/src/script/ui/action/zoom.js
@@ -24,7 +24,7 @@ export const zoomList = [
 
 export default {
   zoom: {
-    shortcut: ['Mod+Shift+0'],
+    shortcut: ['Mod+0'],
     selected: (editor) => editor.zoom(),
     action: (editor) => editor.zoom(1),
     hidden: (options) => isHidden(options, 'zoom')


### PR DESCRIPTION
Closes #2353 

Note: 
1. it is proposed to change shortcut to `CTRL+0` due to problems with Windows 10 (https://github.com/epam/ketcher/issues/2353#issuecomment-1497249764)
2. The browser default behavior of shortcut `CTRL+0` is prevented
 