### PR TITLE
#2402 Atom under mouse cursor on click and drag freezes on canvas if you move cursor away from dragged atom

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -135,10 +135,10 @@ class AtomTool {
   }
 
   mousemove(event) {
-    this.editor.hoverIcon.show()
     const rnd = this.editor.render
 
     if (!this.dragCtx || !this.dragCtx.item) {
+      this.editor.hoverIcon.show()
       this.editor.hoverIcon.updatePosition()
 
       this.editor.hover(
@@ -147,6 +147,8 @@ class AtomTool {
         event
       )
       return
+    } else {
+      this.editor.hoverIcon.hide()
     }
 
     const dragCtx = this.dragCtx


### PR DESCRIPTION
Closes #2402 