### PR TITLE
Backmerge: #2427 – When moving a structure outside of the canvas, structure does not move smoothly

### DIFF
--- a/packages/ketcher-core/src/application/render/canvasExtension.ts
+++ b/packages/ketcher-core/src/application/render/canvasExtension.ts
@@ -1,6 +1,21 @@
-import { Vec2 } from 'ketcher-core'
+import { Vec2 } from 'domain/entities'
 
 const edgeOffset = 150
+const scrollMultiplier = 2
+const moveDelta = 1
+let lastX = 0
+let lastY = 0
+
+export function getDirections(event) {
+  const { layerX, layerY } = event
+  const isMovingRight = layerX - lastX > moveDelta
+  const isMovingLeft = lastX - layerX > moveDelta
+  const isMovingTop = lastY - layerY > moveDelta
+  const isMovingBottom = layerY - lastY > moveDelta
+  lastX = layerX
+  lastY = layerY
+  return { isMovingRight, isMovingLeft, isMovingTop, isMovingBottom }
+}
 
 export function isCloseToEdgeOfScreen(event) {
   const { clientX, clientY } = event
@@ -67,6 +82,12 @@ export function shiftAndExtendCanvasByVector(vector: Vec2, render) {
     render.setPaperSize(render.sz.add(extensionVector))
     render.setOffset(render.options.offset.add(vector))
     render.ctab.translate(vector)
+    render.setViewBox(render.options.zoom)
+    /**
+     * When canvas extends previous (0, 0) coordinates may become (100, 100)
+     */
+    lastX += extensionVector.x
+    lastY += extensionVector.y
   }
 
   scrollByVector(vector, render)
@@ -75,6 +96,6 @@ export function shiftAndExtendCanvasByVector(vector: Vec2, render) {
 
 export function scrollByVector(vector: Vec2, render) {
   const clientArea = render.clientArea
-  clientArea.scrollLeft += vector.x * render.options.scale
-  clientArea.scrollTop += vector.y * render.options.scale
+  clientArea.scrollLeft += (vector.x * render.options.scale) / scrollMultiplier
+  clientArea.scrollTop += (vector.y * render.options.scale) / scrollMultiplier
 }

--- a/packages/ketcher-core/src/application/render/index.ts
+++ b/packages/ketcher-core/src/application/render/index.ts
@@ -1,2 +1,3 @@
 export * from './raphaelRender'
 export * from './restruct'
+export * from './canvasExtension'

--- a/packages/ketcher-core/src/application/render/raphaelRender.js
+++ b/packages/ketcher-core/src/application/render/raphaelRender.js
@@ -232,8 +232,9 @@ Render.prototype.update = function (
       const sz = cb.sz().floor()
       const delta = this.oldCb.p0.sub(cb.p0).ceil()
       this.oldBb = bb
+      // TO DO: decrease canvas size, when it has empty space. This logic needs to be defined in the future
       if (
-        (!this.sz || sz.x !== this.sz.x || sz.y !== this.sz.y) &&
+        (!this.sz || sz.x > this.sz.x || sz.y > this.sz.y) &&
         options.extendCanvas
       ) {
         this.setPaperSize(sz)

--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -28,7 +28,12 @@ import {
   ReSGroup,
   Vec2,
   Atom,
-  Bond
+  Bond,
+  getDirections,
+  isCloseToEdgeOfCanvas,
+  isCloseToEdgeOfScreen,
+  scrollByVector,
+  shiftAndExtendCanvasByVector
 } from 'ketcher-core'
 
 import LassoHelper from './helper/lasso'
@@ -42,12 +47,6 @@ import { getGroupIdsFromItemArrays } from './helper/getGroupIdsFromItems'
 import { getMergeItems } from './helper/getMergeItems'
 import { updateSelectedAtoms } from 'src/script/ui/state/modal/atoms'
 import { updateSelectedBonds } from 'src/script/ui/state/modal/bonds'
-import {
-  isCloseToEdgeOfCanvas,
-  isCloseToEdgeOfScreen,
-  scrollByVector,
-  shiftAndExtendCanvasByVector
-} from '../utils/canvasExtension'
 
 class SelectTool {
   #mode: string
@@ -213,7 +212,7 @@ class SelectTool {
       editor.hover(getHoverToFuse(dragCtx.mergeItems))
 
       extendCanvas(rnd, event)
-      editor.update(dragCtx.action, true)
+      editor.update(dragCtx.action, true, { extendCanvas: false })
       return true
     }
 
@@ -469,47 +468,49 @@ function extendCanvas(render, event) {
     isCloseToRightEdgeOfScreen,
     isCloseToBottomEdgeOfScreen
   } = isCloseToEdgeOfScreen(event)
+  const { isMovingLeft, isMovingRight, isMovingTop, isMovingBottom } =
+    getDirections(event)
 
-  if (isCloseToLeftEdgeOfCanvas) {
+  if (isCloseToLeftEdgeOfCanvas && isMovingLeft) {
     shiftAndExtendCanvasByVector(new Vec2(-offset, 0, 0), render)
   }
 
-  if (isCloseToTopEdgeOfCanvas) {
+  if (isCloseToTopEdgeOfCanvas && isMovingTop) {
     shiftAndExtendCanvasByVector(new Vec2(0, -offset, 0), render)
   }
 
-  if (isCloseToRightEdgeOfCanvas) {
+  if (isCloseToRightEdgeOfCanvas && isMovingRight) {
     shiftAndExtendCanvasByVector(new Vec2(offset, 0, 0), render)
   }
 
-  if (isCloseToBottomEdgeOfCanvas) {
+  if (isCloseToBottomEdgeOfCanvas && isMovingBottom) {
     shiftAndExtendCanvasByVector(new Vec2(0, offset, 0), render)
   }
 
   const isCloseToSomeEdgeOfCanvas = [
-    isCloseToTopEdgeOfCanvas,
-    isCloseToRightEdgeOfCanvas,
-    isCloseToBottomEdgeOfCanvas,
-    isCloseToLeftEdgeOfCanvas
+    isCloseToTopEdgeOfCanvas && isMovingTop,
+    isCloseToRightEdgeOfCanvas && isMovingRight,
+    isCloseToBottomEdgeOfCanvas && isMovingBottom,
+    isCloseToLeftEdgeOfCanvas && isMovingLeft
   ].some((isCloseToEdge) => isCloseToEdge)
 
   if (isCloseToSomeEdgeOfCanvas) {
     return
   }
 
-  if (isCloseToTopEdgeOfScreen) {
+  if (isCloseToTopEdgeOfScreen && isMovingTop) {
     scrollByVector(new Vec2(0, -offset), render)
   }
 
-  if (isCloseToBottomEdgeOfScreen) {
+  if (isCloseToBottomEdgeOfScreen && isMovingBottom) {
     scrollByVector(new Vec2(0, offset), render)
   }
 
-  if (isCloseToLeftEdgeOfScreen) {
+  if (isCloseToLeftEdgeOfScreen && isMovingLeft) {
     scrollByVector(new Vec2(-offset, 0), render)
   }
 
-  if (isCloseToRightEdgeOfScreen) {
+  if (isCloseToRightEdgeOfScreen && isMovingRight) {
     scrollByVector(new Vec2(offset, 0), render)
   }
 }


### PR DESCRIPTION
closes #2427 
* #2427 – prevented canvas size decrease