### PR TITLE
#2245 Settings: `Terminal and Hetero` is not selected as default and `on` option is not working

### DIFF
--- a/packages/ketcher-core/src/application/render/options.js
+++ b/packages/ketcher-core/src/application/render/options.js
@@ -16,6 +16,7 @@
 
 import { Vec2 } from 'domain/entities'
 import utils from '../editor/shared/utils'
+import { ShowHydrogenLabels } from './restruct/reatom'
 
 function defaultOptions(opt) {
   const scaleFactor = opt.scale || 100
@@ -46,7 +47,7 @@ function defaultOptions(opt) {
     // atoms
     carbonExplicitly: false,
     showCharge: true,
-    showHydrogenLabels: 'on',
+    showHydrogenLabels: ShowHydrogenLabels.TerminalAndHetero,
     showValence: true,
     // bonds
     aromaticCircle: true,

--- a/packages/ketcher-core/src/application/render/restruct/index.ts
+++ b/packages/ketcher-core/src/application/render/restruct/index.ts
@@ -29,6 +29,7 @@ import ReStruct from './restruct'
 import ReText from './retext'
 
 export * from './generalEnumTypes'
+export * from './reatom'
 export {
   ReAtom,
   ReBond,

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -496,6 +496,7 @@ function isLabelVisible(restruct, options, atom) {
   const shouldBeVisible =
     neighborsLength ||
     options.carbonExplicitly ||
+    options.showHydrogenLabels === ShowHydrogenLabels.On ||
     atom.a.alias ||
     atom.a.isotope !== 0 ||
     atom.a.radical !== 0 ||
@@ -529,15 +530,15 @@ function isLabelVisible(restruct, options, atom) {
   return false
 }
 
-function displayHydrogen(hydrogenLabels, atom) {
+function displayHydrogen(hydrogenLabels: ShowHydrogenLabels, atom: ReAtom) {
   return (
     hydrogenLabels === ShowHydrogenLabels.On ||
     (hydrogenLabels === ShowHydrogenLabels.Terminal &&
       atom.a.neighbors.length < 2) ||
     (hydrogenLabels === ShowHydrogenLabels.Hetero &&
-      atom.label.text.toLowerCase() !== 'c') ||
+      atom.label?.text.toLowerCase() !== 'c') ||
     (hydrogenLabels === ShowHydrogenLabels.TerminalAndHetero &&
-      (atom.a.neighbors.length < 2 || atom.label.text.toLowerCase() !== 'c'))
+      (atom.a.neighbors.length < 2 || atom.label?.text.toLowerCase() !== 'c'))
   )
 }
 

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -172,6 +172,7 @@ class ReAtom extends ReObject {
     let leftMargin
     let implh
     let isHydrogen
+    let isHydrogenIsotope
     let label
     let index: any = null
 
@@ -184,6 +185,7 @@ class ReAtom extends ReObject {
         (-label.rbb.width / 2) * (options.zoom > 1 ? 1 : options.zoom)
       implh = Math.floor(this.a.implicitH)
       isHydrogen = label.text === 'H'
+      isHydrogenIsotope = label.text === 'D' || label.text === 'T'
       restruct.addReObjectPath(LayerMap.data, this.visel, label.path, ps, true)
     }
     if (options.showAtomIds) {
@@ -206,7 +208,7 @@ class ReAtom extends ReObject {
     }
     this.setHover(this.hover, render)
 
-    if (this.showLabel && !this.a.pseudo) {
+    if (this.showLabel && (!this.a.pseudo || isHydrogenIsotope)) {
       let hydroIndex: any = null
       if (isHydrogen && implh > 0) {
         hydroIndex = showHydroIndex(this, render, implh, rightMargin)
@@ -545,8 +547,12 @@ function displayHydrogen(hydrogenLabels: ShowHydrogenLabels, atom: ReAtom) {
 function setHydrogenPos(struct, atom) {
   // check where should the hydrogen be put on the left of the label
   if (atom.a.neighbors.length === 0) {
-    const element = Elements.get(atom.a.label)
-    return !element || Boolean(element.leftH)
+    if (atom.a.label === 'D' || atom.a.label === 'T') {
+      return false
+    } else {
+      const element = Elements.get(atom.a.label)
+      return !element || Boolean(element.leftH)
+    }
   }
 
   let yl = 1

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -46,7 +46,7 @@ interface ElemAttr {
 
 const StereoLabelMinOpacity = 0.3
 
-enum ShowHydrogenLabels {
+export enum ShowHydrogenLabels {
   Off = 'off',
   Hetero = 'Hetero',
   Terminal = 'Terminal',

--- a/packages/ketcher-core/src/domain/entities/atom.ts
+++ b/packages/ketcher-core/src/domain/entities/atom.ts
@@ -303,17 +303,21 @@ export class Atom {
       return true
     }
     const element = Elements.get(label)
-    if (!element) {
-      this.implicitH = 0
-      return true
-    }
-
-    const groupno = element.group
+    const groupno = element?.group
     const rad = radicalElectrons(this.radical)
     let valence = conn
     let hyd = 0
     const absCharge = Math.abs(charge)
-    if (groupno === 1) {
+
+    if (groupno === undefined) {
+      if (label === 'D' || label === 'T') {
+        valence = 1
+        hyd = 1 - rad - conn - absCharge
+      } else {
+        this.implicitH = 0
+        return true
+      }
+    } else if (groupno === 1) {
       if (
         label === 'H' ||
         label === 'Li' ||

--- a/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
+++ b/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { StereLabelStyleType, StereoColoringType } from 'ketcher-core'
+import {
+  StereLabelStyleType,
+  StereoColoringType,
+  ShowHydrogenLabels
+} from 'ketcher-core'
 import Ajv, { SchemaObject } from 'ajv'
 
 type ExtendedSchema = SchemaObject & {
@@ -195,8 +199,8 @@ const render: {
   },
   showHydrogenLabels: {
     title: 'Show hydrogen labels',
-    enum: ['off', 'Hetero', 'Terminal', 'Terminal and Hetero', 'on'],
-    default: 'on'
+    enum: Object.values(ShowHydrogenLabels),
+    default: ShowHydrogenLabels.TerminalAndHetero
   },
   // Bonds
   aromaticCircle: {


### PR DESCRIPTION
Closes #2245 

Notice: This PR adds implicit _H_ to _D_ and _T_ according to the issue description. The red underline will show if the number of linked bonds is more than one.

![Screenshot 2023-04-12 155549](https://user-images.githubusercontent.com/27288153/231405895-966bf6ad-f398-4e97-a531-a275c38739e4.png)
