### PR TITLE
#2442 When mouse hovering on atom or bond hotkey CTRL+Z (Undo) is not working

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -45,6 +45,15 @@ export function handleHotkeyOverItem(props: HandleHotkeyOverItemProps) {
   } else if (props.newAction.tool) {
     handleTool(props)
   }
+
+  handleOtherActions(props)
+}
+
+function handleOtherActions({
+  dispatch,
+  newAction
+}: HandleHotkeyOverItemProps) {
+  dispatch(onAction(newAction))
 }
 
 function handleEraser({ editor, hoveredItem }: HandleHotkeyOverItemProps) {

--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -44,9 +44,9 @@ export function handleHotkeyOverItem(props: HandleHotkeyOverItemProps) {
     handleDialog(props)
   } else if (props.newAction.tool) {
     handleTool(props)
+  } else {
+    handleOtherActions(props)
   }
-
-  handleOtherActions(props)
 }
 
 function handleOtherActions({


### PR DESCRIPTION
Closes [#2442](https://github.com/epam/ketcher/issues/2442)

In this case we are catching actions while hovering items, but we handle just tools and dialogs ignoring others. That's why we need to add handler for others actions