### PR TITLE
#2257 Unable to add a bond to a functional group by bond tool

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
@@ -1,25 +1,23 @@
 import * as utils from 'application/editor/actions/utils'
 
 import { restruct, singleBond } from './data'
-
 import { fromBondAddition } from 'application/editor/actions'
 
-const [action, begin, end] = fromBondAddition(
-  restruct as any,
-  singleBond as any,
-  1,
-  { label: 'C' }
-)
+const reStruct = Object.assign({}, restruct) as any
+reStruct.molecule.sgroups = []
+const [action, begin, end] = fromBondAddition(reStruct, singleBond, 1, {
+  label: 'C'
+})
 
 describe('Bond Addition', () => {
-  it('function atomForNewBond was called when end undefined', () => {
+  test('function `atomForNewBond` will be called if `endAtomPos` is `undefined`', () => {
     const spy = jest.spyOn(utils, 'atomForNewBond')
-    fromBondAddition(restruct as any, singleBond as any, 3, { label: 'C' })
+    fromBondAddition(reStruct, singleBond, 3, { label: 'C' })
     expect(spy).toHaveBeenCalled()
   })
-  it('function atomGetAttr was called', () => {
+  test('function `atomGetAttr` will be called', () => {
     const spy = jest.spyOn(utils, 'atomGetAttr')
-    fromBondAddition(restruct as any, singleBond as any, 5, 1)
+    fromBondAddition(reStruct, singleBond, 5, 1)
     expect(spy).toHaveBeenCalled()
   })
   it('should contain operation CalcImplicitH', () => {
@@ -34,10 +32,10 @@ describe('Bond Addition', () => {
     )
     expect(addFragment).toBeDefined()
   })
-  it('bond begin should be defined', () => {
+  test('bond begin should be defined', () => {
     expect(begin).toBeDefined()
   })
-  it('bond end should be defined', () => {
+  test('bond end should be defined', () => {
     expect(end).toBeDefined()
   })
 })

--- a/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
@@ -8,13 +8,13 @@ const [action, begin, end] = fromBondAddition(
   restruct as any,
   singleBond as any,
   1,
-  undefined
+  { label: 'C' }
 )
 
 describe('Bond Addition', () => {
   it('function atomForNewBond was called when end undefined', () => {
     const spy = jest.spyOn(utils, 'atomForNewBond')
-    fromBondAddition(restruct as any, singleBond as any, 3, undefined)
+    fromBondAddition(restruct as any, singleBond as any, 3, { label: 'C' })
     expect(spy).toHaveBeenCalled()
   })
   it('function atomGetAttr was called', () => {

--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -226,7 +226,7 @@ export function mergeFragmentsIfNeeded(action, restruct, srcId, dstId) {
   const frid = atomGetAttr(restruct, srcId, 'fragment')
   const frid2 = atomGetAttr(restruct, dstId, 'fragment')
   if (frid2 === frid || typeof frid !== 'number' || typeof frid2 !== 'number') {
-    return
+    return frid
   }
 
   const struct = restruct.molecule
@@ -249,6 +249,8 @@ export function mergeFragmentsIfNeeded(action, restruct, srcId, dstId) {
   mergeSgroups(action, restruct, fridAtoms, dstId)
   action.addOp(new FragmentDelete(frid2).perform(restruct))
   action.mergeWith(moveAtomsAction)
+
+  return frid
 }
 
 export function mergeSgroups(action, restruct, srcAtoms, dstAtom) {

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -67,7 +67,7 @@ export function fromBondAddition(
       action.addOp(new FragmentAdd().perform(reStruct)) as FragmentAdd
     ).frid
 
-    const newBeginAtomId = (
+    const newBeginAtomId: number = (
       action.addOp(
         new AtomAdd(
           { ...beginAtomAttr, fragment: newFragmentId },
@@ -76,7 +76,7 @@ export function fromBondAddition(
       ) as AtomAdd
     ).data.aid
 
-    const newEndAtomId = (
+    const newEndAtomId: number = (
       action.addOp(
         new AtomAdd(
           { ...endAtomAttr, fragment: newFragmentId },
@@ -94,7 +94,7 @@ export function fromBondAddition(
   ) => {
     const fragmentId = atomGetAttr(reStruct, endAtomId, 'fragment')
 
-    const newBeginAtomId = (
+    const newBeginAtomId: number = (
       action.addOp(
         new AtomAdd(
           { ...beginAtomAttr, fragment: fragmentId },
@@ -122,7 +122,7 @@ export function fromBondAddition(
   ) => {
     const fragmentId = atomGetAttr(reStruct, beginAtomId, 'fragment')
 
-    const newEndAtomId = (
+    const newEndAtomId: number = (
       action.addOp(
         new AtomAdd(
           {

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -103,9 +103,11 @@ export function fromBondAddition(
       ) as AtomAdd
     ).data.aid
 
+    const endAtom = struct.atoms.get(endAtomId)
     if (
+      endAtom &&
       !FunctionalGroup.isAtomInContractedFunctionalGroup(
-        struct.atoms.get(endAtomId),
+        endAtom,
         struct.sgroups,
         struct.functionalGroups,
         false
@@ -134,9 +136,11 @@ export function fromBondAddition(
       ) as AtomAdd
     ).data.aid
 
+    const beginAtom = struct.atoms.get(beginAtomId)
     if (
+      beginAtom &&
       !FunctionalGroup.isAtomInContractedFunctionalGroup(
-        struct.atoms.get(beginAtomId),
+        beginAtom,
         struct.sgroups,
         struct.functionalGroups,
         false

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -20,7 +20,9 @@ import {
   Neighbor,
   StereoLabel,
   Struct,
-  Vec2
+  Vec2,
+  AtomAttributes,
+  BondAttributes
 } from 'domain/entities'
 import {
   AtomAdd,
@@ -46,77 +48,133 @@ import { StereoValidator } from 'domain/helpers'
 import utils from '../shared/utils'
 
 export function fromBondAddition(
-  restruct: ReStruct,
-  bond: any,
-  begin: any,
-  end: any,
-  pos?: Vec2,
-  pos2?: Vec2
+  reStruct: ReStruct,
+  bond: Partial<BondAttributes>,
+  begin: number | AtomAttributes,
+  end: number | AtomAttributes,
+  beginAtomPos?: Vec2,
+  endAtomPos?: Vec2
 ): [Action, number, number, number] {
-  // eslint-disable-line
-  if (end === undefined) {
-    const atom = atomForNewBond(restruct, begin, bond)
-    end = atom.atom
-    pos = atom.pos
-  }
   const action = new Action()
-  const struct = restruct.molecule
-  let mergeFragments = false
 
-  let frid = null
+  const mouseDownNothingAndUpNothing = (
+    beginAtomAttr: AtomAttributes,
+    endAtomAttr: AtomAttributes
+  ) => {
+    const newFragmentId = (
+      action.addOp(new FragmentAdd().perform(reStruct)) as FragmentAdd
+    ).frid
 
-  if (!(typeof begin === 'number')) {
-    if (typeof end === 'number') frid = atomGetAttr(restruct, end, 'fragment')
+    const newBeginAtomId = (
+      action.addOp(
+        new AtomAdd(
+          { ...beginAtomAttr, fragment: newFragmentId },
+          beginAtomPos
+        ).perform(reStruct)
+      ) as AtomAdd
+    ).data.aid
+
+    const newEndAtomId = (
+      action.addOp(
+        new AtomAdd(
+          { ...endAtomAttr, fragment: newFragmentId },
+          endAtomPos
+        ).perform(reStruct)
+      ) as AtomAdd
+    ).data.aid
+
+    return [newBeginAtomId, newEndAtomId] as const
+  }
+
+  const mouseDownNothingAndUpAtom = (
+    beginAtomAttr: AtomAttributes,
+    endAtomId: number
+  ) => {
+    const fragmentId = atomGetAttr(reStruct, endAtomId, 'fragment')
+
+    const newBeginAtomId = (
+      action.addOp(
+        new AtomAdd(
+          { ...beginAtomAttr, fragment: fragmentId },
+          beginAtomPos
+        ).perform(reStruct)
+      ) as AtomAdd
+    ).data.aid
+
+    mergeSgroups(action, reStruct, [newBeginAtomId], endAtomId)
+    return [newBeginAtomId, endAtomId] as const
+  }
+
+  const mouseDownAtomAndUpNothing = (
+    beginAtomId: number,
+    endAtomAttr: AtomAttributes
+  ) => {
+    const fragmentId = atomGetAttr(reStruct, beginAtomId, 'fragment')
+
+    const newEndAtomId = (
+      action.addOp(
+        new AtomAdd(
+          {
+            ...endAtomAttr,
+            fragment: fragmentId
+          },
+          endAtomPos ?? atomForNewBond(reStruct, begin, bond).pos
+        ).perform(reStruct)
+      ) as AtomAdd
+    ).data.aid
+
+    mergeSgroups(action, reStruct, [newEndAtomId], beginAtomId)
+    return [beginAtomId, newEndAtomId] as const
+  }
+
+  let beginAtomId: number, endAtomId: number
+  if (typeof begin !== 'number' && typeof end !== 'number') {
+    ;[beginAtomId, endAtomId] = mouseDownNothingAndUpNothing(begin, end)
+  } else if (typeof begin !== 'number' && typeof end === 'number') {
+    ;[beginAtomId, endAtomId] = mouseDownNothingAndUpAtom(begin, end)
+  } else if (typeof begin === 'number' && typeof end !== 'number') {
+    ;[beginAtomId, endAtomId] = mouseDownAtomAndUpNothing(begin, end)
   } else {
-    frid = atomGetAttr(restruct, begin, 'fragment')
-    if (typeof end === 'number') mergeFragments = true
+    ;[beginAtomId, endAtomId] = [begin as number, end as number]
   }
 
-  if (frid == null) {
-    frid = (action.addOp(new FragmentAdd().perform(restruct)) as FragmentAdd)
-      .frid
+  if (atomGetAttr(reStruct, beginAtomId, 'label') === '*') {
+    action.addOp(new AtomAttr(beginAtomId, 'label', 'C').perform(reStruct))
   }
 
-  if (!(typeof begin === 'number')) {
-    begin.fragment = frid
-    begin = (action.addOp(new AtomAdd(begin, pos).perform(restruct)) as AtomAdd)
-      .data.aid
-    if (typeof end === 'number') mergeSgroups(action, restruct, [begin], end)
-    pos = pos2
-  } else if (atomGetAttr(restruct, begin, 'label') === '*') {
-    action.addOp(new AtomAttr(begin, 'label', 'C').perform(restruct))
+  if (atomGetAttr(reStruct, endAtomId, 'label') === '*') {
+    action.addOp(new AtomAttr(endAtomId, 'label', 'C').perform(reStruct))
   }
 
-  if (!(typeof end === 'number')) {
-    end.fragment = frid
-    // TODO: <op>.data.aid here is a hack, need a better way to access the id of a created atom
-    end = (action.addOp(new AtomAdd(end, pos).perform(restruct)) as AtomAdd)
-      .data.aid
-    if (typeof begin === 'number') mergeSgroups(action, restruct, [end], begin)
-  } else if (atomGetAttr(restruct, end, 'label') === '*') {
-    action.addOp(new AtomAttr(end, 'label', 'C').perform(restruct))
-  }
-
-  const bid = (
-    action.addOp(new BondAdd(begin, end, bond).perform(restruct)) as BondAdd
+  const struct = reStruct.molecule
+  const newBondId = (
+    action.addOp(
+      new BondAdd(beginAtomId, endAtomId, bond).perform(reStruct)
+    ) as BondAdd
   ).data.bid
-
-  const bnd = struct.bonds.get(bid)
-
-  if (bnd) {
-    action.addOp(new CalcImplicitH([bnd.begin, bnd.end]).perform(restruct))
-    action.mergeWith(fromBondStereoUpdate(restruct, bnd))
+  const newBond = struct.bonds.get(newBondId)
+  if (newBond) {
+    action.addOp(
+      new CalcImplicitH([newBond.begin, newBond.end]).perform(reStruct)
+    )
+    action.mergeWith(fromBondStereoUpdate(reStruct, newBond))
   }
 
   action.operations.reverse()
 
-  if (mergeFragments) mergeFragmentsIfNeeded(action, restruct, begin, end)
-
-  if (struct.frags.get(frid || 0)?.stereoAtoms && !bond.stereo) {
-    action.addOp(new FragmentStereoFlag(frid || 0).perform(restruct))
+  const mergedFragmentId = mergeFragmentsIfNeeded(
+    action,
+    reStruct,
+    beginAtomId,
+    endAtomId
+  )
+  if (struct.frags.get(mergedFragmentId || 0)?.stereoAtoms && !bond.stereo) {
+    action.addOp(
+      new FragmentStereoFlag(mergedFragmentId || 0).perform(reStruct)
+    )
   }
 
-  return [action, begin, end, bid]
+  return [action, beginAtomId, endAtomId, newBondId]
 }
 
 export function fromBondsAttrs(

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -22,7 +22,8 @@ import {
   Struct,
   Vec2,
   AtomAttributes,
-  BondAttributes
+  BondAttributes,
+  FunctionalGroup
 } from 'domain/entities'
 import {
   AtomAdd,
@@ -56,6 +57,7 @@ export function fromBondAddition(
   endAtomPos?: Vec2
 ): [Action, number, number, number] {
   const action = new Action()
+  const struct = reStruct.molecule
 
   const mouseDownNothingAndUpNothing = (
     beginAtomAttr: AtomAttributes,
@@ -101,7 +103,16 @@ export function fromBondAddition(
       ) as AtomAdd
     ).data.aid
 
-    mergeSgroups(action, reStruct, [newBeginAtomId], endAtomId)
+    if (
+      !FunctionalGroup.isAtomInContractedFunctionalGroup(
+        struct.atoms.get(endAtomId),
+        struct.sgroups,
+        struct.functionalGroups,
+        false
+      )
+    ) {
+      mergeSgroups(action, reStruct, [newBeginAtomId], endAtomId)
+    }
     return [newBeginAtomId, endAtomId] as const
   }
 
@@ -123,7 +134,17 @@ export function fromBondAddition(
       ) as AtomAdd
     ).data.aid
 
-    mergeSgroups(action, reStruct, [newEndAtomId], beginAtomId)
+    if (
+      !FunctionalGroup.isAtomInContractedFunctionalGroup(
+        struct.atoms.get(beginAtomId),
+        struct.sgroups,
+        struct.functionalGroups,
+        false
+      )
+    ) {
+      mergeSgroups(action, reStruct, [newEndAtomId], beginAtomId)
+    }
+
     return [beginAtomId, newEndAtomId] as const
   }
 
@@ -146,7 +167,6 @@ export function fromBondAddition(
     action.addOp(new AtomAttr(endAtomId, 'label', 'C').perform(reStruct))
   }
 
-  const struct = reStruct.molecule
   const newBondId = (
     action.addOp(
       new BondAdd(beginAtomId, endAtomId, bond).perform(reStruct)

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -149,11 +149,15 @@ export function fromBondAddition(
   }
 
   let beginAtomId: number, endAtomId: number
-  if (typeof begin !== 'number' && typeof end !== 'number') {
+
+  const startsOnAtom = typeof begin === 'number'
+  const endsOnAtom = typeof end === 'number'
+
+  if (!startsOnAtom && !endsOnAtom) {
     ;[beginAtomId, endAtomId] = mouseDownNothingAndUpNothing(begin, end)
-  } else if (typeof begin !== 'number' && typeof end === 'number') {
+  } else if (!startsOnAtom && endsOnAtom) {
     ;[beginAtomId, endAtomId] = mouseDownNothingAndUpAtom(begin, end)
-  } else if (typeof begin === 'number' && typeof end !== 'number') {
+  } else if (startsOnAtom && !endsOnAtom) {
     ;[beginAtomId, endAtomId] = mouseDownAtomAndUpNothing(begin, end)
   } else {
     ;[beginAtomId, endAtomId] = [begin as number, end as number]

--- a/packages/ketcher-core/src/application/editor/actions/chain.ts
+++ b/packages/ketcher-core/src/application/editor/actions/chain.ts
@@ -53,7 +53,14 @@ export function fromChain(restruct, p0, v, nSect, atomId) {
   for (let i = 0; i < nSect; i++) {
     const pos = new Vec2(dx * (i + 1), i & 1 ? 0 : dy).rotate(v).add(p0)
 
-    const ret = fromBondAddition(restruct, {}, id0, {}, pos)
+    const ret = fromBondAddition(
+      restruct,
+      {},
+      id0,
+      { label: 'C' },
+      undefined,
+      pos
+    )
     action = ret[0].mergeWith(action)
     id0 = ret[2]
     chainItems.bonds.push(ret[3])

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -55,6 +55,7 @@ function extraBondAction(restruct, aid, angle) {
       { type: 1 },
       aid,
       middleAtom.atom,
+      undefined,
       middleAtom.pos.get_xy0()
     )
     action = actionRes[0]

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -650,6 +650,15 @@ export class SGroup {
     })
     return !expanded && isSGroup
   }
+
+  static getAttachmentAtomIdBySGroupId(sGroupId: number, struct: Struct) {
+    const functionalGroup = struct.functionalGroups.get(sGroupId)
+    if (!SGroup.isSaltOrSolvent(functionalGroup?.name || '')) {
+      const sGroup = struct.sgroups.get(sGroupId)
+      return sGroup?.getAttAtomId(struct)
+    }
+    return undefined
+  }
 }
 
 function descriptorIntersects(sgroups: [], topLeftPoint: Vec2): boolean {

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -651,6 +651,9 @@ export class SGroup {
     return !expanded && isSGroup
   }
 
+  /**
+   * @returns `undefined`: if it's salt or solvent
+   */
   static getAttachmentAtomIdBySGroupId(sGroupId: number, struct: Struct) {
     const functionalGroup = struct.functionalGroups.get(sGroupId)
     if (!SGroup.isSaltOrSolvent(functionalGroup?.name || '')) {

--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -178,7 +178,7 @@ class AtomTool {
       this.#bondProps,
       dragCtx.item.id,
       Object.assign({}, this.atomProps),
-      newAtomPos,
+      undefined,
       newAtomPos
     )[0]
     this.editor.update(dragCtx.action, true)

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -168,10 +168,10 @@ class BondTool {
           ) {
             const closestAttachmentAtomId =
               SGroup.getAttachmentAtomIdBySGroupId(closestSGroup.id, molecule)
-            if (
-              closestAttachmentAtomId &&
-              closestAttachmentAtomId !== beginAtom
-            ) {
+            const isSaltOrSolvent = closestAttachmentAtomId === undefined
+            const isBeginFunctionalGroupItself =
+              closestAttachmentAtomId === beginAtom
+            if (!isSaltOrSolvent && !isBeginFunctionalGroupItself) {
               endAtom = {
                 id: closestAttachmentAtomId,
                 map: 'atoms'

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -154,7 +154,6 @@ class BondTool {
         let endAtom
         let beginPos
         let endPos
-        const extraNeighbour: Array<number> = []
         if ('item' in dragCtx && dragCtx.item.map === 'atoms') {
           // first mousedown event intersect with any atom
           beginAtom = dragCtx.item.id
@@ -190,17 +189,6 @@ class BondTool {
             fGroup && (SGroup.getAtoms(molecule, fGroup.item) as any)
           if (endAtom && fGroup && endAtom.id !== fGroupAtoms?.[0]) {
             this.editor.event.removeFG.dispatch({ fgIds: [fGroupId] })
-            endAtom = null
-          }
-          if (endAtom && fGroup && endAtom.id === fGroupAtoms?.[0]) {
-            const atomNeighbours = molecule.atomGetNeighbors(endAtom.id)
-            atomNeighbours?.forEach((nei) => {
-              !fGroupAtoms?.includes(nei.aid) &&
-                !extraNeighbour.includes(nei.aid) &&
-                extraNeighbour.push(nei.aid)
-            })
-          }
-          if (extraNeighbour.length >= 1) {
             endAtom = null
           }
         } else {

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -109,12 +109,7 @@ class BondTool {
 
     let attachmentAtomId: number | undefined
     if (ci?.map === 'functionalGroups') {
-      const functionalGroup = molecule.functionalGroups.get(ci.id)
-      if (!SGroup.isSaltOrSolvent(functionalGroup?.name || '')) {
-        const sGroupId = ci.id
-        const sGroup = molecule.sgroups.get(sGroupId)
-        attachmentAtomId = sGroup?.getAttAtomId(molecule)
-      }
+      attachmentAtomId = SGroup.getAttachmentAtomIdBySGroupId(ci.id, molecule)
     }
 
     const rnd = this.editor.render
@@ -209,7 +204,7 @@ class BondTool {
           // first mousedown event intersect with any canvas
           beginAtom = this.atomProps
           beginPos = dragCtx.xy0
-          endAtom = editor.findItem(event, ['atoms'])
+          endAtom = editor.findItem(event, ['atoms', 'functionalGroups'])
           const atomResult: Array<number> = []
           const result: Array<number> = []
           if (
@@ -223,6 +218,21 @@ class BondTool {
               endAtom.id
             )
             if (atomId !== null) atomResult.push(atomId)
+          } else if (endAtom?.map === 'functionalGroups') {
+            const functionalGroup = molecule.functionalGroups.get(endAtom.id)
+            if (!SGroup.isSaltOrSolvent(functionalGroup?.name || '')) {
+              const attachmentAtomId = SGroup.getAttachmentAtomIdBySGroupId(
+                endAtom.id,
+                molecule
+              )
+              endAtom =
+                attachmentAtomId === undefined
+                  ? null
+                  : {
+                      map: 'atoms',
+                      id: attachmentAtomId
+                    }
+            }
           }
           if (atomResult.length > 0) {
             for (const id of atomResult) {

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -107,7 +107,7 @@ class BondTool {
       return
     }
 
-    let attachmentAtomId
+    let attachmentAtomId: number | undefined
     if (ci?.map === 'functionalGroups') {
       const functionalGroup = molecule.functionalGroups.get(ci.id)
       if (!SGroup.isSaltOrSolvent(functionalGroup?.name || '')) {
@@ -172,11 +172,13 @@ class BondTool {
               functionalGroups
             )
           ) {
-            const sGroup = sgroups.get(closestSGroup.id)
-            const sGroupAtoms = SGroup.getAtoms(molecule, sGroup?.item)
-            endAtom = {
-              id: sGroupAtoms[0],
-              map: 'atoms'
+            const sGroup = molecule.sgroups.get(closestSGroup.id)
+            const closestAttachmentAtomId = sGroup?.getAttAtomId(molecule)
+            if (closestAttachmentAtomId !== beginAtom) {
+              endAtom = {
+                id: closestAttachmentAtomId,
+                map: 'atoms'
+              }
             }
           }
           const fGroupId =

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -231,7 +231,7 @@ class BondTool {
             // first mousedown event intersect with any atom and
             // rotation only, leght of bond = 1;
             const atom = rnd.ctab.molecule.atoms.get(beginAtom)
-            beginPos = utils.calcNewAtomPos(
+            endPos = utils.calcNewAtomPos(
               atom?.pp.get_xy0(),
               xy1,
               event.ctrlKey
@@ -301,12 +301,9 @@ class BondTool {
       } else if (dragCtx.item.map === 'atoms') {
         // click on atom
         this.editor.update(
-          fromBondAddition(
-            rnd.ctab,
-            this.bondProps,
-            dragCtx.item.id,
-            undefined
-          )[0]
+          fromBondAddition(rnd.ctab, this.bondProps, dragCtx.item.id, {
+            label: 'C'
+          })[0]
         )
         delete this.dragCtx.existedBond
       } else if (dragCtx.item.map === 'bonds') {

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -167,9 +167,12 @@ class BondTool {
               functionalGroups
             )
           ) {
-            const sGroup = molecule.sgroups.get(closestSGroup.id)
-            const closestAttachmentAtomId = sGroup?.getAttAtomId(molecule)
-            if (closestAttachmentAtomId !== beginAtom) {
+            const closestAttachmentAtomId =
+              SGroup.getAttachmentAtomIdBySGroupId(closestSGroup.id, molecule)
+            if (
+              closestAttachmentAtomId &&
+              closestAttachmentAtomId !== beginAtom
+            ) {
               endAtom = {
                 id: closestAttachmentAtomId,
                 map: 'atoms'

--- a/packages/ketcher-react/src/script/editor/tool/chain.ts
+++ b/packages/ketcher-react/src/script/editor/tool/chain.ts
@@ -22,7 +22,8 @@ import {
   fromItemsFuse,
   getHoverToFuse,
   getItemsToFuse,
-  FunctionalGroup
+  FunctionalGroup,
+  SGroup
 } from 'ketcher-core'
 
 import { atomLongtapEvent } from './atom'
@@ -44,7 +45,11 @@ class ChainTool {
     const molecule = struct.molecule
     const functionalGroups = molecule.functionalGroups
     const rnd = this.editor.render
-    const ci = this.editor.findItem(event, ['atoms', 'bonds'])
+    const ci = this.editor.findItem(event, [
+      'atoms',
+      'bonds',
+      'functionalGroups'
+    ])
     const atomResult: Array<number> = []
     const bondResult: Array<number> = []
     const result: Array<number> = []
@@ -113,6 +118,19 @@ class ChainTool {
       atomLongtapEvent(this, rnd)
     }
 
+    if (ci?.map === 'functionalGroups') {
+      const functionalGroup = molecule.functionalGroups.get(ci.id)
+      if (!SGroup.isSaltOrSolvent(functionalGroup?.name || '')) {
+        const sGroupId = ci.id
+        const sGroup = molecule.sgroups.get(sGroupId)
+        const attachmentAtomId = sGroup?.getAttAtomId(molecule)
+        this.dragCtx.item = {
+          map: 'atoms',
+          id: attachmentAtomId
+        }
+      }
+    }
+
     if (!this.dragCtx.item)
       // ci.type == 'Canvas'
       delete this.dragCtx.item
@@ -124,7 +142,11 @@ class ChainTool {
     const restruct = editor.render.ctab
     const dragCtx = this.dragCtx
 
-    editor.hover(this.editor.findItem(event, ['atoms', 'bonds']), null, event)
+    editor.hover(
+      this.editor.findItem(event, ['atoms', 'bonds', 'functionalGroups']),
+      null,
+      event
+    )
     if (!dragCtx) {
       return true
     }

--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -219,7 +219,7 @@ function handleBondTool({ hoveredItemId, newAction, editor }: HandlersProps) {
     editor.render.ctab,
     newAction.opts,
     hoveredItemId,
-    undefined
+    { label: 'C' }
   )[0]
   editor.update(newBond)
 }


### PR DESCRIPTION
- Resolves: #2257 
- Refactors `fromBondAddition`

Notice: this PR also fixes another 3 bugs of Bond Tool:

https://user-images.githubusercontent.com/27288153/233392678-ee54ec42-e1c4-4761-a41c-273dd5cb1b9a.mp4


https://user-images.githubusercontent.com/27288153/233393118-718617ac-c414-4116-a0cf-383e48123460.mp4


https://user-images.githubusercontent.com/27288153/233400508-6c210a51-aca7-422c-8983-37b2de2f0612.mp4

