### PR TITLE
#2267- Using Template Tool, Salts and Solvents should replace Atoms, Functional Groups, and Salts and Solvents & #1994 - Salts and Solvents: Edit notification appears instead of replacing new Salt or Solvent

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -194,7 +194,7 @@ class TemplateTool {
     const dragCtx = this.dragCtx
     const ci = dragCtx.item
 
-    if (!ci || this.isSaltOrSolvent) {
+    if (!ci) {
       //  ci.type == 'Canvas'
       delete dragCtx.item
       return
@@ -258,6 +258,11 @@ class TemplateTool {
         null,
         event
       )
+      return true
+    }
+
+    if (this.isSaltOrSolvent) {
+      delete this.dragCtx.item
       return true
     }
 
@@ -436,20 +441,7 @@ class TemplateTool {
     let action, functionalGroupRemoveAction
     let pasteItems = null
 
-    if (this.isSaltOrSolvent) {
-      addSaltsAndSolventsOnCanvasWithoutMerge(
-        restruct,
-        this.template,
-        dragCtx,
-        this.editor
-      )
-      this.editor.hover(
-        this.editor.findItem(event, this.findItems),
-        null,
-        event
-      )
-      return true
-    } else if (
+    if (
       ci?.map === 'functionalGroups' &&
       FunctionalGroup.isContractedFunctionalGroup(
         ci.id,
@@ -458,9 +450,23 @@ class TemplateTool {
       this.isModeFunctionalGroup &&
       this.targetGroupsIds.length
     ) {
-      functionalGroupRemoveAction = new Action()
       const restruct = this.editor.render.ctab
       const functionalGroupToReplace = this.struct.sgroups.get(ci.id)!
+
+      if (
+        this.isSaltOrSolvent &&
+        functionalGroupToReplace.isGroupAttached(this.struct)
+      ) {
+        addSaltsAndSolventsOnCanvasWithoutMerge(
+          restruct,
+          this.template,
+          dragCtx,
+          this.editor
+        )
+        return true
+      }
+
+      functionalGroupRemoveAction = new Action()
       const attachmentAtomId = functionalGroupToReplace.getAttAtomId(
         this.struct
       )
@@ -489,8 +495,18 @@ class TemplateTool {
         dragCtx.action = action
       } else if (ci.map === 'atoms') {
         const degree = restruct.atoms.get(ci.id)?.a.neighbors.length
-        let angle
 
+        if (degree && degree >= 1 && this.isSaltOrSolvent) {
+          addSaltsAndSolventsOnCanvasWithoutMerge(
+            restruct,
+            this.template,
+            dragCtx,
+            this.editor
+          )
+          return true
+        }
+
+        let angle
         if (degree && degree > 1) {
           // common case
           angle = null


### PR DESCRIPTION
Closes #2267 
Cloese #1994 