### PR TITLE
#2460 Structure on canvas becomes 'undefined' when atom is hovered and Functional Group selected using hotkey

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/templates.js
+++ b/packages/ketcher-react/src/script/ui/action/templates.js
@@ -21,7 +21,7 @@ const templateLib = {
   'template-lib': {
     shortcut: 'Shift+t',
     title: 'Custom Templates',
-    action: { dialog: 'templates', prop: { tab: null } },
+    action: { dialog: 'templates', prop: { tab: 0 } },
     selected: (editor) => editor._tool.mode === 'classic',
     disabled: (editor, server, options) => !options.app.templates,
     hidden: (options) => isHidden(options, 'template-lib')

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -116,7 +116,11 @@ function keyHandle(dispatch, state, hotKeys, event) {
       // check if atom is currently hovered over
       // in this case we do not want to activate the corresponding tool
       // and just insert the atom directly
-      if (hoveredItem && newAction.tool !== 'select') {
+      if (
+        hoveredItem &&
+        newAction.tool !== 'select' &&
+        newAction.dialog !== 'templates'
+      ) {
         newAction = getCurrentAction(group[index]) || newAction
         handleHotkeyOverItem({
           hoveredItem,


### PR DESCRIPTION
Closes [#2460](https://github.com/epam/ketcher/issues/2460)

We need to handle 'templates' dialogs on hovered items in the same way as regularly. That's why I added one more condition to keyHandler. Also fixed opening right tab by using 'shift + T'