### PR TITLE
Backmerge: #2502 – It is not possible to scroll to the top of a structure pasted partially outside a canvas (#2506)

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/helper/dropAndMerge.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/dropAndMerge.ts
@@ -19,7 +19,8 @@ type MergeItems = {
 export function dropAndMerge(
   editor: Editor,
   mergeItems: any,
-  action?: Action
+  action?: Action,
+  isPaste?: boolean
 ): Action {
   const restruct = editor.render.ctab
   const isMerging = !!mergeItems
@@ -50,7 +51,7 @@ export function dropAndMerge(
   if (isMerging) editor.selection(null)
 
   if (dropItemAction?.operations.length > 0) {
-    editor.update(dropItemAction, false, { resizeCanvas: false })
+    editor.update(dropItemAction, false, { resizeCanvas: !!isPaste })
   }
 
   return dropItemAction

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -207,7 +207,9 @@ class PasteTool {
       const action = this.action
       delete this.action
       if (!this.isSingleContractedGroup || !this.mergeItems) {
-        this.editor.update(dropAndMerge(this.editor, this.mergeItems, action))
+        this.editor.update(
+          dropAndMerge(this.editor, this.mergeItems, action, true)
+        )
       }
     }
   }


### PR DESCRIPTION
closes #2502 