### PR TITLE
Backmerge: #2502 – It is not possible to scroll to the top of a structure pasted partially outside a canvas (#2520)

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/helper/dropAndMerge.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/dropAndMerge.ts
@@ -20,7 +20,7 @@ export function dropAndMerge(
   editor: Editor,
   mergeItems: any,
   action?: Action,
-  isPaste?: boolean
+  resizeCanvas?: boolean
 ): Action {
   const restruct = editor.render.ctab
   const isMerging = !!mergeItems
@@ -51,7 +51,7 @@ export function dropAndMerge(
   if (isMerging) editor.selection(null)
 
   if (dropItemAction?.operations.length > 0) {
-    editor.update(dropItemAction, false, { resizeCanvas: !!isPaste })
+    editor.update(dropItemAction, false, { resizeCanvas: !!resizeCanvas })
   }
 
   return dropItemAction

--- a/packages/ketcher-react/src/script/editor/tool/helper/isAtomOutSideCanvas.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/isAtomOutSideCanvas.ts
@@ -1,0 +1,16 @@
+import { Atom } from 'ketcher-core'
+
+export function hasAtomsOutsideCanvas(atoms: Atom[], render, scale: number) {
+  return atoms.some((atom) => {
+    const canvasSize = render.sz
+    const { offset } = render.options
+    const xSize = atom.pp.x * scale
+    const ySize = atom.pp.y * scale
+    return (
+      xSize > canvasSize.x ||
+      xSize + offset.x < 0 ||
+      ySize > canvasSize.y ||
+      ySize + offset.y < 0
+    )
+  })
+}

--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -47,6 +47,7 @@ import { getGroupIdsFromItemArrays } from './helper/getGroupIdsFromItems'
 import { getMergeItems } from './helper/getMergeItems'
 import { updateSelectedAtoms } from 'src/script/ui/state/modal/atoms'
 import { updateSelectedBonds } from 'src/script/ui/state/modal/bonds'
+import { hasAtomsOutsideCanvas } from './helper/isAtomOutSideCanvas'
 
 class SelectTool {
   #mode: string
@@ -268,7 +269,18 @@ class SelectTool {
     /* end */
 
     if (this.dragCtx?.item) {
-      dropAndMerge(editor, this.dragCtx.mergeItems, this.dragCtx.action)
+      const atoms = Array.from(editor.struct().atoms.values())
+      const shouldResizeCanvas = hasAtomsOutsideCanvas(
+        atoms,
+        editor.render,
+        editor.options().scale
+      )
+      dropAndMerge(
+        editor,
+        this.dragCtx.mergeItems,
+        this.dragCtx.action,
+        shouldResizeCanvas
+      )
       delete this.dragCtx
     } else if (this.#lassoHelper.running()) {
       // TODO it catches more events than needed, to be re-factored


### PR DESCRIPTION
closes #2502 