### PR TITLE
#2288 Tooltip appears after dragging abbreviation and stay on canvas until release click

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -35,7 +35,7 @@ import { customOnChangeHandler } from './utils'
 import { isEqual } from 'lodash/fp'
 import toolMap from './tool'
 import { Highlighter } from './highlighter'
-import { showFunctionalGroupsTooltip } from './utils/functionalGroupsTooltip'
+import { setFunctionalGroupsTooltip } from './utils/functionalGroupsTooltip'
 import { contextMenuInfo } from '../ui/views/components/ContextMenu/contextMenu.types'
 import { HoverIcon } from './HoverIcon'
 
@@ -374,7 +374,7 @@ class Editor implements KetcherEditor {
 
     if (!event) return
 
-    showFunctionalGroupsTooltip(this)
+    setFunctionalGroupsTooltip(this, true)
   }
 
   update(
@@ -382,6 +382,8 @@ class Editor implements KetcherEditor {
     ignoreHistory?: boolean,
     options = { resizeCanvas: true }
   ) {
+    setFunctionalGroupsTooltip(this, false)
+
     if (action === true) {
       this.render.update(true, null, options) // force
     } else {
@@ -452,7 +454,7 @@ class Editor implements KetcherEditor {
 
   subscribe(eventName: any, handler: any) {
     const subscriber = {
-      handler: handler
+      handler
     }
 
     switch (eventName) {

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -1,23 +1,33 @@
 import { FunctionalGroup } from 'ketcher-core'
+import Editor from '../Editor'
 
 let showTooltipTimer: ReturnType<typeof setTimeout> | null = null
 
 export const TOOLTIP_DELAY = 300
 
-export function showTooltip(editor, infoPanelData) {
+function hideTooltip(editor: Editor) {
   editor.event.showInfo.dispatch(null)
 
   if (showTooltipTimer) {
     clearTimeout(showTooltipTimer)
   }
-  if (infoPanelData) {
-    showTooltipTimer = setTimeout(() => {
-      editor.event.showInfo.dispatch(infoPanelData)
-    }, TOOLTIP_DELAY)
-  }
 }
 
-export function showFunctionalGroupsTooltip(editor) {
+function showTooltip(editor: Editor, infoPanelData: any) {
+  hideTooltip(editor)
+
+  showTooltipTimer = setTimeout(() => {
+    editor.event.showInfo.dispatch(infoPanelData)
+  }, TOOLTIP_DELAY)
+}
+
+export function setFunctionalGroupsTooltip(editor: Editor, isShow: boolean) {
+  if (!isShow) {
+    hideTooltip(editor)
+
+    return
+  }
+
   let infoPanelData: any = null
   const checkFunctionGroupTypes = ['sgroups', 'functionalGroups']
   const closestCollapsibleStructures = editor.findItem(


### PR DESCRIPTION
Closes [#2288](https://github.com/epam/ketcher/issues/2288)

Added functional to hide tooltip when we are moving function group or adding new atoms