### PR TITLE
#2528 – Erase tool does not completely remove the Functional Groups if it selecting via the hot key CTRL + A

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/erase.ts
+++ b/packages/ketcher-core/src/application/editor/actions/erase.ts
@@ -109,6 +109,9 @@ export function fromFragmentDeletion(restruct, rawSelection) {
     })
   })
 
+  selection.atoms = Array.from(new Set(selection.atoms))
+  selection.bonds = Array.from(new Set(selection.bonds))
+
   selection.atoms.forEach((aid) => {
     restruct.molecule.atomGetNeighbors(aid).forEach((nei) => {
       if (selection.bonds.indexOf(nei.bid) === -1) {


### PR DESCRIPTION
closes #2528 

During selection atoms and bonds may be included into selection multiple times:
1. Because selecting atoms and bonds directly
2. Because of s-group selection, which also includes selection of its atoms and bonds

When user tries to delete a s-group, code tried to delete already removed bond, what caused an exception.