### PR TITLE
Backmerge: #2528 – Erase tool does not completely remove the Functional Groups if it selecting via the hot key CTRL + A (#2536)

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/erase.ts
+++ b/packages/ketcher-core/src/application/editor/actions/erase.ts
@@ -109,6 +109,9 @@ export function fromFragmentDeletion(restruct, rawSelection) {
     })
   })
 
+  selection.atoms = Array.from(new Set(selection.atoms))
+  selection.bonds = Array.from(new Set(selection.bonds))
+
   selection.atoms.forEach((aid) => {
     restruct.molecule.atomGetNeighbors(aid).forEach((nei) => {
       if (selection.bonds.indexOf(nei.bid) === -1) {


### PR DESCRIPTION
closes #2528