### PR TITLE
#2483:  Pressing Clear Canvas with Reaction Arrow under mouse cursor causes errors in DevTool console

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/index.js
+++ b/packages/ketcher-react/src/script/ui/action/index.js
@@ -28,6 +28,7 @@ import help from './help'
 import functionalGroups from './functionalGroups'
 import fullscreen from './fullscreen'
 import { SettingsManager } from '../utils/settingsManager'
+import { removeStructAction } from '../state/shared'
 
 export * from './action.types'
 
@@ -38,12 +39,10 @@ const config = {
     action: {
       thunk: (dispatch, getState) => {
         const editor = getState().editor
+
+        dispatch(removeStructAction())
+
         if (!editor.struct().isBlank()) editor.struct(null)
-        const savedSelectedTool = SettingsManager.selectionTool
-        dispatch({
-          type: 'ACTION',
-          action: savedSelectedTool || tools['select-rectangle'].action
-        })
       }
     },
     hidden: (options) => isHidden(options, 'clear')


### PR DESCRIPTION
Actions ordering was changed in clear action, reused removeStructAction.