### PR TITLE
Backmerge: #2517 File with Superatom opens without part of structure

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -32,7 +32,13 @@ import { Action } from './action'
 import { Vec2 } from 'domain/entities'
 import { fromSgroupAddition } from './sgroup'
 
-export function fromPaste(restruct, pstruct, point, angle = 0) {
+export function fromPaste(
+  restruct,
+  pstruct,
+  point,
+  angle = 0,
+  sGroupsIdExpanded: number[] = []
+) {
   const xy0 = getStructCenter(pstruct)
   const offset = Vec2.diff(point, xy0)
 
@@ -97,6 +103,9 @@ export function fromPaste(restruct, pstruct, point, angle = 0) {
   pstruct.sgroups.forEach((sg) => {
     const newsgid = restruct.molecule.sgroups.newId()
     const sgAtoms = sg.atoms.map((aid) => aidMap.get(aid))
+    if (sg.type === 'SUP' && sGroupsIdExpanded?.includes(sg.id)) {
+      sg.data.expanded = true
+    }
     const sgAction = fromSgroupAddition(
       restruct,
       sg.type,

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -32,13 +32,7 @@ import { Action } from './action'
 import { Vec2 } from 'domain/entities'
 import { fromSgroupAddition } from './sgroup'
 
-export function fromPaste(
-  restruct,
-  pstruct,
-  point,
-  angle = 0,
-  sGroupsIdExpanded: number[] = []
-) {
+export function fromPaste(restruct, pstruct, point, angle = 0) {
   const xy0 = getStructCenter(pstruct)
   const offset = Vec2.diff(point, xy0)
 
@@ -103,9 +97,6 @@ export function fromPaste(
   pstruct.sgroups.forEach((sg) => {
     const newsgid = restruct.molecule.sgroups.newId()
     const sgAtoms = sg.atoms.map((aid) => aidMap.get(aid))
-    if (sg.type === 'SUP' && sGroupsIdExpanded?.includes(sg.id)) {
-      sg.data.expanded = true
-    }
     const sgAction = fromSgroupAddition(
       restruct,
       sg.type,

--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -227,6 +227,15 @@ export class FunctionalGroup {
     return false
   }
 
+  static getAttachmentPointCount(sGroup, molecule): number {
+    return sGroup.atoms?.reduce((count, currentAtom) => {
+      if (FunctionalGroup.isAttachmentPointAtom(currentAtom, molecule)) {
+        count++
+      }
+      return count
+    }, 0)
+  }
+
   static isFirstAtomInFunctionalGroup(sgroups, aid): boolean {
     for (const sg of sgroups.values()) {
       if (FunctionalGroup.isFunctionalGroup(sg) && aid === sg.atoms[0]) {

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -18,8 +18,10 @@ import {
   fromItemsFuse,
   fromPaste,
   fromTemplateOnAtom,
+  FunctionalGroup,
   getHoverToFuse,
   getItemsToFuse,
+  setExpandSGroup,
   SGroup,
   Struct,
   Vec2
@@ -58,6 +60,21 @@ class PasteTool {
 
     const [action, pasteItems] = fromPaste(rnd.ctab, this.struct, point)
     this.action = action
+    this.editor.update(this.action, true)
+
+    struct.sgroups.forEach((sgroup) => {
+      const count = FunctionalGroup.getAttachmentPointCount(
+        sgroup,
+        this.editor.render.ctab.molecule
+      )
+      if (count > 1) {
+        action.mergeWith(
+          setExpandSGroup(this.editor.render.ctab, sgroup.id, {
+            expanded: true
+          })
+        )
+      }
+    })
     this.editor.update(this.action, true)
 
     this.findItems = ['functionalGroups']
@@ -155,11 +172,23 @@ class PasteTool {
       this.dragCtx.action = action
       this.editor.update(this.dragCtx.action, true)
     } else {
+      const sGroupsIdExpanded: number[] = []
+      this.struct.sgroups.forEach((sgroup) => {
+        const count = FunctionalGroup.getAttachmentPointCount(
+          sgroup,
+          this.struct
+        )
+        if (count > 1) {
+          sGroupsIdExpanded.push(sgroup.id)
+        }
+      })
       // common paste logic
       const [action, pasteItems] = fromPaste(
         this.editor.render.ctab,
         this.struct,
-        this.editor.render.page2obj(event)
+        this.editor.render.page2obj(event),
+        0,
+        sGroupsIdExpanded
       )
       this.action = action
       this.editor.update(this.action, true, { resizeCanvas: false })

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -62,12 +62,13 @@ class PasteTool {
     this.action = action
     this.editor.update(this.action, true)
 
+    // todo delete after supporting expand - collapse for 2 attachment points
     struct.sgroups.forEach((sgroup) => {
-      const count = FunctionalGroup.getAttachmentPointCount(
+      const countAttachmentPoint = FunctionalGroup.getAttachmentPointCount(
         sgroup,
         this.editor.render.ctab.molecule
       )
-      if (count > 1) {
+      if (countAttachmentPoint > 1) {
         action.mergeWith(
           setExpandSGroup(this.editor.render.ctab, sgroup.id, {
             expanded: true
@@ -172,23 +173,21 @@ class PasteTool {
       this.dragCtx.action = action
       this.editor.update(this.dragCtx.action, true)
     } else {
-      const sGroupsIdExpanded: number[] = []
+      // todo delete after supporting expand - collapse for 2 attachment points
       this.struct.sgroups.forEach((sgroup) => {
-        const count = FunctionalGroup.getAttachmentPointCount(
+        const countAttachmentPoint = FunctionalGroup.getAttachmentPointCount(
           sgroup,
           this.struct
         )
-        if (count > 1) {
-          sGroupsIdExpanded.push(sgroup.id)
+        if (countAttachmentPoint > 1) {
+          sgroup.data.expanded = true
         }
       })
       // common paste logic
       const [action, pasteItems] = fromPaste(
         this.editor.render.ctab,
         this.struct,
-        this.editor.render.page2obj(event),
-        0,
-        sGroupsIdExpanded
+        this.editor.render.page2obj(event)
       )
       this.action = action
       this.editor.update(this.action, true, { resizeCanvas: false })

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -180,7 +180,7 @@ class PasteTool {
           this.struct
         )
         if (countAttachmentPoint > 1) {
-          sgroup.data.expanded = true
+          sgroup.setAttr('expanded', true)
         }
       })
       // common paste logic

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useFunctionalGroupEoc.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useFunctionalGroupEoc.ts
@@ -1,4 +1,4 @@
-import { Action, setExpandSGroup } from 'ketcher-core'
+import { Action, FunctionalGroup, setExpandSGroup } from 'ketcher-core'
 import { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
 import { useAppContext } from 'src/hooks'
@@ -44,8 +44,21 @@ const useFunctionalGroupEoc = () => {
     },
     []
   )
+  const disabled = useCallback(({ props }: ItemEventParams) => {
+    const editor = getKetcherInstance().editor as Editor
+    const molecule = editor.render.ctab.molecule
+    return Boolean(
+      props?.functionalGroups?.every(
+        (functionalGroup) =>
+          FunctionalGroup.getAttachmentPointCount(
+            functionalGroup?.relatedSGroup,
+            molecule
+          ) > 1
+      )
+    )
+  }, [])
 
-  return [handler, hidden] as const
+  return [handler, hidden, disabled] as const
 }
 
 export default useFunctionalGroupEoc

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/FunctionalGroupMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/FunctionalGroupMenuItems.tsx
@@ -3,14 +3,18 @@ import useFunctionalGroupEoc from '../hooks/useFunctionalGroupEoc'
 import useFunctionalGroupRemove from '../hooks/useFunctionalGroupRemove'
 
 const FunctionalGroupMenuItems: React.FC = (props) => {
-  const [handleExpandOrContract, ExpandOrContractHidden] =
-    useFunctionalGroupEoc()
+  const [
+    handleExpandOrContract,
+    ExpandOrContractHidden,
+    ExpandOrContractDisabled
+  ] = useFunctionalGroupEoc()
   const handleRemove = useFunctionalGroupRemove()
 
   return (
     <>
       <Item
         {...props}
+        disabled={(params) => ExpandOrContractDisabled(params)}
         hidden={(params) => ExpandOrContractHidden(params, true)}
         onClick={(params) => handleExpandOrContract(params, true)}
       >
@@ -18,6 +22,7 @@ const FunctionalGroupMenuItems: React.FC = (props) => {
       </Item>
       <Item
         {...props}
+        disabled={(params) => ExpandOrContractDisabled(params)}
         hidden={(params) => ExpandOrContractHidden(params, false)}
         onClick={(params) => handleExpandOrContract(params, false)}
       >


### PR DESCRIPTION
if sgroup has more than 1 attachment point, we should expand sgroup. I made this logic for paste tool. "Expanded" function invokes in 2 places: 
1) constructor - in that case we firstly render struct from paste and after what we make expand sgroup
2) mouse move - I can't invoke function "setExpandSGroup" because struct and editor have absolutely different id for atoms and sgroups.  I create array sGroupsIdExpanded with id "s groups" which need to be expanded and put this array in "fromPaste" function. if id sgroup  is exist in "sGroupsIdExpanded" than field expanded = true

https://user-images.githubusercontent.com/100932091/235716156-d8c4d236-a5e0-4022-87fe-27de1426e979.mov
