### PR TITLE
Backmerge: #2273 - When user selects and moves atom on Functional Group or Salt it doesn't replaces atom in the structure

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/helper/dropAndMerge.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/dropAndMerge.ts
@@ -91,32 +91,29 @@ function extractAttachmentAtom(mergeItems: MergeItems, editor: Editor) {
     atoms: new Map(mergeItems.atoms),
     bonds: new Map(mergeItems.bonds)
   }
-  const removeNonAttachmentAtoms = new Action()
-  const removeSGroup = new Action()
+
+  const action = new Action()
 
   mergeItems.atomToFunctionalGroup?.forEach((functionalGroupId, srcAtomId) => {
     const sGroup = struct.sgroups.get(functionalGroupId)
+
     const attachmentAtomId = sGroup?.getAttAtomId(struct)
 
-    if (attachmentAtomId) {
-      const attachmentAtom = struct.atoms.get(attachmentAtomId)
-      if (SGroup.isAtomInContractedSGroup(attachmentAtom, struct.sgroups)) {
-        return
-      }
-      newMergeItems.atoms.set(srcAtomId, attachmentAtomId)
-
-      removeNonAttachmentAtoms.mergeWith(
+    if (attachmentAtomId !== undefined) {
+      const atomsToDelete = [...SGroup.getAtoms(struct, sGroup)].filter(
+        (atomId) => atomId !== attachmentAtomId
+      )
+      const bondsToDelete = [...SGroup.getBonds(struct, sGroup)]
+      action.mergeWith(fromSgroupDeletion(reStruct, functionalGroupId))
+      action.mergeWith(
         fromFragmentDeletion(reStruct, {
-          atoms: [...SGroup.getAtoms(struct, sGroup)].filter(
-            (atomId) => atomId !== attachmentAtomId
-          ),
-          bonds: [...SGroup.getBonds(struct, sGroup)]
+          atoms: atomsToDelete,
+          bonds: bondsToDelete
         })
       )
-
-      removeSGroup.mergeWith(fromSgroupDeletion(reStruct, functionalGroupId))
+      newMergeItems.atoms.set(srcAtomId, attachmentAtomId)
     }
   })
 
-  return [newMergeItems, removeNonAttachmentAtoms] as const
+  return [newMergeItems, action] as const
 }


### PR DESCRIPTION
Closes #2273 