### PR TITLE
#2463 Rotation Tool: display predefined rotation angles and current angle

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -228,7 +228,7 @@ class Editor implements KetcherEditor {
 
     const isSelectToolChosen = name === 'select'
     if (!isSelectToolChosen) {
-      this.rotateController.hide()
+      this.rotateController.clean()
     }
 
     if (!tool || tool.isNotActiveTool) {
@@ -363,7 +363,7 @@ class Editor implements KetcherEditor {
 
     this.render.ctab.setSelection(this._selection) // eslint-disable-line
     this.event.selectionChange.dispatch(this._selection) // eslint-disable-line
-    this._selection === null && this.rotateController.hide()
+    this._selection === null && this.rotateController.clean()
 
     this.render.update(false, null, { resizeCanvas: false })
     return this._selection // eslint-disable-line

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -321,9 +321,10 @@ class Editor implements KetcherEditor {
     }
 
     let ReStruct = this.render.ctab
-
+    let selectAll = false
     this._selection = null // eslint-disable-line
     if (ci === 'all') {
+      selectAll = true
       // TODO: better way will be this.struct()
       ci = structObjects.reduce((res, key) => {
         res[key] = Array.from(ReStruct[key].keys())
@@ -363,7 +364,12 @@ class Editor implements KetcherEditor {
 
     this.render.ctab.setSelection(this._selection) // eslint-disable-line
     this.event.selectionChange.dispatch(this._selection) // eslint-disable-line
-    this._selection === null && this.rotateController.clean()
+
+    if (selectAll) {
+      this.rotateController.rerender()
+    } else if (this._selection === null) {
+      this.rotateController.clean()
+    }
 
     this.render.update(false, null, { resizeCanvas: false })
     return this._selection // eslint-disable-line

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -74,7 +74,7 @@ describe('Rotate controller', () => {
     }
 
     // @ts-ignore
-    controller.mouseDown({
+    controller.dragStart({
       buttons: 2, // Right button
       stopPropagation: () => null
     })

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -11,6 +11,7 @@ describe('Rotate controller', () => {
   it(`hides for one visible atom`, () => {
     const paper = jest.fn()
     const controller = new RotateController({
+      selection: () => null,
       render: {
         paper
       }
@@ -34,6 +35,7 @@ describe('Rotate controller', () => {
     const NonSelectTool = new RotateTool(editor, undefined)
     const paper = jest.fn()
     const controller = new RotateController({
+      selection: () => null,
       tool: () => NonSelectTool,
       render: { paper }
     } as any)

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import RotateTool from './rotate'
-import RotateController from './rotate-controller'
+import { Vec2 } from 'ketcher-core'
 import Editor from '../Editor'
+import RotateTool from './rotate'
+import RotateController, { getDifference } from './rotate-controller'
 
 describe('Rotate controller', () => {
   /**
@@ -80,5 +81,84 @@ describe('Rotate controller', () => {
     })
 
     expect(changeCrossColor).toBeCalledTimes(0)
+  })
+
+  /**
+   * Steps to check:
+   * Select and move a big structure to edge of canvas,
+   * then rotate it by the handle
+   */
+  test('center changes with `scale` and `offset`', () => {
+    const controller = new RotateController({ selection: () => null } as any)
+    // @ts-ignore
+    controller.originalCenter = new Vec2(1, 1)
+    // @ts-ignore
+    controller.editor.render = {
+      options: {
+        scale: 2,
+        offset: new Vec2(1, 1)
+      }
+    }
+
+    // @ts-ignore
+    expect(controller.center.x).toBe(3)
+    // @ts-ignore
+    expect(controller.center.y).toBe(3)
+  })
+
+  it('shows half predefined degrees', () => {
+    let structRotateDegree = 180
+    let predefinedDegree1 = 90
+    let predefinedDegree2 = -90
+    let predefinedDegree3 = 89
+    let predefinedDegree4 = -89
+    expect(
+      getDifference(predefinedDegree1, structRotateDegree)
+    ).toBeLessThanOrEqual(90)
+    expect(
+      getDifference(predefinedDegree2, structRotateDegree)
+    ).toBeLessThanOrEqual(90)
+    expect(
+      getDifference(predefinedDegree3, structRotateDegree)
+    ).toBeGreaterThan(90)
+    expect(
+      getDifference(predefinedDegree4, structRotateDegree)
+    ).toBeGreaterThan(90)
+
+    structRotateDegree = 135
+    predefinedDegree1 = 45
+    predefinedDegree2 = -135
+    predefinedDegree3 = 44
+    predefinedDegree4 = -134
+    expect(
+      getDifference(predefinedDegree1, structRotateDegree)
+    ).toBeLessThanOrEqual(90)
+    expect(
+      getDifference(predefinedDegree2, structRotateDegree)
+    ).toBeLessThanOrEqual(90)
+    expect(
+      getDifference(predefinedDegree3, structRotateDegree)
+    ).toBeGreaterThan(90)
+    expect(
+      getDifference(predefinedDegree4, structRotateDegree)
+    ).toBeGreaterThan(90)
+
+    structRotateDegree = -135
+    predefinedDegree1 = -45
+    predefinedDegree2 = 135
+    predefinedDegree3 = -44
+    predefinedDegree4 = 134
+    expect(
+      getDifference(predefinedDegree1, structRotateDegree)
+    ).toBeLessThanOrEqual(90)
+    expect(
+      getDifference(predefinedDegree2, structRotateDegree)
+    ).toBeLessThanOrEqual(90)
+    expect(
+      getDifference(predefinedDegree3, structRotateDegree)
+    ).toBeGreaterThan(90)
+    expect(
+      getDifference(predefinedDegree4, structRotateDegree)
+    ).toBeGreaterThan(90)
   })
 })

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -286,6 +286,8 @@ class RotateController {
         })
       this.protractor.push(degreeText)
     }
+
+    this.protractor.toBack()
   }
 
   // NOTE: When handle is non-arrow function, `this` is element itself

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -254,7 +254,7 @@ class RotateController {
     predefinedDegrees.reduce((previousDegree, currentDegree, currentIndex) => {
       const isDrawingDegree0 = currentIndex === 0
       const gap = currentDegree - previousDegree
-      const abs = Math.abs(currentDegree - structRotateDegree)
+      const diff = getDifference(currentDegree, structRotateDegree)
 
       if (isDrawingDegree0) {
         degreeLine = paper
@@ -275,7 +275,7 @@ class RotateController {
           .rotate(gap, this.center!.x, this.center!.y)
       }
       degreeLine!.attr({
-        stroke: abs > 90 ? 'none' : PROTRACTOR_COLOR
+        stroke: diff > 90 ? 'none' : PROTRACTOR_COLOR
       })
       this.protractor!.push(degreeLine)
 
@@ -287,7 +287,7 @@ class RotateController {
       const degreeText = paper
         .text(textPos.x, textPos.y, `${currentDegree}°`)
         .attr({
-          fill: abs > 90 ? 'none' : STYLE.INITIAL_COLOR,
+          fill: diff > 90 ? 'none' : STYLE.INITIAL_COLOR,
           'font-size': DEGREE_FONT_SIZE
         })
 
@@ -483,6 +483,8 @@ class RotateController {
   }
 }
 
+export default RotateController
+
 const rotatePoint = (centerPoint: Vec2, startPoint: Vec2, angle: number) => {
   const oCenter = centerPoint
   const oStart = startPoint
@@ -494,4 +496,21 @@ const rotatePoint = (centerPoint: Vec2, startPoint: Vec2, angle: number) => {
   return oEnd
 }
 
-export default RotateController
+const getDifference = (currentDegree: number, structRotateDegree: number) => {
+  let abs = 0
+
+  // HACK: https://github.com/epam/ketcher/pull/2574#issuecomment-1539509046
+  if (structRotateDegree > 90) {
+    const positiveCurrentDegree =
+      currentDegree < 0 ? currentDegree + 360 : currentDegree
+    abs = Math.abs(positiveCurrentDegree - structRotateDegree)
+  } else if (structRotateDegree < -90) {
+    const negativeCurrentDegree =
+      currentDegree > 0 ? currentDegree - 360 : currentDegree
+    abs = Math.abs(negativeCurrentDegree - structRotateDegree)
+  } else {
+    abs = Math.abs(currentDegree - structRotateDegree)
+  }
+
+  return abs
+}

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -511,7 +511,10 @@ const rotatePoint = (centerPoint: Vec2, startPoint: Vec2, angle: number) => {
   return oEnd
 }
 
-const getDifference = (currentDegree: number, structRotateDegree: number) => {
+export const getDifference = (
+  currentDegree: number,
+  structRotateDegree: number
+) => {
   let abs = 0
 
   // HACK: https://github.com/epam/ketcher/pull/2574#issuecomment-1539509046

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -287,7 +287,12 @@ class RotateController {
       const degreeText = paper
         .text(textPos.x, textPos.y, `${currentDegree}°`)
         .attr({
-          fill: diff > 90 ? 'none' : STYLE.INITIAL_COLOR,
+          fill:
+            diff > 90
+              ? 'none'
+              : currentDegree !== 0 && currentDegree === structRotateDegree
+              ? STYLE.ACTIVE_COLOR
+              : STYLE.INITIAL_COLOR,
           'font-size': DEGREE_FONT_SIZE
         })
 

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -307,14 +307,16 @@ class RotateController {
     const TEXT_COLOR = '#333333'
 
     // Doc: https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
-    arc.attr({
-      path:
-        `M${rotateArcStart.x},${rotateArcStart.y}` +
-        `A${this.protractorRadius},${this.protractorRadius} ` +
-        `0 0,${structRotateDegree < 0 ? '0' : '1'} ` +
-        `${rotateArcEnd.x},${rotateArcEnd.y}`,
-      stroke: STYLE.ACTIVE_COLOR
-    })
+    arc
+      .attr({
+        path:
+          `M${rotateArcStart.x},${rotateArcStart.y}` +
+          `A${this.protractorRadius},${this.protractorRadius} ` +
+          `0 0,${structRotateDegree < 0 ? '0' : '1'} ` +
+          `${rotateArcEnd.x},${rotateArcEnd.y}`,
+        stroke: STYLE.ACTIVE_COLOR
+      })
+      .toBack()
 
     text.attr({
       text: `${structRotateDegree}°`,
@@ -413,14 +415,6 @@ class RotateController {
           new Vec2(dxFromStart, dyFromStart).scaled(1 / options.zoom) // HACK: zoom in/out
         )
 
-        const newProtractorRadius =
-          Vec2.dist(newHandleCenter, this.center) -
-          STYLE.HANDLE_MARGIN -
-          STYLE.HANDLE_RADIUS
-        this.protractorRadius =
-          newProtractorRadius >= 0 ? newProtractorRadius : 0
-        this.redrawProtractor()
-
         this.link
           ?.attr({
             path:
@@ -440,13 +434,21 @@ class RotateController {
         const rotateDegree = utils.degrees(newRotateAngle - lastRotateAngle)
         this.cross?.rotate(rotateDegree, this.center.x, this.center.y)
 
+        this.rotateTool.mousemove(event)
+        const newProtractorRadius =
+          Vec2.dist(newHandleCenter, this.center) -
+          STYLE.HANDLE_MARGIN -
+          STYLE.HANDLE_RADIUS
+        this.protractorRadius =
+          newProtractorRadius >= 0 ? newProtractorRadius : 0
+        this.drawRotateArc(this.rotateTool.dragCtx.angle)
+        // NOTE: drawing protractor last
+        this.redrawProtractor(this.rotateTool.dragCtx.angle)
+
         lastHandleCenter = newHandleCenter
         lastRotateAngle = newRotateAngle
-
-        this.rotateTool.mousemove(event)
-        this.drawRotateArc(this.rotateTool.dragCtx.angle)
       },
-      100
+      40 // 25fps
     )
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -29,9 +29,10 @@ class RotateController {
   private rotateTool?: RotateTool
 
   private handle?: RaphaelElement // [circle, arrowSet]
-  private rectangle?: RaphaelElement
+  private boundingRect?: RaphaelElement
   private cross?: RaphaelElement
   private link?: RaphaelElement
+  // private protractor?: RaphaelElement
 
   constructor(editor: Editor) {
     this.editor = editor
@@ -60,7 +61,7 @@ class RotateController {
     this.handle?.undrag()
 
     this.cross?.hide()
-    this.rectangle?.hide()
+    this.boundingRect?.hide()
     this.handle?.hide()
     this.link?.hide()
   }
@@ -133,7 +134,7 @@ class RotateController {
       STYLE.RECT_PADDING +
       render.options.atomSelectionPlateRadius
 
-    this.rectangle = render.paper
+    this.boundingRect = render.paper
       .rect(
         rectStartX,
         rectStartY,
@@ -257,6 +258,7 @@ class RotateController {
     let lastHandleCenter = this.initialHandleCenter
     let lastRotateAngle = utils.calcAngle(lastHandleCenter, this.center)
 
+    // TODO: @yuleicul after 130px numbers disappear should be done or not?
     return (
       dxFromStart: number,
       dyFromStart: number,
@@ -289,7 +291,7 @@ class RotateController {
       const newRotateAngle = utils.calcAngle(newHandleCenter, this.center)
       const rotateDegree = utils.degrees(newRotateAngle - lastRotateAngle)
       this.cross?.rotate(rotateDegree, this.center?.x, this.center?.y)
-      this.rectangle?.rotate(rotateDegree, this.center?.x, this.center?.y)
+      this.boundingRect?.rotate(rotateDegree, this.center?.x, this.center?.y)
 
       lastHandleCenter = newHandleCenter
       lastRotateAngle = newRotateAngle

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -411,7 +411,7 @@ class RotateController {
     const arrowSet = this.handle?.[1]
     arrowSet?.attr({ fill: 'none' })
 
-    this.rotateTool.mousedown(event)
+    this.rotateTool.mousedown(event, true)
   }
 
   private dragMove = () => {
@@ -438,9 +438,9 @@ class RotateController {
           return
         }
 
-        const options = this.editor.render.options
+        const render = this.editor.render
         const newHandleCenter = this.initialHandleCenter.add(
-          new Vec2(dxFromStart, dyFromStart).scaled(1 / options.zoom) // HACK: zoom in/out
+          new Vec2(dxFromStart, dyFromStart).scaled(1 / render.options.zoom) // HACK: zoom in/out
         )
 
         this.link
@@ -462,7 +462,10 @@ class RotateController {
         const rotateDegree = utils.degrees(newRotateAngle - lastRotateAngle)
         this.cross?.rotate(rotateDegree, this.center.x, this.center.y)
 
-        this.rotateTool.mousemove(event)
+        this.rotateTool.mousemove(
+          event,
+          render.view2obj(newHandleCenter.scaled(render.options.zoom))
+        )
         const newProtractorRadius =
           Vec2.dist(newHandleCenter, this.center) -
           STYLE.HANDLE_MARGIN -

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -363,12 +363,13 @@ class RotateController {
       return
     }
 
+    const isDragPaused = !this.boundingRect
     this.handle?.attr({
-      cursor: 'grab'
+      cursor: isDragPaused ? 'not-allowed' : 'grab'
     })
     const circle = this.handle?.[0]
     circle.attr({
-      fill: STYLE.ACTIVE_COLOR
+      fill: isDragPaused ? STYLE.INITIAL_COLOR : STYLE.ACTIVE_COLOR
     })
   }
 
@@ -392,19 +393,26 @@ class RotateController {
       return
     }
 
-    this.boundingRect?.hide()
+    const isDragPaused = !this.boundingRect
+    if (isDragPaused) {
+      // Fix protractor staying after screenshot/being paused
+      // see https://github.com/epam/ketcher/pull/2574#issuecomment-1539201020
+      this.clean()
+      return
+    }
+
+    this.boundingRect?.remove()
+    delete this.boundingRect
     this.drawProtractor(0)
     this.cross?.attr({
       stroke: STYLE.ACTIVE_COLOR
     })
-    this.link
-      ?.attr({
-        path:
-          `M${this.center?.x},${this.center?.y}` +
-          `L${this.initialHandleCenter?.x},${this.initialHandleCenter?.y}`,
-        stroke: STYLE.ACTIVE_COLOR
-      })
-      .toFront()
+    this.link?.attr({
+      path:
+        `M${this.center?.x},${this.center?.y}` +
+        `L${this.initialHandleCenter?.x},${this.initialHandleCenter?.y}`,
+      stroke: STYLE.ACTIVE_COLOR
+    })
     this.handle?.attr({
       cursor: 'grabbing'
     })
@@ -443,14 +451,12 @@ class RotateController {
           new Vec2(dxFromStart, dyFromStart).scaled(1 / render.options.zoom) // HACK: zoom in/out
         )
 
-        this.link
-          ?.attr({
-            path:
-              `M${this.center.x},${this.center.y}` +
-              `L${newHandleCenter.x},${newHandleCenter.y}`,
-            stroke: STYLE.ACTIVE_COLOR
-          })
-          .toFront()
+        this.link?.attr({
+          path:
+            `M${this.center.x},${this.center.y}` +
+            `L${newHandleCenter.x},${newHandleCenter.y}`,
+          stroke: STYLE.ACTIVE_COLOR
+        })
 
         const delta = newHandleCenter.sub(lastHandleCenter)
         this.handle?.translate(delta.x, delta.y)

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -58,11 +58,17 @@ class RotateTool {
     }
   }
 
-  mousedown(event) {
+  /**
+   * @param rotatedByHandle when rotated by handle (see: ./rotate-controller),
+   *        starting angle should be `-Math.PI / 2` from the X axis
+   */
+  mousedown(event, rotatedByHandle?: boolean) {
     const xy0 = this.getCenter(this.editor, event)[0]
     this.dragCtx = {
       xy0,
-      angle1: utils.calcAngle(xy0, this.editor.render.page2obj(event))
+      angle1: rotatedByHandle
+        ? -Math.PI / 2
+        : utils.calcAngle(xy0, this.editor.render.page2obj(event))
     }
     return true
   }
@@ -138,7 +144,11 @@ class RotateTool {
     return [xy0, visibleAtoms] as const
   }
 
-  mousemove(event) {
+  /**
+   * @param handleCenter when rotated by handle (see: ./rotate-controller),
+   *        moving position should be handle's center
+   */
+  mousemove(event, handleCenter?: Vec2) {
     if (!this.dragCtx) {
       this.editor.hover(null, null, event)
       return true
@@ -147,7 +157,7 @@ class RotateTool {
     const rnd = this.editor.render
     const dragCtx = this.dragCtx
 
-    const pos = rnd.page2obj(event)
+    const pos = handleCenter || rnd.page2obj(event)
     let angle = utils.calcAngle(dragCtx.xy0, pos) - dragCtx.angle1
 
     if (!event.ctrlKey) {

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -144,11 +144,7 @@ class RotateTool {
     return [xy0, visibleAtoms] as const
   }
 
-  /**
-   * @param handleCenter when rotated by handle (see: ./rotate-controller),
-   *        moving position should be handle's center
-   */
-  mousemove(event, handleCenter?: Vec2) {
+  mousemove(event) {
     if (!this.dragCtx) {
       this.editor.hover(null, null, event)
       return true
@@ -157,7 +153,7 @@ class RotateTool {
     const rnd = this.editor.render
     const dragCtx = this.dragCtx
 
-    const pos = handleCenter || rnd.page2obj(event)
+    const pos = rnd.page2obj(event)
     let angle = utils.calcAngle(dragCtx.xy0, pos) - dragCtx.angle1
 
     if (!event.ctrlKey) {

--- a/packages/ketcher-react/src/script/ui/action/index.js
+++ b/packages/ketcher-react/src/script/ui/action/index.js
@@ -180,9 +180,9 @@ const config = {
     shortcut: 'Mod+a',
     action: {
       thunk: (dispatch, getState) => {
-        getState().editor.selection('all')
         const selectionTool = getState().toolbar.visibleTools.select
         dispatch({ type: 'ACTION', action: tools[selectionTool].action })
+        getState().editor.selection('all')
       }
     },
     hidden: (options) => isHidden(options, 'select-all')


### PR DESCRIPTION
Closes #2463 

Note: 
1. According to UX design, the predefined degrees will be hidden if the radius is less than 65px.

![rotation-2463-01](https://user-images.githubusercontent.com/27288153/236607655-7fd38674-4115-4952-93f9-5ff84e4b864f.gif)

~~2. One **existing** implementation that needs attention is **15° is the smallest rotation degree**, which means the user cannot rotate like 13° or 34° etc.~~

~~[rotation-2463-02](https://user-images.githubusercontent.com/27288153/236608057-12083049-3bf8-421d-b8ff-3770e8cd00ea.gif)~~

