### PR TITLE
#2512 Toolbar arrow is active after the Ketcher with iFrame is loaded and disappears when you click on it

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.module.less
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.module.less
@@ -43,8 +43,6 @@
 }
 
 .groupItem {
-  margin: 2px;
-
   // TODO: move to action button styles, when all buttons will have same style
   svg {
     right: 2px;

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.module.less
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.module.less
@@ -43,6 +43,8 @@
 }
 
 .groupItem {
+  margin: 2px 0;
+
   // TODO: move to action button styles, when all buttons will have same style
   svg {
     right: 2px;

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -58,7 +58,7 @@ const LeftToolbar = (props: Props) => {
   const { ref, height } = useResizeObserver<HTMLDivElement>()
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
   const [startRef, startInView] = useInView({ threshold: 1 })
-  const [endRef, endInView] = useInView({ threshold: 1 })
+  const [endRef, endInView] = useInView({ threshold: 0.8 })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
 
   type ItemProps = {

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -57,11 +57,8 @@ const LeftToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { ref, height } = useResizeObserver<HTMLDivElement>()
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
-  const [startRef, startInView] = useInView({
-    threshold: 1,
-    initialInView: true
-  })
-  const [endRef, endInView] = useInView({ threshold: 1, initialInView: true })
+  const [startRef, startInView] = useInView({ threshold: 1 })
+  const [endRef, endInView] = useInView({ threshold: 1 })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
 
   type ItemProps = {

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -57,8 +57,11 @@ const LeftToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { ref, height } = useResizeObserver<HTMLDivElement>()
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
-  const [startRef, startInView] = useInView({ threshold: 1 })
-  const [endRef, endInView] = useInView({ threshold: 0.8 })
+  const [startRef, startInView] = useInView({
+    threshold: 1,
+    initialInView: true
+  })
+  const [endRef, endInView] = useInView({ threshold: 1, initialInView: true })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
 
   type ItemProps = {
@@ -195,12 +198,14 @@ const LeftToolbar = (props: Props) => {
           <Group className={classes.groupItem} items={[{ id: 'text' }]} />
         </div>
       </div>
-      <ArrowScroll
-        startInView={startInView}
-        endInView={endInView}
-        scrollUp={scrollUp}
-        scrollDown={scrollDown}
-      />
+      {height && scrollRef?.current?.scrollHeight > height && (
+        <ArrowScroll
+          startInView={startInView}
+          endInView={endInView}
+          scrollUp={scrollUp}
+          scrollDown={scrollDown}
+        />
+      )}
     </div>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -57,8 +57,8 @@ const LeftToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { ref, height } = useResizeObserver<HTMLDivElement>()
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
-  const [startRef, startInView] = useInView({ threshold: 0.8 })
-  const [endRef, endInView] = useInView({ threshold: 0.8 })
+  const [startRef, startInView] = useInView({ threshold: 1 })
+  const [endRef, endInView] = useInView({ threshold: 1 })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
 
   type ItemProps = {

--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
@@ -51,7 +51,7 @@ const RightToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { active, onAction, freqAtoms } = rest
   const [startRef, startInView] = useInView({ threshold: 1 })
-  const [endRef, endInView] = useInView({ threshold: 1 })
+  const [endRef, endInView] = useInView({ threshold: 0.9 })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
 
@@ -69,7 +69,12 @@ const RightToolbar = (props: Props) => {
         <Group className={classes.atomsList}>
           <AtomsList
             ref={startRef}
-            atoms={basicAtoms}
+            atoms={basicAtoms.slice(0, 1)}
+            active={active}
+            onAction={onAction}
+          />
+          <AtomsList
+            atoms={basicAtoms.slice(1)}
             active={active}
             onAction={onAction}
           />
@@ -80,10 +85,11 @@ const RightToolbar = (props: Props) => {
         <Group>
           <div ref={sizeRef}>
             <ToolbarGroupItem id="any-atom" {...rest} />
-            <ToolbarGroupItem id="extended-table" {...rest} />
+            <div ref={endRef}>
+              <ToolbarGroupItem id="extended-table" {...rest} />
+            </div>
           </div>
         </Group>
-        <div ref={endRef}></div>
       </div>
       <ArrowScroll
         startInView={startInView}

--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
@@ -52,11 +52,8 @@ const RightToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { active, onAction, freqAtoms } = rest
   const { ref, height } = useResizeObserver<HTMLDivElement>()
-  const [startRef, startInView] = useInView({
-    threshold: 1,
-    initialInView: true
-  })
-  const [endRef, endInView] = useInView({ threshold: 1, initialInView: true })
+  const [startRef, startInView] = useInView({ threshold: 1 })
+  const [endRef, endInView] = useInView({ threshold: 1 })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
@@ -27,6 +27,7 @@ import { basicAtoms } from '../../../action/atoms'
 import classes from './RightToolbar.module.less'
 import clsx from 'clsx'
 import { useInView } from 'react-intersection-observer'
+import { useResizeObserver } from '../../../../../hooks'
 
 const Group: FC<{ className?: string } & PropsWithChildren> = ({
   children,
@@ -50,8 +51,12 @@ type Props = RightToolbarProps & RightToolbarCallProps
 const RightToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { active, onAction, freqAtoms } = rest
-  const [startRef, startInView] = useInView({ threshold: 1 })
-  const [endRef, endInView] = useInView({ threshold: 0.9 })
+  const { ref, height } = useResizeObserver<HTMLDivElement>()
+  const [startRef, startInView] = useInView({
+    threshold: 1,
+    initialInView: true
+  })
+  const [endRef, endInView] = useInView({ threshold: 1, initialInView: true })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
 
@@ -64,7 +69,7 @@ const RightToolbar = (props: Props) => {
   }
 
   return (
-    <div className={clsx(classes.root, className)}>
+    <div className={clsx(classes.root, className)} ref={ref}>
       <div className={classes.buttons} ref={scrollRef}>
         <Group className={classes.atomsList}>
           <AtomsList
@@ -91,12 +96,14 @@ const RightToolbar = (props: Props) => {
           </div>
         </Group>
       </div>
-      <ArrowScroll
-        startInView={startInView}
-        endInView={endInView}
-        scrollUp={scrollUp}
-        scrollDown={scrollDown}
-      />
+      {height && scrollRef?.current?.scrollHeight > height && (
+        <ArrowScroll
+          startInView={startInView}
+          endInView={endInView}
+          scrollUp={scrollUp}
+          scrollDown={scrollDown}
+        />
+      )}
     </div>
   )
 }

--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
@@ -50,8 +50,8 @@ type Props = RightToolbarProps & RightToolbarCallProps
 const RightToolbar = (props: Props) => {
   const { className, ...rest } = props
   const { active, onAction, freqAtoms } = rest
-  const [startRef, startInView] = useInView({ threshold: 0.95 })
-  const [endRef, endInView] = useInView({ threshold: 0.8 })
+  const [startRef, startInView] = useInView({ threshold: 1 })
+  const [endRef, endInView] = useInView({ threshold: 1 })
   const sizeRef = useRef() as MutableRefObject<HTMLDivElement>
   const scrollRef = useRef() as MutableRefObject<HTMLDivElement>
 


### PR DESCRIPTION
Closes #2512

Details:
1) I have set the visibility threshold for the "scroll up" and "scroll down" reference elements to 1 (100%). This means that we consider the reference element as visible only when the entire element is within the view area. 
2) To address potential issues with the right toolbar, I have extracted the first basic atom into a separate element. This allows us to link the "scroll up" reference to a single button. If we were to leave the reference on the entire "atoms list" group, it could cause problems when the height values are low. In such cases, the height of the "atoms list" group would be greater than the actual view area height, resulting in the "scroll up" toolbar arrow persisting permanently.
3) The "arrow scroll" component appears only when the height of the toolbar content is greater than the height of the view area.

Corner iFrame heights:
Left toolbar: 609-610px
Right toolbar: 499-500px