### PR TITLE
#2583 - Rotation tool: ability to move the center of rotation

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -537,7 +537,10 @@ class RotateController {
     this.drawLink('long')
     this.drawHandle('active')
 
-    this.rotateTool.mousedown(event, true)
+    const originalHandleCenter = this.handleCenter
+      .sub(this.render.options.offset)
+      .scaled(1 / this.render.options.scale)
+    this.rotateTool.mousedown(event, originalHandleCenter, this.originalCenter)
   }
 
   private dragMove = throttle(

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -343,7 +343,6 @@ class RotateController {
     }
   }
 
-  // @yuleicul zoom out, zero is not on the correct pos
   private drawProtractor(
     structRotateDegree: number,
     radius: number,
@@ -405,7 +404,7 @@ class RotateController {
       this.protractor?.push(degreeText)
 
       return currentDegree
-    }, -1)
+    }, 0)
 
     this.protractor.toBack()
   }

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -28,7 +28,7 @@ class RotateController {
   private editor: Editor
   private rotateTool: RotateTool
   private originalCenter!: Vec2
-  private initialHandleCenter!: Vec2
+  private normalizedCenterInitialHandleVec!: Vec2
   private handleCenter!: Vec2
   private isRotating!: boolean
   private isMovingCenter!: boolean
@@ -48,7 +48,7 @@ class RotateController {
 
   private init() {
     this.originalCenter = new Vec2()
-    this.initialHandleCenter = new Vec2()
+    this.normalizedCenterInitialHandleVec = new Vec2()
     this.handleCenter = new Vec2()
     this.isRotating = false
     this.isMovingCenter = false
@@ -114,10 +114,12 @@ class RotateController {
     }
 
     const rectStartY = this.drawBoundingRect(visibleAtoms)
-    this.initialHandleCenter = this.handleCenter = new Vec2(
+
+    this.handleCenter = new Vec2(
       this.center.x,
       rectStartY - STYLE.HANDLE_MARGIN - STYLE.HANDLE_RADIUS
     )
+
     this.drawLink()
     this.drawCross()
     this.drawHandle()
@@ -473,23 +475,21 @@ class RotateController {
   private getProtractorBaseInfo(radius: number) {
     const DEGREE_TEXT_MARGIN = 10
 
-    const centerHandleVec = this.initialHandleCenter.sub(this.center)
-    const normalizedCenterHandleVec = centerHandleVec.normalized()
-
     const distBetweenDegree0TextAndCenter =
       radius +
       STYLE.HANDLE_MARGIN +
       STYLE.HANDLE_RADIUS * 2 +
       DEGREE_TEXT_MARGIN
-    const centerDegree0TextVec = normalizedCenterHandleVec.scaled(
+    const centerDegree0TextVec = this.normalizedCenterInitialHandleVec.scaled(
       distBetweenDegree0TextAndCenter
     )
     const degree0TextPos = this.center.add(centerDegree0TextVec)
 
     const lineLength =
       radius >= 65 ? STYLE.HANDLE_MARGIN : STYLE.HANDLE_MARGIN / 2
-    const centerLineStartVec = normalizedCenterHandleVec.scaled(radius)
-    const lineVec = normalizedCenterHandleVec.scaled(lineLength)
+    const centerLineStartVec =
+      this.normalizedCenterInitialHandleVec.scaled(radius)
+    const lineVec = this.normalizedCenterInitialHandleVec.scaled(lineLength)
     const lineStart = this.center.add(centerLineStartVec)
     const lineEnd = lineStart.add(lineVec)
     const lineEndHalf = lineStart.addScaled(lineVec, 1 / 2)
@@ -505,7 +505,7 @@ class RotateController {
       })
 
     const arcStartPos = this.center.add(
-      normalizedCenterHandleVec.scaled(radius)
+      this.normalizedCenterInitialHandleVec.scaled(radius)
     )
 
     const TEXT_MARGIN_LEFT = 20
@@ -544,6 +544,9 @@ class RotateController {
 
     this.boundingRect?.remove()
     delete this.boundingRect
+
+    const centerHandleVec = this.handleCenter.sub(this.center)
+    this.normalizedCenterInitialHandleVec = centerHandleVec.normalized()
 
     const newProtractorRadius =
       Vec2.dist(this.handleCenter, this.center) -

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -136,7 +136,11 @@ class RotateController {
       crossArea?.hover(this.hoverCrossIn, this.hoverCrossOut)
       crossArea?.mousedown(this.dragCrossStart)
       crossArea?.mouseup(this.dragCrossEnd)
-      crossArea?.drag(this.dragCrossMove, undefined, this.dragCrossEnd)
+      crossArea?.drag(
+        this.dragCrossMove,
+        undefined,
+        this.dragCrossEndOUtOfBounding
+      )
     }
   }
 
@@ -165,9 +169,6 @@ class RotateController {
       default: {
         const cross = this.paper
           .path(`M0,0` + `h8` + `M0,0` + `h-8` + `M0,0` + `v8` + `M0,0` + `v-8`)
-          // todo @yuleicul cursor
-          // todo @yuleicul event stop / when cross and atom are overlapped
-          // todo @yuleicul make it bigger to conviently move
           .attr({
             stroke: STYLE.INITIAL_COLOR,
             'stroke-width': 2,
@@ -175,10 +176,8 @@ class RotateController {
           })
         // HACK: increase hover/drag area
         const circle = this.paper.circle(0, 0, 10).attr({
-          // fill: 'white',
-          // opacity: 0,
           fill: 'red',
-          opacity: 0.5
+          opacity: 0
         })
         this.cross = this.paper.set()
         this.cross?.push(cross, circle)
@@ -257,9 +256,6 @@ class RotateController {
         this.handle
           ?.transform('')
           .translate(this.handleCenter.x, this.handleCenter.y)
-          .attr({
-            cursor: 'grabbing' // todo@yuleicul remove? -> check on react-app-aweird
-          })
         break
       }
 
@@ -627,19 +623,16 @@ class RotateController {
       return
     }
 
-    console.log('hoverCrossIn')
     this.drawCross('active')
     this.drawLink('long')
   }
 
-  // fix @yuleicul link shanshuo
   private hoverCrossOut = (event: MouseEvent) => {
     const isSomeButtonPressed = event.buttons !== 0
     if (isSomeButtonPressed) {
       return
     }
 
-    console.log('hoverCrossOut')
     this.drawCross('inactive')
     this.drawLink('short')
   }
@@ -669,13 +662,16 @@ class RotateController {
     40
   )
 
-  // todo @yuleicul drag out of bounding
   private dragCrossEnd = (event: MouseEvent) => {
     event.stopPropagation()
-    console.log('dragCrossEnd')
 
     this.isMovingCenter = false
     this.originalCenter = this.render.page2obj(event)
+  }
+
+  private dragCrossEndOUtOfBounding = (_event: MouseEvent) => {
+    this.isMovingCenter = false
+    this.rerender()
   }
 }
 

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -1,4 +1,4 @@
-import { Scale, Vec2 } from 'ketcher-core'
+import { Scale, Struct, Vec2 } from 'ketcher-core'
 import { throttle } from 'lodash'
 import Editor from '../Editor'
 import RotateTool from './rotate'
@@ -131,11 +131,13 @@ class RotateController {
       this.dragEnd // Fix rotation getting stuck when mouseup outside window
     )
 
-    const crossArea = this.cross?.[1]
-    crossArea?.hover(this.hoverCrossIn, this.hoverCrossOut)
-    crossArea?.mousedown(this.dragCrossStart)
-    crossArea?.mouseup(this.dragCrossEnd)
-    crossArea?.drag(this.dragCrossMove, undefined, this.dragCrossEnd)
+    if (isEveryAtomInTheSameFragment(visibleAtoms, this.render.ctab.molecule)) {
+      const crossArea = this.cross?.[1]
+      crossArea?.hover(this.hoverCrossIn, this.hoverCrossOut)
+      crossArea?.mousedown(this.dragCrossStart)
+      crossArea?.mouseup(this.dragCrossEnd)
+      crossArea?.drag(this.dragCrossMove, undefined, this.dragCrossEnd)
+    }
   }
 
   private drawCross(state?: CrossState) {
@@ -711,4 +713,14 @@ export const getDifference = (
   }
 
   return abs
+}
+
+const isEveryAtomInTheSameFragment = (atomIds: number[], struct: Struct) => {
+  const fragmentId = struct.atoms.get(atomIds[0])?.fragment
+  if (fragmentId === undefined) {
+    return
+  }
+  return atomIds.every(
+    (atomId) => struct.atoms.get(atomId)?.fragment === fragmentId
+  )
 }

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -58,17 +58,14 @@ class RotateTool {
     }
   }
 
-  /**
-   * @param rotatedByHandle when rotated by handle (see: ./rotate-controller),
-   *        starting angle should be `-Math.PI / 2` from the X axis
-   */
-  mousedown(event, rotatedByHandle?: boolean) {
-    const xy0 = this.getCenter(this.editor, event)[0]
+  mousedown(event, handleCenter?: Vec2, center?: Vec2) {
+    const xy0 = center || this.getCenter(this.editor, event)[0]
     this.dragCtx = {
       xy0,
-      angle1: rotatedByHandle
-        ? -Math.PI / 2
-        : utils.calcAngle(xy0, this.editor.render.page2obj(event))
+      angle1: utils.calcAngle(
+        xy0,
+        handleCenter || this.editor.render.page2obj(event)
+      )
     }
     return true
   }


### PR DESCRIPTION
Closes: #2583 

## Checkpoints:
- It shouldn't be moved if selected structures are connected with any other non-selected ones.

![rotation-2583-01](https://github.com/epam/ketcher/assets/27288153/fad90650-f0fe-48d0-a227-0cea28751b92)

- It should reset to default if dropping center out of canvas' bounding

![rotation-2583-02](https://github.com/epam/ketcher/assets/27288153/0e663a09-c986-49da-a423-621bbce0a44e)


- It should reset to default after finishing rotating

![rotation-2583-03](https://github.com/epam/ketcher/assets/27288153/3ef9c3c7-23ba-4b7f-b0fd-2836149e0a20)

