### PR TITLE
#2576 - Right click menu shown for highlighted functional group instead of clicked

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --passWithNoTests",
+    "test": "react-scripts test --passWithNoTests --watchAll=false",
     "eject": "react-scripts eject",
     "serve": "serve -s build"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
     "build:remote:analyze": "cross-env MODE=remote run-s prebuild build:react:analyze postbuild",
     "test": "run-s test:prettier test:stylelint test:eslint test:unit",
     "test:eslint": "eslint . --ext .ts,.js,.jsx,.tsx",
-    "test:unit": "react-app-rewired test --passWithNoTests",
+    "test:unit": "react-app-rewired test --passWithNoTests --watchAll=false",
     "test:stylelint": "stylelint \"./**/*.{css,less}\" --formatter verbose",
     "test:prettier": "prettier --check \"./**/*.{js,ts,jsx,tsx,json}\"",
     "prettier:write": "prettier --write \"./**/*.{js,jsx,json,ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "postinstall": "husky install",
     "precommit": "lint-staged --allow-empty && npm run prettier:write --workspaces --if-present",
-    "prepush": "npm run test:eslint --workspaces --if-present",
+    "prepush": "npm run test --workspaces --if-present",
     "build": "npm run build:packages && npm run build:example",
     "build:core": "npm run build -w ketcher-core",
     "build:standalone": "npm run build -w ketcher-standalone",

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -92,7 +92,11 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
           selectedSGroupsIds
         })
       ) {
-        triggerType = ContextMenuTriggerType.Selection
+        if (!selection.bonds && !selection.atoms) {
+          triggerType = ContextMenuTriggerType.None
+        } else {
+          triggerType = ContextMenuTriggerType.Selection
+        }
       } else {
         // closestItem is outside of selection
         editor.selection(null)
@@ -100,6 +104,10 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
       }
 
       switch (triggerType) {
+        case ContextMenuTriggerType.None: {
+          return
+        }
+
         case ContextMenuTriggerType.ClosestItem: {
           showProps = getMenuPropsForClosestItem(editor, closestItem)
           break
@@ -151,8 +159,7 @@ const getIsItemInSelection = ({
       return (
         item.map in selection &&
         Array.isArray(selection[item.map]) &&
-        selection[item.map].includes(item.id) &&
-        (selection.bonds || selection.atoms)
+        selection[item.map].includes(item.id)
       )
   }
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -33,7 +33,7 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
   const { getKetcherInstance } = useAppContext()
   const { show } = useContextMenu<ContextMenuShowProps>()
 
-  const getSelectedFunctionalGroups = useCallback(() => {
+  const getSelectedGroupsInfo = useCallback(() => {
     const editor = getKetcherInstance().editor as Editor
     const struct = editor.struct()
     const selectedAtomIds = editor.selection()?.atoms
@@ -75,13 +75,14 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
       const closestItem = editor.findItem(event, null)
       const selection = editor.selection()
       const { selectedFunctionalGroups, selectedSGroupsIds } =
-        getSelectedFunctionalGroups()
+        getSelectedGroupsInfo()
 
       let showProps: ContextMenuShowProps = null
       let triggerType: ContextMenuTriggerType
 
       if (!closestItem) {
         if (selection) {
+          // if it was a click outside of any item
           editor.selection(null)
         }
         return
@@ -132,7 +133,7 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
           props: showProps
         })
     },
-    [getKetcherInstance, getSelectedFunctionalGroups, show]
+    [getKetcherInstance, getSelectedGroupsInfo, show]
   )
 
   return (
@@ -233,7 +234,7 @@ function getMenuPropsForClosestItem(
   }
 }
 
-const ENHANCED_FLAGS_MAP_NAME = 'enhancedFlags'
+const IGNORED_MAPS_LIST = ['enhancedFlags']
 
 function getMenuPropsForSelection(
   selection: Selection | null,
@@ -256,17 +257,21 @@ function getMenuPropsForSelection(
     return {
       id: CONTEXT_MENU_ID.FOR_BONDS,
       bondIds: selection.bonds,
-      extraItemsSelected: !onlyHasProperty(selection, 'bonds', [
-        ENHANCED_FLAGS_MAP_NAME
-      ])
+      extraItemsSelected: !onlyHasProperty(
+        selection,
+        'bonds',
+        IGNORED_MAPS_LIST
+      )
     }
   } else if (atomsInSelection && !bondsInSelection) {
     return {
       id: CONTEXT_MENU_ID.FOR_ATOMS,
       atomIds: selection.atoms,
-      extraItemsSelected: !onlyHasProperty(selection, 'atoms', [
-        ENHANCED_FLAGS_MAP_NAME
-      ])
+      extraItemsSelected: !onlyHasProperty(
+        selection,
+        'atoms',
+        IGNORED_MAPS_LIST
+      )
     }
   } else {
     return {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -26,7 +26,6 @@ import {
   ContextMenuTriggerType,
   GetIsItemInSelectionArgs
 } from './contextMenu.types'
-import { onlyHasProperty } from './utils'
 import { Selection } from '../../../../editor/Editor'
 
 const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
@@ -121,6 +120,7 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
             selection,
             selectedFunctionalGroups
           )
+          break
         }
       }
 
@@ -239,18 +239,22 @@ function getMenuPropsForSelection(
   if (!selection) {
     return null
   }
+
+  const bondsInSelection = 'bonds' in selection
+  const atomsInSelection = 'atoms' in selection
+
   if (selectedFunctionalGroups.size > 0) {
     const functionalGroups = Array.from(selectedFunctionalGroups.values())
     return {
       id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
       functionalGroups
     }
-  } else if (onlyHasProperty(selection, 'bonds')) {
+  } else if (bondsInSelection && !atomsInSelection) {
     return {
       id: CONTEXT_MENU_ID.FOR_BONDS,
       bondIds: selection.bonds
     }
-  } else if (onlyHasProperty(selection, 'atoms')) {
+  } else if (atomsInSelection && !bondsInSelection) {
     return {
       id: CONTEXT_MENU_ID.FOR_ATOMS,
       atomIds: selection.atoms

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -81,6 +81,9 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
       let triggerType: ContextMenuTriggerType
 
       if (!closestItem) {
+        if (selection) {
+          editor.selection(null)
+        }
         return
       } else if (!selection) {
         triggerType = ContextMenuTriggerType.ClosestItem

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -27,6 +27,7 @@ import {
   GetIsItemInSelectionArgs
 } from './contextMenu.types'
 import { Selection } from '../../../../editor/Editor'
+import { onlyHasProperty } from './utils'
 
 const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
   const { getKetcherInstance } = useAppContext()
@@ -232,6 +233,8 @@ function getMenuPropsForClosestItem(
   }
 }
 
+const ENHANCED_FLAGS_MAP_NAME = 'enhancedFlags'
+
 function getMenuPropsForSelection(
   selection: Selection | null,
   selectedFunctionalGroups: Map<number, FunctionalGroup>
@@ -252,12 +255,18 @@ function getMenuPropsForSelection(
   } else if (bondsInSelection && !atomsInSelection) {
     return {
       id: CONTEXT_MENU_ID.FOR_BONDS,
-      bondIds: selection.bonds
+      bondIds: selection.bonds,
+      extraItemsSelected: !onlyHasProperty(selection, 'bonds', [
+        ENHANCED_FLAGS_MAP_NAME
+      ])
     }
   } else if (atomsInSelection && !bondsInSelection) {
     return {
       id: CONTEXT_MENU_ID.FOR_ATOMS,
-      atomIds: selection.atoms
+      atomIds: selection.atoms,
+      extraItemsSelected: !onlyHasProperty(selection, 'atoms', [
+        ENHANCED_FLAGS_MAP_NAME
+      ])
     }
   } else {
     return {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -19,8 +19,15 @@ import { PropsWithChildren, useCallback } from 'react'
 import { useContextMenu } from 'react-contexify'
 import { useAppContext } from 'src/hooks'
 import Editor from 'src/script/editor'
-import { ContextMenuShowProps, CONTEXT_MENU_ID } from './contextMenu.types'
+import {
+  ClosestItem,
+  CONTEXT_MENU_ID,
+  ContextMenuShowProps,
+  ContextMenuTriggerType,
+  GetIsItemInSelectionArgs
+} from './contextMenu.types'
 import { onlyHasProperty } from './utils'
+import { Selection } from '../../../../editor/Editor'
 
 const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
   const { getKetcherInstance } = useAppContext()
@@ -30,8 +37,9 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
     const editor = getKetcherInstance().editor as Editor
     const struct = editor.struct()
     const selectedAtomIds = editor.selection()?.atoms
-    // Map could do deduplication
+    // Map and Set can do deduplication
     const selectedFunctionalGroups = new Map<number, FunctionalGroup>()
+    const selectedSGroupsIds: Set<number> = new Set()
 
     selectedAtomIds?.forEach((atomId) => {
       const functionalGroup = FunctionalGroup.findFunctionalGroupByAtom(
@@ -45,9 +53,18 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
           functionalGroup.relatedSGroupId,
           functionalGroup
         )
+
+      const sGroupId = struct.sgroups.find((_, sGroup) =>
+        sGroup.atoms.includes(atomId)
+      )
+
+      sGroupId !== null && selectedSGroupsIds.add(sGroupId)
     })
 
-    return selectedFunctionalGroups
+    return {
+      selectedFunctionalGroups,
+      selectedSGroupsIds
+    }
   }, [getKetcherInstance])
 
   const handleDisplay = useCallback<React.MouseEventHandler<HTMLDivElement>>(
@@ -57,102 +74,42 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
       const editor = getKetcherInstance().editor as Editor
       const closestItem = editor.findItem(event, null)
       const selection = editor.selection()
-      const functionalGroupsInSelection = getSelectedFunctionalGroups()
+      const { selectedFunctionalGroups, selectedSGroupsIds } =
+        getSelectedFunctionalGroups()
 
       let showProps: ContextMenuShowProps = null
+      let triggerType: ContextMenuTriggerType
 
-      if (selection && !selection.bonds && !selection.atoms) {
+      if (!closestItem) {
         return
+      } else if (!selection) {
+        triggerType = ContextMenuTriggerType.ClosestItem
+      } else if (
+        getIsItemInSelection({
+          item: closestItem,
+          selection,
+          selectedFunctionalGroups,
+          selectedSGroupsIds
+        })
+      ) {
+        triggerType = ContextMenuTriggerType.Selection
+      } else {
+        // closestItem is outside of selection
+        editor.selection(null)
+        triggerType = ContextMenuTriggerType.ClosestItem
       }
 
-      if (closestItem) {
-        const struct = editor.struct()
-
-        switch (closestItem.map) {
-          case 'bonds':
-            {
-              const functionalGroup = FunctionalGroup.findFunctionalGroupByBond(
-                struct,
-                struct.functionalGroups,
-                closestItem.id,
-                true
-              )
-
-              showProps =
-                functionalGroup === null
-                  ? {
-                      id: CONTEXT_MENU_ID.FOR_BONDS,
-                      bondIds: [closestItem.id]
-                    }
-                  : {
-                      id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-                      functionalGroups: [functionalGroup]
-                    }
-            }
-            break
-
-          case 'atoms': {
-            const functionalGroup = FunctionalGroup.findFunctionalGroupByAtom(
-              struct.functionalGroups,
-              closestItem.id,
-              true
-            )
-
-            showProps =
-              functionalGroup === null
-                ? {
-                    id: CONTEXT_MENU_ID.FOR_ATOMS,
-                    atomIds: [closestItem.id]
-                  }
-                : {
-                    id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-                    functionalGroups: [functionalGroup]
-                  }
-            break
-          }
-
-          case 'sgroups':
-          case 'functionalGroups': {
-            const sGroup = struct.sgroups.get(closestItem.id)
-            const functionalGroup = FunctionalGroup.findFunctionalGroupBySGroup(
-              struct.functionalGroups,
-              sGroup
-            )
-
-            showProps = functionalGroup
-              ? {
-                  id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-                  functionalGroups: [functionalGroup]
-                }
-              : null
-            break
-          }
+      switch (triggerType) {
+        case ContextMenuTriggerType.ClosestItem: {
+          showProps = getMenuPropsForClosestItem(editor, closestItem)
+          break
         }
-      } else if (selection) {
-        if (functionalGroupsInSelection.size > 0) {
-          const functionalGroups = Array.from(
-            functionalGroupsInSelection.values()
+
+        case ContextMenuTriggerType.Selection: {
+          showProps = getMenuPropsForSelection(
+            selection,
+            selectedFunctionalGroups
           )
-          showProps = {
-            id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-            functionalGroups
-          }
-        } else if (onlyHasProperty(selection, 'bonds')) {
-          showProps = {
-            id: CONTEXT_MENU_ID.FOR_BONDS,
-            bondIds: selection.bonds
-          }
-        } else if (onlyHasProperty(selection, 'atoms')) {
-          showProps = {
-            id: CONTEXT_MENU_ID.FOR_ATOMS,
-            atomIds: selection.atoms
-          }
-        } else {
-          showProps = {
-            id: CONTEXT_MENU_ID.FOR_SELECTION,
-            bondIds: selection.bonds,
-            atomIds: selection.atoms
-          }
         }
       }
 
@@ -171,6 +128,130 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
       {children}
     </div>
   )
+}
+
+const getIsItemInSelection = ({
+  item,
+  selection,
+  selectedSGroupsIds,
+  selectedFunctionalGroups
+}: GetIsItemInSelectionArgs): boolean => {
+  if (!item || !selection) {
+    return false
+  }
+
+  switch (item.map) {
+    case 'sgroups':
+      return selectedSGroupsIds.has(item.id)
+
+    case 'functionalGroups':
+      return Array.from(selectedFunctionalGroups.keys()).includes(item.id)
+
+    default:
+      return (
+        item.map in selection &&
+        Array.isArray(selection[item.map]) &&
+        selection[item.map].includes(item.id) &&
+        (selection.bonds || selection.atoms)
+      )
+  }
+}
+
+function getMenuPropsForClosestItem(
+  editor: Editor,
+  closestItem: ClosestItem
+): ContextMenuShowProps | null {
+  const struct = editor.struct()
+
+  switch (closestItem.map) {
+    case 'bonds': {
+      const functionalGroup = FunctionalGroup.findFunctionalGroupByBond(
+        struct,
+        struct.functionalGroups,
+        closestItem.id,
+        true
+      )
+
+      return functionalGroup === null
+        ? {
+            id: CONTEXT_MENU_ID.FOR_BONDS,
+            bondIds: [closestItem.id]
+          }
+        : {
+            id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+            functionalGroups: [functionalGroup]
+          }
+    }
+
+    case 'atoms': {
+      const functionalGroup = FunctionalGroup.findFunctionalGroupByAtom(
+        struct.functionalGroups,
+        closestItem.id,
+        true
+      )
+
+      return functionalGroup === null
+        ? {
+            id: CONTEXT_MENU_ID.FOR_ATOMS,
+            atomIds: [closestItem.id]
+          }
+        : {
+            id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+            functionalGroups: [functionalGroup]
+          }
+    }
+
+    case 'sgroups':
+    case 'functionalGroups': {
+      const sGroup = struct.sgroups.get(closestItem.id)
+      const functionalGroup = FunctionalGroup.findFunctionalGroupBySGroup(
+        struct.functionalGroups,
+        sGroup
+      )
+
+      return functionalGroup
+        ? {
+            id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+            functionalGroups: [functionalGroup]
+          }
+        : null
+    }
+
+    default:
+      return null
+  }
+}
+
+function getMenuPropsForSelection(
+  selection: Selection | null,
+  selectedFunctionalGroups: Map<number, FunctionalGroup>
+): ContextMenuShowProps | null {
+  if (!selection) {
+    return null
+  }
+  if (selectedFunctionalGroups.size > 0) {
+    const functionalGroups = Array.from(selectedFunctionalGroups.values())
+    return {
+      id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+      functionalGroups
+    }
+  } else if (onlyHasProperty(selection, 'bonds')) {
+    return {
+      id: CONTEXT_MENU_ID.FOR_BONDS,
+      bondIds: selection.bonds
+    }
+  } else if (onlyHasProperty(selection, 'atoms')) {
+    return {
+      id: CONTEXT_MENU_ID.FOR_ATOMS,
+      atomIds: selection.atoms
+    }
+  } else {
+    return {
+      id: CONTEXT_MENU_ID.FOR_SELECTION,
+      bondIds: selection.bonds,
+      atomIds: selection.atoms
+    }
+  }
 }
 
 export default ContextMenuTrigger

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
@@ -1,5 +1,6 @@
 import { FunctionalGroup } from 'ketcher-core'
 import type { PredicateParams } from 'react-contexify'
+import { Selection } from '../../../../editor/Editor'
 
 export enum CONTEXT_MENU_ID {
   FOR_BONDS = 'context-menu-for-bonds',
@@ -21,4 +22,23 @@ export type ItemEventParams = PredicateParams<ContextMenuShowProps, ItemData>
 
 export type contextMenuInfo = {
   [id in CONTEXT_MENU_ID]?: boolean
+}
+
+export enum ContextMenuTriggerType {
+  None = 'none',
+  Selection = 'selection',
+  ClosestItem = 'closestItem'
+}
+
+export interface ClosestItem {
+  dist: number
+  id: number
+  map: string /* should be enum something like keys of findMaps from packages/ketcher-react/src/script/editor/shared/closest.js */
+}
+
+export interface GetIsItemInSelectionArgs {
+  item: ClosestItem | null
+  selection: Selection | null
+  selectedFunctionalGroups: Map<number, FunctionalGroup>
+  selectedSGroupsIds: Set<number>
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
@@ -1,5 +1,5 @@
 import { FunctionalGroup } from 'ketcher-core'
-import type { PredicateParams } from 'react-contexify'
+import type { TriggerEvent, PredicateParams } from 'react-contexify'
 import { Selection } from '../../../../editor/Editor'
 
 export enum CONTEXT_MENU_ID {
@@ -16,7 +16,13 @@ export type ContextMenuShowProps = {
   functionalGroups?: FunctionalGroup[]
   bondIds?: number[]
   atomIds?: number[]
+  extraItemsSelected?: boolean
 } | null
+
+export interface MenuItemsProps {
+  triggerEvent?: TriggerEvent
+  propsFromTrigger?: ContextMenuShowProps
+}
 
 export type ItemEventParams = PredicateParams<ContextMenuShowProps, ItemData>
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
@@ -37,8 +37,8 @@ export enum ContextMenuTriggerType {
 }
 
 export interface ClosestItem {
-  dist: number
   id: number
+  dist: number
   map: string /* should be enum something like keys of findMaps from packages/ketcher-react/src/script/editor/shared/closest.js */
 }
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
@@ -1,9 +1,11 @@
+import { FC } from 'react'
 import { Item } from 'react-contexify'
 import useAtomEdit from '../hooks/useAtomEdit'
 import useAtomStereo from '../hooks/useAtomStereo'
 import useDelete from '../hooks/useDelete'
+import { MenuItemsProps } from '../contextMenu.types'
 
-const AtomMenuItems: React.FC = (props) => {
+const AtomMenuItems: FC<MenuItemsProps> = (props) => {
   const [handleEdit] = useAtomEdit()
   const [handleStereo, stereoDisabled] = useAtomStereo()
   const handleDelete = useDelete()
@@ -11,7 +13,9 @@ const AtomMenuItems: React.FC = (props) => {
   return (
     <>
       <Item {...props} onClick={handleEdit}>
-        Edit...
+        {props.propsFromTrigger?.extraItemsSelected
+          ? 'Edit selected atoms...'
+          : 'Edit...'}
       </Item>
 
       <Item {...props} disabled={stereoDisabled} onClick={handleStereo}>

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react'
 import { Item, Submenu } from 'react-contexify'
 import tools from 'src/script/ui/action/tools'
 import Icon from 'src/script/ui/component/view/icon'
@@ -8,10 +9,11 @@ import useBondSGroupEdit from '../hooks/useBondSGroupEdit'
 import useBondTypeChange from '../hooks/useBondTypeChange'
 import useDelete from '../hooks/useDelete'
 import { formatTitle, getNonQueryBondNames, queryBondNames } from '../utils'
+import { MenuItemsProps } from '../contextMenu.types'
 
 const nonQueryBondNames = getNonQueryBondNames(tools)
 
-const BondMenuItems: React.FC = (props) => {
+const BondMenuItems: FC<MenuItemsProps> = (props) => {
   const [handleEdit] = useBondEdit()
   const [handleTypeChange] = useBondTypeChange()
   const [handleSGroupAttach, sGroupAttachHidden] = useBondSGroupAttach()
@@ -22,7 +24,9 @@ const BondMenuItems: React.FC = (props) => {
   return (
     <>
       <Item {...props} onClick={handleEdit}>
-        Edit...
+        {props.propsFromTrigger?.extraItemsSelected
+          ? 'Edit selected bonds...'
+          : 'Edit...'}
       </Item>
 
       {nonQueryBondNames.map((name) => (

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/FunctionalGroupMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/FunctionalGroupMenuItems.tsx
@@ -1,8 +1,10 @@
+import { FC } from 'react'
 import { Item } from 'react-contexify'
 import useFunctionalGroupEoc from '../hooks/useFunctionalGroupEoc'
 import useFunctionalGroupRemove from '../hooks/useFunctionalGroupRemove'
+import { MenuItemsProps } from '../contextMenu.types'
 
-const FunctionalGroupMenuItems: React.FC = (props) => {
+const FunctionalGroupMenuItems: FC<MenuItemsProps> = (props) => {
   const [
     handleExpandOrContract,
     ExpandOrContractHidden,

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react'
 import { Item, Submenu } from 'react-contexify'
 import tools from 'src/script/ui/action/tools'
 import Icon from 'src/script/ui/component/view/icon'
@@ -8,10 +9,11 @@ import useBondEdit from '../hooks/useBondEdit'
 import useBondTypeChange from '../hooks/useBondTypeChange'
 import useDelete from '../hooks/useDelete'
 import { formatTitle, getBondNames } from '../utils'
+import { MenuItemsProps } from '../contextMenu.types'
 
 const bondNames = getBondNames(tools)
 
-const SelectionMenuItems: React.FC = (props) => {
+const SelectionMenuItems: FC<MenuItemsProps> = (props) => {
   const [handleBondEdit, bondEditDisabled] = useBondEdit()
   const [handleAtomEdit, atomEditDisabled] = useAtomEdit()
   const [handleTypeChange, bondTypeChangeDisabled] = useBondTypeChange()
@@ -21,11 +23,11 @@ const SelectionMenuItems: React.FC = (props) => {
   return (
     <>
       <Item {...props} disabled={bondEditDisabled} onClick={handleBondEdit}>
-        Edit selected bond(s)...
+        Edit selected bonds...
       </Item>
 
       <Item {...props} disabled={atomEditDisabled} onClick={handleAtomEdit}>
-        Edit selected atom(s)...
+        Edit selected atoms...
       </Item>
 
       <Submenu

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.test.ts
@@ -33,7 +33,7 @@ describe('Utils', () => {
       ]
 
     it.each(testTable)(
-      'Should check that only required field is present in the object except ignore list',
+      'Should check that only a required field is present in the object except ignore list',
       (testObject, requiredPropName, ignoreList, expectedResult) => {
         const result = onlyHasProperty(testObject, requiredPropName, ignoreList)
         expect(result).toBe(expectedResult)

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.test.ts
@@ -1,0 +1,43 @@
+import { onlyHasProperty } from './utils'
+
+describe('Utils', () => {
+  describe('onlyHasProperty', () => {
+    type OptionalObject = Record<string, unknown>
+    const REQUIRED_PROP_NAME = 'atoms'
+    const ANOTHER_PROP_NAME = 'bonds'
+    const ANOTHER_PROP_NAME2 = 'sgroups'
+
+    const testTable: [OptionalObject, string, string[] | undefined, boolean][] =
+      [
+        [{}, REQUIRED_PROP_NAME, undefined, false],
+        [{ [ANOTHER_PROP_NAME]: null }, REQUIRED_PROP_NAME, undefined, false],
+        [
+          { [ANOTHER_PROP_NAME]: null, [ANOTHER_PROP_NAME2]: null },
+          REQUIRED_PROP_NAME,
+          undefined,
+          false
+        ],
+        [
+          { [REQUIRED_PROP_NAME]: null, [ANOTHER_PROP_NAME2]: null },
+          REQUIRED_PROP_NAME,
+          undefined,
+          false
+        ],
+        [{ [REQUIRED_PROP_NAME]: null }, REQUIRED_PROP_NAME, undefined, false],
+        [
+          { [REQUIRED_PROP_NAME]: null, [ANOTHER_PROP_NAME2]: null },
+          REQUIRED_PROP_NAME,
+          [ANOTHER_PROP_NAME2],
+          false
+        ]
+      ]
+
+    it.each(testTable)(
+      'Should check that only required field is present in the object except ignore list',
+      (testObject, requiredPropName, ignoreList, expectedResult) => {
+        const result = onlyHasProperty(testObject, requiredPropName, ignoreList)
+        expect(result).toBe(expectedResult)
+      }
+    )
+  })
+})

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.test.ts
@@ -23,12 +23,22 @@ describe('Utils', () => {
           undefined,
           false
         ],
-        [{ [REQUIRED_PROP_NAME]: null }, REQUIRED_PROP_NAME, undefined, false],
+        [{ [REQUIRED_PROP_NAME]: null }, REQUIRED_PROP_NAME, undefined, true],
         [
           { [REQUIRED_PROP_NAME]: null, [ANOTHER_PROP_NAME2]: null },
           REQUIRED_PROP_NAME,
           [ANOTHER_PROP_NAME2],
-          false
+          true
+        ],
+        [
+          {
+            [REQUIRED_PROP_NAME]: null,
+            [ANOTHER_PROP_NAME]: null,
+            [ANOTHER_PROP_NAME2]: null
+          },
+          REQUIRED_PROP_NAME,
+          [ANOTHER_PROP_NAME, ANOTHER_PROP_NAME2],
+          true
         ]
       ]
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.ts
@@ -41,3 +41,16 @@ export const getNonQueryBondNames = (tools) => {
 }
 
 export const noOperation = () => null
+
+export function onlyHasProperty<T extends object>(
+  checkedObject: T,
+  key: keyof T,
+  ignoredProps: string[] = []
+) {
+  const props = Object.keys(checkedObject).filter(
+    (key) => !ignoredProps.includes(key)
+  )
+
+  const numberOfProps = props.length
+  return numberOfProps === 1 && key in checkedObject
+}

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.ts
@@ -41,11 +41,3 @@ export const getNonQueryBondNames = (tools) => {
 }
 
 export const noOperation = () => null
-
-export function onlyHasProperty<T extends object>(
-  checkedObject: T,
-  key: keyof T
-) {
-  const numberOfProps = Object.keys(checkedObject).length
-  return numberOfProps === 1 && key in checkedObject
-}


### PR DESCRIPTION
* Show context menu for the closest item only if there is no selected item(s)
* Show context menu for a selection only if a user clicked on an item included in the selection
* Otherwise reset the current selection and show the context menu for the closest item
* Clear selection if a user clicks RMB outside of selection and other items
* Remove parentheses from menu items for General selection context menu
* Show "Edit selected atom..." menu item if atoms and something except bonds and Functional Groups are selected
* Show "Edit selected bonds..." menu item if bonds and something except atoms and Functional Groups are selected