### PR TITLE
Backmerge: #2614 – Contracted unknown superatom is parsed as expanded and brackets with name are lost (#2615)

### DIFF
--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -1065,7 +1065,10 @@ export class Struct {
 
   bindSGroupsToFunctionalGroups() {
     this.sgroups.forEach((sgroup) => {
-      if (FunctionalGroup.isFunctionalGroup(sgroup)) {
+      if (
+        FunctionalGroup.isFunctionalGroup(sgroup) ||
+        SGroup.isSuperAtom(sgroup)
+      ) {
         this.functionalGroups.add(new FunctionalGroup(sgroup))
       }
     })


### PR DESCRIPTION
closes #2614 