### PR TITLE
#2619 - Add ketcher api method getCDXml() for retrieving molecule in CDXml format

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -217,6 +217,22 @@ export class Ketcher {
     )
   }
 
+  getCDXml(): Promise<string> {
+    return getStructure(
+      SupportedFormat.cdxml,
+      this.#formatterFactory,
+      this.#editor.struct()
+    )
+  }
+
+  getCDX(): Promise<string> {
+    return getStructure(
+      SupportedFormat.cdx,
+      this.#formatterFactory,
+      this.#editor.struct()
+    )
+  }
+
   getInchi(withAuxInfo = false): Promise<string> {
     return getStructure(
       withAuxInfo ? SupportedFormat.inChIAuxInfo : SupportedFormat.inChI,


### PR DESCRIPTION
Closes #2619 