### PR TITLE
 #2566 improve page loading performance

### DIFF
--- a/packages/ketcher-react/src/script/ui/App/AppHidden/AppHidden.tsx
+++ b/packages/ketcher-react/src/script/ui/App/AppHidden/AppHidden.tsx
@@ -30,7 +30,11 @@ const AppHidden = (props: Props) => {
   const { staticResourcesUrl } = useSettingsContext()
 
   useEffect(() => {
-    onInitTmpls(ref.current, staticResourcesUrl)
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(() => onInitTmpls(ref.current, staticResourcesUrl))
+    } else {
+      onInitTmpls(ref.current, staticResourcesUrl)
+    }
   }, [])
 
   return <div style={{ display: 'none' }} ref={ref} />

--- a/packages/ketcher-react/src/script/ui/state/saltsAndSolvents/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/saltsAndSolvents/index.ts
@@ -23,7 +23,6 @@ import {
   SdfSerializer,
   Struct
 } from 'ketcher-core'
-import { RenderStruct } from '../../utils'
 import templatesRawData from '../../../../templates/salts-and-solvents.sdf'
 import { MODES } from 'src/constants'
 
@@ -55,28 +54,8 @@ const initSaltsAndSolvents = (lib: SdfItem[]) => ({
   payload: { lib }
 })
 
-// This prerender adds part of structures to cache to speed up loading of Salts and Solvents tab
-const prerenderPartOfStructures = (saltsAndSolvents: Struct[], settings) => {
-  const part = saltsAndSolvents.slice(0, 50)
-  part.forEach((struct) => {
-    const div = document.createElement('div')
-    div.style.width = '100px'
-    div.style.height = '100px'
-    div.style.display = 'none'
-    document.body.appendChild(div)
-    RenderStruct.render(div, struct, {
-      ...settings,
-      autoScaleMargin: 10,
-      cachePrefix: 'saltsAndSolvents',
-      downScale: true
-    })
-    div.remove()
-  })
-}
-
 export function initSaltsAndSolventsTemplates() {
-  return async (dispatch, getState) => {
-    const { settings } = getState().options
+  return async (dispatch) => {
     const saltsAndSolventsProvider = SaltsAndSolventsProvider.getInstance()
     const functionalGroupsProvider = FunctionalGroupsProvider.getInstance()
     const sdfSerializer = new SdfSerializer()
@@ -89,7 +68,6 @@ export function initSaltsAndSolventsTemplates() {
       },
       []
     )
-    prerenderPartOfStructures(saltsAndSolvents, settings)
     saltsAndSolventsProvider.setSaltsAndSolventsList(saltsAndSolvents)
     functionalGroupsProvider.addToFunctionalGroupsList(saltsAndSolvents)
     dispatch(initSaltsAndSolvents(templates))


### PR DESCRIPTION
First part of changes to improve page loading performance.
It removes `prerenderPartOfStructures` function, which took the vast majority of time.
Also it postpones rendering of templates via `requestIdleCallback`.
In my cases it reduced page loading time (First contentful paint) from ~15 seconds to ~8 seconds on cold start and ~2s on subsequent loads.