### PR TITLE
#2625 Rotation tool: cancel rotation by pressing "Escape" key

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -3,10 +3,11 @@ import { Vec2 } from 'ketcher-core'
 import Editor from '../Editor'
 import RotateTool from './rotate'
 import RotateController, { getDifference } from './rotate-controller'
+import SelectTool from './select'
 
 describe('Rotate controller', () => {
   /**
-   * Steps to check:
+   * Steps to check manually:
    * Select one atom/functional group using Select Tool
    */
   it(`hides for one visible atom`, () => {
@@ -27,7 +28,7 @@ describe('Rotate controller', () => {
   })
 
   /**
-   * Steps to check:
+   * Steps to check manually:
    * 1. Select at least two atoms (then controller shows)
    * 2. click Rotate Tool
    */
@@ -50,7 +51,7 @@ describe('Rotate controller', () => {
   })
 
   /**
-   * Steps to check:
+   * Steps to check manually:
    * Click `zoom in` or press `Ctrl+=`
    */
   it('rerenders while zooming', () => {
@@ -63,7 +64,7 @@ describe('Rotate controller', () => {
   })
 
   /**
-   * Steps to check:
+   * Steps to check manually:
    * Drag handle by right mouse button
    */
   it('can be only dragged by left mouse button', () => {
@@ -84,7 +85,7 @@ describe('Rotate controller', () => {
   })
 
   /**
-   * Steps to check:
+   * Steps to check manually:
    * Select and move a big structure to edge of canvas,
    * then rotate it by the handle
    */
@@ -160,5 +161,29 @@ describe('Rotate controller', () => {
     expect(
       getDifference(predefinedDegree4, structRotateDegree)
     ).toBeGreaterThan(90)
+  })
+
+  /**
+   * Steps to check manually:
+   * 1. Press 'Escape' while rotating
+   * 2. Undo
+   */
+  it(`cancels rotation without modifying history stack`, () => {
+    const editor = new Editor(document, {})
+    // @ts-ignore
+    editor.rotateController.rotateTool.dragCtx = {
+      action: { operations: [], perform: () => undefined }
+    }
+    editor.rotateController.isRotating = true
+    const updateRender = jest.spyOn(editor.render, 'update')
+
+    editor.rotateController.revert()
+    const selectTool = new SelectTool(editor, '')
+    selectTool.mouseup(new MouseEvent('mouseup'))
+
+    expect(updateRender).toBeCalled()
+    expect(selectTool.isMousedDown).toBe(false)
+
+    expect(editor.historyStack).toHaveLength(0)
   })
 })

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -1,4 +1,4 @@
-import { Scale, Vec2 } from 'ketcher-core'
+import { Action, Scale, Vec2 } from 'ketcher-core'
 import { throttle } from 'lodash'
 import Editor from '../Editor'
 import { getGroupIdsFromItemArrays } from './helper/getGroupIdsFromItems'
@@ -26,13 +26,13 @@ const RIGHT_ARROW_PATH =
   'M15.4493 13.0588L14.1862 12.3486C14.5482 11.7029 14.7559 10.9823 14.7932 10.243C14.8305 9.50371 14.6963 8.76582 14.4012 8.08695C14.1062 7.40809 13.6581 6.80665 13.0921 6.32962C12.5261 5.85259 11.8574 5.51288 11.1384 5.33704L11.3754 6.64501L7.29492 5.18124L10.6022 2.37834L10.8616 3.81095C11.8691 3.95145 12.827 4.33573 13.6523 4.93043C14.4776 5.52513 15.1452 6.31227 15.5973 7.22353C16.0493 8.13478 16.2721 9.1426 16.2463 10.1595C16.2205 11.1764 15.9469 12.1716 15.4493 13.0588Z'
 
 class RotateController {
+  isRotating!: boolean
   private editor: Editor
   private rotateTool: RotateTool
   private originalCenter!: Vec2
   private normalizedCenterInitialHandleVec!: Vec2
   private handleCenter!: Vec2
   private initialRadius!: number
-  private isRotating!: boolean
   private isMovingCenter!: boolean
 
   private handle?: RaphaelElement
@@ -107,6 +107,20 @@ class RotateController {
     delete this.protractor
     this.rotateArc?.remove()
     delete this.rotateArc
+  }
+
+  /**
+   * Revert rotation by pressing "Escape" key
+   */
+  revert() {
+    if (!this.rotateTool.dragCtx?.action || !this.isRotating) {
+      return
+    }
+
+    const action: Action = this.rotateTool.dragCtx.action
+    action.perform(this.render.ctab)
+    this.render.update()
+    this.rerender()
   }
 
   private isPartOfFragmentSelected() {

--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -54,6 +54,7 @@ class SelectTool {
   #lassoHelper: LassoHelper
   editor: Editor
   dragCtx: any
+  isMousedDown = false
 
   constructor(editor, mode) {
     this.editor = editor
@@ -70,6 +71,7 @@ class SelectTool {
   }
 
   mousedown(event) {
+    this.isMousedDown = true
     const rnd = this.editor.render
     const ctab = rnd.ctab
     const molecule = ctab.molecule
@@ -232,6 +234,11 @@ class SelectTool {
   }
 
   mouseup(event) {
+    if (!this.isMousedDown) {
+      return
+    }
+    this.isMousedDown = false
+
     const editor = this.editor
     const selected = editor.selection()
     const struct = editor.render.ctab

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -82,6 +82,8 @@ function keyHandle(dispatch, state, hotKeys, event) {
     }
 
     event.preventDefault()
+  } else if (editor.rotateController.isRotating && key === 'Escape') {
+    editor.rotateController.revert()
   } else if ((group = keyNorm.lookup(hotKeys, event)) !== undefined) {
     const index = checkGroupOnTool(group, actionTool) // index currentTool in group || -1
     const groupLength = group !== null ? group.length : 1


### PR DESCRIPTION
Closes #2625 

### Checkpoints

1. History stack shouldn't be changed after reverting rotation

![revert-rotation-01](https://github.com/epam/ketcher/assets/27288153/73fa3c94-1cca-46e9-be77-9acaf4d545c5)

2. The reverted structure should stay selected

![revert-rotation-02](https://github.com/epam/ketcher/assets/27288153/adc954ad-aa16-4c22-a88d-c7b3f0eebeb2)

