### PR TITLE
Backmerge: #2624 - Rotation tool: incorrect selection box for s-groups (#2674)

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useFunctionalGroupEoc.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useFunctionalGroupEoc.ts
@@ -29,6 +29,7 @@ const useFunctionalGroupEoc = () => {
       })
 
       editor.update(action)
+      editor.rotateController.rerender()
       highlightFG(dispatch, { group: null, id: null })
     },
     [dispatch, getKetcherInstance]


### PR DESCRIPTION
Closes #2624 
Backmerge #2674 