### PR TITLE
#2694 – Improve performance of Templates Modal

### DIFF
--- a/packages/ketcher-core/src/application/render/renderStruct.ts
+++ b/packages/ketcher-core/src/application/render/renderStruct.ts
@@ -43,7 +43,6 @@ export class RenderStruct {
         ...options
       })
       rnd.setMolecule(preparedStruct)
-      rnd.update(true, options.viewSz)
       if (needCache) {
         renderCache.set(cacheKey, rnd.clientArea.innerHTML)
       }


### PR DESCRIPTION
Found optimisation opportunity – `rnd.setMolecule(preparedStruct)` already performs render. By removing this, it is required 1,5-2x less time to render structures in templates modal.