### PR TITLE
#2680 Reaction arrow and text don't rotate with rotated objects

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/rotate.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rotate.ts
@@ -18,9 +18,10 @@ import {
   AtomMove,
   BondAttr,
   EnhancedFlagMove,
-  RxnArrowMove,
+  RxnArrowRotate,
   RxnPlusMove,
-  SGroupDataMove
+  SGroupDataMove,
+  TextMove
 } from '../operations'
 import { Bond, Fragment, Pile, Vec2 } from 'domain/entities'
 import {
@@ -250,11 +251,8 @@ export function fromRotate(restruct, selection, center, angle) {
   }
 
   if (selection.rxnArrows) {
-    selection.rxnArrows.forEach((aid) => {
-      const arrow = struct.rxnArrows.get(aid)
-      action.addOp(
-        new RxnArrowMove(aid, rotateDelta(arrow.center(), center, angle))
-      )
+    selection.rxnArrows.forEach((arrowId) => {
+      action.addOp(new RxnArrowRotate(arrowId, angle, center))
     })
   }
 
@@ -262,6 +260,15 @@ export function fromRotate(restruct, selection, center, angle) {
     selection.rxnPluses.forEach((pid) => {
       const plus = struct.rxnPluses.get(pid)
       action.addOp(new RxnPlusMove(pid, rotateDelta(plus.pp, center, angle)))
+    })
+  }
+
+  if (selection.texts) {
+    selection.texts.forEach((textId) => {
+      const text = struct.texts.get(textId)
+      action.addOp(
+        new TextMove(textId, rotateDelta(text.position, center, angle))
+      )
     })
   }
 

--- a/packages/ketcher-core/src/application/editor/operations/OperationType.ts
+++ b/packages/ketcher-core/src/application/editor/operations/OperationType.ts
@@ -39,6 +39,7 @@ export const OperationType = Object.freeze({
   RXN_ARROW_ADD: 'Add rxn arrow',
   RXN_ARROW_DELETE: 'Delete rxn arrow',
   RXN_ARROW_MOVE: 'Move rxn arrow',
+  RXN_ARROW_ROTATE: 'Rotate rxn arrow',
   RXN_ARROW_RESIZE: 'Resize rxn arrow',
   RXN_PLUS_ADD: 'Add rxn plus',
   RXN_PLUS_DELETE: 'Delete rxn plus',

--- a/packages/ketcher-core/src/application/editor/operations/Text/TextMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/Text/TextMove.ts
@@ -22,13 +22,13 @@ import { Scale } from 'domain/helpers'
 interface TextMoveData {
   id: any
   d: any
-  noinvalidate: boolean
+  noinvalidate?: boolean
 }
 
 export class TextMove extends BaseOperation {
   data: TextMoveData
 
-  constructor(id: any, d: any, noinvalidate: boolean) {
+  constructor(id: any, d: any, noinvalidate?: boolean) {
     super(OperationType.TEXT_MOVE)
     this.data = { id, d, noinvalidate }
   }

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowRotate.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowRotate.ts
@@ -1,0 +1,56 @@
+import utils from 'application/editor/shared/utils'
+import { ReStruct } from 'application/render'
+import { Vec2 } from 'domain/entities'
+import { OperationType } from '../OperationType'
+import Base from '../base'
+
+interface RxnArrowRotateData {
+  id: number
+  angle: number
+  center: Vec2
+  noinvalidate?: boolean
+}
+
+export class RxnArrowRotate extends Base {
+  data: RxnArrowRotateData
+
+  constructor(id: number, angle: number, center: Vec2, noinvalidate?: boolean) {
+    super(OperationType.RXN_ARROW_ROTATE)
+    this.data = { id, angle, center, noinvalidate }
+  }
+
+  execute(reStruct: ReStruct) {
+    const degree = utils.degrees(this.data.angle)
+
+    const arrowId = this.data.id
+    const arrow = reStruct.molecule.rxnArrows.get(arrowId)
+    if (arrow) {
+      // Note: Struct and ReStruct are in two different systems,
+      //       must manually update struct's position
+      arrow.pos = arrow.pos.map((p) =>
+        p.rotateAroundOrigin(degree, this.data.center)
+      )
+    }
+
+    const options = reStruct.render.options
+    const drawingCenter = this.data.center
+      .scaled(options.scale)
+      .add(options.offset)
+
+    reStruct.rxnArrows.get(arrowId)?.visel.rotate(degree, drawingCenter)
+
+    if (!this.data.noinvalidate) {
+      Base.invalidateItem(reStruct, 'rxnArrows', arrowId, 1)
+    }
+  }
+
+  invert() {
+    const move = new RxnArrowRotate(
+      this.data.id,
+      -this.data.angle,
+      this.data.center,
+      this.data.noinvalidate
+    )
+    return move
+  }
+}

--- a/packages/ketcher-core/src/application/editor/operations/rxn/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/index.ts
@@ -107,5 +107,6 @@ class RxnArrowDelete extends Base {
 
 export { RxnArrowAdd, RxnArrowDelete }
 export * from './RxnArrowMove'
+export * from './RxnArrowRotate'
 export * from './RxnArrowResize'
 export * from './plus'

--- a/packages/ketcher-core/src/application/operations/operations.types.ts
+++ b/packages/ketcher-core/src/application/operations/operations.types.ts
@@ -44,6 +44,7 @@ export type OperationType =
   | 'RXN_ARROW_ADD'
   | 'RXN_ARROW_DELETE'
   | 'RXN_ARROW_MOVE'
+  | 'RXN_ARROW_ROTATE'
   | 'RXN_ARROW_RESIZE'
   | 'RXN_PLUS_ADD'
   | 'RXN_PLUS_DELETE'

--- a/packages/ketcher-core/src/application/render/restruct/visel.js
+++ b/packages/ketcher-core/src/application/render/restruct/visel.js
@@ -22,7 +22,9 @@ class Visel {
   constructor(type) {
     this.type = type
     this.paths = []
+    /** @type {Box2Abs[]} */
     this.boxes = []
+    /** @type {Box2Abs | null} */
     this.boundingBox = null
     this.oldBoundingBox = null
     this.exts = []
@@ -69,6 +71,27 @@ class Visel {
       if (this.boundingBox !== null) {
         this.boundingBox = this.boundingBox.translate(delta)
       }
+    }
+  }
+
+  /**
+   * @param {number} degree
+   * @param {Vec2} center
+   */
+  rotate(degree, center) {
+    for (let i = 0; i < this.paths.length; ++i) {
+      this.paths[i].rotate(degree, center.x, center.y)
+    }
+
+    for (let j = 0; j < this.boxes.length; ++j) {
+      this.boxes[j] = this.boxes[j].transform((point) =>
+        point.rotateAroundOrigin(degree, center)
+      )
+    }
+    if (this.boundingBox !== null) {
+      this.boundingBox = this.boundingBox.transform((point) =>
+        point.rotateAroundOrigin(degree, center)
+      )
     }
   }
 }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -102,6 +102,7 @@ export interface Selection {
   enhancedFlags?: Array<number>
   rxnPluses?: Array<number>
   rxnArrows?: Array<number>
+  texts?: Array<number>
 }
 
 class Editor implements KetcherEditor {

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -74,13 +74,7 @@ class RotateController {
   rerender() {
     this.clean()
     this.init()
-
-    const [originalCenter, visibleAtoms] = this.rotateTool.getCenter(
-      this.editor
-    )
-
-    this.originalCenter = originalCenter
-    this.show(visibleAtoms)
+    this.show()
   }
 
   clean() {
@@ -127,14 +121,34 @@ class RotateController {
     )
   }
 
-  private show(visibleAtoms: number[]) {
+  private show() {
+    const [originalCenter, visibleAtoms] = this.rotateTool.getCenter(
+      this.editor
+    )
+
+    const { texts, rxnArrows, rxnPluses } = this.editor.selection() || {}
+
+    const isMoreThanOneItemBeingSelected =
+      visibleAtoms.concat(texts || [], rxnArrows || [], rxnPluses || [])
+        .length > 1
+
     const enable =
-      visibleAtoms.length > 1 && this.editor.tool() instanceof SelectTool
+      (isMoreThanOneItemBeingSelected || rxnArrows?.length) &&
+      this.editor.tool() instanceof SelectTool &&
+      originalCenter
+
     if (!enable) {
       return
     }
 
-    const rectStartY = this.drawBoundingRect(visibleAtoms)
+    this.originalCenter = originalCenter
+
+    const rectStartY = this.drawBoundingRect(
+      visibleAtoms,
+      texts,
+      rxnArrows,
+      rxnPluses
+    )
 
     this.handleCenter = new Vec2(
       this.center.x,
@@ -213,13 +227,21 @@ class RotateController {
     }
   }
 
-  private drawBoundingRect(visibleAtoms: number[]) {
+  private drawBoundingRect(
+    visibleAtoms: number[],
+    texts?: number[],
+    rxnArrows?: number[],
+    rxnPluses?: number[]
+  ) {
     const RECT_RADIUS = 20
     const RECT_PADDING = 10
 
     const rectBox = this.render.ctab
       .getVBoxObj({
         atoms: visibleAtoms,
+        texts,
+        rxnArrows,
+        rxnPluses,
         sgroups: getGroupIdsFromItemArrays(this.render.ctab.molecule, {
           atoms: visibleAtoms
         })


### PR DESCRIPTION
Closes #2680 

Add support to rotate the selected reaction arrows, reaction pluses, and texts.
Notice that if only one reaction plus or text is selected, the rotation handle will not show up. However, it will show up if only one reaction arrow is selected, see:

![rotate-arrow](https://github.com/epam/ketcher/assets/27288153/e8265a39-a6d6-42bf-9e26-6a645fe2641c)
