### PR TITLE
Backmerge: #2681 – Calculate CIP: stereolabels appears under structure; #2679 – Highlight colors for Simple Objects do not match the new design; #2683 – Missing circles to expand reaction arrows (#2706)

### DIFF
--- a/packages/ketcher-core/src/application/render/options.js
+++ b/packages/ketcher-core/src/application/render/options.js
@@ -95,7 +95,7 @@ function defaultOptions(opt) {
       'stroke-width': '1px'
     },
     hoverStyleSimpleObject: {
-      stroke: '#0c0',
+      stroke: '#57FF8F',
       'stroke-width': scaleFactor / 4,
       'stroke-linecap': 'round',
       'stroke-opacity': 0.6

--- a/packages/ketcher-core/src/application/render/restruct/generalEnumTypes.ts
+++ b/packages/ketcher-core/src/application/render/restruct/generalEnumTypes.ts
@@ -14,12 +14,17 @@
  * limitations under the License.
  ***************************************************************************/
 
+/*
+  This map is used to draw anything on 'layers'
+  You can treat these values as z-index: backround has the lowest z-index, indices has the highest
+*/
 export enum LayerMap {
   background = 'background',
   selectionPlate = 'selectionPlate',
   hovering = 'hovering',
   warnings = 'warnings',
   data = 'data',
+  additionalInfo = 'additionalInfo',
   indices = 'indices'
 }
 

--- a/packages/ketcher-core/src/application/render/restruct/rerxnarrow.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rerxnarrow.ts
@@ -123,18 +123,10 @@ class ReRxnArrow extends ReObject {
     return refPoints
   }
 
-  makeSelectionPlate(restruct: ReStruct, _paper, styles) {
-    const render = restruct.render
-    const options = restruct.render.options
-
+  makeAdditionalInfo(restruct: ReStruct) {
+    const scaleFactor = restruct.render.options.scale
     const refPoints = this.getReferencePoints()
-    const scaleFactor = options.scale
     const selectionSet = restruct.render.paper.set()
-    selectionSet.push(
-      render.paper
-        .path(this.generatePath(render, options, 'selection'))
-        .attr(styles.selectionStyle)
-    )
 
     refPoints.forEach((rp) => {
       const scaledRP = Scale.obj2scaled(rp, restruct.render.options)
@@ -144,6 +136,20 @@ class ReRxnArrow extends ReObject {
           .attr({ fill: 'black' })
       )
     })
+
+    return selectionSet
+  }
+
+  makeSelectionPlate(restruct: ReStruct, _paper, styles) {
+    const render = restruct.render
+    const options = restruct.render.options
+    const selectionSet = restruct.render.paper.set()
+
+    selectionSet.push(
+      render.paper
+        .path(this.generatePath(render, options, 'selection'))
+        .attr(styles.selectionStyle)
+    )
     return selectionSet
   }
 

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -638,9 +638,19 @@ class ReStruct {
           item.visel,
           item.selectionPlate
         )
+
+        if (typeof item.makeAdditionalInfo === 'function') {
+          item.additionalInfo = item.makeAdditionalInfo(this)
+          this.addReObjectPath(
+            LayerMap.additionalInfo,
+            item.visel,
+            item.additionalInfo
+          )
+        }
       }
       if (item.selectionPlate) {
         item.selectionPlate.show()
+        item.additionalInfo?.show()
         item.cip?.rectangle.attr({
           fill: '#7f7',
           stroke: '#7f7'
@@ -648,6 +658,7 @@ class ReStruct {
       }
     } else if (exists && item.selectionPlate) {
       item.selectionPlate.hide()
+      item.additionalInfo?.hide()
       item.cip?.rectangle.attr({
         fill: '#fff',
         stroke: '#fff'

--- a/packages/ketcher-core/src/application/render/util.ts
+++ b/packages/ketcher-core/src/application/render/util.ts
@@ -186,7 +186,7 @@ function drawCIPLabel({
   cipValuePath.path.translateAbs(0.5 * box.width, -0.5 * box.height)
   path.push(cipValuePath.path.toFront())
 
-  restruct.addReObjectPath(LayerMap.data, visel, path, null, true)
+  restruct.addReObjectPath(LayerMap.additionalInfo, visel, path, null, true)
 
   return cipValuePath
 }


### PR DESCRIPTION
closes #2681 
closes #2679 
closes #2683 