### PR TITLE
Backmerge: #2719 – Preview images for Functional Groups and Salts and Solvents are less readable (#2724)

### DIFF
--- a/packages/ketcher-core/src/application/render/renderStruct.ts
+++ b/packages/ketcher-core/src/application/render/renderStruct.ts
@@ -42,6 +42,7 @@ export class RenderStruct {
         autoScale: true,
         ...options
       })
+      preparedStruct.rescale()
       rnd.setMolecule(preparedStruct)
       if (needCache) {
         renderCache.set(cacheKey, rnd.clientArea.innerHTML)


### PR DESCRIPTION
closes #2719 