### PR TITLE
#2766 – Can not open .rxn files with S-Group properties

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/schema.json
+++ b/packages/ketcher-core/src/domain/serializers/ket/schema.json
@@ -479,7 +479,6 @@
           }
         },
         "then": {
-          "required": ["fieldName"],
           "properties": {
             "context": {
               "enum": ["Fragment", "Multifragment", "Bond", "Atom", "Group"]


### PR DESCRIPTION
closes #2766 
Ketcher failed to validate a response from Indigo, because field "fieldName" was absent.
Removing "fieldName" from required fields as according to Molfile specification it is optional field.