### PR TITLE
#2738 – Migrate to Indigo v1.12.0-rc.2 in-browser module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11879,9 +11879,9 @@
       }
     },
     "node_modules/indigo-ketcher": {
-      "version": "1.12.0-rc.1",
-      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.12.0-rc.1.tgz",
-      "integrity": "sha512-GiyTsM7gVDNxEFtb70hzm9nn51N/7aD/szyJoKd1rwh+XsPwQRptobDPsuAe/6td7LWefdWpTaTED/hV0+BEPA==",
+      "version": "1.12.0-rc.2",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.12.0-rc.2.tgz",
+      "integrity": "sha512-G9ucERRtTmoJ7Pbeb8J9l+O76y08E4xBwRrKI+YeCawKVYusIYk/omw0ek2KdERR2d+M8xOvydXP68ClKrtMBA==",
       "dependencies": {
         "looks-same": "^8.1.0"
       }
@@ -25098,7 +25098,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
-        "indigo-ketcher": "1.12.0-rc.1",
+        "indigo-ketcher": "1.12.0-rc.2",
         "ketcher-core": "*"
       },
       "devDependencies": {

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -20,12 +20,12 @@ describe('Rotate controller', () => {
       tool,
       render: { paper }
     } as any)
+    let visibleAtoms = [1]
     // @ts-ignore
     controller.rotateTool.getCenter = () => [new Vec2(), visibleAtoms]
     expect(tool()).toBeInstanceOf(SelectTool)
     expect(selection()).toBe(null)
 
-    let visibleAtoms = [1]
     // @ts-ignore
     controller.show()
     expect(paper).toBeCalledTimes(0)

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "indigo-ketcher": "1.12.0-rc.1",
+    "indigo-ketcher": "1.12.0-rc.2",
     "ketcher-core": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
closes #2738 