### PR TITLE
#2760 Snap partially selected structure to an attachment bond when rotated

### DIFF
--- a/packages/ketcher-core/src/application/render/draw.ts
+++ b/packages/ketcher-core/src/application/render/draw.ts
@@ -976,14 +976,19 @@ function bondSingle(
   halfBond1: HalfBond,
   halfBond2: HalfBond,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   const a = halfBond1.p;
   const b = halfBond2.p;
-  return paper.path(makeStroke(a, b)).attr(options.lineattr).attr({
-    fill: color,
-    stroke: color,
-  });
+  return paper
+    .path(makeStroke(a, b))
+    .attr(options.lineattr)
+    .attr({
+      fill: color,
+      stroke: color,
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondSingleUp(
@@ -992,6 +997,7 @@ function bondSingleUp(
   b2: Vec2,
   b3: Vec2,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   // eslint-disable-line max-params
@@ -1009,7 +1015,8 @@ function bondSingleUp(
     .attr({
       fill: color,
       stroke: color,
-    });
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondSingleStereoBold(
@@ -1019,6 +1026,7 @@ function bondSingleStereoBold(
   a3: Vec2,
   a4: Vec2,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   // eslint-disable-line max-params
@@ -1034,11 +1042,12 @@ function bondSingleStereoBold(
       tfx(a4.x),
       tfx(a4.y),
     )
-    .attr(options.lineattr);
-  bond.attr({
-    stroke: color,
-    fill: color,
-  });
+    .attr(options.lineattr)
+    .attr({
+      stroke: color,
+      fill: color,
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
   return bond;
 }
 
@@ -1048,6 +1057,7 @@ function bondDoubleStereoBold(
   b1: Vec2,
   b2: Vec2,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   // eslint-disable-line max-params
@@ -1059,7 +1069,8 @@ function bondDoubleStereoBold(
       .attr({
         stroke: color,
         fill: color,
-      }),
+      })
+      .attr(isSnapping ? options.bondSnappingStyle : {}),
   ]);
 }
 
@@ -1070,6 +1081,7 @@ function bondSingleDown(
   nlines: number,
   step: number,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   // eslint-disable-line max-params
@@ -1087,10 +1099,14 @@ function bondSingleDown(
     q = r.addScaled(n, (-bsp * (i + 0.5)) / (nlines - 0.5));
     path += makeStroke(p, q);
   }
-  return paper.path(path).attr(options.lineattr).attr({
-    fill: color,
-    stroke: color,
-  });
+  return paper
+    .path(path)
+    .attr(options.lineattr)
+    .attr({
+      fill: color,
+      stroke: color,
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondSingleEither(
@@ -1100,6 +1116,7 @@ function bondSingleEither(
   nlines: number,
   step: number,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   // eslint-disable-line max-params
@@ -1115,10 +1132,14 @@ function bondSingleEither(
       .addScaled(n, ((i & 1 ? -1 : +1) * bsp * (i + 0.5)) / (nlines - 0.5));
     path += 'L' + tfx(r.x) + ',' + tfx(r.y);
   }
-  return paper.path(path).attr(options.lineattr).attr({
-    fill: color,
-    stroke: color,
-  });
+  return paper
+    .path(path)
+    .attr(options.lineattr)
+    .attr({
+      fill: color,
+      stroke: color,
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondDouble(
@@ -1129,6 +1150,7 @@ function bondDouble(
   b2: Vec2,
   cisTrans: boolean,
   options: RenderOptions,
+  isSnapping: boolean,
 ) {
   // eslint-disable-line max-params
   return paper
@@ -1145,7 +1167,8 @@ function bondDouble(
       tfx(b2.x),
       tfx(b2.y),
     )
-    .attr(options.lineattr);
+    .attr(options.lineattr)
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondSingleOrDouble(
@@ -1154,6 +1177,7 @@ function bondSingleOrDouble(
   halfBond2: HalfBond,
   nSect: number,
   options: RenderOptions,
+  isSnapping: boolean,
 ) {
   // eslint-disable-line max-statements, max-params
   const a = halfBond1.p;
@@ -1174,7 +1198,10 @@ function bondSingleOrDouble(
     }
     pp = pi;
   }
-  return paper.path(path).attr(options.lineattr);
+  return paper
+    .path(path)
+    .attr(options.lineattr)
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondTriple(
@@ -1182,6 +1209,7 @@ function bondTriple(
   halfBond1: HalfBond,
   halfBond2: HalfBond,
   options: RenderOptions,
+  isSnapping: boolean,
   color = '#000',
 ) {
   const a = halfBond1.p;
@@ -1197,7 +1225,8 @@ function bondTriple(
     .attr({
       fill: color,
       stroke: color,
-    });
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondAromatic(
@@ -1205,9 +1234,16 @@ function bondAromatic(
   paths: string[],
   bondShift: number,
   options: RenderOptions,
+  isSnapping: boolean,
 ) {
-  const l1 = paper.path(paths[0]).attr(options.lineattr);
-  const l2 = paper.path(paths[1]).attr(options.lineattr);
+  const l1 = paper
+    .path(paths[0])
+    .attr(options.lineattr)
+    .attr(isSnapping ? options.bondSnappingStyle : {});
+  const l2 = paper
+    .path(paths[1])
+    .attr(options.lineattr)
+    .attr(isSnapping ? options.bondSnappingStyle : {});
   if (bondShift !== undefined && bondShift !== null) {
     (bondShift > 0 ? l1 : l2).attr({ 'stroke-dasharray': '- ' });
   }
@@ -1220,13 +1256,15 @@ function bondAny(
   halfBond1: HalfBond,
   halfBond2: HalfBond,
   options: RenderOptions,
+  isSnapping: boolean,
 ) {
   const a = halfBond1.p;
   const b = halfBond2.p;
   return paper
     .path(makeStroke(a, b))
     .attr(options.lineattr)
-    .attr({ 'stroke-dasharray': '- ' });
+    .attr({ 'stroke-dasharray': '- ' })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondHydrogen(
@@ -1234,13 +1272,18 @@ function bondHydrogen(
   halfBond1: HalfBond,
   halfBond2: HalfBond,
   options: RenderOptions,
+  isSnapping: boolean,
 ) {
   const a = halfBond1.p;
   const b = halfBond2.p;
-  return paper.path(makeStroke(a, b)).attr(options.lineattr).attr({
-    'stroke-dasharray': '.',
-    'stroke-linecap': 'square',
-  });
+  return paper
+    .path(makeStroke(a, b))
+    .attr(options.lineattr)
+    .attr({
+      'stroke-dasharray': '.',
+      'stroke-linecap': 'square',
+    })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function bondDative(
@@ -1248,13 +1291,15 @@ function bondDative(
   halfBond1: HalfBond,
   halfBond2: HalfBond,
   options: RenderOptions,
+  isSnapping: boolean,
 ) {
   const a = halfBond1.p;
   const b = halfBond2.p;
   return paper
     .path(makeStroke(a, b))
     .attr(options.lineattr)
-    .attr({ 'arrow-end': 'block-midium-long' });
+    .attr({ 'arrow-end': 'block-midium-long' })
+    .attr(isSnapping ? options.bondSnappingStyle : {});
 }
 
 function reactingCenter(

--- a/packages/ketcher-core/src/application/render/options.ts
+++ b/packages/ketcher-core/src/application/render/options.ts
@@ -82,6 +82,11 @@ function defaultOptions(options: RenderOptions): RenderOptions {
       fill: '#365CFF',
       stroke: '#365CFF',
     },
+    bondSnappingStyle: {
+      fill: '#365CFF',
+      stroke: '#365CFF',
+      'stroke-width': options.bondThickness * 1.5
+    },
     /* eslint-enable quote-props */
     selectionStyle: {
       fill: '#57FF8F',

--- a/packages/ketcher-core/src/application/render/options.ts
+++ b/packages/ketcher-core/src/application/render/options.ts
@@ -85,7 +85,7 @@ function defaultOptions(options: RenderOptions): RenderOptions {
     bondSnappingStyle: {
       fill: '#365CFF',
       stroke: '#365CFF',
-      'stroke-width': options.bondThickness * 1.5
+      'stroke-width': options.bondThickness * 1.5,
     },
     /* eslint-enable quote-props */
     selectionStyle: {

--- a/packages/ketcher-core/src/application/render/render.types.ts
+++ b/packages/ketcher-core/src/application/render/render.types.ts
@@ -53,6 +53,7 @@ export type RenderOptions = {
   /* styles */
   lineattr: RenderOptionStyles;
   arrowSnappingStyle: RenderOptionStyles;
+  bondSnappingStyle: RenderOptionStyles;
   selectionStyle: RenderOptionStyles;
   hoverStyle: RenderOptionStyles;
   sgroupBracketStyle: RenderOptionStyles;

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -320,7 +320,7 @@ class ReStruct {
    * and this lead to unstable flip tool work
    */
   // eslint-disable-next-line no-use-before-define
-  getSelectionRotationCenter(selection: SelectionMap): Vec2 | undefined {
+  getSelectionBoxCenter(selection: SelectionMap): Vec2 | undefined {
     let boundingBox: Box2Abs | null = null;
 
     for (const atomId of selection.atoms ?? []) {

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -84,6 +84,7 @@ class ReStruct {
   private enhancedFlagsChanged: Map<number, ReEnhancedFlag> = new Map();
   private bondsChanged: Map<number, ReEnhancedFlag> = new Map();
   private textsChanged: Map<number, ReText> = new Map();
+  private snappingBonds: number[] = [];
   constructor(molecule, render: Render) {
     // eslint-disable-line max-statements
     this.render = render;
@@ -760,6 +761,18 @@ class ReStruct {
         stroke: '#fff',
       });
     }
+  }
+
+  addSnappingBonds(bondId: number) {
+    this.snappingBonds.push(bondId);
+  }
+
+  clearSnappingBonds() {
+    this.snappingBonds = [];
+  }
+
+  isSnappingBond(bondId: number) {
+    return this.snappingBonds.includes(bondId);
   }
 }
 

--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -21,6 +21,7 @@ import { Bond } from './bond';
 import { Pool } from './pool';
 import { SGroup } from './sgroup';
 import { Struct } from './struct';
+import { HalfBond } from './halfBond';
 
 export class FunctionalGroup {
   #sgroup: SGroup;
@@ -213,6 +214,19 @@ export class FunctionalGroup {
         atomsInSGroup.includes(bond.end)
       );
     });
+  }
+
+  static isHalfBondInContractedFunctionalGroup(
+    halfBond: HalfBond,
+    struct: Struct,
+  ) {
+    const bond = struct.bonds.get(halfBond.bid);
+    assert(bond != null);
+    return this.isBondInContractedFunctionalGroup(
+      bond,
+      struct.sgroups,
+      struct.functionalGroups,
+    );
   }
 
   static isContractedFunctionalGroup(sgroupId, functionalGroups): boolean {

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import { Atom, radicalElectrons } from './atom';
-
+import { EditorSelection } from 'application/editor';
 import { Bond } from './bond';
 import { Box2Abs } from './box2Abs';
 import { Elements } from 'domain/constants';
@@ -1117,5 +1117,42 @@ export class Struct {
       }
     }
     return groupsIds;
+  }
+
+  getBondIdByHalfBond(halfBondId: number) {
+    const halfBond = this.halfBonds.get(halfBondId);
+    if (halfBond) {
+      return halfBond.bid;
+    }
+    return undefined;
+  }
+
+  /**
+   * @returns visibleAtoms = selected atoms
+   *                       - atoms in contracted functional groups
+   *                       + functional groups's attachment atoms
+   */
+  getSelectedVisibleAtoms(selection: EditorSelection | null) {
+    return (
+      selection?.atoms?.filter((atomId) => {
+        const atom = this.atoms.get(atomId);
+        if (!atom) {
+          return false;
+        }
+        const isAtomNotInContractedGroup =
+          !FunctionalGroup.isAtomInContractedFunctionalGroup(
+            atom,
+            this.sgroups,
+            this.functionalGroups,
+            false,
+          );
+        if (isAtomNotInContractedGroup) {
+          return true;
+        }
+        const groupId = this.getGroupIdFromAtomId(atomId);
+        const sgroup = this.sgroups.get(groupId as number);
+        return sgroup?.getAttachmentAtomId() === atomId;
+      }) || []
+    );
   }
 }

--- a/packages/ketcher-react/src/script/editor/shared/utils.js
+++ b/packages/ketcher-react/src/script/editor/shared/utils.js
@@ -36,9 +36,31 @@ function degrees(angle) {
   return degree;
 }
 
+/**
+ * @param {number} angle angle (in radians) from the X axis
+ * @returns {number} normalized angle (in radians) from the X axis
+ * @example
+ * normalizeAngleRelativeToXAxis(PI / 2) === PI / 2
+ * normalizeAngleRelativeToXAxis(PI) === PI
+ * normalizeAngleRelativeToXAxis(3/2 * PI) === -PI / 2
+ * normalizeAngleRelativeToXAxis(2 * PI) === 0
+ * normalizeAngleRelativeToXAxis(3 * PI) === PI
+ */
+function normalizeAngle(angle) {
+  const angleWithinFullCircle = angle % (2 * Math.PI);
+  if (angleWithinFullCircle > Math.PI) {
+    return angleWithinFullCircle - 2 * Math.PI;
+  }
+  if (angleWithinFullCircle <= -Math.PI) {
+    return angleWithinFullCircle + 2 * Math.PI;
+  }
+  return angleWithinFullCircle;
+}
+
 export default {
   calcAngle,
   fracAngle,
   calcNewAtomPos,
   degrees,
+  normalizeAngle,
 };

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -15,14 +15,22 @@ describe('Rotate controller', () => {
     const tool = () => new SelectTool();
     const paper = jest.fn();
     const selection = () => null;
-    const controller = new RotateController({
+    const visibleAtoms = [1];
+    const editor = {
       selection,
       tool,
-      render: { paper },
-    } as any);
-    let visibleAtoms = [1];
+      render: {
+        paper,
+        ctab: {
+          molecule: {
+            getSelectedVisibleAtoms: () => visibleAtoms,
+          },
+        },
+      },
+    };
+    const controller = new RotateController(editor as any);
     // @ts-ignore
-    controller.rotateTool.getCenter = () => [new Vec2(), visibleAtoms];
+    controller.rotateTool.getCenter = () => new Vec2();
     expect(tool()).toBeInstanceOf(SelectTool);
     expect(selection()).toBe(null);
 
@@ -30,9 +38,9 @@ describe('Rotate controller', () => {
     controller.show();
     expect(paper).toBeCalledTimes(0);
 
-    visibleAtoms = [1, 2];
+    visibleAtoms.push(2);
     // @ts-ignore
-    controller.rotateTool.getCenter = () => [new Vec2(), visibleAtoms];
+    controller.rotateTool.getCenter = () => new Vec2();
     expect(() => {
       // @ts-ignore
       controller.show();
@@ -48,14 +56,22 @@ describe('Rotate controller', () => {
     const editor = new Editor(document, {});
     const NonSelectTool = new RotateTool(editor, undefined);
     const paper = jest.fn();
+    const visibleAtoms = [0, 1];
     const controller = new RotateController({
       selection: () => null,
       tool: () => NonSelectTool,
-      render: { paper },
+      render: {
+        paper,
+        ctab: {
+          // @ts-ignore
+          molecule: {
+            getSelectedVisibleAtoms: () => visibleAtoms,
+          },
+        },
+      },
     } as any);
-    const visibleAtoms = [0, 1];
     // @ts-ignore
-    controller.rotateTool.getCenter = () => [new Vec2(), visibleAtoms];
+    controller.rotateTool.getCenter = () => new Vec2();
     expect(visibleAtoms.length).toBeGreaterThan(1);
 
     // @ts-ignore
@@ -184,6 +200,7 @@ describe('Rotate controller', () => {
    */
   it(`cancels rotation without modifying history stack`, () => {
     const editor = new Editor(document, {});
+    editor.render.ctab.molecule.getSelectedVisibleAtoms = () => [];
     // @ts-ignore
     editor.rotateController.rotateTool.dragCtx = {
       action: { operations: [], perform: () => undefined },

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -142,8 +142,9 @@ class RotateController {
   }
 
   private show() {
-    const [originalCenter, visibleAtoms] = this.rotateTool.getCenter(
-      this.editor,
+    const originalCenter = this.rotateTool.getCenter();
+    const visibleAtoms = this.render.ctab.molecule.getSelectedVisibleAtoms(
+      this.editor.selection(),
     );
 
     const { texts, rxnArrows, rxnPluses } = this.editor.selection() || {};

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -1,6 +1,7 @@
 import { Action, Scale, Vec2 } from 'ketcher-core';
 import { throttle } from 'lodash';
 import Editor from '../Editor';
+import utils from '../shared/utils';
 import { getGroupIdsFromItemArrays } from './helper/getGroupIdsFromItems';
 import RotateTool from './rotate';
 import SelectTool from './select';
@@ -13,6 +14,7 @@ type RaphaelElement = {
 type LinkState = 'long' | 'short' | 'moveCenter' | 'moveHandle';
 type CrossState = 'active' | 'inactive' | 'offset' | 'move';
 type HandleState = 'hoverIn' | 'hoverOut' | 'active' | 'move';
+type SnapAngleIndicatorState = 'noLine' | 'noText' | 'default';
 
 const STYLE = {
   HANDLE_MARGIN: 15,
@@ -42,6 +44,7 @@ class RotateController {
   private link?: RaphaelElement;
   private protractor?: RaphaelElement;
   private rotateArc?: RaphaelElement;
+  private snapAngleIndicator?: RaphaelElement;
 
   constructor(editor: Editor) {
     this.editor = editor;
@@ -107,6 +110,8 @@ class RotateController {
     delete this.protractor;
     this.rotateArc?.remove();
     delete this.rotateArc;
+    this.snapAngleIndicator?.remove();
+    delete this.snapAngleIndicator;
   }
 
   /**
@@ -714,13 +719,15 @@ class RotateController {
           rotateArcStart,
           textPos,
         );
-        // NOTE: draw protractor last
+        // NOTE: draw protractor behind arc
         this.drawProtractor(
           this.rotateTool.dragCtx?.angle || 0,
           newRadius,
           degree0Line,
           degree0TextPos,
         );
+
+        this.updateSnapAngleIndicator();
       },
       40, // 25fps
     );
@@ -804,6 +811,99 @@ class RotateController {
       rotateHandlePosition: handleCenterInViewport,
     });
   }, 40);
+
+  private updateSnapAngleIndicator() {
+    const snapAngleDrawingProps = this.rotateTool.snapAngleDrawingProps;
+    if (
+      snapAngleDrawingProps === null ||
+      (snapAngleDrawingProps.snapMode === 'multiple-bonds' &&
+        snapAngleDrawingProps.isSnapping)
+    ) {
+      this.snapAngleIndicator?.remove();
+    } else {
+      const { isSnapping, absoluteAngle, relativeAngle, snapMode } =
+        snapAngleDrawingProps;
+      const drawingState: SnapAngleIndicatorState = isSnapping
+        ? 'noLine'
+        : snapMode === 'multiple-bonds'
+        ? 'noText'
+        : 'default';
+      this.drawSnapAngleIndicator(drawingState, absoluteAngle, relativeAngle);
+    }
+  }
+
+  private drawSnapAngleIndicator(
+    state: SnapAngleIndicatorState,
+    absoluteSnapAngle: number,
+    relativeSnapAngle: number,
+  ) {
+    this.snapAngleIndicator?.remove();
+    this.snapAngleIndicator = this.paper.set() as RaphaelElement;
+    const LINE_LENGTH = 30;
+    const TEXT_FONT_SIZE = 12;
+    const relativeSnapAngleInDegrees = utils.degrees(relativeSnapAngle);
+
+    switch (state) {
+      case 'noLine': {
+        const textAngle = utils.normalizeAngle(
+          absoluteSnapAngle - relativeSnapAngle / 2,
+        );
+        const textPosition = new Vec2(20, 0).rotate(textAngle);
+        const text = this.paper
+          .text(
+            textPosition.x,
+            textPosition.y,
+            `${Math.abs(relativeSnapAngleInDegrees)}°`,
+          )
+          .attr({
+            'font-size': TEXT_FONT_SIZE,
+            fill: STYLE.ACTIVE_COLOR,
+          });
+        this.snapAngleIndicator.push(text);
+        break;
+      }
+
+      case 'noText': {
+        const lineVector = new Vec2(LINE_LENGTH, 0).rotate(absoluteSnapAngle);
+        const line = this.paper
+          .path(`M0,0` + `l${lineVector.x},${lineVector.y}`)
+          .attr({
+            'stroke-dasharray': '-',
+            stroke: STYLE.INITIAL_COLOR,
+          });
+        this.snapAngleIndicator.push(line);
+        break;
+      }
+
+      default: {
+        const lineVector = new Vec2(LINE_LENGTH, 0).rotate(absoluteSnapAngle);
+        const line = this.paper
+          .path(`M0,0` + `l${lineVector.x},${lineVector.y}`)
+          .attr({
+            'stroke-dasharray': '-',
+            stroke: STYLE.INITIAL_COLOR,
+          });
+        const textPosition = new Vec2(LINE_LENGTH + 15, 0).rotate(
+          absoluteSnapAngle,
+        );
+        const text = this.paper
+          .text(
+            textPosition.x,
+            textPosition.y,
+            `${Math.abs(relativeSnapAngleInDegrees)}°`,
+          )
+          .attr({
+            'font-size': TEXT_FONT_SIZE,
+            fill: STYLE.INITIAL_COLOR,
+          });
+        this.snapAngleIndicator.push(line);
+        this.snapAngleIndicator.push(text);
+        break;
+      }
+    }
+
+    this.snapAngleIndicator.translate(this.center.x, this.center.y);
+  }
 }
 
 export default RotateController;

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -843,59 +843,52 @@ class RotateController {
     const TEXT_FONT_SIZE = 12;
     const relativeSnapAngleInDegrees = utils.degrees(relativeSnapAngle);
 
+    const drawText = (textPosition: Vec2) =>
+      this.paper
+        .text(
+          textPosition.x,
+          textPosition.y,
+          `${Math.abs(relativeSnapAngleInDegrees)}°`,
+        )
+        .attr({
+          'font-size': TEXT_FONT_SIZE,
+        });
+
+    const drawLine = () => {
+      const lineVector = new Vec2(LINE_LENGTH, 0).rotate(absoluteSnapAngle);
+      return this.paper.path(`M0,0` + `l${lineVector.x},${lineVector.y}`).attr({
+        'stroke-dasharray': '-',
+        stroke: STYLE.INITIAL_COLOR,
+      });
+    };
+
     switch (state) {
       case 'noLine': {
         const textAngle = utils.normalizeAngle(
           absoluteSnapAngle - relativeSnapAngle / 2,
         );
         const textPosition = new Vec2(20, 0).rotate(textAngle);
-        const text = this.paper
-          .text(
-            textPosition.x,
-            textPosition.y,
-            `${Math.abs(relativeSnapAngleInDegrees)}°`,
-          )
-          .attr({
-            'font-size': TEXT_FONT_SIZE,
-            fill: STYLE.ACTIVE_COLOR,
-          });
+        const text = drawText(textPosition).attr({
+          fill: STYLE.ACTIVE_COLOR,
+        });
         this.snapAngleIndicator.push(text);
         break;
       }
 
       case 'noText': {
-        const lineVector = new Vec2(LINE_LENGTH, 0).rotate(absoluteSnapAngle);
-        const line = this.paper
-          .path(`M0,0` + `l${lineVector.x},${lineVector.y}`)
-          .attr({
-            'stroke-dasharray': '-',
-            stroke: STYLE.INITIAL_COLOR,
-          });
+        const line = drawLine();
         this.snapAngleIndicator.push(line);
         break;
       }
 
       default: {
-        const lineVector = new Vec2(LINE_LENGTH, 0).rotate(absoluteSnapAngle);
-        const line = this.paper
-          .path(`M0,0` + `l${lineVector.x},${lineVector.y}`)
-          .attr({
-            'stroke-dasharray': '-',
-            stroke: STYLE.INITIAL_COLOR,
-          });
+        const line = drawLine();
         const textPosition = new Vec2(LINE_LENGTH + 15, 0).rotate(
           absoluteSnapAngle,
         );
-        const text = this.paper
-          .text(
-            textPosition.x,
-            textPosition.y,
-            `${Math.abs(relativeSnapAngleInDegrees)}°`,
-          )
-          .attr({
-            'font-size': TEXT_FONT_SIZE,
-            fill: STYLE.INITIAL_COLOR,
-          });
+        const text = drawText(textPosition).attr({
+          fill: STYLE.INITIAL_COLOR,
+        });
         this.snapAngleIndicator.push(line);
         this.snapAngleIndicator.push(text);
         break;

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -18,6 +18,7 @@ import {
   Atom,
   Bond,
   FlipDirection,
+  FunctionalGroup,
   Vec2,
   fromFlip,
   fromItemsFuse,
@@ -171,7 +172,7 @@ class RotateTool implements Tool {
         rxnArrows?.length ||
         rxnPluses?.length)
     ) {
-      center = this.reStruct.getSelectionRotationCenter({
+      center = this.reStruct.getSelectionBoxCenter({
         atoms: visibleAtoms,
         texts,
         rxnArrows,
@@ -277,6 +278,7 @@ class RotateTool implements Tool {
     }
 
     const centerAtom = this.struct.atoms.get(this.centerAtomId);
+    assert(centerAtom != null);
     const {
       rotatableHalfBondIds,
       rotatableHalfBondAngles,
@@ -390,20 +392,27 @@ class RotateTool implements Tool {
 
   private partitionNeighborsBySelection(
     selection: Selection | null,
-    atom?: Atom,
+    atom: Atom,
   ) {
     const rotatableHalfBondIds: number[] = [];
     const rotatableHalfBondAngles: number[] = [];
     const fixedHalfBondIds: number[] = [];
     const fixedHalfBondAngles: number[] = [];
 
-    atom?.neighbors.forEach((halfBondId) => {
+    atom.neighbors.forEach((halfBondId) => {
       const halfBond = this.struct.halfBonds.get(halfBondId);
       assert(halfBond != null);
       const neighborAtomId = halfBond.end;
       if (selection?.atoms?.includes(neighborAtomId)) {
-        rotatableHalfBondIds.push(halfBondId);
-        rotatableHalfBondAngles.push(halfBond.ang);
+        if (
+          !FunctionalGroup.isHalfBondInContractedFunctionalGroup(
+            halfBond,
+            this.struct,
+          )
+        ) {
+          rotatableHalfBondIds.push(halfBondId);
+          rotatableHalfBondAngles.push(halfBond.ang);
+        }
       } else {
         fixedHalfBondIds.push(halfBondId);
         fixedHalfBondAngles.push(halfBond.ang);


### PR DESCRIPTION
Closes #2760 

Note: for easy review, this PR has been divided into 2 commits. One is refactoring, the other is the new feature.

## Basic acceptance criteria

### One bond

Snap positions are 90, 120, and 180 degrees.

![snap-bond-02](https://github.com/epam/ketcher/assets/27288153/840aa021-ce6a-49a0-9c5a-fe6e38b3769b)


### More than one bonds

Snap positions are bisectors of any two bonds

![snap-bond-03](https://github.com/epam/ketcher/assets/27288153/71560498-2e56-490b-b026-d0dbcfc99d7e)


### Works for every type of bond

![snap-bond-01](https://github.com/epam/ketcher/assets/27288153/481b98d5-d018-4db4-8e93-eacc0087fe05)

