### PR TITLE
#2753 Snap arrows to horizontal and vertical orientation

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select.ts
@@ -290,8 +290,10 @@ class SelectTool implements Tool {
         editor.render,
         editor.options().scale
       )
-      this.updateArrowResizingState(this.dragCtx.item.id, false)
-      this.editor.update(true)
+      if (this.dragCtx.item.map === 'rxnArrows') {
+        this.updateArrowResizingState(this.dragCtx.item.id, false)
+        this.editor.update(true)
+      }
       dropAndMerge(
         editor,
         this.dragCtx.mergeItems,


### PR DESCRIPTION
Closes #2753 

fix: double-clicking on atoms or bonds to open edit modals