### PR TITLE
#2803 – When user moves mouse, there is a constant update in the '3D Viewer' window

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
@@ -17,6 +17,7 @@
 import * as structFormat from '../../../../../data/convert/structConverter'
 
 import { Component, createRef } from 'react'
+import { createSelector } from 'reselect'
 import Form, { Field } from '../../../../../component/form/form/form'
 import {
   FormatterFactory,
@@ -443,10 +444,15 @@ class SaveDialog extends Component {
   }
 }
 
+const getOptions = (state) => state.options
+const serverSettingsSelector = createSelector([getOptions], (options) =>
+  options.getServerSettings()
+)
+
 const mapStateToProps = (state) => ({
   server: state.options.app.server ? state.server : null,
   struct: state.editor.struct(),
-  options: state.options.getServerSettings(),
+  options: serverSettingsSelector(state),
   formState: state.modal.form,
   moleculeErrors: state.modal.form.moleculeErrors,
   checkState: state.options.check,

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Miew/Miew.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Miew/Miew.tsx
@@ -28,6 +28,7 @@ import { connect } from 'react-redux'
 import { load } from '../../../../../state'
 import { pick } from 'lodash/fp'
 import { Miew as MiewAsType } from 'miew'
+import { createSelector } from 'reselect'
 
 const Viewer = lazy(() => import('miew-react'))
 
@@ -188,8 +189,13 @@ const MiewDialog = ({
   )
 }
 
+const getOptionsSettings = (state) => state.options.settings
+const miewOptionsSelector = createSelector([getOptionsSettings], (settings) =>
+  createMiewOptions(pick(MIEW_OPTIONS, settings))
+)
+
 const mapStateToProps = (state) => ({
-  miewOpts: createMiewOptions(pick(MIEW_OPTIONS, state.options.settings)),
+  miewOpts: miewOptionsSelector(state),
   server: state.options.app.server ? state.server : null,
   struct: state.editor.struct(),
   miewTheme: state.options.settings.miewTheme

--- a/packages/ketcher-react/src/script/ui/views/toolbars/BottomToolbar/BottomToolbar.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/BottomToolbar/BottomToolbar.container.ts
@@ -27,13 +27,14 @@ import { onAction } from '../../../state'
 
 type StateProps = Omit<BottomToolbarProps, 'className'>
 type OwnProps = Pick<BottomToolbarProps, 'className'>
+const disableableButtons = []
 
 const mapStateToProps = (state): StateProps => ({
   active: state.actionState && state.actionState.activeTool,
   status: state.actionState || {},
   opened: state.toolbar.opened,
   indigoVerification: state.requestsStatuses.indigoVerification,
-  disableableButtons: []
+  disableableButtons
 })
 
 const mapDispatchToProps = (dispatch: Dispatch): BottomToolbarCallProps => ({

--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.container.ts
@@ -27,6 +27,7 @@ import { onAction } from '../../../state'
 
 type StateProps = Omit<RightToolbarProps, 'className'>
 type OwnProps = Pick<RightToolbarProps, 'className'>
+const disableableButtons = []
 
 const mapStateToProps = (state): StateProps => ({
   active: state.actionState && state.actionState.activeTool,
@@ -34,7 +35,7 @@ const mapStateToProps = (state): StateProps => ({
   freqAtoms: state.toolbar.freqAtoms,
   opened: state.toolbar.opened,
   indigoVerification: state.requestsStatuses.indigoVerification,
-  disableableButtons: []
+  disableableButtons
 })
 
 const mapDispatchToProps = (dispatch: Dispatch): RightToolbarCallProps => ({

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
@@ -22,6 +22,37 @@ import { onAction } from '../../../state'
 import action from 'src/script/ui/action/index.js'
 import { shortcutStr } from '../shortcutStr'
 import { removeStructAction } from 'src/script/ui/state/shared'
+import { createSelector } from 'reselect'
+
+const getActionState = (state) => state.actionState || {}
+
+const disabledButtonsSelector = createSelector(
+  [getActionState],
+  (actionState) =>
+    Object.keys(actionState).reduce((acc: string[], item) => {
+      if (actionState[item]?.disabled) {
+        acc.push(item)
+      }
+      return acc
+    }, [])
+)
+const hiddenButtonsSelector = createSelector([getActionState], (actionState) =>
+  Object.keys(actionState).reduce((acc: string[], item) => {
+    if (actionState[item]?.hidden) {
+      acc.push(item)
+    }
+    return acc
+  }, [])
+)
+
+const disableableButtons = [
+  'layout',
+  'clean',
+  'arom',
+  'dearom',
+  'cip',
+  'enhanced-stereo'
+]
 
 const shortcuts = Object.keys(action).reduce((acc, key) => {
   if (action[key]?.shortcut) {
@@ -33,44 +64,15 @@ const shortcuts = Object.keys(action).reduce((acc, key) => {
 }, {})
 
 const mapStateToProps = (state: any) => {
-  const actionState = state.actionState || {}
-
-  const disabledButtons = Object.keys(actionState).reduce(
-    (acc: string[], item) => {
-      if (actionState[item]?.disabled) {
-        acc.push(item)
-      }
-      return acc
-    },
-    []
-  )
-
-  const hiddenButtons = Object.keys(actionState).reduce(
-    (acc: string[], item) => {
-      if (actionState[item]?.hidden) {
-        acc.push(item)
-      }
-      return acc
-    },
-    []
-  )
-
   return {
     currentZoom: Math.round(state.actionState?.zoom?.selected * 100),
-    disabledButtons,
-    hiddenButtons,
+    disabledButtons: disabledButtonsSelector(state),
+    hiddenButtons: hiddenButtonsSelector(state),
     shortcuts,
     status: state.actionState || {},
     opened: state.toolbar.opened,
     indigoVerification: state.requestsStatuses.indigoVerification,
-    disableableButtons: [
-      'layout',
-      'clean',
-      'arom',
-      'dearom',
-      'cip',
-      'enhanced-stereo'
-    ]
+    disableableButtons
   }
 }
 


### PR DESCRIPTION
closes #2803 
closes #2809 

Moved reference type variables to upper scope to prevent unnececessary rerenders
In addition, added selectors for components, which rerendered due to variables with referenced type