### PR TITLE
Fix `innerRef` warning in development environment

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx
@@ -175,6 +175,7 @@ function FieldSet({
   onSelect,
   type = 'radio',
   checked,
+  innerRef,
   ...rest
 }) {
   return (
@@ -183,6 +184,7 @@ function FieldSet({
         <li key={title} className={classes.fieldSetItem}>
           <label className={classes.fieldSetLabel}>
             <input
+              ref={innerRef}
               type={type}
               defaultChecked={
                 type === 'radio' ? selected(val, checked) : selected(val, value)


### PR DESCRIPTION
Fix the following warning in development environment:
> Warning: React does not recognize the `innerRef` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `innerref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

**Steps to reproduce:**
1. Use S-Group Tool to select some objects
2. Check the console

![sgroup-react-warning](https://github.com/epam/ketcher/assets/27288153/a79e0b11-a246-43e3-99af-4d38fce6ac71)