### PR TITLE
#2810 Part of the structure disappears when opening a contracted Superatom with multiple connection points

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -103,6 +103,9 @@ export function fromPaste(
     const newsgid = restruct.molecule.sgroups.newId()
     const sgAtoms = sg.atoms.map((aid) => aidMap.get(aid))
     const attachmentPoints = sg.cloneAttachmentPoints(aidMap)
+    if (sg.isNotContractible(pstruct)) {
+      sg.setAttr('expanded', true)
+    }
     const sgAction = fromSgroupAddition(
       restruct,
       sg.type,


### PR DESCRIPTION
Closes #2810 

- fixed expanded property calculation for sgroups during mousemove of paste tool