### PR TITLE
#2806 All inner space of selected Functional Group is highlighted if structure selected via CTRL+A

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/resgroup.js
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.js
@@ -186,7 +186,7 @@ class ReSGroup extends ReObject {
       sGroupItem.hovering = this.getContractedSelectionContour(render).attr(
         options.hoverStyle
       )
-    } else {
+    } else if (!this.selected) {
       sGroupItem.hovering = paper
         .path(
           'M{0},{1}L{2},{3}L{4},{5}L{6},{7}L{0},{1}',


### PR DESCRIPTION
Closes #2806 

- added highlighting prevention if sgroup selected

## Basic acceptance criteria
### Select functional group/super atom and hover it

https://github.com/epam/ketcher/assets/14859362/aa26728a-c174-4829-9b32-cba8cc80b7c2

