### PR TITLE
Backmerge: #2805 horizontal and vertical flips are working incorrectly (affect position) with some atoms, texts and functional groups (#2827)

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/rotate.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rotate.ts
@@ -138,7 +138,7 @@ function fromTextFlip(
     //      `pos`: a box (not bounding box)
     // `TextMove` is to move `position`, so we have to calculate the flipped `position`
     const textMiddleLeft = text.pos[0]
-    const textMiddleRight = text.pos[3]
+    const textMiddleRight = text.pos[2]
     const textCenter = Vec2.centre(textMiddleLeft, textMiddleRight)
 
     const difference = flipPointByCenter(textCenter, center, flipDirection)

--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -20,7 +20,7 @@ import {
   RawDraftContentState,
   RawDraftInlineStyleRange
 } from 'draft-js'
-import { Text, TextCommand, Vec2 } from 'domain/entities'
+import { Box2Abs, Text, TextCommand, Vec2 } from 'domain/entities'
 import { flatten, isEqual } from 'lodash/fp'
 
 import { LayerMap } from './generalEnumTypes'
@@ -72,6 +72,11 @@ class ReText extends ReObject {
     )
 
     return refPoints
+  }
+
+  getVBoxObj(): Box2Abs {
+    const [leftTopPoint, _, rightBottomPoint] = this.getReferencePoints()
+    return new Box2Abs(leftTopPoint, rightBottomPoint)
   }
 
   hoverPath(render: any): any {

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -153,13 +153,12 @@ class RotateTool implements Tool {
         rxnArrows?.length ||
         rxnPluses?.length)
     ) {
-      const selectionBoundingBox = editor.render.ctab.getVBoxObj({
+      center = editor.render.ctab.getSelectionRotationCenter({
         atoms: visibleAtoms,
         texts,
         rxnArrows,
         rxnPluses
       })
-      center = selectionBoundingBox?.centre()
     }
 
     return [center, visibleAtoms] as const


### PR DESCRIPTION
closes #2805 

* #2805 - fix Horizontal and vertical flips

* #2805 - refactor restruct getSelectionRotationCenter and getVBoxObj