### PR TITLE
#2817 Rotation tool: cancel rotation by pressing 'right click' button

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -110,7 +110,7 @@ class RotateController {
   }
 
   /**
-   * Revert rotation by pressing "Escape" key
+   * Revert rotation by pressing "Escape" key or "Right click" button
    */
   revert() {
     if (!this.rotateTool.dragCtx?.action || !this.isRotating) {

--- a/packages/ketcher-react/src/script/ui/state/mouse.ts
+++ b/packages/ketcher-react/src/script/ui/state/mouse.ts
@@ -24,7 +24,7 @@ const handleMouseMove = (dispatch, event: MouseEvent) => {
 }
 
 export function initMouseListener(element) {
-  return function (dispatch) {
+  return function (dispatch, getState) {
     const throttledHandleMouseMove = throttle(
       handleMouseMove,
       MOUSE_MOVE_THROTTLE_TIMEOUT
@@ -33,5 +33,24 @@ export function initMouseListener(element) {
     element.addEventListener('pointermove', (event: MouseEvent) =>
       throttledHandleMouseMove(dispatch, event)
     )
+    element.addEventListener(
+      'mousedown',
+      function (event: MouseEvent) {
+        const isBothLeftAndRightClick = event.buttons === 3
+        if (isBothLeftAndRightClick) {
+          rightClickHandle(getState)
+        }
+      },
+      true
+    )
+  }
+}
+
+function rightClickHandle(getState) {
+  const state = getState()
+  const { editor } = state
+
+  if (editor.rotateController.isRotating) {
+    editor.rotateController.revert()
   }
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -81,7 +81,8 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
       let triggerType: ContextMenuTriggerType
 
       if (!closestItem) {
-        if (selection) {
+        const isLeftMouseButtonPressed = event.buttons === 1
+        if (selection && !isLeftMouseButtonPressed) {
           // if it was a click outside of any item
           editor.selection(null)
         }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- the rotation should is cancelled and the structure revert to the original position it was in when rotation was started
- the structure stays selected

[video: Cancel Rotate on right click](https://clipchamp.com/watch/ymYauyz09bW)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [x] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
