### PR TITLE
#2879 – Incorrect display of attachment points for some Functional Groups

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -655,7 +655,7 @@ function isLabelVisible(restruct, options, atom) {
     atom.a.neighbors.length === 0 ||
     (atom.a.neighbors.length < 2 && visibleTerminal)
 
-  if (isAttachmentPointAtom && atom.a.neighbors.length > 0 && isCarbon) {
+  if (isAttachmentPointAtom && isCarbon) {
     return false
   }
 

--- a/packages/ketcher-react/src/templates/fg.sdf
+++ b/packages/ketcher-react/src/templates/fg.sdf
@@ -1273,11 +1273,11 @@ Ketcher 11161713142D 1   1.00000     0.00000     0
   1  4  1  0  0  0  0
   1  5  1  0  0  0  0
 G    1  0
-M  CHG  3   2  -1   4  -1   5  -1
+M  CHG  3   2   0   4  -1   5  -1
 M  STY  1   1 SUP
 M  SLB  1   1   1
 M  SAL   1  5   1   2   3   4   5
-M  SAP   1  1   1   0
+M  SAP   1  1   2   0
 M  SMT   1 PO4
 M  END
 
@@ -1307,7 +1307,7 @@ M  STY  1   1 SUP
 M  SLB  1   1   1
 M  SMT   1 PO4H2
 M  SAL   1 5   1   2   3   4   5
-M  SAP   1  1   2   0
+M  SAP   1  1   5   0
 M  END
 
 >  <group>
@@ -1455,7 +1455,7 @@ Ketcher 11161713142D 1   1.00000     0.00000     0
    -1.2500    2.3500    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
    -1.2500   -0.6500    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
   1  2  2  0  0  0  0
-  1  3  2  0  0  0  0
+  1  3  1  0  0  0  0
 G    1  0
 M  STY  1   1 SUP
 M  SLB  1   1   1
@@ -1541,11 +1541,11 @@ Ketcher 11161713142D 1   1.00000     0.00000     0
   1  4  2  0  0  0  0
   1  5  1  0  0  0  0
 G    1  0
-M  CHG  2   2  -1   5  -1
+M  CHG  2   2   0   5  -1
 M  STY  1   1 SUP
 M  SLB  1   1   1
 M  SAL   1  5   1   2   3   4   5
-M  SAP   1  1   1   0
+M  SAP   1  1   2   0
 M  SMT   1 SO4
 M  END
 
@@ -1575,7 +1575,7 @@ M  STY  1   1 SUP
 M  SLB  1   1   1
 M  SMT   1 SO4H
 M  SAL   1 5   1   2   3   4   5
-M  SAP   1  1   2   0
+M  SAP   1  1   5   0
 M  END
 
 >  <group>


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
There are no actual changes in application logic. It just changes the display for some specific functional groups

closes #2879 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] branch name doesn't contain '#'
- [x] PR name follows the pattern `#1234 – issue name`
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
