### PR TITLE
#2765 - introduce to .ket file specification attachment point informa…

### DIFF
--- a/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
@@ -29,16 +29,16 @@ export class SGroupAttachmentPoint {
    * NOTE: The logic is not supported in the current implementation of Ketcher.
    * Only reading from file and saving to file.
    */
-  public readonly additionalData: string;
+  public readonly attachmentId: string | undefined;
 
   constructor(
     atomId: number,
     leaveAtomId: number | undefined,
-    additionalData: string | undefined,
+    attachmentId: string | undefined,
   ) {
     this.atomId = atomId;
     this.leaveAtomId = leaveAtomId;
-    this.additionalData = this.formatAdditionalInfo(additionalData);
+    this.attachmentId = attachmentId;
   }
 
   clone(atomIdMap: Map<number, number>): SGroupAttachmentPoint {
@@ -48,18 +48,7 @@ export class SGroupAttachmentPoint {
     return new SGroupAttachmentPoint(
       newAtomId,
       newLeaveAtomId,
-      this.additionalData,
+      this.attachmentId,
     );
-  }
-
-  /**
-   * based on specification we need only first two symbols from the string,
-   * in case of empty we should use two spaces ('  ')
-   */
-  private formatAdditionalInfo(additionalData: string | undefined) {
-    const DEFAULT_ADDITIONAL_INFO = '  ';
-    return additionalData !== undefined
-      ? String(additionalData).slice(0, 2)
-      : DEFAULT_ADDITIONAL_INFO;
   }
 }

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
@@ -18,6 +18,7 @@ import { Atom, Bond, SGroup, Struct } from 'domain/entities';
 
 import { Elements } from 'domain/constants';
 import { ifDef } from 'utilities';
+import { SGroupAttachmentPoint } from 'domain/entities/sGroupAttachmentPoint';
 import { mergeFragmentsToStruct } from './mergeFragmentsToStruct';
 
 export function toRlabel(values) {
@@ -175,6 +176,11 @@ export function sgroupToStruct(source) {
       ifDef(sgroup.data, 'name', source.name);
       ifDef(sgroup.data, 'expanded', source.expanded);
       ifDef(sgroup, 'id', source.id);
+      source.attachmentPoints?.forEach((sourceAttachmentPoint: any) => {
+        sgroup.addAttachmentPoint(
+          sgroupAttachmentPointToStruct(sourceAttachmentPoint),
+        );
+      });
       break;
     }
     case 'DAT': {
@@ -189,4 +195,11 @@ export function sgroupToStruct(source) {
       break;
   }
   return sgroup;
+}
+
+function sgroupAttachmentPointToStruct(source: any): SGroupAttachmentPoint {
+  const atomId = source.attachmentAtom as number;
+  const leavingAtomId = source.leavingAtom as number | undefined;
+  const attachmentId = source.attachmentId as string | undefined;
+  return new SGroupAttachmentPoint(atomId, leavingAtomId, attachmentId);
 }

--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
@@ -17,6 +17,7 @@
 import { SGroup, Struct } from 'domain/entities';
 
 import { ifDef } from 'utilities';
+import { SGroupAttachmentPoint } from 'domain/entities/sGroupAttachmentPoint';
 
 function fromRlabel(rg) {
   const res: Array<any> = [];
@@ -127,7 +128,7 @@ function bondToKet(source) {
   return result;
 }
 
-function sgroupToKet(struct, source) {
+function sgroupToKet(struct, source: SGroup) {
   const result = {};
 
   ifDef(result, 'type', source.type);
@@ -153,6 +154,12 @@ function sgroupToKet(struct, source) {
       ifDef(result, 'name', source.data.name || '');
       ifDef(result, 'expanded', source.data.expanded);
       ifDef(result, 'id', source.id);
+      ifDef(
+        result,
+        'attachmentPoints',
+        source.getAttachmentPoints().map(sgroupAttachmentPointToKet),
+        [],
+      );
       break;
     }
     case 'DAT': {
@@ -168,6 +175,16 @@ function sgroupToKet(struct, source) {
     default:
       break;
   }
+
+  return result;
+}
+
+function sgroupAttachmentPointToKet(source: SGroupAttachmentPoint) {
+  const result = {};
+
+  ifDef(result, 'attachmentAtom', source.atomId);
+  ifDef(result, 'leavingAtom', source.leaveAtomId);
+  ifDef(result, 'attachmentId', source.attachmentId);
 
   return result;
 }

--- a/packages/ketcher-core/src/domain/serializers/mol/__tests__/v2000.parseSGroup.SAP.test.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/__tests__/v2000.parseSGroup.SAP.test.ts
@@ -10,7 +10,7 @@ describe('parseSGroup', () => {
     expect(sGroupId).toBe(0);
     expect(attachmentPoints[0].atomId).toBe(1);
     expect(attachmentPoints[0].leaveAtomId).toBeUndefined();
-    expect(attachmentPoints[0].additionalData).toBe('  ');
+    expect(attachmentPoints[0].attachmentId).toBe('  ');
   });
 
   it('parseSGroupSAPLineV2000 should parse valid SAP line with two attachment points', () => {
@@ -23,6 +23,6 @@ describe('parseSGroup', () => {
     expect(attachmentPoints.length).toBe(2);
     expect(attachmentPoints[1].atomId).toBe(2);
     expect(attachmentPoints[1].leaveAtomId).toBe(0);
-    expect(attachmentPoints[1].additionalData).toBe('  ');
+    expect(attachmentPoints[1].attachmentId).toBe('  ');
   });
 });

--- a/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
@@ -643,7 +643,11 @@ export class Molfile {
       this.mapping[attachmentPoint.leaveAtomId as number] ?? 0;
     this.writePaddedNumber(leaveAtomId, 3);
     this.writeWhiteSpace(1);
-    this.writePadded(attachmentPoint.additionalData, 2);
+
+    const attachmentId = attachmentPoint.attachmentId
+      ? attachmentPoint.attachmentId.slice(0, 2)
+      : '  ';
+    this.writePadded(attachmentId, 2);
     this.writeCR();
   }
 }


### PR DESCRIPTION
closed #2765

## How the feature works? / How did you fix the issue?
- ability to open `.ket` file with sgroup attachment points
- ability to save to `.ket` file with sgroup attachment points

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
