### PR TITLE
#2128 - Automatically adjust zoom when opening a structure

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -337,11 +337,14 @@ class Editor implements KetcherEditor {
     const paper = this.render.paper;
     const MIN_ZOOM_VALUE = 0.1;
     const MAX_ZOOM_VALUE = 1;
-    const newZoomValue =
+    const MARGIN = 0.02;
+    let newZoomValue =
       paper.height - clientAreaBoundingBox.height >
       paper.width - clientAreaBoundingBox.width
         ? clientAreaBoundingBox.height / paper.height
         : clientAreaBoundingBox.width / paper.width;
+
+    newZoomValue -= MARGIN;
 
     if (newZoomValue < MAX_ZOOM_VALUE) {
       this.zoom(


### PR DESCRIPTION
Closes #2128 

- added margin for structure autoscaling after import

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
<img width="1512" alt="Screenshot 2023-07-18 at 12 43 39" src="https://github.com/epam/ketcher/assets/14859362/4c703e64-7c52-4ede-8681-27761ae3d199">


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
