### PR TITLE
Backmerge: #2940 – No modal windows are opened during R-Group adding

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/Editor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/Editor.jsx
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onZoomIn,
     onZoomOut,
-    ...initEditor(dispatch),
+    ...dispatch(initEditor),
   };
 };
 


### PR DESCRIPTION
Closes https://github.com/epam/ketcher/issues/2940
