### PR TITLE
Backmerge: #2940 – No modal windows are opened during R-Group adding

### DIFF
--- a/packages/ketcher-core/src/application/editor/editor.types.ts
+++ b/packages/ketcher-core/src/application/editor/editor.types.ts
@@ -64,6 +64,8 @@ export interface Editor {
     message: Subscription;
     elementEdit: PipelineSubscription;
     bondEdit: PipelineSubscription;
+    zoomIn: PipelineSubscription;
+    zoomOut: PipelineSubscription;
     rgroupEdit: PipelineSubscription;
     sgroupEdit: PipelineSubscription;
     sdataEdit: PipelineSubscription;

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -133,6 +133,8 @@ class Editor implements KetcherEditor {
   event: {
     message: Subscription;
     elementEdit: PipelineSubscription;
+    zoomIn: PipelineSubscription;
+    zoomOut: PipelineSubscription;
     bondEdit: PipelineSubscription;
     rgroupEdit: PipelineSubscription;
     sgroupEdit: PipelineSubscription;
@@ -188,6 +190,8 @@ class Editor implements KetcherEditor {
       message: new Subscription(),
       elementEdit: new PipelineSubscription(),
       bondEdit: new PipelineSubscription(),
+      zoomIn: new PipelineSubscription(),
+      zoomOut: new PipelineSubscription(),
       rgroupEdit: new PipelineSubscription(),
       sgroupEdit: new PipelineSubscription(),
       sdataEdit: new PipelineSubscription(),

--- a/packages/ketcher-react/src/script/ui/App/App.tsx
+++ b/packages/ketcher-react/src/script/ui/App/App.tsx
@@ -26,7 +26,7 @@ import { createTheme, ThemeProvider } from '@mui/material';
 import AppClipArea from '../views/AppClipArea';
 import { AppHiddenContainer } from './AppHidden';
 import AppModalContainer from '../views/modal';
-import Editor from '../views/Editor';
+import ConnectedEditor from '../views/Editor';
 import classes from './App.module.less';
 import { initFGTemplates } from '../state/functionalGroups';
 import { initSaltsAndSolventsTemplates } from '../state/saltsAndSolvents';
@@ -61,6 +61,9 @@ const App = (props: Props) => {
     dispatch(initSaltsAndSolventsTemplates());
     window.scrollTo(0, 0);
   }, []);
+
+  // Temporary workaround: add proper types for Editor
+  const Editor = ConnectedEditor as React.ComponentType<{ className: string }>;
 
   return (
     <ThemeProvider theme={muiTheme}>

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -229,5 +229,8 @@ export default function initEditor(dispatch, getState) {
         dispatch(updateFloatingTools(payload));
       },
     ),
+
+    onZoomIn: updateAction,
+    onZoomOut: updateAction,
   };
 }

--- a/packages/ketcher-react/src/script/ui/views/Editor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/Editor.jsx
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onZoomIn,
     onZoomOut,
-    ...initEditor(dispatch),
+    ...dispatch(initEditor),
   };
 };
 

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -224,6 +224,8 @@ class StructEditor extends Component {
       onEnhancedStereoEdit,
       onQuickEdit,
       onBondEdit,
+      onZoomIn,
+      onZoomOut,
       onRgroupEdit,
       onSgroupEdit,
       onRemoveFG,


### PR DESCRIPTION
closes #2940

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
