### PR TITLE
#2833 Lookup Abbreviations window disappears when user change browser tab

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/AbbreviationLookup/AbbreviationLookup.test.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/AbbreviationLookup/AbbreviationLookup.test.tsx
@@ -90,7 +90,7 @@ describe('AbbreviationLookup', () => {
       wrapper: KetcherWrapper,
     });
     const input = screen.getByRole('combobox');
-    fireEvent.blur(input);
+    input.blur();
 
     expect(mockedDispatch).toHaveBeenCalledWith(closeAbbreviationLookup());
   });

--- a/packages/ketcher-react/src/script/ui/dialog/AbbreviationLookup/AbbreviationLookup.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/AbbreviationLookup/AbbreviationLookup.tsx
@@ -17,6 +17,7 @@
 import {
   ChangeEvent,
   CSSProperties,
+  FocusEvent,
   KeyboardEvent,
   MutableRefObject,
   SyntheticEvent,
@@ -137,8 +138,10 @@ export const AbbreviationLookup = ({ options }: Props) => {
     event.stopPropagation();
   };
 
-  const handleBlur = () => {
-    closePanel();
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    if (event.target !== document.activeElement) {
+      closePanel();
+    }
   };
 
   return (


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Resolves https://github.com/epam/ketcher/issues/2833

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
