### PR TITLE
#2742 [Part 3] Allow removing R-Group Attachment Points using Erase Tool

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/rgroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rgroupAttachmentPoint.ts
@@ -1,25 +1,29 @@
+import assert from 'assert';
 import { ReStruct } from 'application/render';
+import { Struct } from 'domain/entities';
 import {
   RGroupAttachmentPointAdd,
   RGroupAttachmentPointRemove,
 } from '../operations';
 import { Action } from './action';
-import { Struct } from 'domain/entities';
+import { fromAtomsAttrs } from '.';
 
-function fromRGroupAttachmentPointUpdate(
+export function fromRGroupAttachmentPointUpdate(
   restruct: ReStruct,
   atomId: number,
   attpnt,
 ) {
   const action = new Action();
-  action.mergeWith(
-    fromRGroupAttachmentPointsDeletion(restruct.molecule, atomId),
-  );
-  action.mergeWith(fromRGroupAttachmentPointAddition(attpnt, atomId));
-  return action.perform(restruct);
+  action.mergeWith(fromRGroupAttachmentPointsDeletionByAtom(restruct, atomId));
+  action.mergeWith(fromRGroupAttachmentPointAddition(restruct, attpnt, atomId));
+  return action;
 }
 
-function fromRGroupAttachmentPointAddition(attpnt, atomId: number) {
+function fromRGroupAttachmentPointAddition(
+  restruct: ReStruct,
+  attpnt,
+  atomId: number,
+) {
   const action = new Action();
   switch (attpnt) {
     case 1:
@@ -58,17 +62,65 @@ function fromRGroupAttachmentPointAddition(attpnt, atomId: number) {
     default:
       break;
   }
-  return action;
+  return action.perform(restruct);
 }
 
-function fromRGroupAttachmentPointsDeletion(struct: Struct, atomId: number) {
+function fromRGroupAttachmentPointsDeletionByAtom(
+  restruct: ReStruct,
+  atomId: number,
+) {
   const action = new Action();
   const attachmentPointsToDelete =
-    struct.getRGroupAttachmentPointsByAtomId(atomId);
+    restruct.molecule.getRGroupAttachmentPointsByAtomId(atomId);
   attachmentPointsToDelete.forEach((rgroupAttachmentPointId) => {
     action.addOp(new RGroupAttachmentPointRemove(rgroupAttachmentPointId));
   });
-  return action;
+  return action.perform(restruct);
 }
 
-export { fromRGroupAttachmentPointUpdate };
+export function fromRGroupAttachmentPointDeletion(
+  restruct: ReStruct,
+  id: number,
+) {
+  const { atomId, newAttpnt } = getNewAtomAttpnt(restruct.molecule, id);
+  const actionToUpdateAtomsAttrs = fromAtomsAttrs(
+    restruct,
+    atomId,
+    { attpnt: newAttpnt },
+    null,
+  );
+
+  const actionToDeletePoint = new Action();
+  actionToDeletePoint.addOp(new RGroupAttachmentPointRemove(id));
+
+  return actionToDeletePoint
+    .perform(restruct)
+    .mergeWith(actionToUpdateAtomsAttrs);
+}
+
+function getNewAtomAttpnt(
+  struct: Struct,
+  rgroupAttachmentPointToDelete: number,
+) {
+  const pointToDelete = struct.rgroupAttachmentPoints.get(
+    rgroupAttachmentPointToDelete,
+  );
+  assert(pointToDelete != null);
+  const attachedAtomId = pointToDelete.atomId;
+  const attachedAtom = struct.atoms.get(attachedAtomId);
+  const currentAttpnt = attachedAtom?.attpnt;
+
+  let newAttpnt = 0;
+  if (currentAttpnt === 1 || currentAttpnt === 2) {
+    newAttpnt = 0;
+  } else if (currentAttpnt === 3) {
+    const pointToDeleteType = pointToDelete.type;
+    if (pointToDeleteType === 'primary') {
+      newAttpnt = 2;
+    } else if (pointToDeleteType === 'secondary') {
+      newAttpnt = 1;
+    }
+  }
+
+  return { atomId: attachedAtomId, newAttpnt };
+}

--- a/packages/ketcher-core/src/application/editor/operations/OperationType.ts
+++ b/packages/ketcher-core/src/application/editor/operations/OperationType.ts
@@ -74,6 +74,7 @@ export const OperationType = Object.freeze({
 export enum OperationPriority {
   ATOM_ATTR = 1,
   BOND_ADD = 1,
+  R_GROUP_ATTACHMENT_POINT_REMOVE = 1,
   ATOM_MOVE = 2,
   BOND_ATTR = 2,
   BOND_MOVE = 2,
@@ -81,7 +82,6 @@ export enum OperationPriority {
   S_GROUP_ATOM_ADD = 3,
   S_GROUP_ATTACHMENT_POINT_ADD = 3,
   R_GROUP_ATTACHMENT_POINT_ADD = 3,
-  R_GROUP_ATTACHMENT_POINT_REMOVE = 3,
   S_GROUP_ATTR = 4,
   ATOM_DELETE = 5,
   FRAGMENT_STEREO_FLAG = 6,

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
@@ -34,7 +34,7 @@ class RGroupAttachmentPointRemove extends BaseOperation {
     assert(item != null && reItem != null);
 
     this.data.atomId = item.atomId;
-    this.data.attachmentPointType = item.attachmentPointType;
+    this.data.attachmentPointType = item.type;
 
     restruct.markItemRemoved();
     restruct.clearVisel(reItem.visel);

--- a/packages/ketcher-core/src/application/editor/shared/constants.ts
+++ b/packages/ketcher-core/src/application/editor/shared/constants.ts
@@ -28,6 +28,7 @@ export const selectionKeys = [
   'frags',
   'sgroups',
   'rgroups',
+  'rgroupAttachmentPoints',
   'rxnArrows',
   'rxnPluses',
   'simpleObjects',

--- a/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
@@ -168,7 +168,7 @@ class ReRGroupAttachmentPoint extends ReObject {
     const showLabel = isAttachmentPointLabelRequired(restruct);
     if (showLabel) {
       // in case of isTrisectionRequired (trisection case) we should show labels '1' and '2' for those separated vectors
-      const labelText = this.item.attachmentPointType === 'primary' ? '1' : '2';
+      const labelText = this.item.type === 'primary' ? '1' : '2';
       showAttachmentPointLabel(
         this.reAtom,
         restruct.render,
@@ -242,11 +242,7 @@ class ReRGroupAttachmentPoint extends ReObject {
       return;
     }
     if (this.isTrisectionAttachmentPoint()) {
-      return trisectionLargestSector(
-        this.reAtom,
-        struct,
-        this.item.attachmentPointType,
-      );
+      return trisectionLargestSector(this.reAtom, struct, this.item.type);
     } else {
       const hasOnlyOneBond = this.reAtom.a.neighbors.length === 1;
       const directionVector = hasOnlyOneBond

--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -101,6 +101,19 @@ export class FunctionalGroup {
     return null;
   }
 
+  static isRGroupAttachmentPointInsideFunctionalGroup(
+    molecule: Struct,
+    id: number,
+  ) {
+    const rgroupAttachmentPoint = molecule.rgroupAttachmentPoints.get(id);
+    assert(rgroupAttachmentPoint != null);
+    const attachedAtom = rgroupAttachmentPoint.atomId;
+    return FunctionalGroup.atomsInFunctionalGroup(
+      molecule.functionalGroups,
+      attachedAtom,
+    );
+  }
+
   static findFunctionalGroupByAtom(
     functionalGroups: Pool<FunctionalGroup>,
     atomId: number,

--- a/packages/ketcher-core/src/domain/entities/rgroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/entities/rgroupAttachmentPoint.ts
@@ -2,10 +2,10 @@ export type RGroupAttachmentPointType = 'primary' | 'secondary';
 
 export class RGroupAttachmentPoint {
   atomId: number;
-  attachmentPointType: RGroupAttachmentPointType;
+  type: RGroupAttachmentPointType;
 
-  constructor(atomId: number, attachmentPointType: RGroupAttachmentPointType) {
+  constructor(atomId: number, type: RGroupAttachmentPointType) {
     this.atomId = atomId;
-    this.attachmentPointType = attachmentPointType;
+    this.type = type;
   }
 }

--- a/packages/ketcher-react/src/script/editor/tool/eraser.ts
+++ b/packages/ketcher-react/src/script/editor/tool/eraser.ts
@@ -165,6 +165,19 @@ class EraserTool implements Tool {
       }
     }
 
+    if (selected && functionalGroups.size && selected.rgroupAttachmentPoints) {
+      for (const rgroupAttachmentPointId of selected.rgroupAttachmentPoints) {
+        const attachedAtomId =
+          FunctionalGroup.isRGroupAttachmentPointInsideFunctionalGroup(
+            molecule,
+            rgroupAttachmentPointId,
+          );
+        if (attachedAtomId !== null) {
+          atomsResult.push(attachedAtomId);
+        }
+      }
+    }
+
     if (atomsResult.length > 0) {
       for (const id of atomsResult) {
         const fgId = FunctionalGroup.findFunctionalGroupByAtom(
@@ -275,6 +288,15 @@ class EraserTool implements Tool {
         )
       ) {
         bondResult.push(bondId);
+      }
+    } else if (functionalGroups && ci?.map === 'rgroupAttachmentPoints') {
+      const attachedAtomId =
+        FunctionalGroup.isRGroupAttachmentPointInsideFunctionalGroup(
+          molecule,
+          ci.id,
+        );
+      if (attachedAtomId !== null) {
+        atomResult.push(attachedAtomId);
       }
     }
 

--- a/packages/ketcher-react/src/script/editor/tool/eraser.ts
+++ b/packages/ketcher-react/src/script/editor/tool/eraser.ts
@@ -20,6 +20,7 @@ import {
   fromOneAtomDeletion,
   fromOneBondDeletion,
   fromPlusDeletion,
+  fromRGroupAttachmentPointDeletion,
   fromSgroupDeletion,
   fromSimpleObjectDeletion,
   fromTextDeletion,
@@ -50,6 +51,7 @@ class EraserTool implements Tool {
       'sgroupData',
       'simpleObjects',
       'texts',
+      'rgroupAttachmentPoints',
     ];
     this.lassoHelper = new LassoHelper(mode || 0, editor, null);
 
@@ -341,6 +343,8 @@ class EraserTool implements Tool {
       this.editor.update(fromSimpleObjectDeletion(restruct, ci.id));
     } else if (ci.map === 'texts') {
       this.editor.update(fromTextDeletion(restruct, ci.id));
+    } else if (ci.map === 'rgroupAttachmentPoints') {
+      this.editor.update(fromRGroupAttachmentPointDeletion(restruct, ci.id));
     } else {
       // TODO re-factoring needed - should be "map-independent"
       console.error(


### PR DESCRIPTION
This PR is one of the small PRs to resolve #2742 for easy review.
This PR is open for reviews but **please do not merge it**.

## What is done in this PR?

- Allow removing attachment points using Erase Tool 
(You can also remove attachment points by selecting and pressing the key `Del`)

![rgroup-ap-erase](https://github.com/epam/ketcher/assets/27288153/2698caf1-cc3c-40d0-a7aa-5f0639882a6d)

- Disallow removing attachment points inside functional groups

![rgroup-ap-erase-sgroup](https://github.com/epam/ketcher/assets/27288153/bf551f6a-6d86-4ce3-a620-aca81cb0b423)






## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
