### PR TITLE
#2958 - Atom lable disappears after updating R-Group attachment point to none

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -648,7 +648,7 @@ function shouldDisplayStereoLabel(
 }
 
 function isLabelVisible(restruct, options, atom) {
-  const isAttachmentPointAtom = atom.a.attpnt;
+  const isAttachmentPointAtom = Boolean(atom.a.attpnt);
   const isCarbon = atom.a.label.toLowerCase() === 'c';
   const visibleTerminal =
     options.showHydrogenLabels !== ShowHydrogenLabels.Off &&

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -648,7 +648,7 @@ function shouldDisplayStereoLabel(
 }
 
 function isLabelVisible(restruct, options, atom) {
-  const isAttachmentPointAtom = atom.a.attpnt != null;
+  const isAttachmentPointAtom = atom.a.attpnt;
   const isCarbon = atom.a.label.toLowerCase() === 'c';
   const visibleTerminal =
     options.showHydrogenLabels !== ShowHydrogenLabels.Off &&

--- a/packages/ketcher-core/src/domain/entities/atom.ts
+++ b/packages/ketcher-core/src/domain/entities/atom.ts
@@ -46,6 +46,13 @@ export interface AtomAttributes {
   substitutionCount?: number;
   ringBondCount?: number;
   explicitValence?: number;
+  /**
+   *  Values can be `0 | 1 | 2 | 3 | null`.
+   * `1` - has a `primary` R-Group Attachment Point
+   * `2` - has a `secondary` R-Group Attachment Point
+   * `3` - has a `primary` and a `secondary` R-Group Attachment Points
+   * `null` and `0` both mean the atom has no R-Group Attachment Points
+   */
   attpnt?: any;
   rglabel?: string | null;
   charge?: number;


### PR DESCRIPTION
## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
