### PR TITLE
#2742 [Part 4] Fix display of template and `InfoPanel`

### DIFF
--- a/packages/ketcher-core/src/application/render/renderStruct.ts
+++ b/packages/ketcher-core/src/application/render/renderStruct.ts
@@ -66,6 +66,11 @@ function convertAllSGroupAttachmentPointsToRGroupAttachmentPoints(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const attachmentPointAtom = struct.atoms.get(attachmentPoint.atomId)!;
       attachmentPointAtom.setRGAttachmentPointForDisplayPurpose();
+      const rgroupAttachmentPoint =
+        attachmentPoint.convertToRGroupAttachmentPointForDisplayPurpose(
+          attachmentPoint.atomId,
+        );
+      struct.rgroupAttachmentPoints.add(rgroupAttachmentPoint);
     });
   });
 }

--- a/packages/ketcher-core/src/domain/entities/rgroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/entities/rgroupAttachmentPoint.ts
@@ -8,4 +8,9 @@ export class RGroupAttachmentPoint {
     this.atomId = atomId;
     this.type = type;
   }
+
+  clone(atomToNewAtom?: Map<number, number> | null) {
+    const newAtomId = atomToNewAtom?.get(this.atomId);
+    return new RGroupAttachmentPoint(newAtomId ?? this.atomId, this.type);
+  }
 }

--- a/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { RGroupAttachmentPoint } from './rgroupAttachmentPoint';
 
 /**
  * This is data model for Sgrou attachment point.
@@ -50,5 +51,19 @@ export class SGroupAttachmentPoint {
       newLeaveAtomId,
       this.attachmentId,
     );
+  }
+
+  /**
+   * Trick: used for cloned struct for tooltips, for preview, for templates
+   *
+   * Why?
+   * Currently, tooltips are implemented with removing sgroups (wrong implementation)
+   * That's why we need to mark atoms as sgroup attachment points.
+   *
+   * If we change preview approach to flagged (option for showing sgroups without abbreviation),
+   * then we will be able to remove this hack.
+   */
+  convertToRGroupAttachmentPointForDisplayPurpose(attachedAtomId: number) {
+    return new RGroupAttachmentPoint(attachedAtomId, 'primary');
   }
 }

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
+import assert from 'assert';
 import { Atom, radicalElectrons } from './atom';
 import { EditorSelection } from 'application/editor';
 import { Bond } from './bond';
@@ -132,6 +133,7 @@ export class Struct {
     aidMap?: Map<number, number> | null,
     simpleObjectsSet?: Pile<number> | null,
     textsSet?: Pile<number> | null,
+    rgroupAttachmentPointSet?: Pile<number> | null,
   ): Struct {
     return this.mergeInto(
       new Struct(),
@@ -142,6 +144,7 @@ export class Struct {
       aidMap,
       simpleObjectsSet,
       textsSet,
+      rgroupAttachmentPointSet,
     );
   }
 
@@ -185,12 +188,16 @@ export class Struct {
     aidMap?: Map<number, number> | null,
     simpleObjectsSet?: Pile<number> | null,
     textsSet?: Pile<number> | null,
+    rgroupAttachmentPointSet?: Pile<number> | null,
   ): Struct {
     atomSet = atomSet || new Pile<number>(this.atoms.keys());
     bondSet = bondSet || new Pile<number>(this.bonds.keys());
     simpleObjectsSet =
       simpleObjectsSet || new Pile<number>(this.simpleObjects.keys());
     textsSet = textsSet || new Pile<number>(this.texts.keys());
+    rgroupAttachmentPointSet =
+      rgroupAttachmentPointSet ||
+      new Pile<number>(this.rgroupAttachmentPoints.keys());
     aidMap = aidMap || new Map();
 
     bondSet = bondSet.filter((bid) => {
@@ -287,6 +294,12 @@ export class Struct {
 
     textsSet.forEach((id) => {
       cp.texts.add(this.texts.get(id)!.clone());
+    });
+
+    rgroupAttachmentPointSet.forEach((id) => {
+      const rgroupAttachmentPoint = this.rgroupAttachmentPoints.get(id);
+      assert(rgroupAttachmentPoint != null);
+      cp.rgroupAttachmentPoints.add(rgroupAttachmentPoint.clone(aidMap));
     });
 
     if (!dropRxnSymbols) {

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -1,5 +1,6 @@
-import Editor from '../Editor';
+import assert from 'assert';
 import { Bond, SGroup, Struct } from 'ketcher-core';
+import Editor from '../Editor';
 
 let showTooltipTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -17,30 +18,46 @@ type InfoPanelData = {
  * But due to current rendering approach for sgroups (ungrouping sgroups)
  * - we have to use RGroup attachment points on atoms for this purposes
  */
-// @yuleicul FIXME: R-Group and S-Group AttachmentPoints both disappear on infoPanel and template modal
 function convertSGroupAttachmentPointsToRGroupAttachmentPoints(
   struct: Struct,
   sGroup: SGroup,
   atomsIdMapping: Map<number, number>,
 ) {
   sGroup.getAttachmentPoints().forEach((attachmentPoint) => {
-    const attachmentPointAtom = struct.atoms.get(
-      atomsIdMapping.get(attachmentPoint.atomId)!,
-    )!;
+    const atomId = atomsIdMapping.get(attachmentPoint.atomId);
+    assert(atomId != null);
+    const attachmentPointAtom = struct.atoms.get(atomId);
+    assert(attachmentPointAtom != null);
     attachmentPointAtom.setRGAttachmentPointForDisplayPurpose();
+    const rgroupAttachmentPoint =
+      attachmentPoint.convertToRGroupAttachmentPointForDisplayPurpose(atomId);
+    struct.rgroupAttachmentPoints.add(rgroupAttachmentPoint);
   });
 }
 
 function makeStruct(editor: Editor, sGroup: SGroup) {
   const existingStruct = editor.struct();
   const struct = new Struct();
-  const atomsIdMapping = new Map();
 
-  sGroup.atoms.forEach((atomId) => {
-    const atom = existingStruct.atoms.get(atomId)!;
-    const atomIdInTooltip = struct.atoms.add(atom.clone());
-    atomsIdMapping.set(atomId, atomIdInTooltip);
-  });
+  const atomsIdMapping = makeAtoms(sGroup, existingStruct, struct);
+  makeRGroupAttachmentPoints(sGroup, existingStruct, struct, atomsIdMapping);
+  makeBonds(sGroup, existingStruct, struct, atomsIdMapping);
+
+  convertSGroupAttachmentPointsToRGroupAttachmentPoints(
+    struct,
+    sGroup,
+    atomsIdMapping,
+  );
+
+  return struct;
+}
+
+function makeBonds(
+  sGroup: SGroup,
+  existingStruct: Struct,
+  struct: Struct,
+  atomsIdMapping: Map<number, number>,
+) {
   Array.from(existingStruct.bonds).forEach((value) => {
     const [_, bond] = value as [number, Bond];
     const clonedBond = bond.clone(atomsIdMapping);
@@ -50,14 +67,37 @@ function makeStruct(editor: Editor, sGroup: SGroup) {
       struct.bonds.add(clonedBond);
     }
   });
+}
 
-  convertSGroupAttachmentPointsToRGroupAttachmentPoints(
-    struct,
-    sGroup,
-    atomsIdMapping,
-  );
+function makeRGroupAttachmentPoints(
+  sGroup: SGroup,
+  existingStruct: Struct,
+  struct: Struct,
+  atomsIdMapping: Map<number, number>,
+) {
+  sGroup.atoms.forEach((atomId: number) => {
+    const rgroupAttachmentPointIds =
+      existingStruct.getRGroupAttachmentPointsByAtomId(atomId);
+    rgroupAttachmentPointIds.forEach((id) => {
+      const rgroupAttachmentPoint =
+        existingStruct.rgroupAttachmentPoints.get(id);
+      assert(rgroupAttachmentPoint != null);
+      struct.rgroupAttachmentPoints.add(
+        rgroupAttachmentPoint.clone(atomsIdMapping),
+      );
+    });
+  });
+}
 
-  return struct;
+function makeAtoms(sGroup: SGroup, existingStruct: Struct, struct: Struct) {
+  const atomsIdMapping = new Map();
+  sGroup.atoms.forEach((atomId: number) => {
+    const atom = existingStruct.atoms.get(atomId);
+    assert(atom != null);
+    const atomIdInTooltip = struct.atoms.add(atom.clone());
+    atomsIdMapping.set(atomId, atomIdInTooltip);
+  });
+  return atomsIdMapping;
 }
 
 function hideTooltip(editor: Editor) {


### PR DESCRIPTION
This PR is one of the small PRs to resolve #2742  for easy review.
This PR is open for reviews but **please do not merge it**.

## What is done in this PR?

- Fix S-Group attachment points disappearing in template and `InfoPanel`, which was caused by #2928 
![sgroup-attachemnt-template](https://github.com/epam/ketcher/assets/27288153/b423d741-80c5-4446-9651-e9161e9c2ba0)


- Fix R-Group attachment points disappearing in `InfoPanel`, which was caused by #2928 
![rgroup-attachemnt-pannel](https://github.com/epam/ketcher/assets/27288153/b0845292-c855-4072-b4a4-0ec58baba3a9)


- Fix the bounding box in Save Modal, which was mentioned in the additional acceptance criteria in #2742 
![rgroup-attachemnt-save](https://github.com/epam/ketcher/assets/27288153/554b6c64-7c2d-490d-8585-b26ba49a9268)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
