### PR TITLE
#2742 [Part 5] Allow editing attachment points by context menu

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -383,8 +383,6 @@ class ReStruct {
 
     let boundingBox = this.getBoundingBoxForSelection(selection);
 
-    // @yuleicul TODO: selectionBox for R-Group attachment points
-
     boundingBox = boundingBox || new Box2Abs(0, 0, 0, 0);
     return boundingBox;
   }

--- a/packages/ketcher-core/src/domain/entities/atom.ts
+++ b/packages/ketcher-core/src/domain/entities/atom.ts
@@ -212,6 +212,10 @@ export class Atom {
     });
   }
 
+  get isRGroupAttachmentPointEditDisabled() {
+    return this.label === 'R#' && this.rglabel !== null;
+  }
+
   /**
    * Trick: used for cloned struct for tooltips, for preview, for templates
    *

--- a/packages/ketcher-react/src/script/editor/tool/apoint.ts
+++ b/packages/ketcher-react/src/script/editor/tool/apoint.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  ***************************************************************************/
 
-import {
-  fromAtomsAttrs,
-  fromRGroupAttachmentPointUpdate,
-  FunctionalGroup,
-} from 'ketcher-core';
+import assert from 'assert';
+import { FunctionalGroup } from 'ketcher-core';
 import Editor from '../Editor';
 import { Tool } from './Tool';
+import { editRGroupAttachmentPoint } from './apoint.utils';
 
 class APointTool implements Tool {
   private readonly editor: Editor;
@@ -85,36 +83,12 @@ class APointTool implements Tool {
     if (ci && ci.map === 'atoms') {
       this.editor.hover(null);
       const atom = molecule.atoms.get(ci.id);
+      assert(atom != null);
 
-      if (atom?.label === 'R#' && atom?.rglabel !== null) return;
+      if (!atom.isRGroupAttachmentPointEditDisabled) {
+        editRGroupAttachmentPoint(editor, atom, ci.id);
+      }
 
-      const res = editor.event.elementEdit.dispatch({
-        attpnt: atom?.attpnt,
-      });
-      Promise.resolve(res)
-        .then((newatom) => {
-          const previousAttpnt = atom?.attpnt;
-          const currentAttpnt = newatom.attpnt;
-          if (previousAttpnt !== currentAttpnt) {
-            const actionFromAtomsAttrs = fromAtomsAttrs(
-              editor.render.ctab,
-              ci.id,
-              newatom,
-              null,
-            );
-            const actionFromRGroupAttachmentPointUpdate =
-              fromRGroupAttachmentPointUpdate(
-                editor.render.ctab,
-                ci.id,
-                currentAttpnt,
-              );
-            const action = actionFromAtomsAttrs.mergeWith(
-              actionFromRGroupAttachmentPointUpdate,
-            );
-            editor.update(action);
-          }
-        })
-        .catch(() => null); // w/o changes
       return true;
     }
     return true;

--- a/packages/ketcher-react/src/script/editor/tool/apoint.utils.ts
+++ b/packages/ketcher-react/src/script/editor/tool/apoint.utils.ts
@@ -1,0 +1,41 @@
+import {
+  Atom,
+  Editor,
+  fromAtomsAttrs,
+  fromRGroupAttachmentPointUpdate,
+} from 'ketcher-core';
+
+export async function editRGroupAttachmentPoint(
+  editor: Editor,
+  atom: Atom,
+  atomId: number,
+) {
+  try {
+    const newAtom = await editor.event.elementEdit.dispatch({
+      attpnt: atom.attpnt,
+    });
+
+    const previousAttpnt = atom?.attpnt;
+    const currentAttpnt = newAtom.attpnt;
+    if (previousAttpnt !== currentAttpnt) {
+      const actionFromAtomsAttrs = fromAtomsAttrs(
+        editor.render.ctab,
+        atomId,
+        newAtom,
+        null,
+      );
+      const actionFromRGroupAttachmentPointUpdate =
+        fromRGroupAttachmentPointUpdate(
+          editor.render.ctab,
+          atomId,
+          currentAttpnt,
+        );
+      const action = actionFromAtomsAttrs.mergeWith(
+        actionFromRGroupAttachmentPointUpdate,
+      );
+      editor.update(action);
+    }
+  } catch (_error) {
+    // close modal without any operations
+  }
+}

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
@@ -25,6 +25,7 @@ import AtomMenuItems from './menuItems/AtomMenuItems';
 import BondMenuItems from './menuItems/BondMenuItems';
 import FunctionalGroupMenuItems from './menuItems/FunctionalGroupMenuItems';
 import SelectionMenuItems from './menuItems/SelectionMenuItems';
+import RGroupAttachmentPointMenuItems from './menuItems/RGroupAttachmentPointMenuItems';
 
 const props: Partial<MenuProps> = {
   animation: false,
@@ -85,6 +86,16 @@ const ContextMenu: React.FC = () => {
         }
       >
         <FunctionalGroupMenuItems />
+      </Menu>
+
+      <Menu
+        {...props}
+        id={CONTEXT_MENU_ID.FOR_R_GROUP_ATTACHMENT_POINT}
+        onVisibilityChange={(visible) =>
+          trackVisibility(CONTEXT_MENU_ID.FOR_R_GROUP_ATTACHMENT_POINT, visible)
+        }
+      >
+        <RGroupAttachmentPointMenuItems />
       </Menu>
     </>
   );

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -98,7 +98,11 @@ const ContextMenuTrigger: React.FC<PropsWithChildren> = ({ children }) => {
           selectedSGroupsIds,
         })
       ) {
-        if (!selection.bonds && !selection.atoms) {
+        if (
+          !selection.bonds &&
+          !selection.atoms &&
+          !selection.rgroupAttachmentPoints
+        ) {
           triggerType = ContextMenuTriggerType.None;
         } else {
           triggerType = ContextMenuTriggerType.Selection;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.utils.ts
@@ -95,6 +95,13 @@ export function getMenuPropsForClosestItem(
         : null;
     }
 
+    case 'rgroupAttachmentPoints': {
+      return {
+        id: CONTEXT_MENU_ID.FOR_R_GROUP_ATTACHMENT_POINT,
+        rgroupAttachmentPoints: [closestItem.id],
+      };
+    }
+
     default:
       return null;
   }
@@ -112,6 +119,8 @@ export function getMenuPropsForSelection(
 
   const bondsInSelection = 'bonds' in selection;
   const atomsInSelection = 'atoms' in selection;
+  const isRGroupAttachmentPointsSelected =
+    'rgroupAttachmentPoints' in selection;
 
   if (selectedFunctionalGroups.size > 0) {
     const functionalGroups = Array.from(selectedFunctionalGroups.values());
@@ -119,7 +128,11 @@ export function getMenuPropsForSelection(
       id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
       functionalGroups,
     };
-  } else if (bondsInSelection && !atomsInSelection) {
+  } else if (
+    bondsInSelection &&
+    !atomsInSelection &&
+    !isRGroupAttachmentPointsSelected
+  ) {
     return {
       id: CONTEXT_MENU_ID.FOR_BONDS,
       bondIds: selection.bonds,
@@ -129,13 +142,31 @@ export function getMenuPropsForSelection(
         IGNORED_MAPS_LIST,
       ),
     };
-  } else if (atomsInSelection && !bondsInSelection) {
+  } else if (
+    atomsInSelection &&
+    !bondsInSelection &&
+    !isRGroupAttachmentPointsSelected
+  ) {
     return {
       id: CONTEXT_MENU_ID.FOR_ATOMS,
       atomIds: selection.atoms,
       extraItemsSelected: !onlyHasProperty(
         selection,
         'atoms',
+        IGNORED_MAPS_LIST,
+      ),
+    };
+  } else if (
+    isRGroupAttachmentPointsSelected &&
+    !bondsInSelection &&
+    !atomsInSelection
+  ) {
+    return {
+      id: CONTEXT_MENU_ID.FOR_R_GROUP_ATTACHMENT_POINT,
+      rgroupAttachmentPoints: selection.rgroupAttachmentPoints,
+      extraItemsSelected: !onlyHasProperty(
+        selection,
+        'rgroupAttachmentPoints',
         IGNORED_MAPS_LIST,
       ),
     };

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
@@ -7,6 +7,7 @@ export enum CONTEXT_MENU_ID {
   FOR_ATOMS = 'context-menu-for-atoms',
   FOR_SELECTION = 'context-menu-for-selection',
   FOR_FUNCTIONAL_GROUPS = 'context-menu-for-functional-groups',
+  FOR_R_GROUP_ATTACHMENT_POINT = 'context-menu-for-rgroup-attachment-point',
 }
 
 export type ItemData = unknown;
@@ -17,6 +18,7 @@ export type ContextMenuShowProps = {
   bondIds?: number[];
   atomIds?: number[];
   extraItemsSelected?: boolean;
+  rgroupAttachmentPoints?: number[];
 } | null;
 
 export interface MenuItemsProps {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRGroupAttachmentPointEdit.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRGroupAttachmentPointEdit.ts
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import assert from 'assert';
+import { useAppContext } from 'src/hooks';
+import Editor from 'src/script/editor';
+import { ItemEventParams } from '../contextMenu.types';
+import { editRGroupAttachmentPoint } from 'src/script/editor/tool/apoint.utils';
+
+const useRGroupAttachmentPointEdit = () => {
+  const { getKetcherInstance } = useAppContext();
+
+  const handler = useCallback(
+    ({ props }: ItemEventParams) => {
+      const editor = getKetcherInstance().editor as Editor;
+      const restruct = editor.render.ctab;
+      const atomId = props?.atomIds?.[0];
+      assert(atomId != null);
+      const atom = restruct.molecule.atoms.get(atomId);
+      assert(atom != null);
+
+      editRGroupAttachmentPoint(editor, atom, atomId);
+    },
+    [getKetcherInstance],
+  );
+
+  const disabled = useCallback(
+    ({ props }: ItemEventParams) => {
+      const editor = getKetcherInstance().editor as Editor;
+      const restruct = editor.render.ctab;
+      const atomId = props?.atomIds?.[0];
+      assert(atomId != null);
+      const atom = restruct.molecule.atoms.get(atomId);
+      assert(atom != null);
+
+      return atom.isRGroupAttachmentPointEditDisabled;
+    },
+    [getKetcherInstance],
+  );
+
+  const hidden = useCallback(({ props }: ItemEventParams) => {
+    const atomLength = props?.atomIds?.length || 0;
+    return atomLength > 1;
+  }, []);
+
+  return [handler, disabled, hidden] as const;
+};
+
+export default useRGroupAttachmentPointEdit;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRGroupAttachmentPointRemove.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRGroupAttachmentPointRemove.ts
@@ -1,0 +1,33 @@
+import { Action, fromRGroupAttachmentPointDeletion } from 'ketcher-core';
+import { useCallback } from 'react';
+import { useAppContext } from 'src/hooks';
+import Editor from 'src/script/editor';
+import { ItemEventParams } from '../contextMenu.types';
+
+const useDelete = () => {
+  const { getKetcherInstance } = useAppContext();
+
+  const handler = useCallback(
+    async ({ props }: ItemEventParams) => {
+      const editor = getKetcherInstance().editor as Editor;
+      const restruct = editor.render.ctab;
+      const pointsToDelete = props?.rgroupAttachmentPoints || [];
+
+      const action = pointsToDelete.reduce((previousAction, currentPoint) => {
+        const currentAction = fromRGroupAttachmentPointDeletion(
+          restruct,
+          currentPoint,
+        );
+        return previousAction.mergeWith(currentAction);
+      }, new Action());
+
+      editor.update(action);
+      editor.selection(null);
+    },
+    [getKetcherInstance],
+  );
+
+  return handler;
+};
+
+export default useDelete;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
@@ -4,10 +4,16 @@ import useAtomEdit from '../hooks/useAtomEdit';
 import useAtomStereo from '../hooks/useAtomStereo';
 import useDelete from '../hooks/useDelete';
 import { MenuItemsProps } from '../contextMenu.types';
+import useRGroupAttachmentPointEdit from '../hooks/useRGroupAttachmentPointEdit';
 
 const AtomMenuItems: FC<MenuItemsProps> = (props) => {
   const [handleEdit] = useAtomEdit();
   const [handleStereo, stereoDisabled] = useAtomStereo();
+  const [
+    handleEditRGroupAttachmentPoint,
+    rgroupAttachmentPointDisabled,
+    rgroupAttachmentPointHidden,
+  ] = useRGroupAttachmentPointEdit();
   const handleDelete = useDelete();
 
   return (
@@ -20,6 +26,15 @@ const AtomMenuItems: FC<MenuItemsProps> = (props) => {
 
       <Item {...props} disabled={stereoDisabled} onClick={handleStereo}>
         Enhanced stereochemistry...
+      </Item>
+
+      <Item
+        {...props}
+        disabled={rgroupAttachmentPointDisabled}
+        hidden={rgroupAttachmentPointHidden}
+        onClick={handleEditRGroupAttachmentPoint}
+      >
+        Edit R-Group attachment point...
       </Item>
 
       <Item {...props} onClick={handleDelete}>

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/RGroupAttachmentPointMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/RGroupAttachmentPointMenuItems.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { Item } from 'react-contexify';
+import { MenuItemsProps } from '../contextMenu.types';
+import useRGroupAttachmentPointRemove from '../hooks/useRGroupAttachmentPointRemove';
+
+const RGroupAttachmentPointMenuItems: FC<MenuItemsProps> = (props) => {
+  const handleRemove = useRGroupAttachmentPointRemove();
+
+  return (
+    <>
+      <Item {...props} onClick={handleRemove}>
+        Remove
+      </Item>
+    </>
+  );
+};
+
+export default RGroupAttachmentPointMenuItems;


### PR DESCRIPTION
This PR is one of the small PRs to resolve #2742  for easy review.
This PR is open for reviews but **please do not merge it**.

## What is done in this PR?

- Allow **editing** R-Group attachment points by context menu
![rgroup-attachemnt-right-click-edit](https://github.com/epam/ketcher/assets/27288153/ab2c3b47-bd66-4249-87b8-def4652965f2)

- Allow **removing** R-Group attachment points by context menu
![rgroup-attachemnt-right-click-remove](https://github.com/epam/ketcher/assets/27288153/086e5798-6d50-423e-bc27-1e9236c925b4)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
