### PR TITLE
#2989 error message appears when copypaste structure with s group properties functional groups and salts and solvents

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -621,7 +621,10 @@ class ReStruct {
   getAttachmentsPointsVBox(atomsIds: number[]): Box2Abs | null {
     let result: Box2Abs | null = null;
     for (const atomId of atomsIds) {
-      const reAtom = this.atoms.get(atomId)!;
+      const reAtom = this.atoms.get(atomId);
+      if (!reAtom) {
+        return null;
+      }
       const bbox = reAtom.getVBoxObjOfAttachmentPoint(this.render);
       if (bbox) {
         result = result ? Box2Abs.union(result, bbox) : bbox;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

closes #2989 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
