### PR TITLE
#3045 - Fix bugs for Preview monomers

### DIFF
--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/GroupBlock/styles.ts
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/GroupBlock/styles.ts
@@ -97,15 +97,19 @@ export const MonomerName = styled.span<{ selected?: boolean; empty: boolean }>(
   }),
 );
 
-export const GroupIcon = styled(Icon)<{ selected?: boolean; empty?: boolean }>(
-  (props) => ({
-    color: props.empty
-      ? 'transparent'
-      : props.selected
-      ? props.theme.ketcher.color.background.primary
-      : props.theme.ketcher.color.icon.grey,
-    stroke: props.selected
-      ? props.theme.ketcher.color.background.primary
-      : props.theme.ketcher.color.icon.grey,
-  }),
-);
+export const GroupIcon = styled(Icon)<{
+  selected?: boolean;
+  empty?: boolean;
+  name?: string;
+}>((props) => ({
+  color: props.empty
+    ? 'transparent'
+    : props.selected
+    ? props.theme.ketcher.color.background.primary
+    : props.theme.ketcher.color.icon.grey,
+  stroke: props.selected
+    ? props.theme.ketcher.color.background.primary
+    : props.theme.ketcher.color.icon.grey,
+  paddingRight:
+    props.name === 'sugar' ? '5px' : props.name === 'phosphate' ? '1px' : 0,
+}));

--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
+import { useCallback, useMemo } from 'react';
 import { EmptyFunction } from 'helpers';
+import { debounce } from 'lodash';
 import { MonomerItem } from '../monomerLibraryItem';
 import { MonomerItemType } from '../monomerLibraryItem/types';
 import { GroupContainer, GroupTitle, ItemsContainer } from './styles';
@@ -36,17 +38,27 @@ const MonomerGroup = ({
     dispatch(showPreview());
   };
 
+  const dispatchShowPreview = useCallback(
+    (payload) => dispatch(showPreview(payload)),
+    [dispatch],
+  );
+
+  const debouncedShowPreview = useMemo(
+    () => debounce((p) => dispatchShowPreview(p), 500),
+    [dispatchShowPreview],
+  );
+
   const handleItemMouseMove = (
     monomer: MonomerItemType,
     e: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
-    if (preview.monomer) {
+    if (preview.monomer || !e.currentTarget) {
       return;
     }
 
     const cardCoordinates = e.currentTarget.getBoundingClientRect();
     const previewStyle = calculatePreviewPosition(monomer, cardCoordinates);
-    dispatch(showPreview({ monomer, style: previewStyle }));
+    debouncedShowPreview({ monomer, style: previewStyle });
   };
 
   return (

--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -34,10 +34,6 @@ const MonomerGroup = ({
   const dispatch = useAppDispatch();
   const preview = useAppSelector(selectShowPreview);
 
-  const handleItemMouseLeave = () => {
-    dispatch(showPreview());
-  };
-
   const dispatchShowPreview = useCallback(
     (payload) => dispatch(showPreview(payload)),
     [dispatch],
@@ -47,6 +43,11 @@ const MonomerGroup = ({
     () => debounce((p) => dispatchShowPreview(p), 500),
     [dispatchShowPreview],
   );
+
+  const handleItemMouseLeave = () => {
+    debouncedShowPreview.cancel();
+    dispatch(showPreview());
+  };
 
   const handleItemMouseMove = (
     monomer: MonomerItemType,

--- a/packages/ketcher-polymer-editor-react/src/components/shared/MonomerPreview/index.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/shared/MonomerPreview/index.tsx
@@ -42,7 +42,7 @@ const MonomerPreview = ({ className }: IPreviewProps) => {
 };
 
 const StyledPreview = styled(MonomerPreview)`
-  z-index: 1;
+  z-index: 5;
   position: absolute;
   width: ${preview.width}px;
   height: ${preview.height}px;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Small fixes for Monomer preview - z-index of popup is increased; debounce for hover added.
Also fixed paddings for icon in RNA Editor

https://github.com/epam/ketcher/assets/60065704/22857482-f0d2-45ef-baae-40775611545f



Closes #3045

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
/
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
