### PR TITLE
#2963 - Copy/Cut/Paste + Undo/Redo makes objects appear randomly on the canvas, their initial amount increases

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -227,9 +227,7 @@ class PasteTool implements Tool {
       const action = this.action;
       delete this.action;
       if (!this.isSingleContractedGroup || !this.mergeItems) {
-        this.editor.update(
-          dropAndMerge(this.editor, this.mergeItems, action, true),
-        );
+        dropAndMerge(this.editor, this.mergeItems, action, true);
       }
     }
   }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Fixes ghosting appearing when moving the canvas after pasting and undo/redo.
Fixes having to press undo/redo twice for each paste.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
