### PR TITLE
#2679 Highlight colors for Simple Objects do not match the new design

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -129,7 +129,7 @@ class ReText extends ReObject {
   drawHover(render: any): any {
     if (!this.paths.length) return null;
     const ret = this.hoverPath(render).attr(render.options.hoverStyle);
-    render.ctab.addReObjectPath(LayerMap.data, this.visel, ret);
+    render.ctab.addReObjectPath(LayerMap.hovering, this.visel, ret);
     return ret;
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
![image](https://github.com/epam/ketcher/assets/35161544/8180b74b-7546-4d8e-8fa8-51352794220b)

![image](https://github.com/epam/ketcher/assets/35161544/1e26bad0-e5ca-46c7-bc8a-7d85f44c3ef7)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
