### PR TITLE
#3064-added qa team members for 'auto_assign'

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -16,3 +16,9 @@ reviewGroups:
     - nanoblit
     - chgayane
     - AKZhuk
+  QA:
+    - Zhirnoff
+    - AleksandraSmolianinova
+    - MartaWilliams
+    - krakmielepam
+    - y-holik


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
