### PR TITLE
#2541 - missing tool word for arrow filled triangle

### DIFF
--- a/demo/src/constants/buttons.ts
+++ b/demo/src/constants/buttons.ts
@@ -58,8 +58,8 @@ export const allButtons = [
   // text group
   'text',
   // right
-  'enhanced-stereo'
-]
+  'enhanced-stereo',
+];
 
 // A map of keys to labels for a dropdown
 export const buttonLabelMap = {
@@ -80,7 +80,7 @@ export const buttonLabelMap = {
   'reaction-plus': 'Reaction Plus Tool',
   arrows: 'Arrows',
   'reaction-arrow-open-angle': 'Arrow Open Angle',
-  'reaction-arrow-filled-triangle': 'Arrow Filled Triangle',
+  'reaction-arrow-filled-triangle': 'Arrow Filled Triangle Tool',
   'reaction-arrow-filled-bow': 'Arrow Filled Bow',
   'reaction-arrow-dashed-open-angle': 'Arrow Dashed Open Angle',
   'reaction-arrow-failed': 'Arrow Failed',
@@ -120,8 +120,8 @@ export const buttonLabelMap = {
   'shape-line': 'Shape Line',
   text: 'Add Text Tool',
   'enhanced-stereo': 'Stereochemistry',
-  fullscreen: 'Full screen mode'
-}
+  fullscreen: 'Full screen mode',
+};
 
 // Keys of buttons we initially hide in our demo app
 export const initiallyHidden = [
@@ -133,5 +133,5 @@ export const initiallyHidden = [
   'cip',
   'check',
   'analyse',
-  'recognize'
-]
+  'recognize',
+];

--- a/packages/ketcher-react/src/script/ui/action/tools.js
+++ b/packages/ketcher-react/src/script/ui/action/tools.js
@@ -113,7 +113,7 @@ const toolActions = {
     hidden: (options) => isHidden(options, 'reaction-arrow-open-angle'),
   },
   'reaction-arrow-filled-triangle': {
-    title: 'Arrow Filled Triangle',
+    title: 'Arrow Filled Triangle Tool',
     action: { tool: 'reactionarrow', opts: RxnArrowMode.FilledTriangle },
     hidden: (options) => isHidden(options, 'reaction-arrow-filled-triangle'),
   },

--- a/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
@@ -1,4 +1,4 @@
-import toolActions from '../../../../../../ketcher-react/src/script/ui/action/tools';
+import toolActions from '../../action/tools';
 
 describe('ToolActions', () => {
   it('should have a "title" property for each tool', () => {

--- a/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
@@ -1,0 +1,9 @@
+import toolActions from '../../../../../../ketcher-react/src/script/ui/action/tools';
+
+describe('ToolActions', () => {
+  it('should have a "title" property for each tool', () => {
+    Object.values(toolActions).forEach((tool) => {
+      expect(tool).toHaveProperty('title');
+    });
+  });
+});

--- a/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
@@ -1,10 +1,20 @@
 import toolActions from '../../action/tools';
 
-describe('ToolActions', () => {
-  const toolsWithTitles = Object.values(toolActions);
+const toolsWithoutTitles = [
+  'bonds',
+  'arrows',
+  'reaction-mapping-tools',
+  'rgroup',
+  'shapes',
+];
+const isToolWithTitle = (tool) => !toolsWithoutTitles.includes(tool);
+const toolsWithTitles = Object.values(toolActions).filter(isToolWithTitle);
 
-  it('should have a "title" property for each tool', () => {
-    toolsWithTitles.forEach((tool) => {
+describe('ToolActions', () => {
+  const tools = toolsWithTitles;
+
+  it('should have a "title" property for each tool that is not hidden', () => {
+    tools.forEach((tool) => {
       expect(tool.title).toBeTruthy();
     });
   });

--- a/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
@@ -8,13 +8,15 @@ const toolsWithoutTitles = [
   'shapes',
 ];
 const isToolWithTitle = (tool) => !toolsWithoutTitles.includes(tool);
-const toolsWithTitles = Object.values(toolActions).filter(isToolWithTitle);
+const toolsWithTitles = Object.keys(toolActions).filter(isToolWithTitle);
 
 describe('ToolActions', () => {
-  const tools = toolsWithTitles;
-
   it('should have a "title" property for each tool that is not hidden', () => {
-    tools.forEach((tool) => {
+    toolsWithTitles.forEach((toolKey) => {
+      const tool = toolActions[toolKey];
+      if (tool.title === undefined) {
+        console.error(`Tool without title: ${toolKey}`);
+      }
       expect(tool.title).toBeTruthy();
     });
   });

--- a/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
@@ -1,9 +1,13 @@
 import toolActions from '../../action/tools';
 
 describe('ToolActions', () => {
+  const toolsWithTitles = Object.values(toolActions).filter(
+    (tool) => tool.title !== undefined,
+  );
+
   it('should have a "title" property for each tool', () => {
-    Object.values(toolActions).forEach((tool) => {
-      expect(tool).toHaveProperty('title');
+    toolsWithTitles.forEach((tool) => {
+      expect(tool.title).toBeTruthy();
     });
   });
 });

--- a/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/ToolActions.test.tsx
@@ -1,9 +1,7 @@
 import toolActions from '../../action/tools';
 
 describe('ToolActions', () => {
-  const toolsWithTitles = Object.values(toolActions).filter(
-    (tool) => tool.title !== undefined,
-  );
+  const toolsWithTitles = Object.values(toolActions);
 
   it('should have a "title" property for each tool', () => {
     toolsWithTitles.forEach((tool) => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Navigate to ketcher
Navigate mouse to Arrow Filled Triangle
AR: it is "Arrow Filled Triangle"
ER: it should be "Arrow Filled Triangle Tool"
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
