### PR TITLE
#3091 – Cannot open CDX files on Mac

### DIFF
--- a/packages/ketcher-react/src/script/ui/utils/fileOpener.js
+++ b/packages/ketcher-react/src/script/ui/utils/fileOpener.js
@@ -45,7 +45,13 @@ function throughFileReader(file) {
     const rd = new FileReader(); // eslint-disable-line no-undef
 
     rd.onload = () => {
-      const content = isCDX ? rd.result.slice(37) : rd.result;
+      let content;
+      if (isCDX) {
+        const base64String = rd.result.split(',').at(-1);
+        content = base64String;
+      } else {
+        content = rd.result;
+      }
       if (file.msClose) file.msClose();
       resolve(content);
     };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

The problem occurred because the number of characters for Mime Type was hardcoded. Now I've provided the universal solution.

closes #3091 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
