### PR TITLE
Backmerge: #3151 - Migrate to Indigo v1.14.0-rc.2 in-browser module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13171,9 +13171,9 @@
       }
     },
     "node_modules/indigo-ketcher": {
-      "version": "1.14.0-rc.1",
-      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.14.0-rc.1.tgz",
-      "integrity": "sha512-khpvrmCS08UkLoNfJgv+sMVSdb23lECpdI6Sgsi98naFKsMB7LIWVV1o5Y4IalD7KZNm7w1jUkWLmhgfHH5+Cg=="
+      "version": "1.14.0-rc.2",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.14.0-rc.2.tgz",
+      "integrity": "sha512-MLKY7lUDx7FOvXZaz5rRjxR045oOjEJiXtGbIGb40wt4dHQuJFok1QYWCMmXLw5XVQ4bU7YTPmnZ7Z3sDUPKGw=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -26248,7 +26248,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
-        "indigo-ketcher": "1.14.0-rc.1",
+        "indigo-ketcher": "1.14.0-rc.2",
         "ketcher-core": "*"
       },
       "devDependencies": {

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "indigo-ketcher": "1.14.0-rc.1",
+    "indigo-ketcher": "1.14.0-rc.2",
     "ketcher-core": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
closes #3151 


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
