### PR TITLE
Backmerge: #2849 – When zoom out or zoom in, atoms and templates are located not under the mouse cursor

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -714,8 +714,8 @@ function updateLastCursorPosition(editor: Editor, event) {
       editor.render.clientArea.getBoundingClientRect();
 
     editor.lastCursorPosition = {
-      x: event.pageX - clientAreaBoundingBox.x,
-      y: event.pageY - clientAreaBoundingBox.y,
+      x: event.clientX - clientAreaBoundingBox.x,
+      y: event.clientY - clientAreaBoundingBox.y,
     };
   }
 }

--- a/packages/ketcher-react/src/script/editor/HoverIcon.ts
+++ b/packages/ketcher-react/src/script/editor/HoverIcon.ts
@@ -1,4 +1,4 @@
-import type { ElementLabel, AtomColor } from 'ketcher-core';
+import { type ElementLabel, type AtomColor, Vec2 } from 'ketcher-core';
 import Editor from './Editor';
 
 const HOVER_ICON_OPACITY = 0.7;
@@ -76,8 +76,16 @@ export class HoverIcon {
   }
 
   updatePosition() {
+    const render = this.editor.render;
     const { x, y } = this.editor.lastCursorPosition;
-    this.element.attr({ x, y });
+    const currentPosition = new Vec2(x, y);
+    const scrollPosition = render.scrollPos();
+    const zoom = render.options.zoom;
+    const newPosition = currentPosition.add(scrollPosition).scaled(1 / zoom);
+    this.element.attr({
+      x: newPosition.x,
+      y: newPosition.y,
+    });
   }
 
   show() {


### PR DESCRIPTION
closes #2849 

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request