### PR TITLE
Backmerge: #3176 – Drawing gets broken after dragging a Functional Group onto an atom

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -38,8 +38,8 @@ export function atomGetDegree(restruct, aid) {
   return restruct.atoms.get(aid).a.neighbors.length;
 }
 
-export function atomGetSGroups(restruct, aid) {
-  return Array.from(restruct.atoms.get(aid).a.sgs);
+export function atomGetSGroups(restruct, atomId: number): number[] {
+  return Array.from(restruct.atoms.get(atomId).a.sgs);
 }
 
 export function atomGetPos(restruct, id) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

closes #3176 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request