### PR TITLE
#3238 – Enhanced stereochemistry is disabled via right-click for stereocenters after pasting structure through API in Ket format

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -62,7 +62,7 @@ export function findStereoAtoms(
     const connectedBonds = Atom.getConnectedBondIds(struct, atomId);
     const connectedWithStereoBond = connectedBonds.some((bondId: number) => {
       const bond = struct.bonds.get(bondId);
-      return bond?.stereo;
+      return bond?.begin === atomId && bond?.stereo;
     });
     return connectedWithStereoBond;
   });

--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { AtomAttributes, Bond, Struct, Vec2 } from 'domain/entities';
+import { Atom, AtomAttributes, Bond, Struct, Vec2 } from 'domain/entities';
 
 import closest from '../shared/closest';
 import { difference } from 'lodash';
@@ -46,12 +46,26 @@ export function atomGetPos(restruct, id) {
   return restruct.molecule.atoms.get(id).pp;
 }
 
-export function findStereoAtoms(struct, aids: number[] | undefined): number[] {
-  if (!aids) {
+export function findStereoAtoms(
+  struct: Struct,
+  atomIds: number[] | undefined,
+): number[] {
+  if (!atomIds) {
     return [] as number[];
   }
 
-  return aids.filter((aid) => struct.atoms.get(aid).stereoLabel !== null);
+  return atomIds.filter((atomId: number) => {
+    const atom = struct.atoms.get(atomId);
+    if (atom?.stereoLabel !== null) {
+      return true;
+    }
+    const connectedBonds = Atom.getConnectedBondIds(struct, atomId);
+    const connectedWithStereoBond = connectedBonds.some((bondId: number) => {
+      const bond = struct.bonds.get(bondId);
+      return bond?.stereo;
+    });
+    return connectedWithStereoBond;
+  });
 }
 
 export function structSelection(struct): EditorSelection {

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -99,7 +99,6 @@ const LeftToolbar = (props: Props) => {
     return visibleItems.length ? (
       <div className={clsx(classes.group, className)}>
         {visibleItems.map((item) => {
-          console.log('items', item, item.id);
           switch (item.id) {
             case 'bond-common':
               return <Bond {...rest} height={height} key={item.id} />;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

closes #3238 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request