### PR TITLE
Backmerge: #3238 – Enhanced stereochemistry is disabled via right-click for stereocenters after pasting structure through API in Ket format (#3249)

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/utils.ts
+++ b/packages/ketcher-core/src/application/editor/actions/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { AtomAttributes, Bond, Struct, Vec2 } from 'domain/entities';
+import { Atom, AtomAttributes, Bond, Struct, Vec2 } from 'domain/entities';
 
 import closest from '../shared/closest';
 import { difference } from 'lodash';
@@ -46,12 +46,26 @@ export function atomGetPos(restruct, id) {
   return restruct.molecule.atoms.get(id).pp;
 }
 
-export function findStereoAtoms(struct, aids: number[] | undefined): number[] {
-  if (!aids) {
+export function findStereoAtoms(
+  struct: Struct,
+  atomIds: number[] | undefined,
+): number[] {
+  if (!atomIds) {
     return [] as number[];
   }
 
-  return aids.filter((aid) => struct.atoms.get(aid).stereoLabel !== null);
+  return atomIds.filter((atomId: number) => {
+    const atom = struct.atoms.get(atomId);
+    if (atom?.stereoLabel !== null) {
+      return true;
+    }
+    const connectedBonds = Atom.getConnectedBondIds(struct, atomId);
+    const connectedWithStereoBond = connectedBonds.some((bondId: number) => {
+      const bond = struct.bonds.get(bondId);
+      return bond?.begin === atomId && bond?.stereo;
+    });
+    return connectedWithStereoBond;
+  });
 }
 
 export function structSelection(struct): EditorSelection {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

closes #3238 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request