### PR TITLE
#3397 - When you save atom in ket format with substitutionCount great…

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -1137,7 +1137,7 @@ export function getAtomCustomQuery(atom) {
       if (value === '0') return '';
       return value.includes('-') ? value : `+${value}`;
     },
-    explicitValence: (value) => `v${value}`,
+    explicitValence: (value) => (Number(value) !== -1 ? `v${value}` : ''),
     ringBondCount: (value) =>
       Number(value) !== 0 ? getRingBondCountAttrText(Number(value)) : '',
     substitutionCount: (value) =>
@@ -1154,7 +1154,7 @@ export function getAtomCustomQuery(atom) {
 
   for (const propertyName in atom) {
     const value = atom[propertyName];
-    if (propertyName in patterns && value !== null && value !== -1) {
+    if (propertyName in patterns && value !== null) {
       const attrText = patterns[propertyName](value, atom);
       if (attrText) {
         addSemicolon();

--- a/packages/ketcher-core/src/domain/serializers/ket/schema.json
+++ b/packages/ketcher-core/src/domain/serializers/ket/schema.json
@@ -141,22 +141,22 @@
         },
         "ringBondCount": {
           "type": "integer",
-          "enum": [0, -2, -1, 2, 3, 4]
+          "enum": [0, -2, -1, 2, 3, 4, 6, 7, 8, 9]
         },
         "substitutionCount": {
           "type": "integer",
-          "enum": [0, -2, -1, 1, 2, 3, 4, 5, 6]
+          "enum": [0, -2, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         },
         "unsaturatedAtom": {
           "type": "boolean"
         },
         "hCount": {
           "type": "integer",
-          "enum": [-1, 0, 1, 2, 3, 4, 5]
+          "enum": [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         },
         "implicitHCount": {
           "type": "integer",
-          "enum": [0, 1, 2, 3, 4, 5]
+          "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         },
         "mapping": {
           "type": "integer",
@@ -183,17 +183,17 @@
             "ringMembership": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 5
+              "maximum": 9
             },
             "ringSize": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 5
+              "maximum": 9
             },
             "connectivity": {
               "type": "integer",
               "minimum": 0,
-              "maximum": 5
+              "maximum": 9
             },
             "chirality": {
               "type": "string",

--- a/packages/ketcher-react/src/script/ui/data/schema/struct-schema.js
+++ b/packages/ketcher-react/src/script/ui/data/schema/struct-schema.js
@@ -100,7 +100,7 @@ export const atom = {
     },
     hCount: {
       title: 'H count',
-      enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       enumNames: ['', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
       default: 0,
     },


### PR DESCRIPTION
…er then 6 , it is impossible to open it

- Update schema.json
- Fix hCount property


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request