### PR TITLE
#3408 - When insert a smarts with two query groups after inserting smarts with one query group error appear

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -132,10 +132,7 @@ export function load(struct: Struct, options?) {
         const oldStruct = editor.struct().clone();
         parsedStruct.sgroups.forEach((sg, sgId) => {
           const sgroup = oldStruct.sgroups.get(sgId);
-          if (!sgroup) {
-            throw Error('Incorrect sgroupId provided');
-          }
-          const offset = SGroup.getOffset(sgroup);
+          const offset = sgroup ? SGroup.getOffset(sgroup) : null;
           const atomSet = new Pile(sg.atoms);
           const crossBonds = SGroup.getCrossBonds(parsedStruct, atomSet);
           SGroup.bracketPos(sg, parsedStruct, crossBonds);


### PR DESCRIPTION
…arts with one query group error appear

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request