### PR TITLE
Macro: #3525 - Wrong usage of AP when establishing a bond between monomers r1 and r2 r2

### DIFF
--- a/packages/ketcher-core/__tests__/domain/entities/drawingEntitiesManager.test.ts
+++ b/packages/ketcher-core/__tests__/domain/entities/drawingEntitiesManager.test.ts
@@ -46,6 +46,42 @@ describe('Drawing Entities Manager', () => {
     );
   });
 
+  it('should create correct polymer bond when second monomer has only R2 point', () => {
+    const drawingEntitiesManager = new DrawingEntitiesManager();
+    const firstPeptide = new Peptide(peptideMonomerItem);
+    firstPeptide.attachmentPointsToBonds = { R1: null, R2: null };
+    firstPeptide.potentialAttachmentPointsToBonds = { R1: null, R2: null };
+    const secondPeptide = new Peptide(peptideMonomerItem);
+    secondPeptide.attachmentPointsToBonds = { R2: null };
+    secondPeptide.potentialAttachmentPointsToBonds = { R2: null };
+
+    const { polymerBond } = drawingEntitiesManager.addPolymerBond(
+      firstPeptide,
+      new Vec2(0, 0),
+      new Vec2(10, 10),
+    );
+
+    const resultingOperations =
+      drawingEntitiesManager.intendToFinishBondCreation(
+        secondPeptide,
+        polymerBond,
+      ).operations;
+
+    expect(resultingOperations).toHaveLength(2);
+    expect(resultingOperations[0]).toMatchObject({
+      peptide: {
+        potentialAttachmentPointsToBonds: {
+          R1: polymerBond,
+          R2: null,
+        },
+        attachmentPointsToBonds: {
+          R1: null,
+          R2: null,
+        },
+      },
+    });
+  });
+
   it('should delete peptide', () => {
     const drawingEntitiesManager = new DrawingEntitiesManager();
     drawingEntitiesManager.addMonomer(peptideMonomerItem, new Vec2(0, 0));

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -375,6 +375,18 @@ export class DrawingEntitiesManager {
       command.addOperation(operation);
     }
 
+    if (
+      availableAttachmentPointForBondEnd === 'R2' &&
+      !monomer.hasAttachmentPoint('R1') &&
+      bond.firstMonomer.hasAttachmentPoint('R1')
+    ) {
+      // Prevents forming invalid R2-R2 bonds when second monomer does not have R1 point
+      bond.firstMonomer.removePotentialBonds();
+      bond.firstMonomer.setPotentialBond('R1', bond);
+      const operation = new MonomerHoverOperation(bond.firstMonomer, true);
+      command.addOperation(operation);
+    }
+
     const operation = new MonomerHoverOperation(monomer, true);
 
     command.addOperation(operation);

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -378,7 +378,8 @@ export class DrawingEntitiesManager {
     if (
       availableAttachmentPointForBondEnd === 'R2' &&
       !monomer.hasAttachmentPoint('R1') &&
-      bond.firstMonomer.hasAttachmentPoint('R1')
+      bond.firstMonomer.hasAttachmentPoint('R1') &&
+      !bond.firstMonomer.isAttachmentPointUsed('R1')
     ) {
       // Prevents forming invalid R2-R2 bonds when second monomer does not have R1 point
       bond.firstMonomer.removePotentialBonds();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
This fix prevents forming invalid R2-R2 polymer bond in cases when there is an R1 point in the first monomer


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request