### PR TITLE
Macro: #3498 - When switching from the Macromolecules module to the Molecules module an application crashes

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -270,12 +270,18 @@ export class CoreEditor {
     this.unsubscribeEvents();
     const struct = this.micromoleculesEditor.struct();
     const reStruct = this.micromoleculesEditor.render.ctab;
-    MacromoleculesConverter.convertDrawingEntitiesToStruct(
-      this.drawingEntitiesManager,
-      struct,
-      reStruct,
-    );
+    const { conversionErrorMessage } =
+      MacromoleculesConverter.convertDrawingEntitiesToStruct(
+        this.drawingEntitiesManager,
+        struct,
+        reStruct,
+      );
     reStruct.render.setMolecule(struct);
+    if (conversionErrorMessage) {
+      global.ketcher.editor.setMacromoleculeConvertionError(
+        conversionErrorMessage,
+      );
+    }
   }
 
   private switchToMacromolecules() {

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -24,6 +24,7 @@ import { PolymerBondRenderer } from 'application/render/renderers';
 import { Editor } from 'application/editor/editor.types';
 import { MacromoleculesConverter } from 'application/editor/MacromoleculesConverter';
 import { BaseMonomer } from 'domain/entities/BaseMonomer';
+import { ketcherProvider } from 'application/utils';
 
 interface ICoreEditorConstructorParams {
   theme;
@@ -63,7 +64,8 @@ export class CoreEditor {
     this.zoomTool = ZoomTool.initInstance(this.drawingEntitiesManager);
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     editor = this;
-    this.micromoleculesEditor = global.ketcher.editor;
+    const ketcher = ketcherProvider.getKetcher();
+    this.micromoleculesEditor = ketcher?.editor;
     this.switchToMacromolecules();
   }
 
@@ -278,20 +280,21 @@ export class CoreEditor {
       );
     reStruct.render.setMolecule(struct);
     if (conversionErrorMessage) {
-      global.ketcher.editor.setMacromoleculeConvertionError(
-        conversionErrorMessage,
-      );
+      const ketcher = ketcherProvider.getKetcher();
+
+      ketcher.editor.setMacromoleculeConvertionError(conversionErrorMessage);
     }
   }
 
   private switchToMacromolecules() {
     const struct = this.micromoleculesEditor?.struct() || new Struct();
+    const ketcher = ketcherProvider.getKetcher();
     const { modelChanges } =
       MacromoleculesConverter.convertStructToDrawingEntities(
         struct,
         this.drawingEntitiesManager,
       );
     this.renderersContainer.update(modelChanges);
-    global.ketcher.editor?.clear();
+    ketcher?.editor.clear();
   }
 }

--- a/packages/ketcher-core/src/application/editor/editor.types.ts
+++ b/packages/ketcher-core/src/application/editor/editor.types.ts
@@ -79,4 +79,7 @@ export interface Editor {
   render: Render;
   // supposed to be RotateController from 'ketcher-react' package
   rotateController: any;
+  macromoleculeConvertionError: string | null | undefined;
+  setMacromoleculeConvertionError: (errorMessage: string) => void;
+  clearMacromoleculeConvertionError: () => void;
 }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -154,6 +154,7 @@ class Editor implements KetcherEditor {
   };
 
   lastEvent: any;
+  macromoleculeConvertionError: string | null | undefined;
 
   constructor(clientArea, options) {
     this.render = new Render(
@@ -668,6 +669,14 @@ class Editor implements KetcherEditor {
     const action = fromDescriptorsAlign(this.render.ctab);
     this.update(action);
     this.render.update(true);
+  }
+
+  setMacromoleculeConvertionError(errorMessage: string) {
+    this.macromoleculeConvertionError = errorMessage;
+  }
+
+  clearMacromoleculeConvertionError() {
+    this.macromoleculeConvertionError = null;
   }
 }
 

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -37,6 +37,7 @@ import { generateCommonProperties } from './utils';
 import { saveSettings } from '../options';
 import { memoizedDebounce } from '../../utils';
 import { updateFloatingTools } from '../floatingTools';
+import { openInfoModalWithCustomMessage } from '../shared';
 
 export default function initEditor(dispatch, getState) {
   const updateAction = debounce(100, () => dispatch({ type: 'UPDATE' }));
@@ -238,5 +239,8 @@ export default function initEditor(dispatch, getState) {
 
     onZoomIn: updateAction,
     onZoomOut: updateAction,
+
+    onShowMacromoleculesErrorMessage: (payload) =>
+      dispatch(openInfoModalWithCustomMessage(payload)),
   };
 }

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -199,3 +199,13 @@ export function openInfoModal(command: 'Paste' | 'Copy' | 'Cut'): {
     data: { name: 'info-modal', prop: { message: command } },
   };
 }
+
+export function openInfoModalWithCustomMessage(message: string): {
+  type: 'MODAL_OPEN';
+  data: { name: 'info-modal'; prop: { customText: string } };
+} {
+  return {
+    type: 'MODAL_OPEN',
+    data: { name: 'info-modal', prop: { customText: message } },
+  };
+}

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -28,7 +28,7 @@ import Cursor from '../Cursor';
 import { ContextMenu, ContextMenuTrigger } from '../ContextMenu';
 
 import InfoPanel from './InfoPanel';
-import { KetcherLogger } from 'ketcher-core';
+import { KetcherLogger, ketcherProvider } from 'ketcher-core';
 import { getSmoothScrollDelta } from './helpers';
 import InfoTooltip from './InfoTooltip';
 
@@ -151,6 +151,13 @@ class StructEditor extends Component {
     this.editor = new Editor(this.editorRef.current, {
       ...this.props.options,
     });
+    const ketcher = ketcherProvider.getKetcher();
+    if (ketcher?.editor.macromoleculeConvertionError) {
+      this.props.onShowMacromoleculesErrorMessage(
+        ketcher.editor.macromoleculeConvertionError,
+      );
+      ketcher.editor.clearMacromoleculeConvertionError();
+    }
     setupEditor(this.editor, this.props);
     if (this.props.onInit) this.props.onInit(this.editor);
 
@@ -282,6 +289,7 @@ class StructEditor extends Component {
       onApiSettings,
       showAttachmentPoints = true,
       onUpdateFloatingTools,
+      onShowMacromoleculesErrorMessage,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       ...props
     } = this.props;

--- a/packages/ketcher-react/src/script/ui/views/modal/components/InfoModal/InfoModal.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/InfoModal/InfoModal.tsx
@@ -42,7 +42,8 @@ function ErrorInfoModal(props) {
       headerContent={headerContent}
     >
       <div>
-        {isPasteError ? <PasteErrorModalBody /> : defaultCutCopyMessage}
+        {props.customText ||
+          (isPasteError ? <PasteErrorModalBody /> : defaultCutCopyMessage)}
       </div>
     </Dialog>
   );


### PR DESCRIPTION
Closes #3498 

## How the feature works? / How did you fix the issue?
Added handling the cae when monomer doesn't have specific attachment point but we added bond to it.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request