### PR TITLE
Macro: #3539 – When pull bond away from monomer and press 'Escape', bond remains on canvas

### DIFF
--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -173,14 +173,7 @@ class PolymerBond implements BaseTool {
     if (this.isBondConnectionModalOpen) {
       return;
     }
-    if (this.bondRenderer) {
-      const modelChanges =
-        this.editor.drawingEntitiesManager.cancelPolymerBondCreation(
-          this.bondRenderer.polymerBond,
-        );
-      this.editor.renderersContainer.update(modelChanges);
-      this.bondRenderer = undefined;
-    }
+    this.destroy();
   }
 
   public mouseUpMonomer(event) {
@@ -272,7 +265,16 @@ class PolymerBond implements BaseTool {
     this.bondRenderer = undefined;
   };
 
-  public destroy() {}
+  public destroy() {
+    if (this.bondRenderer) {
+      const modelChanges =
+        this.editor.drawingEntitiesManager.cancelPolymerBondCreation(
+          this.bondRenderer.polymerBond,
+        );
+      this.editor.renderersContainer.update(modelChanges);
+      this.bondRenderer = undefined;
+    }
+  }
 
   private shouldInvokeModal(
     firstMonomer: BaseMonomer,

--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -36,6 +36,17 @@ class PolymerBond implements BaseTool {
     this.editor = editor;
   }
 
+  private removeBond(): void {
+    if (this.bondRenderer) {
+      const modelChanges =
+        this.editor.drawingEntitiesManager.cancelPolymerBondCreation(
+          this.bondRenderer.polymerBond,
+        );
+      this.editor.renderersContainer.update(modelChanges);
+      this.bondRenderer = undefined;
+    }
+  }
+
   public mousedown(event) {
     const selectedRenderer = event.target.__data__;
     if (selectedRenderer instanceof BaseMonomerRenderer) {
@@ -173,7 +184,7 @@ class PolymerBond implements BaseTool {
     if (this.isBondConnectionModalOpen) {
       return;
     }
-    this.destroy();
+    this.removeBond();
   }
 
   public mouseUpMonomer(event) {
@@ -266,14 +277,7 @@ class PolymerBond implements BaseTool {
   };
 
   public destroy() {
-    if (this.bondRenderer) {
-      const modelChanges =
-        this.editor.drawingEntitiesManager.cancelPolymerBondCreation(
-          this.bondRenderer.polymerBond,
-        );
-      this.editor.renderersContainer.update(modelChanges);
-      this.bondRenderer = undefined;
-    }
+    this.removeBond();
   }
 
   private shouldInvokeModal(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Can't provide a screenshot, but basically the new behavior is: when a user presses Escape while drawing a bond, the bond is removed (which wasn't happening before).


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request