### PR TITLE
#3542 - after hiding the library panel a residual strip remains concealing content on the canvas

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/tools/SelectRectangleTool.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/tools/SelectRectangleTool.test.ts
@@ -60,6 +60,12 @@ jest.mock('d3', () => {
   };
 });
 
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
 describe('Select Rectangle Tool', () => {
   it('should select drawing entity on mousedown', () => {
     const polymerBond = getFinishedPolymerBond(0, 0, 10, 10);

--- a/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
+++ b/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
@@ -84,9 +84,9 @@ class SelectRectangle implements BaseTool {
       this.brushArea.call(this.brush);
     };
 
-    const canvasElement = select(this.editor.canvas).node();
+    const canvasElement = this.editor.canvas;
 
-    if (canvasElement) {
+    if (canvasElement && typeof ResizeObserver !== 'undefined') {
       this.canvasResizeObserver = new ResizeObserver(handleResizeCanvas);
       this.canvasResizeObserver.observe(canvasElement);
     }

--- a/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
+++ b/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
@@ -86,7 +86,7 @@ class SelectRectangle implements BaseTool {
 
     const canvasElement = this.editor.canvas;
 
-    if (canvasElement && typeof ResizeObserver !== 'undefined') {
+    if (canvasElement) {
       this.canvasResizeObserver = new ResizeObserver(handleResizeCanvas);
       this.canvasResizeObserver.observe(canvasElement);
     }

--- a/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
+++ b/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
@@ -26,6 +26,7 @@ class SelectRectangle implements BaseTool {
   private brushArea;
   private moveStarted;
   private mousePositionAfterMove = new Vec2(0, 0, 0);
+  private canvasResizeObserver?: ResizeObserver;
 
   constructor(private editor: CoreEditor) {
     this.editor = editor;
@@ -71,6 +72,24 @@ class SelectRectangle implements BaseTool {
       .select('rect.selection')
       .style('fill', 'transparent')
       .style('stroke', 'darkgrey');
+
+    const handleResizeCanvas = () => {
+      const { canvas } = this.editor;
+
+      this.brush.extent([
+        [0, 0],
+        [canvas.width.baseVal.value, canvas.height.baseVal.value],
+      ]);
+
+      this.brushArea.call(this.brush);
+    };
+
+    const canvasElement = select(this.editor.canvas).node();
+
+    if (canvasElement) {
+      this.canvasResizeObserver = new ResizeObserver(handleResizeCanvas);
+      this.canvasResizeObserver.observe(canvasElement);
+    }
   }
 
   mousedown(event) {
@@ -143,6 +162,9 @@ class SelectRectangle implements BaseTool {
       this.brush = null;
       this.brushArea = null;
     }
+
+    this.canvasResizeObserver?.disconnect();
+
     const modelChanges =
       this.editor.drawingEntitiesManager.unselectAllDrawingEntities();
 

--- a/packages/ketcher-polymer-editor-react/src/Editor.tsx
+++ b/packages/ketcher-polymer-editor-react/src/Editor.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 import { Provider } from 'react-redux';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Global, ThemeProvider } from '@emotion/react';
 import { createTheme } from '@mui/material/styles';
 import { debounce, merge } from 'lodash';
@@ -30,7 +30,10 @@ import {
 } from 'theming/defaultTheme';
 import { getGlobalStyles } from 'theming/globalStyles';
 import { Layout } from 'components/Layout';
-import { MonomerLibrary } from 'components/monomerLibrary';
+import {
+  MonomerLibrary,
+  MonomerLibraryToggle,
+} from 'components/monomerLibrary';
 import { Menu } from 'components/menu';
 import {
   createEditor,
@@ -124,6 +127,7 @@ function Editor({ theme, togglerComponent }: EditorProps) {
   const editor = useAppSelector(selectEditor);
   const activeTool = useAppSelector(selectEditorActiveTool);
   let keyboardEventListener;
+  const [isMonomerLibraryHidden, setIsMonomerLibraryHidden] = useState(false);
 
   useEffect(() => {
     dispatch(createEditor({ theme, canvas: canvasRef.current }));
@@ -221,7 +225,9 @@ function Editor({ theme, togglerComponent }: EditorProps) {
   return (
     <>
       <Layout>
-        <Layout.Top>{togglerComponent}</Layout.Top>
+        <Layout.Top shortened={isMonomerLibraryHidden}>
+          {togglerComponent}
+        </Layout.Top>
 
         <Layout.Left>
           <MenuComponent />
@@ -251,10 +257,14 @@ function Editor({ theme, togglerComponent }: EditorProps) {
           </svg>
         </Layout.Main>
 
-        <Layout.Right>
+        <Layout.Right hide={isMonomerLibraryHidden}>
           <MonomerLibrary />
         </Layout.Right>
       </Layout>
+      <MonomerLibraryToggle
+        isHidden={isMonomerLibraryHidden}
+        onClick={() => setIsMonomerLibraryHidden((prev) => !prev)}
+      />
       <FullscreenButton />
       <StyledPreview className="polymer-library-preview" />
       <ModalContainer />

--- a/packages/ketcher-polymer-editor-react/src/components/Layout/Layout.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/Layout/Layout.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+import { MONOMER_LIBRARY_WIDTH } from 'components/monomerLibrary';
 
 interface LayoutProps {
   children: JSX.Element | Array<JSX.Element>;
@@ -52,27 +52,29 @@ const Row = styled.div(({ theme }) => ({
   columnGap: '3px',
 }));
 
-const baseLeftRightStyle = css({
-  height: '100%',
-  width: 'fit-content',
-  display: 'flex',
-  flexDirection: 'column',
-});
+const BaseLeftRightStyle = styled.div<{ hide?: boolean }>(
+  ({ hide = false }) => ({
+    height: '100%',
+    width: 'fit-content',
+    display: hide ? 'none' : 'flex',
+    flexDirection: 'column',
+  }),
+);
 
-const Left = styled.div(baseLeftRightStyle);
+const Left = styled(BaseLeftRightStyle)``;
 
-const Right = styled.div(baseLeftRightStyle);
+const Right = styled(BaseLeftRightStyle)``;
 
-const Top = styled.div({
+const Top = styled.div<{ shortened?: boolean }>(({ shortened = false }) => ({
   height: 'fit-content',
-  width: '100%',
+  width: shortened ? `calc(100% - ${MONOMER_LIBRARY_WIDTH})` : '100%',
   marginBottom: '6px',
   display: 'flex',
   justifyContent: 'flex-end',
   backgroundColor: '#FFFFFF',
   boxShadow: '0px 2px 5px rgba(103, 104, 132, 0.15)',
   borderRadius: '4px',
-});
+}));
 
 const Main = styled.div({
   height: '100%',

--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/MonomerLibrary.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/MonomerLibrary.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { Tabs } from 'components/shared/Tabs';
 import styled from '@emotion/styled';
 import { tabsContent } from 'components/monomerLibrary/tabsContent';
@@ -21,18 +21,16 @@ import { useAppDispatch } from 'hooks';
 import { setSearchFilter } from 'state/library';
 import { Icon } from 'ketcher-react';
 
+export const MONOMER_LIBRARY_WIDTH = '254px';
+
 const MonomerLibraryContainer = styled.div(({ theme }) => ({
-  width: '254px',
+  width: MONOMER_LIBRARY_WIDTH,
   height: 'calc(100% - 16px)',
   backgroundColor: theme.ketcher.color.background.primary,
   boxShadow: '0px 2px 5px rgba(103, 104, 132, 0.15)',
   display: 'flex',
   flexDirection: 'column',
   borderRadius: '4px',
-
-  '&.hidden': {
-    visibility: 'hidden',
-  },
 }));
 
 const MonomerLibraryTitle = styled.h3(({ theme }) => ({
@@ -83,71 +81,17 @@ const MonomerLibrarySearch = styled.div(({ theme }) => ({
   },
 }));
 
-const MonomerLibraryToggle = styled.div(({ theme }) => {
-  return {
-    margin: 0,
-    fontSize: theme.ketcher.font.size.regular,
-    color: theme.ketcher.color.text.secondary,
-    position: 'absolute',
-    cursor: 'pointer',
-    top: '12px',
-    right: '4px',
-    visibility: 'visible',
-    opacity: 1,
-    whiteSpace: 'nowrap',
-    display: 'flex',
-    lineHeight: 1,
-    padding: '5px 8px',
-    borderRadius: '4px',
-    userSelect: 'none',
-
-    '& > span': {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-
-      '&.icon': {
-        marginRight: '2px',
-      },
-    },
-
-    '.hidden &': {
-      backgroundColor: theme.ketcher.color.button.primary.active,
-      color: theme.ketcher.color.button.text.primary,
-    },
-  };
-});
-
 const MonomerLibrary = () => {
-  const [isHidden, setIsHidden] = useState(false);
   const dispatch = useAppDispatch();
-
-  const toggleSidebar = () => {
-    setIsHidden(!isHidden);
-  };
 
   const filterResults = (event: ChangeEvent<HTMLInputElement>) => {
     dispatch(setSearchFilter(event.target.value));
   };
 
   return (
-    <MonomerLibraryContainer
-      className={isHidden ? 'hidden monomer-library' : 'shown monomer-library'}
-    >
+    <MonomerLibraryContainer>
       <MonomerLibraryHeader>
         <MonomerLibraryTitle>Library</MonomerLibraryTitle>
-        <MonomerLibraryToggle>
-          <span className="icon">
-            {isHidden ? (
-              <Icon name="arrows-left" />
-            ) : (
-              <Icon name="arrows-right" />
-            )}
-          </span>
-          <span onClick={toggleSidebar}>
-            {isHidden ? 'Show Library' : 'Hide'}
-          </span>
-        </MonomerLibraryToggle>
         <MonomerLibrarySearch>
           <div>
             <span>

--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/MonomerLibraryToggle.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/MonomerLibraryToggle.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import { Icon } from 'ketcher-react';
+
+const StyledMonomerLibraryToggle = styled.div(({ theme }) => {
+  return {
+    margin: 0,
+    fontSize: theme.ketcher.font.size.regular,
+    color: theme.ketcher.color.text.secondary,
+    position: 'absolute',
+    cursor: 'pointer',
+    top: 'calc(12px + 12px)',
+    right: 'calc(4px + 12px)',
+    visibility: 'visible',
+    opacity: 1,
+    whiteSpace: 'nowrap',
+    display: 'flex',
+    lineHeight: 1,
+    padding: '5px 8px',
+    borderRadius: '4px',
+    userSelect: 'none',
+
+    '& > span': {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+
+      '&.icon': {
+        marginRight: '2px',
+      },
+    },
+
+    '&.hidden': {
+      backgroundColor: theme.ketcher.color.button.primary.active,
+      color: theme.ketcher.color.button.text.primary,
+    },
+  };
+});
+
+interface Props {
+  isHidden: boolean;
+  onClick: () => void;
+}
+
+const MonomerLibraryToggle = ({ isHidden, onClick }: Props) => {
+  return (
+    <StyledMonomerLibraryToggle
+      className={isHidden ? 'hidden' : ''}
+      onClick={onClick}
+    >
+      <span className="icon">
+        {isHidden ? <Icon name="arrows-left" /> : <Icon name="arrows-right" />}
+      </span>
+      <span>{isHidden ? 'Show Library' : 'Hide'}</span>
+    </StyledMonomerLibraryToggle>
+  );
+};
+
+export { MonomerLibraryToggle };

--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/index.ts
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/index.ts
@@ -15,3 +15,4 @@
  ***************************************************************************/
 
 export * from './MonomerLibrary';
+export * from './MonomerLibraryToggle';


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Closes https://github.com/epam/ketcher/issues/3542

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [X] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request