### PR TITLE
#3497 - Macro: the "Library" inscription and the "Hide" button are at same height

### DIFF
--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/MonomerLibraryToggle.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/MonomerLibraryToggle.tsx
@@ -8,7 +8,7 @@ const StyledMonomerLibraryToggle = styled.div(({ theme }) => {
     color: theme.ketcher.color.text.secondary,
     position: 'absolute',
     cursor: 'pointer',
-    top: 'calc(12px + 12px)',
+    top: 'calc(8px + 12px)',
     right: 'calc(4px + 12px)',
     visibility: 'visible',
     opacity: 1,


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

<img width="283" alt="image" src="https://github.com/epam/ketcher/assets/60065704/45a7cd45-5be6-4d2a-8e96-372efca1549f">


Closes #3497
## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request