### PR TITLE
#3585 - APs are redrawn incorrectly after opening the modal window

### DIFF
--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -191,6 +191,9 @@ class PolymerBond implements BaseTool {
   }
 
   public mouseLeaveAttachmentPoint(event) {
+    if (this.isBondConnectionModalOpen) {
+      return;
+    }
     const renderer: BaseMonomerRenderer = event.target.__data__;
     if (renderer !== this.bondRenderer?.polymerBond?.firstMonomer?.renderer) {
       const modelChanges =


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

https://github.com/epam/ketcher/assets/70894460/5d730596-aed8-4b5e-8f6c-bb51aa98ad22



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request