### PR TITLE
Macro: #3537 - after deleting search presets apear backMacro: default presets do not appear back after cleaning search field

### DIFF
--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
@@ -45,9 +45,9 @@ import {
   selectActivePreset,
   selectActivePresetMonomerGroup,
   selectActiveRnaBuilderItem,
+  selectFilteredPresets,
   selectIsActivePresetNewAndEmpty,
   selectIsEditMode,
-  selectPresets,
   setActivePreset,
   setActivePresetForContextMenu,
   setActivePresetMonomerGroup,
@@ -82,7 +82,7 @@ export const RnaAccordion = ({ libraryName, duplicatePreset, editPreset }) => {
   const activeRnaBuilderItem = useAppSelector(selectActiveRnaBuilderItem);
   const activePreset = useAppSelector(selectActivePreset);
   const groups = selectMonomerGroups(items);
-  const presets = useAppSelector(selectPresets);
+  const presets = useAppSelector(selectFilteredPresets);
   const isEditMode = useAppSelector(selectIsEditMode);
   const editor = useAppSelector(selectEditor);
   const isActivePresetNewAndEmpty = useAppSelector(

--- a/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/RnaBuilder/RnaBuilder.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/monomerLibrary/RnaBuilder/RnaBuilder.tsx
@@ -28,17 +28,19 @@ import {
   setIsEditMode,
   savePreset,
 } from 'state/rna-builder';
-import { selectFilteredMonomers } from 'state/library';
+import { getSearchTermValue, selectFilteredMonomers } from 'state/library';
 import { Modal } from 'components/shared/modal';
 import { getDefaultPresets } from 'src/helpers/getDefaultPreset';
 import { StyledButton } from 'components/monomerLibrary/RnaBuilder/RnaAccordion/styles';
 import { IRnaPreset } from 'components/monomerLibrary/RnaBuilder/types';
 import { scrollToSelectedPreset } from './RnaEditor/RnaEditor';
+import { useSelector } from 'react-redux';
 
 export const RnaBuilder = ({ libraryName }) => {
   const dispatch = useAppDispatch();
   const hasError = useAppSelector(selectHasUniqueNameError);
   const monomers = useAppSelector(selectFilteredMonomers);
+  const serachValue = useSelector(getSearchTermValue);
   const activePreset = useAppSelector(selectActivePreset);
   const closeErrorModal = () => {
     dispatch(setHasUniqueNameError(false));
@@ -47,7 +49,7 @@ export const RnaBuilder = ({ libraryName }) => {
   useEffect(() => {
     const defaultPresets: IRnaPreset[] = getDefaultPresets(monomers);
     dispatch(setDefaultPresets(defaultPresets));
-  }, [dispatch]);
+  }, [dispatch, serachValue]);
 
   const duplicatePreset = (preset?: IRnaPreset) => {
     const duplicatedPreset = {

--- a/packages/ketcher-polymer-editor-react/src/components/shared/TextArea/TextArea.tsx
+++ b/packages/ketcher-polymer-editor-react/src/components/shared/TextArea/TextArea.tsx
@@ -54,7 +54,7 @@ export const TextArea = ({
   readonly = false,
   selectOnInit = false,
   className,
-  testId
+  testId,
 }: TextEditorProps) => {
   const textArea = useRef<HTMLTextAreaElement>(null);
 

--- a/packages/ketcher-polymer-editor-react/src/state/library/librarySlice.ts
+++ b/packages/ketcher-polymer-editor-react/src/state/library/librarySlice.ts
@@ -91,6 +91,10 @@ export const librarySlice: Slice = createSlice({
   },
 });
 
+export const getSearchTermValue = (state): string => {
+  return state.library.searchFilter;
+};
+
 export const selectMonomersInCategory = (
   items: MonomerItemType[],
   category: LibraryNameType,

--- a/packages/ketcher-polymer-editor-react/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-polymer-editor-react/src/state/rna-builder/rnaBuilderSlice.ts
@@ -192,6 +192,13 @@ export const selectPresetFullName = (preset: IRnaPreset): string => {
   return fullName;
 };
 
+export const selectFilteredPresets = (state: RootState) => {
+  const { searchFilter } = state.library;
+  return [...state.rnaBuilder.presets].filter(({ name }) => {
+    return name.toLowerCase().includes(searchFilter.toLowerCase());
+  });
+};
+
 export const selectHasUniqueNameError = (state: RootState) => {
   return state.rnaBuilder.hasUniqueNameError;
 };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request