### PR TITLE
#3553 - macro while pulling bond onto monomer a preview is shown when hover monomer

### DIFF
--- a/ketcher-autotests/tests/Indigo-Tools/Reaction Auto-mapping tool/reaction-am-tool-veryfing-button.spec.ts
+++ b/ketcher-autotests/tests/Indigo-Tools/Reaction Auto-mapping tool/reaction-am-tool-veryfing-button.spec.ts
@@ -4,7 +4,6 @@ import {
   selectNestedTool,
   openFileAndAddToCanvas,
   takeEditorScreenshot,
-  pressButton,
   selectTopPanelButton,
   TopPanelButton,
   clickOnTheCanvas,

--- a/ketcher-autotests/tests/Settings/Atoms/atoms-settings.spec.ts
+++ b/ketcher-autotests/tests/Settings/Atoms/atoms-settings.spec.ts
@@ -15,10 +15,12 @@ import {
 } from '@utils';
 import { scrollSettingBar } from '@utils/scrollSettingBar';
 
+const DEFAULT_SCROLLBAR_DELAY = 150;
+
 async function setHydrogenLabelsOn(page: Page) {
   await selectTopPanelButton(TopPanelButton.Settings, page);
   await page.getByText('Atoms', { exact: true }).click();
-  await scrollSettingBar(page, 150);
+  await scrollSettingBar(page, DEFAULT_SCROLLBAR_DELAY);
   await page.getByTestId('show-hydrogen-labels-input-span').click();
   await page.getByTestId('On-option').click();
   await pressButton(page, 'Apply');
@@ -31,7 +33,7 @@ async function selectExtendedTableElements(page: Page, element: string) {
 async function atomDefaultSettings(page: Page) {
   await selectTopPanelButton(TopPanelButton.Settings, page);
   await page.getByText('Atoms', { exact: true }).click();
-  await scrollSettingBar(page,150);
+  await scrollSettingBar(page, DEFAULT_SCROLLBAR_DELAY);
 }
 
 async function ringBondCountQuery(page: Page, menuItem: string) {

--- a/ketcher-autotests/tests/utils/canvas/tools/helpers.ts
+++ b/ketcher-autotests/tests/utils/canvas/tools/helpers.ts
@@ -1,5 +1,5 @@
 import { Page } from '@playwright/test';
-import { pressButton, selectOption } from '@utils';
+import { selectOption } from '@utils';
 import { selectButtonByTitle } from '@utils/clicks/selectButtonByTitle';
 import { clickOnFileFormatDropdown } from '@utils/formats';
 import {

--- a/ketcher-autotests/tests/utils/scrollSettingBar.ts
+++ b/ketcher-autotests/tests/utils/scrollSettingBar.ts
@@ -1,10 +1,10 @@
-import { Page } from "@playwright/test";
+import { Page } from '@playwright/test';
 
 // It's a temporary workaround and will be eventually refactored to locator
-export async function scrollSettingBar (page: Page, scrollLength: number){ 
-    const deltaX = 0;
-    const scrollBarCoordinatesX = 638;
-    const scrollBarCoordinatesY = 524;
-    await page.mouse.move(scrollBarCoordinatesX, scrollBarCoordinatesY);
-    await page.mouse.wheel(deltaX, scrollLength);
-  }
+export async function scrollSettingBar(page: Page, scrollLength: number) {
+  const deltaX = 0;
+  const scrollBarCoordinatesX = 638;
+  const scrollBarCoordinatesY = 524;
+  await page.mouse.move(scrollBarCoordinatesX, scrollBarCoordinatesY);
+  await page.mouse.wheel(deltaX, scrollLength);
+}

--- a/packages/ketcher-polymer-editor-react/src/Editor.tsx
+++ b/packages/ketcher-polymer-editor-react/src/Editor.tsx
@@ -110,7 +110,6 @@ function EditorContainer({
   useEffect(() => {
     onInit?.();
   }, [onInit]);
-  console.log('rootElRefЖ', rootElRef);
 
   return (
     <Provider store={store}>
@@ -156,7 +155,6 @@ function Editor({ theme, togglerComponent }: EditorProps) {
     [dispatchShowPreview],
   );
 
-  console.log('editor:', editor);
   useEffect(() => {
     if (editor) {
       editor.events.error.add((errorText) => {

--- a/packages/ketcher-polymer-editor-react/src/Editor.tsx
+++ b/packages/ketcher-polymer-editor-react/src/Editor.tsx
@@ -210,7 +210,8 @@ function Editor({ theme, togglerComponent }: EditorProps) {
     });
     editor?.events.mouseOnMoveMonomer.add((e) => {
       handleClosePreview();
-      if (e.buttons !== 1 || !noPreviewTools.includes(activeTool)) {
+      const isLeftClick = e.buttons === 1;
+      if (!isLeftClick || !noPreviewTools.includes(activeTool)) {
         handleOpenPreview(e);
       }
     });

--- a/packages/ketcher-polymer-editor-react/src/Editor.tsx
+++ b/packages/ketcher-polymer-editor-react/src/Editor.tsx
@@ -91,6 +91,8 @@ interface EditorProps {
   togglerComponent?: JSX.Element;
 }
 
+const noPreviewTools = ['bond-single'];
+
 function EditorContainer({
   onInit,
   theme,
@@ -223,6 +225,8 @@ function Editor({ theme, togglerComponent }: EditorProps) {
     dispatch(closeErrorTooltip());
   };
 
+  const shouldRenderPreview = !noPreviewTools.includes(activeTool);
+
   return (
     <>
       <Layout>
@@ -267,7 +271,9 @@ function Editor({ theme, togglerComponent }: EditorProps) {
         onClick={() => setIsMonomerLibraryHidden((prev) => !prev)}
       />
       <FullscreenButton />
-      <StyledPreview className="polymer-library-preview" />
+      {shouldRenderPreview && (
+        <StyledPreview className="polymer-library-preview" />
+      )}
       <ModalContainer />
       <ErrorModal />
       <Snackbar

--- a/packages/ketcher-polymer-editor-react/src/Editor.tsx
+++ b/packages/ketcher-polymer-editor-react/src/Editor.tsx
@@ -110,6 +110,7 @@ function EditorContainer({
   useEffect(() => {
     onInit?.();
   }, [onInit]);
+  console.log('rootElRefЖ', rootElRef);
 
   return (
     <Provider store={store}>
@@ -155,6 +156,7 @@ function Editor({ theme, togglerComponent }: EditorProps) {
     [dispatchShowPreview],
   );
 
+  console.log('editor:', editor);
   useEffect(() => {
     if (editor) {
       editor.events.error.add((errorText) => {
@@ -210,7 +212,9 @@ function Editor({ theme, togglerComponent }: EditorProps) {
     });
     editor?.events.mouseOnMoveMonomer.add((e) => {
       handleClosePreview();
-      handleOpenPreview(e);
+      if (e.buttons !== 1 || !noPreviewTools.includes(activeTool)) {
+        handleOpenPreview(e);
+      }
     });
   }, [editor, activeTool]);
 
@@ -224,8 +228,6 @@ function Editor({ theme, togglerComponent }: EditorProps) {
   const handleCloseErrorTooltip = () => {
     dispatch(closeErrorTooltip());
   };
-
-  const shouldRenderPreview = !noPreviewTools.includes(activeTool);
 
   return (
     <>
@@ -271,9 +273,7 @@ function Editor({ theme, togglerComponent }: EditorProps) {
         onClick={() => setIsMonomerLibraryHidden((prev) => !prev)}
       />
       <FullscreenButton />
-      {shouldRenderPreview && (
-        <StyledPreview className="polymer-library-preview" />
-      )}
+      <StyledPreview className="polymer-library-preview" />
       <ModalContainer />
       <ErrorModal />
       <Snackbar


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
This PR prevents monomer preview from being displayed when user is drawing a polymer bond

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request