### PR TITLE
#2414 fix for bonds creation broken after merge of undo/redo task.

### DIFF
--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -250,6 +250,7 @@ class PolymerBond implements BaseTool {
         return;
       }
       const modelChanges = this.finishBondCreation(renderer.monomer);
+      this.history.update(modelChanges);
       this.editor.renderersContainer.update(modelChanges);
       this.editor.renderersContainer.deletePolymerBond(
         this.bondRenderer.polymerBond,
@@ -368,7 +369,7 @@ class PolymerBond implements BaseTool {
         firstSelectedAttachmentPoint,
         secondSelectedAttachmentPoint,
       );
-
+    this.history.update(modelChanges);
     this.editor.renderersContainer.update(modelChanges);
     if (firstSelectedAttachmentPoint === secondSelectedAttachmentPoint) {
       this.editor.events.error.dispatch(
@@ -376,6 +377,9 @@ class PolymerBond implements BaseTool {
       );
     }
     this.isBondConnectionModalOpen = false;
+    this.editor.renderersContainer.deletePolymerBond(
+      this.bondRenderer.polymerBond,
+    );
     this.bondRenderer = undefined;
   };
 


### PR DESCRIPTION
- added bond creation to history for more cases (creation through modal window, creation by using specific attachment points)
- fixed temporary bond preview deletion after creation of bond through the modal window

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request