### PR TITLE
#3643 - Error appears in DevTool Console after call 'ketcher.setSettings' before templates initialization

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/templates/init-lib.ts
+++ b/packages/ketcher-react/src/script/ui/state/templates/init-lib.ts
@@ -28,6 +28,7 @@ import templatesRawData from '../../../../templates/library.sdf';
 import { AnyAction, Dispatch } from 'redux';
 
 let cachedInitData: [Dispatch<AnyAction>, string, Element];
+let needReinitializeTemplateLibrary = false;
 
 interface TemplateLibrary {
   type: string;
@@ -79,14 +80,17 @@ export default async function initTmplLib(
     const lib = res.concat(userTmpls());
     dispatch(initLib(lib));
     dispatch(appUpdate({ templates: true }) as unknown as AnyAction);
+    if (needReinitializeTemplateLibrary) {
+      reinitializeTemplateLibrary();
+      needReinitializeTemplateLibrary = false;
+    }
   });
 }
 
 export function reinitializeTemplateLibrary(): void {
   if (!cachedInitData) {
-    throw new Error(
-      'The template library must be initialized before it can be reinitialized',
-    );
+    needReinitializeTemplateLibrary = true;
+    return;
   }
 
   initTmplLib(...cachedInitData);


### PR DESCRIPTION
- added postponing of templates library reinitialization if it is not yet initialized

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request