### PR TITLE
#3623 - Icons are too small if ketcher inserted in react component instead of iframe

### DIFF
--- a/packages/ketcher-react/src/Editor.module.less
+++ b/packages/ketcher-react/src/Editor.module.less
@@ -40,6 +40,8 @@
   color: @main-color;
   min-width: 640px;
   min-height: 400px;
+  /* stylelint-disable-next-line */
+  container-type: size;
 
   select {
     padding: 0 8px !important;

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.tsx
@@ -86,18 +86,22 @@ const ControlsPanel = styled('div')`
     box-sizing: border-box;
   }
 
-  @media only screen and (min-width: 1024px) {
-    height: 40px;
-    gap: 0px;
-    padding-bottom: 0;
-    .group {
-      gap: 4px;
+  @media only screen {
+    @container (min-width: 1024px) {
+      height: 40px;
+      gap: 0px;
+      padding-bottom: 0;
+      .group {
+        gap: 4px;
+      }
     }
   }
 
-  @media only screen and (min-width: 1920px) {
-    height: 64px;
-    gap: 12px;
+  @media only screen {
+    @container (min-width: 1920px) {
+      height: 64px;
+      gap: 12px;
+    }
   }
 `;
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbarIconButton.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbarIconButton.ts
@@ -21,14 +21,18 @@ export const TopToolbarIconButton = styled(IconButton)`
   border-radius: 4px;
   padding: 2px;
 
-  @media only screen and (min-width: 1024px) {
-    height: 32px;
-    width: 32px;
-    padding: 4px;
+  @media only screen {
+    @container (min-width: 1024px) {
+      height: 32px;
+      width: 32px;
+      padding: 4px;
+    }
   }
-  @media only screen and (min-width: 1920px) {
-    height: 40px;
-    width: 40px;
-    padding: 5px;
+  @media only screen {
+    @container (min-width: 1920px) {
+      height: 40px;
+      width: 40px;
+      padding: 5px;
+    }
   }
 `;


### PR DESCRIPTION
- changed media queries for top toolbar icons to container ones

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request