### PR TITLE
#3702 - Macro: 'Uncaught DOMException' error in DevTool console after switch from Macro to Micro mode

### DIFF
--- a/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
+++ b/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
@@ -78,6 +78,9 @@ class SelectRectangle implements BaseTool {
 
     const handleResizeCanvas = () => {
       const { canvas } = this.editor;
+      if (canvas.clientWidth === 0) {
+        return;
+      }
 
       this.brush.extent([
         [0, 0],

--- a/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
+++ b/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
@@ -78,7 +78,7 @@ class SelectRectangle implements BaseTool {
 
     const handleResizeCanvas = () => {
       const { canvas } = this.editor;
-      if (canvas.clientWidth === 0) {
+      if (canvas.clientWidth === 0 || canvas.clientHeight === 0) {
         return;
       }
 


### PR DESCRIPTION
- exit from resize handler in case if canvas has width 0

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request