### PR TITLE
#3766 - Macro: Incorrect attachment point labels parsing from ket

### DIFF
--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -297,17 +297,26 @@ export abstract class BaseMonomer extends DrawingEntity {
     Record<AttachmentPointName, PolymerBond | null>
   > {
     if (this.monomerItem.attachmentPoints) {
-      return this.getAttachmentPointDictFromMonomerDefinition();
+      const { attachmentPointDictionnary } =
+        BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
+          this.monomerItem.attachmentPoints,
+        );
+      return attachmentPointDictionnary;
     } else {
       return this.getAttachmentPointDictFromAtoms();
     }
   }
 
-  public getAttachmentPointDictFromMonomerDefinition(): Partial<
-    Record<AttachmentPointName, PolymerBond | null>
-  > {
-    assert(this.monomerItem.attachmentPoints);
+  public static getAttachmentPointDictFromMonomerDefinition(
+    attachmentPoints: IKetAttachmentPoint[],
+  ): {
+    attachmentPointDictionnary: Partial<
+      Record<AttachmentPointName, PolymerBond | null>
+    >;
+    attachmentPointsList: AttachmentPointName[];
+  } {
     const attachmentPointDictionnary = {};
+    const attachmentPointsList: AttachmentPointName[] = [];
     const attachmentPointTypeToNumber: {
       [key in IKetAttachmentPointType]: (
         attachmentPointNumber?: number,
@@ -319,26 +328,25 @@ export abstract class BaseMonomer extends DrawingEntity {
         assert(attachmentPointNumber);
         return (
           attachmentPointNumber +
-          Number(!('R1' in attachmentPointDictionnary)) -
+          Number(!('R1' in attachmentPointDictionnary)) +
           Number(!('R2' in attachmentPointDictionnary))
         );
       },
     };
-    this.monomerItem.attachmentPoints.forEach(
-      (attachmentPoint, attachmentPointIndex) => {
-        const attachmentPointNumber = attachmentPointIndex + 1;
-        const calculatedLabel = `R${
-          attachmentPoint.type
-            ? attachmentPointTypeToNumber[attachmentPoint.type](
-                attachmentPointNumber,
-              )
-            : attachmentPointNumber
-        }`;
-        attachmentPointDictionnary[attachmentPoint.label || calculatedLabel] =
-          null;
-      },
-    );
-    return attachmentPointDictionnary;
+    attachmentPoints.forEach((attachmentPoint, attachmentPointIndex) => {
+      const attachmentPointNumber = attachmentPointIndex + 1;
+      const calculatedLabel = `R${
+        attachmentPoint.type
+          ? attachmentPointTypeToNumber[attachmentPoint.type](
+              attachmentPointNumber,
+            )
+          : attachmentPointNumber
+      }`;
+      const label = attachmentPoint.label || calculatedLabel;
+      attachmentPointDictionnary[label] = null;
+      attachmentPointsList.push(label as AttachmentPointName);
+    });
+    return { attachmentPointDictionnary, attachmentPointsList };
   }
 
   public get attachmentPointNumberToType() {

--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -337,7 +337,7 @@ export abstract class BaseMonomer extends DrawingEntity {
       const attachmentPointNumber = attachmentPointIndex + 1;
       const calculatedLabel = `R${
         attachmentPoint.type &&
-        attachmentPointTypeToNumber[attachmentPoint.type]
+        typeof attachmentPointTypeToNumber[attachmentPoint.type] === 'function'
           ? attachmentPointTypeToNumber[attachmentPoint.type](
               attachmentPointNumber,
             )

--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -297,11 +297,11 @@ export abstract class BaseMonomer extends DrawingEntity {
     Record<AttachmentPointName, PolymerBond | null>
   > {
     if (this.monomerItem.attachmentPoints) {
-      const { attachmentPointDictionnary } =
+      const { attachmentPointDictionary } =
         BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
           this.monomerItem.attachmentPoints,
         );
-      return attachmentPointDictionnary;
+      return attachmentPointDictionary;
     } else {
       return this.getAttachmentPointDictFromAtoms();
     }
@@ -310,12 +310,12 @@ export abstract class BaseMonomer extends DrawingEntity {
   public static getAttachmentPointDictFromMonomerDefinition(
     attachmentPoints: IKetAttachmentPoint[],
   ): {
-    attachmentPointDictionnary: Partial<
+    attachmentPointDictionary: Partial<
       Record<AttachmentPointName, PolymerBond | null>
     >;
     attachmentPointsList: AttachmentPointName[];
   } {
-    const attachmentPointDictionnary = {};
+    const attachmentPointDictionary = {};
     const attachmentPointsList: AttachmentPointName[] = [];
     const attachmentPointTypeToNumber: {
       [key in IKetAttachmentPointType]: (
@@ -328,8 +328,8 @@ export abstract class BaseMonomer extends DrawingEntity {
         assert(attachmentPointNumber);
         return (
           attachmentPointNumber +
-          Number(!('R1' in attachmentPointDictionnary)) +
-          Number(!('R2' in attachmentPointDictionnary))
+          Number(!('R1' in attachmentPointDictionary)) +
+          Number(!('R2' in attachmentPointDictionary))
         );
       },
     };
@@ -350,10 +350,10 @@ export abstract class BaseMonomer extends DrawingEntity {
       }
       const calculatedLabel =
         attachmentPoint.label || `R${calculatedAttachmentPointNumber}`;
-      attachmentPointDictionnary[calculatedLabel] = null;
+      attachmentPointDictionary[calculatedLabel] = null;
       attachmentPointsList.push(calculatedLabel as AttachmentPointName);
     });
-    return { attachmentPointDictionnary, attachmentPointsList };
+    return { attachmentPointDictionary, attachmentPointsList };
   }
 
   public get attachmentPointNumberToType() {

--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -336,7 +336,8 @@ export abstract class BaseMonomer extends DrawingEntity {
     attachmentPoints.forEach((attachmentPoint, attachmentPointIndex) => {
       const attachmentPointNumber = attachmentPointIndex + 1;
       const calculatedLabel = `R${
-        attachmentPoint.type
+        attachmentPoint.type &&
+        attachmentPointTypeToNumber[attachmentPoint.type]
           ? attachmentPointTypeToNumber[attachmentPoint.type](
               attachmentPointNumber,
             )

--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -335,17 +335,23 @@ export abstract class BaseMonomer extends DrawingEntity {
     };
     attachmentPoints.forEach((attachmentPoint, attachmentPointIndex) => {
       const attachmentPointNumber = attachmentPointIndex + 1;
-      const calculatedLabel = `R${
-        attachmentPoint.type &&
-        typeof attachmentPointTypeToNumber[attachmentPoint.type] === 'function'
-          ? attachmentPointTypeToNumber[attachmentPoint.type](
-              attachmentPointNumber,
-            )
-          : attachmentPointNumber
-      }`;
-      const label = attachmentPoint.label || calculatedLabel;
-      attachmentPointDictionnary[label] = null;
-      attachmentPointsList.push(label as AttachmentPointName);
+      let calculatedAttachmentPointNumber;
+      if (attachmentPoint.type) {
+        const getLabelByTypeAction =
+          attachmentPointTypeToNumber[attachmentPoint.type];
+        calculatedAttachmentPointNumber =
+          typeof getLabelByTypeAction === 'function'
+            ? attachmentPointTypeToNumber[attachmentPoint.type](
+                attachmentPointNumber,
+              )
+            : attachmentPointNumber;
+      } else {
+        calculatedAttachmentPointNumber = attachmentPointNumber;
+      }
+      const calculatedLabel =
+        attachmentPoint.label || `R${calculatedAttachmentPointNumber}`;
+      attachmentPointDictionnary[calculatedLabel] = null;
+      attachmentPointsList.push(calculatedLabel as AttachmentPointName);
     });
     return { attachmentPointDictionnary, attachmentPointsList };
   }

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -322,7 +322,6 @@ export class KetSerializer implements Serializer<Struct> {
             BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
               template.attachmentPoints || [],
             );
-          const parsedAttachmentPointsNumbers = [];
 
           template.attachmentPoints?.forEach(
             (attachmentPoint, attachmentPointIndex) => {
@@ -331,7 +330,6 @@ export class KetSerializer implements Serializer<Struct> {
                   attachmentPoint.attachmentAtom,
               );
               assert(leavingGroupAtom);
-              parsedAttachmentPointsNumbers.push();
               leavingGroupAtom.rglabel = (
                 0 |
                 (1 <<

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -318,6 +318,12 @@ export class KetSerializer implements Serializer<Struct> {
             .monomer as BaseMonomer;
           monomerIdsMap[node.$ref] = monomer?.id;
 
+          const { attachmentPointsList } =
+            BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
+              template.attachmentPoints || [],
+            );
+          const parsedAttachmentPointsNumbers = [];
+
           template.attachmentPoints?.forEach(
             (attachmentPoint, attachmentPointIndex) => {
               const leavingGroupAtom = monomer.monomerItem.struct.atoms.get(
@@ -325,14 +331,18 @@ export class KetSerializer implements Serializer<Struct> {
                   attachmentPoint.attachmentAtom,
               );
               assert(leavingGroupAtom);
+              parsedAttachmentPointsNumbers.push();
               leavingGroupAtom.rglabel = (
                 0 |
                 (1 <<
-                  (attachmentPoint.label
-                    ? Number(attachmentPoint.label.replace('R', '')) - 1
-                    : attachmentPointIndex))
+                  (Number(
+                    (attachmentPoint.label
+                      ? attachmentPoint.label
+                      : attachmentPointsList[attachmentPointIndex]
+                    ).replace('R', ''),
+                  ) -
+                    1))
               ).toString();
-
               assert(monomer.monomerItem.props.MonomerCaps);
               monomer.monomerItem.props.MonomerCaps[
                 convertAttachmentPointNumberToLabel(


### PR DESCRIPTION
- fixed atom rglabel and monomers attachment points parsing from ket in case when label is not set explicitly

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request