### PR TITLE
#3738 - Macro/Micro: Switching from Macromolecules view to Molecules view causes crash if custom aromatic hydrocarbon was connected with monomer

### DIFF
--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -292,7 +292,11 @@ export class MacromoleculesConverter {
         MacromoleculesConverter.getAttachmentPointLabel(beginAtom);
       const endAtomAttachmentPointNumber =
         MacromoleculesConverter.getAttachmentPointLabel(endAtom);
-      if (beginAtomAttachmentPointNumber && endAtomAttachmentPointNumber) {
+      if (
+        beginAtomAttachmentPointNumber &&
+        endAtomAttachmentPointNumber &&
+        (beginAtomSgroup || endAtomSgroup)
+      ) {
         // Here we take monomers from sgroupToMonomer in case of macromolecules structure and
         // from fragmentIdToMonomer in case of micromolecules structure.
         const firstMonomer =

--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -76,20 +76,31 @@ export class MacromoleculesConverter {
   }
 
   private static findAttachmentPointAtom(
-    sgroup: SGroup,
     polymerBond: PolymerBond,
     monomer: BaseMonomer,
     struct: Struct,
+    sgroup?: SGroup,
+    fragmentId?: number,
   ) {
     const attachmentPointName = monomer.getAttachmentPointByBond(polymerBond);
     assert(attachmentPointName);
-    return sgroup.atoms.find(
-      (atomId) =>
-        Number(struct.atoms.get(atomId)?.rglabel) ===
-        MacromoleculesConverter.convertAttachmentPointNameToNumber(
-          attachmentPointName,
-        ),
-    );
+    const attachmentPointNumber =
+      MacromoleculesConverter.convertAttachmentPointNameToNumber(
+        attachmentPointName,
+      );
+
+    return sgroup
+      ? sgroup.atoms.find(
+          (atomId) =>
+            Number(struct.atoms.get(atomId)?.rglabel) === attachmentPointNumber,
+        )
+      : struct.atoms.find((atomId) => {
+          const atom = struct.atoms.get(atomId) as Atom;
+          return (
+            atom.fragment === fragmentId &&
+            Number(atom.rglabel) === attachmentPointNumber
+          );
+        });
   }
 
   public static convertDrawingEntitiesToStruct(
@@ -98,6 +109,7 @@ export class MacromoleculesConverter {
     reStruct?: ReStruct,
   ) {
     const monomerToSgroup = new Map<BaseMonomer, SGroup>();
+    const monomerToFragmentId = new Map<BaseMonomer, number>();
 
     drawingEntitiesManager.micromoleculesHiddenEntities.mergeInto(struct);
 
@@ -105,6 +117,7 @@ export class MacromoleculesConverter {
     drawingEntitiesManager.monomers.forEach((monomer) => {
       if (monomer.monomerItem.props.isMicromoleculeFragment) {
         monomer.monomerItem.struct.mergeInto(struct);
+        monomerToFragmentId.set(monomer, struct.frags.size - 1);
       } else {
         const atomIdsMap = {};
         const monomerMicromolecule = this.convertMonomerToMonomerMicromolecule(
@@ -146,16 +159,18 @@ export class MacromoleculesConverter {
     drawingEntitiesManager.polymerBonds.forEach((polymerBond) => {
       assert(polymerBond.secondMonomer);
       const beginAtom = this.findAttachmentPointAtom(
-        monomerToSgroup.get(polymerBond.firstMonomer) as SGroup,
         polymerBond,
         polymerBond.firstMonomer,
         struct,
+        monomerToSgroup.get(polymerBond.firstMonomer),
+        monomerToFragmentId.get(polymerBond.firstMonomer),
       );
       const endAtom = this.findAttachmentPointAtom(
-        monomerToSgroup.get(polymerBond.secondMonomer) as SGroup,
         polymerBond,
         polymerBond.secondMonomer,
         struct,
+        monomerToSgroup.get(polymerBond.secondMonomer),
+        monomerToFragmentId.get(polymerBond.secondMonomer),
       );
 
       if (!beginAtom || !endAtom) {
@@ -223,9 +238,9 @@ export class MacromoleculesConverter {
     );
   }
 
-  public static getAttachmentPointLabel(atomId: number, struct: Struct) {
+  public static getAttachmentPointLabel(atom: Atom) {
     let attachmentPointLabel = '';
-    const atomRglabel = Number(struct.atoms.get(atomId)?.rglabel);
+    const atomRglabel = Number(atom.rglabel);
     assert(Number.isInteger(atomRglabel));
     for (let rgi = 0; rgi < 32; rgi++) {
       if (atomRglabel & (1 << rgi)) {
@@ -240,6 +255,7 @@ export class MacromoleculesConverter {
     drawingEntitiesManager: DrawingEntitiesManager,
   ) {
     const sgroupToMonomer = new Map<SGroup, BaseMonomer>();
+    const fragmentIdToMonomer = new Map<number, BaseMonomer>();
     const command = new Command();
     struct.sgroups.forEach((sgroup) => {
       if (sgroup instanceof MonomerMicromolecule) {
@@ -255,30 +271,38 @@ export class MacromoleculesConverter {
     let fragmentNumber = 1;
     struct.frags.forEach((_fragment, fragmentId) => {
       const fragmentStruct = struct.getFragment(fragmentId, false);
-      command.merge(
-        this.convertFragmentToChem(
-          fragmentNumber,
-          fragmentStruct,
-          drawingEntitiesManager,
-        ),
+      const monomerAddCommand = this.convertFragmentToChem(
+        fragmentNumber,
+        fragmentStruct,
+        drawingEntitiesManager,
       );
+      fragmentIdToMonomer.set(
+        fragmentId,
+        monomerAddCommand.operations[0].monomer as BaseMonomer,
+      );
+      command.merge(monomerAddCommand);
       fragmentNumber++;
     });
     struct.bonds.forEach((bond) => {
+      const beginAtom = struct.atoms.get(bond.begin) as Atom;
+      const endAtom = struct.atoms.get(bond.end) as Atom;
       const beginAtomSgroup = struct.getGroupFromAtomId(bond.begin);
       const endAtomSgroup = struct.getGroupFromAtomId(bond.end);
       const beginAtomAttachmentPointNumber =
-        MacromoleculesConverter.getAttachmentPointLabel(bond.begin, struct);
+        MacromoleculesConverter.getAttachmentPointLabel(beginAtom);
       const endAtomAttachmentPointNumber =
-        MacromoleculesConverter.getAttachmentPointLabel(bond.end, struct);
-      if (
-        beginAtomAttachmentPointNumber &&
-        endAtomAttachmentPointNumber &&
-        beginAtomSgroup instanceof MonomerMicromolecule &&
-        endAtomSgroup instanceof MonomerMicromolecule
-      ) {
-        const firstMonomer = sgroupToMonomer.get(beginAtomSgroup);
-        const secondMonomer = sgroupToMonomer.get(endAtomSgroup);
+        MacromoleculesConverter.getAttachmentPointLabel(endAtom);
+      if (beginAtomAttachmentPointNumber && endAtomAttachmentPointNumber) {
+        // Here we take monomers from sgroupToMonomer in case of macromolecules structure and
+        // from fragmentIdToMonomer in case of micromolecules structure.
+        const firstMonomer =
+          beginAtomSgroup instanceof MonomerMicromolecule
+            ? sgroupToMonomer.get(beginAtomSgroup)
+            : fragmentIdToMonomer.get(beginAtom.fragment);
+        const secondMonomer =
+          endAtomSgroup instanceof MonomerMicromolecule
+            ? sgroupToMonomer.get(endAtomSgroup)
+            : fragmentIdToMonomer.get(endAtom.fragment);
         assert(firstMonomer);
         assert(secondMonomer);
 

--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -17,9 +17,7 @@ export abstract class BaseMonomer extends DrawingEntity {
   public renderer?: BaseMonomerRenderer = undefined;
   public attachmentPointsToBonds: Partial<
     Record<AttachmentPointName, PolymerBond | null>
-  > = {
-    R1: null,
-  };
+  > = {};
 
   public chosenFirstAttachmentPointForBond: string | null;
   public potentialSecondAttachmentPointForBond: string | null;
@@ -27,9 +25,7 @@ export abstract class BaseMonomer extends DrawingEntity {
 
   public potentialAttachmentPointsToBonds: {
     [key: string]: PolymerBond | null | undefined;
-  } = {
-    R1: null,
-  };
+  } = {};
 
   public attachmentPointsVisible = false;
   public monomerItem: MonomerItemType;
@@ -37,14 +33,16 @@ export abstract class BaseMonomer extends DrawingEntity {
     super(_position);
 
     this.monomerItem = { ...monomerItem };
-    this.attachmentPointsToBonds = this.getAttachmentPointDict();
-    this.potentialAttachmentPointsToBonds = this.getAttachmentPointDict();
+    if (!this.monomerItem.props.isMicromoleculeFragment) {
+      this.attachmentPointsToBonds = this.getAttachmentPointDict();
+      this.potentialAttachmentPointsToBonds = this.getAttachmentPointDict();
+      this.monomerItem.attachmentPoints =
+        this.monomerItem.attachmentPoints ||
+        this.getMonomerDefinitionAttachmentPoints();
+    }
     this.chosenFirstAttachmentPointForBond = null;
     this.potentialSecondAttachmentPointForBond = null;
     this.chosenSecondAttachmentPointForBond = null;
-    this.monomerItem.attachmentPoints =
-      this.monomerItem.attachmentPoints ||
-      this.getMonomerDefinitionAttachmentPoints();
   }
 
   public get label() {

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -486,6 +486,12 @@ export class KetSerializer implements Serializer<Struct> {
     });
     drawingEntitiesManager.polymerBonds.forEach((polymerBond) => {
       assert(polymerBond.secondMonomer);
+      if (
+        polymerBond.firstMonomer.monomerItem.props.isMicromoleculeFragment ||
+        polymerBond.secondMonomer.monomerItem.props.isMicromoleculeFragment
+      ) {
+        return;
+      }
       fileContent.root.connections.push({
         connectionType: 'single',
         endpoint1: {


### PR DESCRIPTION
- added ability to bond micro and macro structures in macro mode

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request