### PR TITLE
#3712 - Macro: Pressing Layout/Clean Up button cleanup all macromoleculas from canvas

### DIFF
--- a/packages/ketcher-core/src/domain/entities/monomerMicromolecule.ts
+++ b/packages/ketcher-core/src/domain/entities/monomerMicromolecule.ts
@@ -20,11 +20,24 @@ import assert from 'assert';
 export class MonomerMicromolecule extends SGroup {
   constructor(type: string, public monomer) {
     super(type);
+    this.data.absolute = false;
+    this.data.attached = false;
   }
 
   public override getContractedPosition(struct: Struct) {
     assert(this.pp);
     const sgroupContractedPosition = super.getContractedPosition(struct);
     return { position: this.pp, atomId: sgroupContractedPosition.atomId };
+  }
+
+  public static clone(monomerMicromolecule: MonomerMicromolecule) {
+    const monomerMicromoleculeClone = new MonomerMicromolecule(
+      monomerMicromolecule.type,
+      monomerMicromolecule.monomer,
+    );
+    monomerMicromoleculeClone.pp = monomerMicromolecule.pp;
+    monomerMicromoleculeClone.atoms = monomerMicromolecule.atoms;
+
+    return monomerMicromoleculeClone;
   }
 }

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -339,7 +339,7 @@ export class SGroup {
   }
 
   static getOffset(sgroup: SGroup): null | Vec2 {
-    if (!sgroup?.pp) return null;
+    if (!sgroup?.pp || !sgroup.bracketBox) return null;
     return Vec2.diff(sgroup.pp, sgroup.bracketBox.p1);
   }
 

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -280,8 +280,13 @@ export class Struct {
 
     this.sgroups.forEach((sg) => {
       if (sg.atoms.some((aid) => !atomSet!.has(aid))) return;
+      const oldSgroup = sg;
 
-      sg = SGroup.clone(sg, aidMap!);
+      sg =
+        oldSgroup instanceof MonomerMicromolecule
+          ? MonomerMicromolecule.clone(oldSgroup)
+          : SGroup.clone(sg, aidMap!);
+
       const id = cp.sgroups.add(sg);
       sg.id = id;
 


### PR DESCRIPTION
- fixed macromolecules cloning in struct to include it into ket for indigo layout

## How the feature works? / How did you fix the issue?
During the struct cloning MonomerMicromolecule was converting into SGroup and we were loosing the information that structure is monomer. To fix that it was implemented clone method in MonomerMicromolecule. Also added setting of several attributes of sgroup in MonomerMicromolecule which needs to render monomers properly n molecules mode.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request