### PR TITLE
#3846 - macro class field is absent after serialisation to ket

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -49,6 +49,12 @@ export class RenderersManager {
   public addMonomer(monomer: BaseMonomer, callback?: () => void) {
     const [, MonomerRenderer] = monomerFactory(monomer.monomerItem);
     const monomerRenderer = new MonomerRenderer(monomer);
+
+    monomer.monomerItem.props = {
+      ...monomer.monomerItem.props,
+      MonomerClass: monomer.constructor.name,
+    };
+
     this.monomers.set(monomer.id, monomerRenderer);
     monomerRenderer.show(this.theme);
     this.markForReEnumeration();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

- added MonomerClass for monomers

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [x] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request