### PR TITLE
Macro: #3874 - R2 label is displayed on attachment atom instead of leaving group in monomer preview

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -56,6 +56,7 @@ import { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { validate } from 'domain/serializers/ket/validate';
 import { MacromoleculesConverter } from 'application/editor/MacromoleculesConverter';
 import { convertAttachmentPointNumberToLabel } from 'domain/helpers/attachmentPointCalculations';
+import { isNumber } from 'lodash';
 
 function parseNode(node: any, struct: any) {
   const type = node.type;
@@ -331,9 +332,12 @@ export class KetSerializer implements Serializer<Struct> {
 
           template.attachmentPoints?.forEach(
             (attachmentPoint, attachmentPointIndex) => {
+              const firstAtomInLeavingGroup =
+                attachmentPoint.leavingGroup?.atoms[0];
               const leavingGroupAtom = monomer.monomerItem.struct.atoms.get(
-                attachmentPoint.leavingGroup?.atoms[0] ||
-                  attachmentPoint.attachmentAtom,
+                isNumber(firstAtomInLeavingGroup)
+                  ? firstAtomInLeavingGroup
+                  : attachmentPoint.attachmentAtom,
               );
               assert(leavingGroupAtom);
               leavingGroupAtom.rglabel = (


### PR DESCRIPTION
- fixed leaving group searching during ket deserialization

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request