### PR TITLE
#3711 - @react-refresh removes Ketcher from DOM

### DIFF
--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -22,7 +22,7 @@ import 'whatwg-fetch';
 import './index.less';
 
 import init, { Config } from './script';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Ketcher } from 'ketcher-core';
 import classes from './Editor.module.less';
@@ -32,7 +32,7 @@ import {
   KETCHER_INIT_EVENT_NAME,
   KETCHER_ROOT_NODE_CLASS_NAME,
 } from './constants';
-import { createRoot } from 'react-dom/client';
+import { createRoot, Root } from 'react-dom/client';
 
 const mediaSizes = {
   smallWidth: 1040,
@@ -50,7 +50,7 @@ function Editor(props: EditorProps) {
     ref: rootElRef,
   });
   const ketcherInitEvent = new Event(KETCHER_INIT_EVENT_NAME);
-
+  const [appRoot, setAppRoot] = useState<Root | null>(null);
   useEffect(() => {
     const appRoot = createRoot(rootElRef.current as HTMLDivElement);
     init({
@@ -63,12 +63,20 @@ function Editor(props: EditorProps) {
         window.dispatchEvent(ketcherInitEvent);
       }
     });
-    return () => {
-      appRoot.unmount();
-    };
+    // set root to a state so we can use it in the other useEffect
+    setAppRoot(appRoot);
     // TODO: provide the list of dependencies after implementing unsubscribe function
   }, []);
-
+  // separate useEffect for cleanup This prevents funkyness in strictmode.
+  useEffect(() => {
+    return () => {
+      // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
+      setTimeout(() => {
+        appRoot?.unmount();
+        setAppRoot(appRoot);
+      });
+    };
+  }, [appRoot]); // if appRoot changes, cleanup
   return (
     <div
       ref={rootElRef}

--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -22,7 +22,7 @@ import 'whatwg-fetch';
 import './index.less';
 
 import init, { Config } from './script';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Ketcher } from 'ketcher-core';
 import classes from './Editor.module.less';
@@ -32,7 +32,7 @@ import {
   KETCHER_INIT_EVENT_NAME,
   KETCHER_ROOT_NODE_CLASS_NAME,
 } from './constants';
-import { createRoot, Root } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 
 const mediaSizes = {
   smallWidth: 1040,
@@ -50,7 +50,7 @@ function Editor(props: EditorProps) {
     ref: rootElRef,
   });
   const ketcherInitEvent = new Event(KETCHER_INIT_EVENT_NAME);
-  const [appRoot, setAppRoot] = useState<Root | null>(null);
+
   useEffect(() => {
     const appRoot = createRoot(rootElRef.current as HTMLDivElement);
     init({
@@ -63,20 +63,12 @@ function Editor(props: EditorProps) {
         window.dispatchEvent(ketcherInitEvent);
       }
     });
-    // set root to a state so we can use it in the other useEffect
-    setAppRoot(appRoot);
+    return () => {
+      appRoot.unmount();
+    };
     // TODO: provide the list of dependencies after implementing unsubscribe function
   }, []);
-  // separate useEffect for cleanup This prevents funkyness in strictmode.
-  useEffect(() => {
-    return () => {
-      // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
-      setTimeout(() => {
-        appRoot?.unmount();
-        setAppRoot(appRoot);
-      });
-    };
-  }, [appRoot]); // if appRoot changes, cleanup
+
   return (
     <div
       ref={rootElRef}

--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -50,7 +50,7 @@ function Editor(props: EditorProps) {
     ref: rootElRef,
   });
   const ketcherInitEvent = new Event(KETCHER_INIT_EVENT_NAME);
-  const isUnmounted = useRef(false);
+
   useEffect(() => {
     const appRoot = createRoot(rootElRef.current as HTMLDivElement);
     init({
@@ -64,14 +64,7 @@ function Editor(props: EditorProps) {
       }
     });
     return () => {
-      if (!isUnmounted.current) {
-        // In StrictMode, React double invokes and the component could be unmounted again due to the timeout.
-        isUnmounted.current = true;
-        // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
-        setTimeout(() => {
-          appRoot.unmount();
-        });
-      }
+      appRoot.unmount();
     };
     // TODO: provide the list of dependencies after implementing unsubscribe function
   }, []);

--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -50,7 +50,7 @@ function Editor(props: EditorProps) {
     ref: rootElRef,
   });
   const ketcherInitEvent = new Event(KETCHER_INIT_EVENT_NAME);
-
+  const isUnmounted = useRef(false);
   useEffect(() => {
     const appRoot = createRoot(rootElRef.current as HTMLDivElement);
     init({
@@ -64,10 +64,14 @@ function Editor(props: EditorProps) {
       }
     });
     return () => {
-      // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
-      setTimeout(() => {
-        appRoot.unmount();
-      });
+      isUnmounted.current = true;
+      // In StrictMode, React double invokes and the component could be unmounted again due to the timeout.
+      if (!isUnmounted.current) {
+        // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
+        setTimeout(() => {
+          appRoot.unmount();
+        });
+      }
     };
     // TODO: provide the list of dependencies after implementing unsubscribe function
   }, []);

--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -64,9 +64,9 @@ function Editor(props: EditorProps) {
       }
     });
     return () => {
-      isUnmounted.current = true;
-      // In StrictMode, React double invokes and the component could be unmounted again due to the timeout.
       if (!isUnmounted.current) {
+        // In StrictMode, React double invokes and the component could be unmounted again due to the timeout.
+        isUnmounted.current = true;
         // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
         setTimeout(() => {
           appRoot.unmount();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The root cause was the `setTimeout`. Due to the double invoke in Strict Mode, it is possible for the cleanup from the first invocation to run after the second `useEffect` has already started. This means that before `setTimeout` get's executed from the first `useEffect`,  there is a new `appRoot` from the second `useEffect`, and it get's unmounted when `setTimeout` function actually executes.

~~The solution is to check if `appRoot` has been mounted or not. This will prevent unmounting twice.~~

`appRoot.unmount();` should be synchronous so that it executes immediately after the unmount. I think it's worth it even if we get the 
`// setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"`
. Otherwise folks who use ketcher with strictmode would not be able to use ketcher at all.

closes #3711 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request