### PR TITLE
#3872 Add support for all query properties in Mol V2000

### DIFF
--- a/packages/ketcher-core/src/application/formatters/formatterFactory.ts
+++ b/packages/ketcher-core/src/application/formatters/formatterFactory.ts
@@ -70,6 +70,7 @@ export class FormatterFactory {
   create(
     format: SupportedFormat,
     options?: FormatterFactoryOptions,
+    queryPropertiesAreUsed?: boolean,
   ): StructFormatter {
     const [molSerializerOptions, structServiceOptions] =
       this.separateOptions(options);
@@ -81,9 +82,18 @@ export class FormatterFactory {
         break;
 
       case SupportedFormat.mol:
-        formatter = new MolfileV2000Formatter(
-          new MolSerializer(molSerializerOptions),
-        );
+        if (queryPropertiesAreUsed) {
+          formatter = new ServerFormatter(
+            this.#structService,
+            new KetSerializer(),
+            format,
+            structServiceOptions,
+          );
+        } else {
+          formatter = new MolfileV2000Formatter(
+            new MolSerializer(molSerializerOptions),
+          );
+        }
         break;
 
       case SupportedFormat.cml:

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -76,8 +76,12 @@ function parseStruct(
       struct = `base64::${struct.replace(/\s/g, '')}`;
     }
     const factory = new FormatterFactory(server);
-
-    const service = factory.create(format, formatterOptions);
+    const queryPropertiesAreUsed = format === 'mol' && struct.includes('MRV'); // temporary check if query properties are used
+    const service = factory.create(
+      format,
+      formatterOptions,
+      queryPropertiesAreUsed,
+    );
     return service.getStructureFromStringAsync(struct);
   } else {
     return Promise.resolve(struct);

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
@@ -182,7 +182,23 @@ class SaveDialog extends Component {
     } else {
       this.setState({ disableControls: true, isLoading: true });
       const factory = new FormatterFactory(server);
-      const service = factory.create(type, { ...options, ignoreChiralFlag });
+      // temporary check if query properties are used
+      const queryPropertiesAreUsed =
+        type === 'mol' &&
+        Array.from(struct.atoms).find(
+          ([_, atom]) =>
+            atom.queryProperties.aromaticity ||
+            atom.queryProperties.connectivity ||
+            atom.queryProperties.ringMembership ||
+            atom.queryProperties.ringSize ||
+            atom.queryProperties.customQuery ||
+            atom.implicitHCount,
+        );
+      const service = factory.create(
+        type,
+        { ...options, ignoreChiralFlag },
+        queryPropertiesAreUsed,
+      );
 
       return service
         .getStructureFromStructAsync(struct)


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Added check for saving in mol v2000 (check for properties) and loading from mol v2000 ('MRV' substring)

<img width="1427" alt="Screenshot 2024-01-15 at 15 45 38" src="https://github.com/epam/ketcher/assets/9428000/677b1e46-c666-491e-b684-120bb025471b">
<img width="1432" alt="Screenshot 2024-01-15 at 15 46 30" src="https://github.com/epam/ketcher/assets/9428000/9e8b887a-be25-486f-9e75-86a537956a6f">

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request