### PR TITLE
Macro: #3900 - The last letter in RNA Builder name field cannot be deleted

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -146,10 +146,16 @@ export const RnaEditorExpanded = ({
   const onChangeName = (event: ChangeEvent<HTMLInputElement>) => {
     if (isEditMode) {
       const newPresetName = event.target.value;
-      if (newPresetName.trim() !== '') {
+      if (newPresetName !== '') {
         setNewPrest({
           ...newPreset,
           name: newPresetName.trim(),
+          editedName: true,
+        });
+      } else {
+        setNewPrest({
+          ...newPreset,
+          name: '',
           editedName: true,
         });
       }

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -146,19 +146,11 @@ export const RnaEditorExpanded = ({
   const onChangeName = (event: ChangeEvent<HTMLInputElement>) => {
     if (isEditMode) {
       const newPresetName = event.target.value;
-      if (newPresetName !== '') {
-        setNewPrest({
-          ...newPreset,
-          name: newPresetName.trim(),
-          editedName: true,
-        });
-      } else {
-        setNewPrest({
-          ...newPreset,
-          name: '',
-          editedName: true,
-        });
-      }
+      setNewPrest({
+        ...newPreset,
+        name: newPresetName.trim(),
+        editedName: true,
+      });
     }
   };
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The trim() method in the `onChangeName` function prevented the deletion of the last letter. Adjusted logic to allow for the removal of all characters, while still trimming input for the new state.

https://github.com/epam/ketcher/assets/72468284/10317cc4-5156-4319-a00a-f6290879ae1c




## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request