### PR TITLE
Macro: #3736 - System marks availiable connection point as unavaliable in Select Connection Point dialog

### DIFF
--- a/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
@@ -191,7 +191,12 @@ function AttachmentPointSelectionPanel({
 
   useEffect(() => {
     setBonds(monomer.attachmentPointsToBonds);
-  }, [selectedAttachmentPoint, monomer]);
+  }, [selectedAttachmentPoint]);
+
+  useEffect(() => {
+    const newConnectedAttachmentPoints = getConnectedAttachmentPoints(bonds);
+    setConnectedAttachmentPoints(newConnectedAttachmentPoints);
+  }, [bonds]);
 
   const getLeavingGroup = (attachmentPoint): LeavingGroup => {
     const { MonomerCaps } = monomer.monomerItem.props;
@@ -201,21 +206,20 @@ function AttachmentPointSelectionPanel({
     const leavingGroup = MonomerCaps[attachmentPoint];
     return leavingGroup === 'O' ? 'OH' : (leavingGroup as LeavingGroup);
   };
-  let bond;
-  if (selectedAttachmentPoint) {
-    bond = monomer.getPotentialBond(selectedAttachmentPoint);
-  }
 
   const handleSelectAttachmentPoint = (attachmentPoint: string) => {
     const newBonds = { ...monomer.attachmentPointsToBonds };
-
-    if (selectedAttachmentPoint) {
-      newBonds[selectedAttachmentPoint] = null;
+    const selectedBond = selectedAttachmentPoint
+      ? newBonds[selectedAttachmentPoint]
+      : null;
+    if (selectedAttachmentPoint && selectedBond) {
+      monomer.removeBond(selectedBond);
     }
 
-    newBonds[attachmentPoint] = bond;
-    setBonds(newBonds);
+    const potentialBond = monomer.getPotentialBond(attachmentPoint);
+    newBonds[attachmentPoint] = potentialBond;
 
+    setBonds(newBonds);
     onSelectAttachmentPoint(attachmentPoint);
 
     const newConnectedAttachmentPoints = getConnectedAttachmentPoints(newBonds);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

An issue where bonds and connected attachment points were not updating correctly in the MonomerConnection component. The commit introduces a new function `handleSelectAttachmentPoint` and a useEffect hook to ensure that bonds and connected attachment points get correctly updated when the selected attachment point changes. Also the commit improves the disabling logic to properly account for the currently selected attachment point.

## Video

https://github.com/epam/ketcher/assets/72468284/5529cc9d-cab7-4490-9a44-716ceca01b7e





## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request