### PR TITLE
#3846 - macro class field is absent after serialisation to ket 

### DIFF
--- a/ketcher-autotests/tests/test-data/KET/monomers-connected-with-bonds-expected.ket
+++ b/ketcher-autotests/tests/test-data/KET/monomers-connected-with-bonds-expected.ket
@@ -347,6 +347,7 @@
                 ]
             }
         ],
+        "class": "Base",
         "classHELM": "RNA",
         "id": "baA___N-benzyl-adenine",
         "fullName": "N-benzyl-adenine",
@@ -532,6 +533,7 @@
                 ]
             }
         ],
+        "class": "Sugar",
         "classHELM": "RNA",
         "id": "12ddR___1',2'-Di-Deoxy-Ribose",
         "fullName": "2'-Di-Deoxy-Ribose",
@@ -638,6 +640,7 @@
                 ]
             }
         ],
+        "class": "Phosphate",
         "classHELM": "RNA",
         "id": "P___Phosphate",
         "fullName": "Phosphate",

--- a/packages/ketcher-core/src/application/editor/operations/monomer/monomerFactory.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/monomerFactory.ts
@@ -12,7 +12,7 @@ import { Chem } from 'domain/entities/Chem';
 import { Sugar } from 'domain/entities/Sugar';
 import { Phosphate } from 'domain/entities/Phosphate';
 import { RNABase } from 'domain/entities/RNABase';
-import { monomerClass } from 'application/formatters/types/ket';
+import { ketMonomerClass } from 'application/formatters/types/ket';
 
 type DerivedClass<T> = new (...args: unknown[]) => T;
 export const MONOMER_CONST = {
@@ -41,11 +41,11 @@ export const monomerFactory = (
 ): [
   Monomer: Monomer,
   MonomerRenderer: DerivedClass<BaseMonomerRenderer>,
-  monomerClass: monomerClass,
+  ketMonomerClass: ketMonomerClass,
 ] => {
   let Monomer;
   let MonomerRenderer;
-  let monomerClass: monomerClass;
+  let ketMonomerClass: ketMonomerClass;
 
   if (
     monomer.props.MonomerType === MONOMER_CONST.CHEM ||
@@ -55,26 +55,26 @@ export const monomerFactory = (
   ) {
     Monomer = Chem;
     MonomerRenderer = ChemRenderer;
-    monomerClass = 'CHEM';
+    ketMonomerClass = 'CHEM';
   } else if (monomer.props.MonomerType === MONOMER_CONST.PEPTIDE) {
     Monomer = Peptide;
     MonomerRenderer = PeptideRenderer;
-    monomerClass = 'PEPTIDE';
+    ketMonomerClass = 'AminoAcid';
   } else {
     if (monomer.props.MonomerNaturalAnalogCode === MONOMER_CONST.R) {
       Monomer = Sugar;
       MonomerRenderer = SugarRenderer;
-      monomerClass = 'RNA';
+      ketMonomerClass = 'Sugar';
     } else if (monomer.props.MonomerNaturalAnalogCode === MONOMER_CONST.P) {
       Monomer = Phosphate;
       MonomerRenderer = PhosphateRenderer;
-      monomerClass = 'RNA';
+      ketMonomerClass = 'Phosphate';
     } else {
       Monomer = RNABase;
       MonomerRenderer = RNABaseRenderer;
-      monomerClass = 'RNA';
+      ketMonomerClass = 'Base';
     }
   }
 
-  return [Monomer, MonomerRenderer, monomerClass];
+  return [Monomer, MonomerRenderer, ketMonomerClass];
 };

--- a/packages/ketcher-core/src/application/formatters/types/ket.ts
+++ b/packages/ketcher-core/src/application/formatters/types/ket.ts
@@ -38,6 +38,16 @@ export type monomerClass =
   | 'DNA'
   | 'MODDNA';
 
+export type ketMonomerClass =
+  | 'AminoAcid'
+  | 'Sugar'
+  | 'Phosphate'
+  | 'Base'
+  | 'Terminator'
+  | 'Linker'
+  | 'Unknown'
+  | 'CHEM';
+
 export type IKetAttachmentPointType = 'left' | 'right' | 'side';
 
 export interface IKetAttachmentPoint {

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -42,7 +42,10 @@ import { monomerToDrawingEntity } from 'domain/serializers/ket/fromKet/monomerTo
 import assert from 'assert';
 import { polymerBondToDrawingEntity } from 'domain/serializers/ket/fromKet/polymerBondToDrawingEntity';
 import { getMonomerUniqueKey } from 'domain/helpers/monomers';
-import { MONOMER_CONST } from 'application/editor/operations/monomer/monomerFactory';
+import {
+  MONOMER_CONST,
+  monomerFactory,
+} from 'application/editor/operations/monomer/monomerFactory';
 import { KetcherLogger } from 'utilities';
 import { Chem } from 'domain/entities/Chem';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
@@ -470,15 +473,15 @@ export class KetSerializer implements Serializer<Struct> {
           seqid: monomer.monomerItem.seqId,
         };
         fileContent.root.nodes.push(getKetRef(monomerName));
+        const [, , monomerClass] = monomerFactory(monomer.monomerItem);
         const templateNameWithPrefix = setMonomerTemplatePrefix(templateId);
-
         if (!fileContent[templateNameWithPrefix]) {
           fileContent[templateNameWithPrefix] = {
             ...JSON.parse(
               this.serializeMicromolecules(monomer.monomerItem.struct, monomer),
             ).mol0,
             type: 'monomerTemplate',
-            class: monomer.monomerItem.props.MonomerClass,
+            class: monomer.monomerItem.props.MonomerClass || monomerClass,
             classHELM: monomer.monomerItem.props.MonomerType,
             id: templateId,
             fullName: monomer.monomerItem.props.Name,


### PR DESCRIPTION
**What was done?**

closes https://github.com/epam/ketcher/issues/3846#event-11428842497
- cherry-pick https://github.com/epam/ketcher/pull/3859

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [x] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request