### PR TITLE
 #3934 Support selection entity selection flag in KET format

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/schema.json
+++ b/packages/ketcher-core/src/domain/serializers/ket/schema.json
@@ -109,6 +109,9 @@
             "type": "number"
           }
         },
+        "selected": {
+          "type": "boolean"
+        },
         "charge": {
           "type": "integer",
           "minimum": -1000,
@@ -252,6 +255,9 @@
             "type": "integer",
             "minimum": 0
           }
+        },
+        "selected": {
+          "type": "boolean"
         },
         "stereobox": {
           "type": "integer",


### PR DESCRIPTION
Update ket schema with new "selected" field for atoms and bonds.
