### PR TITLE
#3961 - system disorganize molecules and labels during loading from pptx file (base64 cdx format)

### DIFF
--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -800,12 +800,8 @@ export class Struct {
     });
 
     this.texts.forEach((item) => {
-      // Scale text only for reactions - i.e file contains reaction arrows
-      const isReactionStruct = this.rxnArrows.size;
-      if (isReactionStruct) {
-        item.pos = item.pos.map((p) => p.scaled(scale));
-        item.position = item.position.scaled(scale);
-      }
+      item.pos = item.pos.map((p) => p.scaled(scale));
+      item.position = item.position.scaled(scale);
     });
   }
 


### PR DESCRIPTION
- fixed texts scaling (removed ignoring scaling for texts if there is no reaction in structure)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
<img width="1031" alt="image" src="https://github.com/epam/ketcher/assets/14859362/a8178138-a428-4e71-97f8-da95a31ef9d3">

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request