### PR TITLE
Backmerge: #4014 - Macro: Monomers (attachment points) cannot be connected by a bond in Firefox browser

### DIFF
--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -214,7 +214,7 @@ class PolymerBond implements BaseTool {
   }
 
   public mouseUpAttachmentPoint(event) {
-    const renderer = event.toElement.__data__;
+    const renderer = event.target.__data__;
     const isFirstMonomerHovered =
       renderer === this.bondRenderer?.polymerBond?.firstMonomer?.renderer;
 
@@ -309,7 +309,7 @@ class PolymerBond implements BaseTool {
   }
 
   public mouseUpMonomer(event) {
-    const renderer = event.toElement.__data__;
+    const renderer = event.target.__data__;
     const isFirstMonomerHovered =
       renderer === this.bondRenderer?.polymerBond?.firstMonomer?.renderer;
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request