### PR TITLE
Macro: #3899 - Attachment points do not disappear when hover is removed from some monomers.

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -113,6 +113,18 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
     }
   }
 
+  public updateAttachmentPoints() {
+    this.hoveredAttachmenPoint = null;
+    if (!this.rootElement) return;
+    if (this.attachmentPoints.length > 0) {
+      this.attachmentPoints.forEach((point) => {
+        point.updateAttachmentPointStyleForHover();
+      });
+    } else {
+      this.drawAttachmentPoints();
+    }
+  }
+
   public redrawAttachmentPointsCoordinates() {
     const chosenAttachmentPointName =
       this.monomer.chosenFirstAttachmentPointForBond;

--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -368,7 +368,7 @@ export class RenderersManager {
   ) {
     this.hoverDrawingEntity(monomer as DrawingEntity);
     monomer.renderer?.hoverAttachmenPoint(attachmentPointName);
-    monomer.renderer?.redrawAttachmentPoints();
+    monomer.renderer?.updateAttachmentPoints();
   }
 
   public update(modelChanges: Command) {

--- a/packages/ketcher-core/src/domain/AttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/AttachmentPoint.ts
@@ -11,7 +11,7 @@ import {
   getSearchFunction,
 } from './helpers/attachmentPointCalculations';
 import { editorEvents } from 'application/editor/editorEvents';
-import { AttachmentPointConstructorParams } from './types';
+import { AttachmentPointConstructorParams, AttachmentPointName } from './types';
 
 export class AttachmentPoint {
   static attachmentPointVector = 12;
@@ -188,6 +188,9 @@ export class AttachmentPoint {
         event.attachmentPointName = this.attachmentPointName;
         this.editorEvents.mouseOverAttachmentPoint.dispatch(event);
       })
+      .on('mouseleave', (event) => {
+        this.editorEvents.mouseLeaveAttachmentPoint.dispatch(event);
+      })
       .on('mousedown', (event) => {
         event.attachmentPointName = this.attachmentPointName;
         this.editorEvents.mouseDownAttachmentPoint.dispatch(event);
@@ -196,10 +199,6 @@ export class AttachmentPoint {
         event.attachmentPointName = this.attachmentPointName;
         this.editorEvents.mouseUpAttachmentPoint.dispatch(event);
       });
-
-    this.element.on('mouseleave', (event) => {
-      this.editorEvents.mouseLeaveAttachmentPoint.dispatch(event);
-    });
 
     return hoverableAreaElement;
   }
@@ -261,6 +260,21 @@ export class AttachmentPoint {
     this.hoverableArea = hoverableArea;
 
     return attachmentPoint;
+  }
+
+  public updateAttachmentPointStyleForHover() {
+    const isAttachmentPointUsed = this.monomer.isAttachmentPointUsed(
+      this.attachmentPointName as AttachmentPointName,
+    );
+    if (isAttachmentPointUsed) {
+      this.attachmentPoint
+        ?.select('line')
+        .style('stroke', AttachmentPoint.colors.fillUsed);
+      this.attachmentPoint
+        ?.select('circle')
+        .style('fill', AttachmentPoint.colors.fillUsed)
+        .attr('stroke', 'white');
+    }
   }
 
   public rotateToAngle(polymerBond: PolymerBond, flip = false) {


### PR DESCRIPTION
Root cause: When mouse over the current attachment points, they will be destoryed in a setTimeout function and new set of attachment points will be created. There would be no issue if current attachment points are destoryed after their mouseleave event be triggered because the mouseleave event will trigger actions to clear the new created attachment points. While if current attachment points are destoryed before its mouseleave event be triggered(because the execution time of the settimeout function couldn't be guaranteed), then their mouseleave event will not be triggered and new created set of attachment points will be left in the view.

Solution: instead of creating new attachment points everytime when mouseover event listener triggered, just update attachment points' styles when there are already old attachment points existing.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request