### PR TITLE
Backmerge: #4045 System doesn't save selection state for custom query bonds

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
@@ -160,8 +160,8 @@ function bondToKet(source) {
     ifDef(result, 'topology', source.topology, 0);
     ifDef(result, 'center', source.reactingCenterStatus, 0);
     ifDef(result, 'cip', source.cip, '');
-    ifDef(result, 'selected', source.getInitiallySelected());
   }
+  ifDef(result, 'selected', source.getInitiallySelected());
   return result;
 }
 


### PR DESCRIPTION
Backmerge of https://github.com/epam/ketcher/pull/4046