### PR TITLE
Backmerge: #3970 - Brackets are displayed incorrectly when a S-Group is added to an atom or an expanded Functional Group or Salt is added to an atom of a structure

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/resgroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.ts
@@ -20,7 +20,6 @@ import {
   Pile,
   SGroup,
   Vec2,
-  Bond,
   Struct,
 } from 'domain/entities';
 import { SgContexts } from 'application/editor/shared/constants';
@@ -40,7 +39,7 @@ interface SGroupdrawBracketsOptions {
   set: any;
   render: Render;
   sgroup: SGroup;
-  crossBonds: { [key: number]: Array<Bond> };
+  crossBonds: { [key: number]: Array<number> };
   atomSet: Pile;
   bracketBox: Box2Abs;
   direction: Vec2;
@@ -460,8 +459,8 @@ function drawAttachedDat(restruct: ReStruct, sgroup: SGroup): any {
 
 function getBracketParameters(
   atomSet: Pile,
-  crossBondsPerAtom: Array<Array<Bond>>,
-  crossBondsValues: Array<Bond>,
+  crossBondsPerAtom: Array<Array<number>>,
+  crossBondsValues: Array<number>,
   attachmentPoints: number[],
   bracketBox: Box2Abs,
   direction: Vec2,
@@ -490,7 +489,7 @@ function getBracketParameters(
     );
   } else if (crossBondsValues.length === 2 && crossBondsPerAtom.length === 1) {
     getBracketParamersWithCrossBondsMoreThan2OnOneAtom(
-      crossBondsValues,
+      crossBondsValues as [number, number],
       mol,
       attachmentPoints,
       render,
@@ -514,7 +513,7 @@ function getBracketParameters(
 }
 
 function getBracketParamersWithCrossBondsMoreThan2OnOneAtom(
-  crossBondsValues: Bond[],
+  crossBondsValues: [number, number],
   mol: Struct,
   attachmentPoints: number[],
   render: Render,
@@ -528,10 +527,12 @@ function getBracketParamersWithCrossBondsMoreThan2OnOneAtom(
   // if bonds direction is clockwise, then negated
   const needNegated =
     Vec2.crossProduct(bondDirections[0], bondDirections[1]) > 0;
-  crossBondsValues = crossBondsValues.sort((id1, id2) => {
-    notTemplateShapeFirstAtom = Math.abs(Number(id1) - Number(id2)) === 1;
-    return notTemplateShapeFirstAtom && !needNegated ? -1 : 0;
-  });
+  notTemplateShapeFirstAtom =
+    Math.abs(Number(crossBondsValues[0]) - Number(crossBondsValues[1])) === 1;
+  if (notTemplateShapeFirstAtom && !needNegated) {
+    crossBondsValues.reverse();
+  }
+
   for (let i = 0; i < crossBondsValues.length; ++i) {
     const bond = mol.bonds.get(Number(crossBondsValues[i]));
     let bondDirection = bond?.getDir(mol) || new Vec2();
@@ -577,7 +578,7 @@ function getBracketParamersWithCrossBondsMoreThan2OnOneAtom(
 
 function getBracketParamersWithCrossBondsEquals2(
   mol: Struct,
-  crossBondsValues: Bond[],
+  crossBondsValues: number[],
   id: number,
   render: Render,
   attachmentPoints: number[],

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -440,9 +440,9 @@ export class SGroup {
   static getCrossBonds(
     mol: any,
     parentAtomSet: Pile<number>,
-  ): { [key: number]: Array<Bond> } {
-    const crossBonds: { [key: number]: Array<Bond> } = {};
-    mol.bonds.forEach((bond, bid) => {
+  ): { [key: number]: Array<number> } {
+    const crossBonds: { [key: number]: Array<number> } = {};
+    mol.bonds.forEach((bond, bid: number) => {
       if (parentAtomSet.has(bond.begin) && !parentAtomSet.has(bond.end)) {
         if (!crossBonds[bond.begin]) {
           crossBonds[bond.begin] = [];
@@ -464,7 +464,7 @@ export class SGroup {
   static bracketPos(
     sGroup,
     mol,
-    crossBondsPerAtom?: { [key: number]: Array<Bond> },
+    crossBondsPerAtom?: { [key: number]: Array<number> },
     remol?: ReStruct,
     render?,
   ): void {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request