### PR TITLE
#3943 - System allow to create atoms with Charge value out or range

### DIFF
--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/SMARTS-attributes/Atom-properties-attributes/atom-properties-attributes.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/SMARTS-attributes/Atom-properties-attributes/atom-properties-attributes.spec.ts
@@ -140,11 +140,9 @@ test.describe('Checking atom properties attributes in SMARTS format', () => {
   });
 
   test('Check that cannot add Charge more than -15', async ({ page }) => {
-    test.fail();
     /**
      * Test case: https://github.com/epam/ketcher/issues/3943
      * Description: Validation should be added +-15 range allowed only
-     * This test will fail until https://github.com/epam/ketcher/issues/3943 is fixed
      */
     await setCharge(page, '-16');
     const applyButton = await page.getByText('Apply');
@@ -153,11 +151,9 @@ test.describe('Checking atom properties attributes in SMARTS format', () => {
   });
 
   test('Check that cannot add Charge more than 15', async ({ page }) => {
-    test.fail();
     /**
      * Test case: https://github.com/epam/ketcher/issues/3943
      * Description: Validation should be added +-15 range allowed only
-     * This test will fail until https://github.com/epam/ketcher/issues/3943 is fixed
      */
     await setCharge(page, '16');
     const applyButton = await page.getByText('Apply');

--- a/packages/ketcher-react/src/script/ui/data/convert/structconv.js
+++ b/packages/ketcher-react/src/script/ui/data/convert/structconv.js
@@ -29,6 +29,7 @@ import {
   getSdataDefault,
   sdataCustomSchema,
 } from '../schema/sdata-schema';
+import { matchCharge } from '../utils';
 
 const DefaultStereoGroupNumber = 1;
 
@@ -183,13 +184,14 @@ export function toAtom(atom) {
       exactChangeFlag: 0,
     });
   }
-  const chargeRegexp = new RegExp(atomSchema.properties.charge.pattern);
-  const pch = chargeRegexp.exec(restAtom.charge);
+  const pch = matchCharge(restAtom.charge);
   const charge = pch ? parseInt(pch[1] + pch[3] + pch[2]) : restAtom.charge;
 
   const conv = Object.assign({}, restAtom, {
     isotope: restAtom.isotope ? Number(restAtom.isotope) : null,
-    charge: restAtom.charge ? Number(charge) : null,
+    // empty charge value by default treated as zero,
+    // no need to pass and display zero values(0, -0) explicitly
+    charge: restAtom.charge && charge !== 0 ? Number(charge) : null,
     alias: restAtom.alias || null,
     exactChangeFlag: +(restAtom.exactChangeFlag ?? false),
     unsaturatedAtom: +(restAtom.unsaturatedAtom ?? false),

--- a/packages/ketcher-react/src/script/ui/data/convert/structconv.js
+++ b/packages/ketcher-react/src/script/ui/data/convert/structconv.js
@@ -21,8 +21,6 @@ import {
   StereoLabel,
   getAtomType,
 } from 'ketcher-core';
-
-import { atom as atomSchema } from '../schema/struct-schema';
 import { capitalize } from 'lodash/fp';
 import {
   sdataSchema,

--- a/packages/ketcher-react/src/script/ui/data/schema/struct-schema.js
+++ b/packages/ketcher-react/src/script/ui/data/schema/struct-schema.js
@@ -58,7 +58,7 @@ export const atom = {
     charge: {
       title: 'Charge',
       type: 'string',
-      pattern: '^([+-]?)([0-9]{1,3})([+-]?)$',
+      pattern: '^([+-]?)(1[0-5]|0|[0-9])([+-]?)$',
       maxLength: 4,
       default: '',
       invalidMessage: 'Invalid charge value',

--- a/packages/ketcher-react/src/script/ui/data/utils.test.ts
+++ b/packages/ketcher-react/src/script/ui/data/utils.test.ts
@@ -1,0 +1,50 @@
+import { matchCharge } from 'src/script/ui/data/utils';
+
+describe('data utils', () => {
+  describe('matchCharge', () => {
+    it('should return null for empty string', () => {
+      const result = matchCharge('');
+      expect(result).toBeNull();
+    });
+    it('should return null for string with positive out of range charge', () => {
+      const result = matchCharge('16');
+      expect(result).toBeNull();
+    });
+    it('should return null for string with negative out of range charge', () => {
+      const result = matchCharge('-16');
+      expect(result).toBeNull();
+    });
+    it('should return expected matched array for string with zero charge', () => {
+      const expectedMatchGroups = ['', '0', ''];
+      const [, signBefore, absoluteValue, signAfter] = matchCharge('0') || [];
+      expect([signBefore, absoluteValue, signAfter]).toEqual(
+        expectedMatchGroups,
+      );
+    });
+    it('should return expected matched array for string with negative zero charge', () => {
+      const expectedMatchGroups = ['-', '0', ''];
+      const [, signBefore, absoluteValue, signAfter] = matchCharge('-0') || [];
+      expect([signBefore, absoluteValue, signAfter]).toEqual(
+        expectedMatchGroups,
+      );
+    });
+    it('should return expected matched array for string with negative zero charge after', () => {
+      const expectedMatchGroups = ['', '0', '-'];
+      const [, signBefore, absoluteValue, signAfter] = matchCharge('0-') || [];
+      expect([signBefore, absoluteValue, signAfter]).toEqual(
+        expectedMatchGroups,
+      );
+    });
+    it('should return expected matched array for string with two signs number', () => {
+      const expectedMatchGroups = ['-', '0', '-'];
+      const [, signBefore, absoluteValue, signAfter] = matchCharge('-0-') || [];
+      expect([signBefore, absoluteValue, signAfter]).toEqual(
+        expectedMatchGroups,
+      );
+    });
+    it('should return null for string with invalid number format', () => {
+      const result = matchCharge('--0');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/ketcher-react/src/script/ui/data/utils.ts
+++ b/packages/ketcher-react/src/script/ui/data/utils.ts
@@ -1,0 +1,16 @@
+import { atom } from './schema/struct-schema';
+
+/**
+ * Get match groups from string representation of charge. It returns RegExpExecArray for charges with values +-[0..15]
+ * overwise returns null
+ *
+ * @example
+ * matchCharge("16") === null
+ * matchCharge("0") === []
+ * matchCharge("-1") === ["-1", "-", "1", ""]
+ * matchCharge("15+") === ["15+", "", "15", "+"]
+ */
+export function matchCharge(charge: string) {
+  const regex = new RegExp(atom.properties.charge.pattern);
+  return regex.exec(charge);
+}

--- a/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/Atom/helper.ts
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/Atom/helper.ts
@@ -1,6 +1,7 @@
 import { AtomType, Elements, genericsList } from 'ketcher-core';
 import { capitalize } from 'lodash';
 import { atom as atomSchema } from '../../../../../data/schema/struct-schema';
+import { matchCharge } from 'src/script/ui/data/utils';
 
 export function atomValid(
   label: string,
@@ -47,8 +48,7 @@ export function chargeValid(
   isMultipleAtoms: boolean,
   isCustomQuery: boolean,
 ) {
-  const regex = new RegExp(atomSchema.properties.charge.pattern);
-  const result = regex.exec(charge);
+  const result = matchCharge(charge);
   const isValidCharge = result && (result[1] === '' || result[3] === '');
   if (isCustomQuery || charge === '') {
     return true;


### PR DESCRIPTION
## How did you fix the issue?
Screenshots
<details>
<summary>Atom's charge out of allowed range</summary>
<img width="313" alt="Screenshot 2024-02-13 at 16 12 42" src="https://github.com/epam/ketcher/assets/50613241/cc705de1-096f-4c38-929c-fe65ef0ebdd6">
</details>
<details>
<summary>Atom's charge in allowed range</summary>
<img width="262" alt="Screenshot 2024-02-13 at 16 12 53" src="https://github.com/epam/ketcher/assets/50613241/a4481f90-ea63-4091-808c-892f046cf42c">
</details>

Please also review fix for corner case with zero charge defined explicitly:
<details>
<summary>Current behaviour</summary>
All zero charge values get displayed on canvas and explicitly shown in atom's property field but get removed after export anyway

https://github.com/epam/ketcher/assets/50613241/cac33a27-ee89-4d65-911b-08f3044788f3


</details>
<details>
<summary>Proposed behavaiour</summary>
All zero values don't get displayed on canvas and don't get shown in atom's property field. So there is no difference with default atom after explicitly setting zero as charge value.

https://github.com/epam/ketcher/assets/50613241/7ab61815-39c5-4121-ab62-0907a378d8f8


</details>

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request