### PR TITLE
#4097 - Cursor position misalignment after switching in fullscreen after changing ketcher settings

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -60,6 +60,9 @@ function setupEditor(editor, props, oldProps = {}) {
       }
     }
   });
+
+  editor.render.unobserveCanvasResize();
+  editor.render.observeCanvasResize();
 }
 
 function removeEditorHandlers(editor, props) {
@@ -249,7 +252,6 @@ class StructEditor extends Component {
     });
 
     this.editorRef.current.addEventListener('wheel', this.handleWheel);
-    this.editor.render.observeCanvasResize();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- fixed canvas resize observer

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request