### PR TITLE
#4082 - Canvas preview render work at 14 times faster in Firefox than in Chrome

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/CDXStructuresViewer/CDXStructuresViewer.module.less
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/CDXStructuresViewer/CDXStructuresViewer.module.less
@@ -20,8 +20,6 @@
   flex-direction: column;
   padding: 1em 2em;
   gap: 1em;
-  width: 60vw;
-  height: 50vh;
   max-width: 60em;
   max-height: 30em;
   border-bottom: 1px solid #e1e5ea;
@@ -31,11 +29,12 @@
   display: flex;
   flex-direction: row;
   gap: 2em;
-  height: 90%;
+  height: 225px;
   justify-content: space-between;
 }
 
 .menuListWrapper {
+  width: 150px;
   background: @color-background-panel;
   padding: 12px 8px;
   border-radius: 8px;
@@ -63,6 +62,10 @@
       background: @color-button-primary-clicked !important;
       color: white;
     }
+
+    :global(.MuiMenuItem-root) {
+      min-height: auto;
+    }
   }
 
   > .header {
@@ -88,11 +91,12 @@
 }
 
 .imageWrapper {
+  width: 300px;
+  height: 225px;
   display: flex;
   justify-content: center;
   align-items: center;
   font-weight: 600;
-  flex: 2;
 }
 
 .image {
@@ -105,4 +109,21 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+}
+
+@media only screen {
+  @container (min-width: 900px) {
+    .imageWrapper {
+      width: 450px;
+      height: 325px;
+    }
+
+    .menuListWrapper {
+      width: 250px;
+    }
+
+    .structuresWrapper {
+      height: 325px;
+    }
+  }
 }


### PR DESCRIPTION
- fixed preview wrapper size to make svg elements reflow faster

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request