### PR TITLE
#3891 - Aromatize/Dearomatize of having abbreviation (Salts and Solvents) on the canvas causes spontaneous random de-abbreviation

### DIFF
--- a/packages/ketcher-core/src/application/render/renderStruct.ts
+++ b/packages/ketcher-core/src/application/render/renderStruct.ts
@@ -74,7 +74,11 @@ export class RenderStruct {
         return;
       }
 
+      console.log('-----START-------');
+      console.log(struct.sgroups);
       const preparedStruct = this.prepareStruct(struct);
+      console.log(preparedStruct.sgroups);
+      console.log('-----END-------');
       preparedStruct.initHalfBonds();
       preparedStruct.initNeighbors();
       preparedStruct.setImplicitHydrogen();

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -156,7 +156,7 @@ class ReStruct {
         this.sgroupData.set(id, new ReDataSGroupData(item));
       } // [MK] sort of a hack, we use the SGroup id for the data field id
       if (FunctionalGroup.isFunctionalGroup(item) || SGroup.isSuperAtom(item)) {
-        this.molecule.functionalGroups.set(id, new FunctionalGroup(item));
+        this.molecule.functionalGroups.add(new FunctionalGroup(item));
       }
     });
   }

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -20,7 +20,6 @@ import {
   Pile,
   Pool,
   RGroupAttachmentPoint,
-  SGroup,
   Struct,
   Vec2,
 } from 'domain/entities';
@@ -154,9 +153,6 @@ class ReStruct {
       this.sgroups.set(id, new ReSGroup(item));
       if (item.type === 'DAT' && !item.data.attached) {
         this.sgroupData.set(id, new ReDataSGroupData(item));
-      } // [MK] sort of a hack, we use the SGroup id for the data field id
-      if (FunctionalGroup.isFunctionalGroup(item) || SGroup.isSuperAtom(item)) {
-        this.molecule.functionalGroups.add(new FunctionalGroup(item));
       }
     });
   }

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -281,7 +281,8 @@ export class Struct {
       if (bondSet!.has(bid)) bidMap.set(bid, cp.bonds.add(bond.clone(aidMap!)));
     });
 
-    this.sgroups.forEach((sg) => {
+    const sgroupIdMap = {};
+    this.sgroups.forEach((sg, sgroupId) => {
       if (sg.atoms.some((aid) => !atomSet!.has(aid))) return;
       const oldSgroup = sg;
 
@@ -292,6 +293,8 @@ export class Struct {
 
       const id = cp.sgroups.add(sg);
       sg.id = id;
+
+      sgroupIdMap[sgroupId] = id;
 
       sg.atoms.forEach((aid) => {
         const atom = cp.atoms.get(aid);
@@ -306,7 +309,10 @@ export class Struct {
 
     this.functionalGroups.forEach((fg) => {
       if (fg.relatedSGroup.atoms.some((aid) => !atomSet!.has(aid))) return;
-      fg = FunctionalGroup.clone(fg);
+      const sgroup = cp.sgroups.get(sgroupIdMap[fg.relatedSGroupId]);
+      // It is possible that there is no sgroup in case of templates library rendering
+      // Sgroup is deleteing before render to show templates without brackets (see RenderStruct.prepareStruct method)
+      fg = sgroup ? new FunctionalGroup(sgroup) : FunctionalGroup.clone(fg);
       cp.functionalGroups.add(fg);
     });
 

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
@@ -67,9 +67,11 @@ export function moleculeToStruct(ketItem: any): Struct {
   }
 
   if (ketItem.sgroups) {
-    ketItem.sgroups.forEach((sgroup) =>
-      struct.sgroups.add(sgroupToStruct(sgroup)),
-    );
+    ketItem.sgroups.forEach((sgroupData) => {
+      const sgroup = sgroupToStruct(sgroupData);
+      const id = struct.sgroups.add(sgroup);
+      sgroup.id = id;
+    });
   }
 
   struct.initHalfBonds();


### PR DESCRIPTION
- fixed functional group id setting

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request