### PR TITLE
#3918 - When deleting part of a structure using a hotkey Del, and preview of structure is under mouse cursor, an error occurs.

### DIFF
--- a/ketcher-autotests/tests/User-Interface/Hot-Keys/hotkeys.spec.ts
+++ b/ketcher-autotests/tests/User-Interface/Hot-Keys/hotkeys.spec.ts
@@ -52,9 +52,7 @@ test.describe('Hot key Del', () => {
     /**
      * Test case: https://github.com/epam/ketcher/issues/3918
      * Description: Part of structure deleted and canvas can be cleared. No console errors.
-     * Test working not in proper way because we have unfixed bug.
      */
-    test.fail();
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
         test.fail(

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -111,7 +111,7 @@ class TemplateTool implements Tool {
   private readonly mode: any;
   private readonly template: any;
   private readonly findItems: Array<string>;
-  private templatePreview: TemplatePreview | null;
+  public templatePreview: TemplatePreview | null;
   private dragCtx: any;
   private targetGroupsIds: Array<number> = [];
   private readonly isSaltOrSolvent: boolean;

--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -160,7 +160,7 @@ class TemplatePreview {
     }
   }
 
-  private hideConnectedPreview() {
+  public hideConnectedPreview() {
     if (this.connectedPreviewAction) {
       this.connectedPreviewAction.perform(this.restruct);
       this.connectedPreviewAction = null;

--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -19,6 +19,7 @@ import { updateSelectedAtoms } from 'src/script/ui/state/modal/atoms';
 import { fromAtom, toAtom, fromBond, toBond } from '../data/convert/structconv';
 import SGroupTool from '../../editor/tool/sgroup';
 import { deleteFunctionalGroups } from '../../editor/tool/helper/deleteFunctionalGroups';
+import TemplateTool from '../../editor/tool/template';
 
 type TNewAction = {
   tool?: string;
@@ -80,6 +81,11 @@ function handleEraser({
 }: HandleHotkeyOverItemProps) {
   const item = mapItemsToArrays(hoveredItem);
   const itemType = Object.keys(hoveredItem)[0];
+  const activeTool = editor.tool();
+
+  if (activeTool instanceof TemplateTool) {
+    activeTool.templatePreview?.hideConnectedPreview();
+  }
 
   if ([STRUCT_TYPE.atoms, STRUCT_TYPE.bonds].includes(itemType)) {
     isFunctionalGroupChange(
@@ -88,11 +94,9 @@ function handleEraser({
     ).then((res) => {
       res && eraseItem({ editor, item });
     });
-
-    return;
+  } else {
+    eraseItem({ editor, item });
   }
-
-  eraseItem({ editor, item });
 }
 
 function handleDialog({


### PR DESCRIPTION
- added template connected preview hiding before erase by hotkey

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request