### PR TITLE
Macro: #4173 - the pop-up window does not appear in fullscreen mode after clicking the “Open” button and the “Save as” button

### DIFF
--- a/packages/ketcher-macromolecules/src/components/shared/modal/Modal.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/modal/Modal.tsx
@@ -8,7 +8,7 @@ import {
 import React, { useMemo } from 'react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Icon } from 'ketcher-react';
+import { Icon, KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR } from 'ketcher-react';
 import { scrollbarThin } from 'theming/mixins';
 import { EmptyFunction } from 'helpers/emptyFunction';
 import styles from './Modal.module.less';
@@ -147,6 +147,9 @@ export const Modal = ({
       PaperProps={paperProps}
       open={isOpen}
       onClose={onClose}
+      container={document.querySelector(
+        KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR,
+      )}
       disableEscapeKeyDown={!showCloseButton}
       className={className}
       sx={{ padding: '24px' }}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

When a specific HTML element enters fullscreen mode using the requestFullscreen API, all other elements outside this element are not rendered. Hence you cannot directly display a dialog outside of the fullscreen element.

So to make a dialog appear at the top of an element that is displayed in fill screen with requestFullscreen api, you can create a dialog inside the fullscreen element and position it correctly.

However, it's important to note that normal MUI Dialog behavior might not work as expected if a specific HTML element is in fullscreen mode because MUI Dialog is attached to the document body by default. You could use the ModalProps in the Dialog component. ModalProps has a property called container that can be used to set the container for the Dialog component.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request