### PR TITLE
#3957 atom query feature export system lost most substitution count values export to molfile

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.js
@@ -172,11 +172,13 @@ function parsePropertyLines(ctab, ctabLines, shift, end, sGroups, rLogic) {
           props.set('ringBondCount', sGroup.readKeyValuePairs(propertyData));
         }
       } else if (type === 'SUB') {
-        if (!props.get('substitutionCount')) {
-          props.set(
-            'substitutionCount',
-            sGroup.readKeyValuePairs(propertyData),
-          );
+        if (!props.get('substitutionCount'))
+          props.set('substitutionCount', new Pool());
+        const rglabels = props.get('substitutionCount');
+        const arrs = sGroup.readKeyMultiValuePairs(propertyData);
+        for (let arri = 0; arri < arrs.length; arri++) {
+          const a2r = arrs[arri];
+          rglabels.set(a2r[0], a2r[1]);
         }
       } else if (type === 'UNS') {
         if (!props.get('unsaturatedAtom')) {

--- a/packages/ketcher-macromolecules/src/Editor.tsx
+++ b/packages/ketcher-macromolecules/src/Editor.tsx
@@ -23,7 +23,6 @@ import {
   hotkeysConfiguration,
   generateMenuShortcuts,
   Nucleotide,
-  Nucleoside,
 } from 'ketcher-core';
 import monomersData from './data/monomers.sdf';
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request