### PR TITLE
#3663 - Macro: After clicking the 'Duplicate and Edit' button and subsequently clicking 'Cancel,' the preset remains saved.

### DIFF
--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -413,6 +413,7 @@ test.describe('RNA Library', () => {
       button: 'right',
     });
     await page.getByTestId('duplicateandedit').locator('div').click();
+    await page.getByTestId('save-btn').click();
     // To avoid unstable test execution
     // Allows see a right preset in a veiwport
     await expandCollapseRnaBuilder(page);

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
@@ -21,7 +21,6 @@ import { setSearchFilter } from 'state/library';
 import { Icon } from 'ketcher-react';
 import { IRnaPreset } from './RnaBuilder/types';
 import {
-  savePreset,
   selectPresets,
   setActivePreset,
   setIsEditMode,
@@ -68,7 +67,6 @@ const MonomerLibrary = React.memo(() => {
       favorite: false,
     };
     dispatch(setActivePreset(duplicatedPreset));
-    dispatch(savePreset(duplicatedPreset));
     dispatch(setIsEditMode(true));
     scrollToSelectedPreset(preset?.name);
   };

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -106,7 +106,9 @@ export const rnaBuilderSlice = createSlice({
         const presetIndexInList = state.presets.findIndex(
           (presetInList) => presetInList.name === preset.presetInList?.name,
         );
-        state.presets.splice(presetIndexInList, 1, newPreset);
+        presetIndexInList === -1
+          ? state.presets.push(newPreset)
+          : state.presets.splice(presetIndexInList, 1, newPreset);
       } else {
         state.presets.push(newPreset);
       }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request