### PR TITLE
Backmerge: #4241 - Pasting large cyclodextrins structure cause Ketcher to freeze

### DIFF
--- a/ketcher-autotests/tests/User-Interface/Editing-Tools/Copy-Cut-Paste/copy-cut-paste.spec.ts
+++ b/ketcher-autotests/tests/User-Interface/Editing-Tools/Copy-Cut-Paste/copy-cut-paste.spec.ts
@@ -25,6 +25,7 @@ import {
   waitForRender,
   resetCurrentTool,
   pressButton,
+  clickAfterItemsToMergeInitialization,
 } from '@utils';
 
 const CANVAS_CLICK_X = 500;
@@ -367,7 +368,7 @@ test.describe('Copy/Cut/Paste Actions', () => {
     await clickOnAtom(page, 'C', anyAtom);
   });
 
-  test('Copy and paste and  Edit the pasted Structure', async ({ page }) => {
+  test('Copy and paste and Edit the pasted Structure', async ({ page }) => {
     /*
     Test case: EPMLSOPKET-1719
     Description: After the clicking the Copy button, the selected object not disappears.
@@ -378,7 +379,7 @@ test.describe('Copy/Cut/Paste Actions', () => {
     const anyAtom = 12;
     await openFileAndAddToCanvas('Molfiles-V2000/query-features.mol', page);
     await copyAndPaste(page);
-    await page.mouse.click(x, y);
+    await clickAfterItemsToMergeInitialization(page, x, y);
     await selectAtomInToolbar(AtomButton.Nitrogen, page);
     await clickOnAtom(page, 'C', anyAtom);
   });
@@ -831,7 +832,7 @@ test.describe('Copy/Cut/Paste Actions', () => {
       page,
     );
     await copyAndPaste(page);
-    await page.mouse.click(x, y);
+    await clickAfterItemsToMergeInitialization(page, x, y);
   });
 
   test('Cut and Paste Aromatic structure and edit', async ({ page }) => {

--- a/ketcher-autotests/tests/utils/clicks/index.ts
+++ b/ketcher-autotests/tests/utils/clicks/index.ts
@@ -11,6 +11,7 @@ import {
   waitForRender,
 } from '..';
 import { AtomLabelType, DropdownIds, DropdownToolIds } from './types';
+import { waitForItemsToMergeInitialization } from '@utils/common/loaders/waitForRender';
 
 type BoundingBox = {
   width: number;
@@ -21,18 +22,33 @@ type BoundingBox = {
 
 const HALF_DIVIDER = 2;
 
+export async function clickAfterItemsToMergeInitialization(
+  page: Page,
+  x: number,
+  y: number,
+  button: 'left' | 'right' = 'left',
+) {
+  await page.mouse.move(x, y);
+  await waitForItemsToMergeInitialization(page);
+  await page.mouse.down({
+    button,
+  });
+  await page.mouse.up({
+    button,
+  });
+}
+
 export async function clickInTheMiddleOfTheScreen(
   page: Page,
   button: 'left' | 'right' = 'left',
 ) {
   const body = (await page.locator('body').boundingBox()) as BoundingBox;
   await waitForRender(page, async () => {
-    await page.mouse.click(
+    await clickAfterItemsToMergeInitialization(
+      page,
       body.x + body?.width / HALF_DIVIDER,
       body.y + body?.height / HALF_DIVIDER,
-      {
-        button,
-      },
+      button,
     );
   });
 }

--- a/ketcher-autotests/tests/utils/common/loaders/waitForRender.ts
+++ b/ketcher-autotests/tests/utils/common/loaders/waitForRender.ts
@@ -38,3 +38,14 @@ async function waitForCustomEvent(
     { eventName, timeout },
   );
 }
+
+export const waitForItemsToMergeInitialization = async (
+  page: Page,
+  callback = emptyFunction,
+  timeout = 200,
+) => {
+  await Promise.all([
+    waitForCustomEvent(page, 'itemsToMergeInitializationComplete', timeout),
+    callback(),
+  ]);
+};

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -114,11 +114,14 @@ export function fromPaste(
       aidMap.get(bond.begin),
       aidMap.get(bond.end),
       bond,
+      false,
     ).perform(restruct) as BondAdd;
     action.addOp(operation);
 
     pasteItems.bonds.push(operation.data.bid);
-    new BondAttr(operation.data.bid, 'isPreview', isPreview).perform(restruct);
+    new BondAttr(operation.data.bid, 'isPreview', isPreview, false).perform(
+      restruct,
+    );
   });
 
   pasteItems.atoms.forEach((aid) => {

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
@@ -22,20 +22,25 @@ type Data = {
   bid: any;
   attribute: any;
   value: any;
+  needInvalidateBond?: boolean;
 };
 
 export class BondAttr extends BaseOperation {
   data: Data | null;
   data2: Data | null;
 
-  constructor(bondId?: any, attribute?: any, value?: any) {
+  constructor(
+    bondId?: any,
+    attribute?: any,
+    value?: any,
+    needInvalidateBond = true,
+  ) {
     super(OperationType.BOND_ATTR, OperationPriority.BOND_ATTR);
-    this.data = { bid: bondId, attribute, value };
+    this.data = { bid: bondId, attribute, value, needInvalidateBond };
     this.data2 = null;
   }
 
   execute(restruct: ReStruct) {
-    console.error('here');
     if (this.data) {
       const { attribute, bid, value } = this.data;
       const bond = restruct.molecule.bonds.get(bid)!;
@@ -50,7 +55,9 @@ export class BondAttr extends BaseOperation {
 
       bond[attribute] = value;
 
-      // BaseOperation.invalidateBond(restruct, bid);
+      if (this.data.needInvalidateBond) {
+        BaseOperation.invalidateBond(restruct, bid);
+      }
       if (attribute === 'type') {
         BaseOperation.invalidateLoop(restruct, bid);
       }

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
@@ -35,6 +35,7 @@ export class BondAttr extends BaseOperation {
   }
 
   execute(restruct: ReStruct) {
+    console.error('here');
     if (this.data) {
       const { attribute, bid, value } = this.data;
       const bond = restruct.molecule.bonds.get(bid)!;
@@ -49,7 +50,7 @@ export class BondAttr extends BaseOperation {
 
       bond[attribute] = value;
 
-      BaseOperation.invalidateBond(restruct, bid);
+      // BaseOperation.invalidateBond(restruct, bid);
       if (attribute === 'type') {
         BaseOperation.invalidateLoop(restruct, bid);
       }

--- a/packages/ketcher-core/src/application/editor/operations/bond/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/index.ts
@@ -28,14 +28,15 @@ type Data = {
   begin: any;
   end: any;
   bid: any;
+  needInvalidateAtoms?: boolean;
 };
 
 class BondAdd extends BaseOperation {
   data: Data;
 
-  constructor(begin?: any, end?: any, bond?: any) {
+  constructor(begin?: any, end?: any, bond?: any, needInvalidateAtoms = true) {
     super(OperationType.BOND_ADD, OperationPriority.BOND_ADD);
-    this.data = { bond, begin, end, bid: null };
+    this.data = { bond, begin, end, bid: null, needInvalidateAtoms };
   }
 
   execute(restruct: ReStruct) {
@@ -47,8 +48,10 @@ class BondAdd extends BaseOperation {
       throw new Error('Distinct atoms expected');
     }
 
-    // BaseOperation.invalidateAtom(restruct, begin, 1);
-    // BaseOperation.invalidateAtom(restruct, end, 1);
+    if (this.data.needInvalidateAtoms) {
+      BaseOperation.invalidateAtom(restruct, begin, 1);
+      BaseOperation.invalidateAtom(restruct, end, 1);
+    }
 
     const pp: {
       type: number;

--- a/packages/ketcher-core/src/application/editor/operations/bond/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/index.ts
@@ -47,8 +47,8 @@ class BondAdd extends BaseOperation {
       throw new Error('Distinct atoms expected');
     }
 
-    BaseOperation.invalidateAtom(restruct, begin, 1);
-    BaseOperation.invalidateAtom(restruct, end, 1);
+    // BaseOperation.invalidateAtom(restruct, begin, 1);
+    // BaseOperation.invalidateAtom(restruct, end, 1);
 
     const pp: {
       type: number;

--- a/packages/ketcher-core/src/application/render/notifyRenderComplete.ts
+++ b/packages/ketcher-core/src/application/render/notifyRenderComplete.ts
@@ -4,3 +4,8 @@ export const notifyRenderComplete = _.debounce(() => {
   const event = new Event('renderComplete');
   window.dispatchEvent(event);
 }, 750);
+
+export const notifyItemsToMergeInitializationComplete = () => {
+  const event = new Event('itemsToMergeInitializationComplete');
+  window.dispatchEvent(event);
+};

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -22,7 +22,7 @@ import { Struct } from './struct';
 import { SaltsAndSolventsProvider } from '../helpers';
 import { Vec2 } from './vec2';
 import { ReStruct } from '../../application/render';
-import { Pool, SGroupAttachmentPoint } from 'domain/entities';
+import { FunctionalGroup, Pool, SGroupAttachmentPoint } from 'domain/entities';
 import { ReSGroup } from 'application/render';
 import { SgContexts } from 'application/editor/shared/constants';
 import assert from 'assert';
@@ -84,6 +84,7 @@ export class SGroup {
   pp: Vec2 | null;
   data: any;
   dataArea: any;
+  functionalGroup: FunctionalGroup | undefined;
   private readonly attachmentPoints: SGroupAttachmentPoint[];
 
   constructor(type: string) {
@@ -134,6 +135,10 @@ export class SGroup {
   // stub
   getAttr(attr: string): any {
     return this.data[attr];
+  }
+
+  setFunctionalGroup(functionalGroup: FunctionalGroup) {
+    this.functionalGroup = functionalGroup;
   }
 
   // TODO: should be group-specific

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -21,6 +21,7 @@ import {
   fromTemplateOnAtom,
   getHoverToFuse,
   getItemsToFuse,
+  notifyItemsToMergeInitializationComplete,
   SGroup,
   Struct,
   Vec2,
@@ -47,6 +48,7 @@ const debouncedSetAndHoverMergeItems = debounce(function (
     needResetTool ? pasteToolInstance : undefined,
   );
   pasteToolInstance.setMergeItems(mergeItems);
+  notifyItemsToMergeInitializationComplete();
 },
 50);
 


### PR DESCRIPTION
- added debounce for structures merge calculations
- added stop handling of mousemove if previous handler in progress
- added functionalGroup link to sgroup to more efficiently search it during different operations (for example for checking is atom in contracted group)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request