### PR TITLE
#4238 - getKet function return ket file without selection flags

### DIFF
--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Entity-Selection-Flag-in-KET-format/entity-selection-flag-in-ket-format.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Entity-Selection-Flag-in-KET-format/entity-selection-flag-in-ket-format.spec.ts
@@ -301,7 +301,6 @@ test.describe('4. User can save and than restore selection for:', () => {
 
   for (const fileName of fileNames) {
     test(`${fileName}`, async ({ page }) => {
-      test.fail(); // https://github.com/epam/ketcher/issues/4238
       await openFileAndAddToCanvasAsNewProject(
         `KET/Entity-Selection-Flag-in-KET-format/BondsAndAtoms/${fileName}`,
         page,

--- a/ketcher-autotests/tests/test-data/KET/three-bond-structure-with-custom-query-to-compare.ket
+++ b/ketcher-autotests/tests/test-data/KET/three-bond-structure-with-custom-query-to-compare.ket
@@ -50,7 +50,8 @@
                     0,
                     1
                 ],
-                "customQuery": "=;@"
+                "customQuery": "=;@",
+                "selected": true
             },
             {
                 "type": 1,

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -35,6 +35,7 @@ import {
   parseAndAddMacromoleculesOnCanvas,
   prepareStructToRender,
 } from './utils';
+import { EditorSelection } from './editor/editor.types';
 
 const allowedApiSettings = {
   'general.dearomatize-on-load': 'dearomatize-on-load',
@@ -189,6 +190,7 @@ export class Ketcher {
       this.#formatterFactory,
       this.#editor.struct(),
       CoreEditor.provideEditorInstance()?.drawingEntitiesManager,
+      this.#editor.selection() as EditorSelection,
     );
   }
 

--- a/packages/ketcher-core/src/application/utils.ts
+++ b/packages/ketcher-core/src/application/utils.ts
@@ -10,6 +10,7 @@ import { ChemicalMimeType, StructService } from 'domain/services';
 import { Coordinates, CoreEditor, EditorHistory } from './editor/internal';
 import { KetSerializer } from 'domain/serializers';
 import assert from 'assert';
+import { EditorSelection } from './editor/editor.types';
 
 class KetcherProvider {
   private ketcherInstance: Ketcher | undefined;
@@ -33,9 +34,14 @@ export function getStructure(
   formatterFactory: FormatterFactory,
   struct: Struct,
   drawingEntitiesManager?: DrawingEntitiesManager,
+  selection?: EditorSelection,
 ): Promise<string> {
   const formatter = formatterFactory.create(structureFormat);
-  return formatter.getStructureFromStructAsync(struct, drawingEntitiesManager);
+  return formatter.getStructureFromStructAsync(
+    struct,
+    drawingEntitiesManager,
+    selection,
+  );
 }
 
 export async function prepareStructToRender(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request