### PR TITLE
#4144 - Connection of bond to atom inside s-group supergroup cause it connected incorrectly in terms of layout

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -24,6 +24,8 @@ import {
   AtomAttributes,
   BondAttributes,
   FunctionalGroup,
+  SGroupAttachmentPoint,
+  SGroup,
 } from 'domain/entities';
 import {
   AtomAdd,
@@ -44,7 +46,7 @@ import {
 } from './atom';
 
 import { Action } from './action';
-import { ReStruct } from '../../render';
+import { ReSGroup, ReStruct } from '../../render';
 import { StereoValidator } from 'domain/helpers';
 import utils from '../shared/utils';
 
@@ -165,6 +167,14 @@ export function fromBondAddition(
     [beginAtomId, endAtomId] = mouseDownAtomAndUpNothing(begin, end);
   } else {
     [beginAtomId, endAtomId] = [begin as number, end as number];
+
+    if (reStruct.sgroups.size > 0) {
+      reStruct.sgroups.forEach((sgroup) => {
+        if (sgroup.item?.type && sgroup.item?.type === 'SUP') {
+          addAttachmentPointToSuperatom(sgroup, beginAtomId, endAtomId);
+        }
+      });
+    }
   }
 
   if (atomGetAttr(reStruct, beginAtomId, 'label') === '*') {
@@ -445,4 +455,36 @@ export function bondChangingAction(
   }
 
   return fromBondsAttrs(restruct, newItemId, bondProps).mergeWith(action);
+}
+
+function addAttachmentPointToSuperatom(
+  sgroup: ReSGroup,
+  beginAtomId: number,
+  endAtomId: number,
+) {
+  (sgroup.item?.atoms as number[]).forEach((atomId) => {
+    if (beginAtomId === atomId || endAtomId === atomId) {
+      if (
+        !(sgroup.item as SGroup)
+          .getAttachmentPoints()
+          .map((attachmentPoint) => attachmentPoint.atomId)
+          .includes(atomId)
+      )
+        sgroup.item?.addAttachmentPoint(
+          new SGroupAttachmentPoint(atomId, undefined, undefined),
+        );
+    }
+  });
+}
+
+export function removeAttachmentPointFromSuperatom(
+  sgroup: ReSGroup,
+  beginAtomId: number | undefined,
+  endAtomId: number | undefined,
+) {
+  (sgroup.item?.atoms as number[]).forEach((atomId) => {
+    if (beginAtomId === atomId || endAtomId === atomId) {
+      sgroup.item?.removeAttachmentPoint(atomId);
+    }
+  });
 }

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -168,7 +168,7 @@ export function fromBondAddition(
   } else {
     [beginAtomId, endAtomId] = [begin as number, end as number];
 
-    if (reStruct.sgroups.size > 0) {
+    if (reStruct.sgroups && reStruct.sgroups.size > 0) {
       reStruct.sgroups.forEach((sgroup) => {
         if (sgroup.item?.type && sgroup.item?.type === 'SUP') {
           addAttachmentPointToSuperatom(sgroup, beginAtomId, endAtomId);

--- a/packages/ketcher-core/src/application/editor/actions/erase.ts
+++ b/packages/ketcher-core/src/application/editor/actions/erase.ts
@@ -30,15 +30,38 @@ import { removeAtomFromSgroupIfNeeded, removeSgroupIfNeeded } from './sgroup';
 import { Action } from './action';
 import assert from 'assert';
 import { atomGetDegree, formatSelection } from './utils';
-import { fromBondStereoUpdate } from '../actions/bond';
+import {
+  fromBondStereoUpdate,
+  removeAttachmentPointFromSuperatom,
+} from '../actions/bond';
 import { fromFragmentSplit } from './fragment';
 import { fromRGroupAttachmentPointDeletion } from './rgroupAttachmentPoint';
+import { ReStruct } from 'application/render';
 
 export function fromOneAtomDeletion(restruct, atomId: number) {
   return fromFragmentDeletion(restruct, { atoms: [atomId] });
 }
 
-function fromBondDeletion(restruct, bid: number, skipAtoms: Array<any> = []) {
+function fromBondDeletion(
+  restruct: ReStruct,
+  bid: number,
+  skipAtoms: Array<any> = [],
+) {
+  if (restruct.sgroups.size > 0) {
+    restruct.sgroups.forEach((sgroup) => {
+      if (sgroup.item?.type && sgroup.item?.type === 'SUP') {
+        const beginAtomConnectedToBond = restruct.bonds.get(bid)?.b.begin;
+        const endAtomConnectedToBond = restruct.bonds.get(bid)?.b.end;
+
+        removeAttachmentPointFromSuperatom(
+          sgroup,
+          beginAtomConnectedToBond,
+          endAtomConnectedToBond,
+        );
+      }
+    });
+  }
+
   let action = new Action();
   const bond: any = restruct.molecule.bonds.get(bid);
   const atomsToRemove: Array<any> = [];

--- a/packages/ketcher-core/src/application/editor/actions/erase.ts
+++ b/packages/ketcher-core/src/application/editor/actions/erase.ts
@@ -47,7 +47,7 @@ function fromBondDeletion(
   bid: number,
   skipAtoms: Array<any> = [],
 ) {
-  if (restruct.sgroups.size > 0) {
+  if (restruct.sgroups && restruct.sgroups.size > 0) {
     restruct.sgroups.forEach((sgroup) => {
       if (sgroup.item?.type && sgroup.item?.type === 'SUP') {
         const beginAtomConnectedToBond = restruct.bonds.get(bid)?.b.begin;

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -143,8 +143,6 @@ export function sGroupAttributeAction(id, attrs) {
 }
 
 export function fromSgroupDeletion(restruct, id) {
-  console.log('fromSgroupAddition');
-
   let action = new Action();
   const struct = restruct.molecule;
 
@@ -195,8 +193,6 @@ export function fromSgroupAddition(
   name?,
   oldSgroup?,
 ) {
-  console.log('fromSgroupAddition');
-
   // eslint-disable-line
   let action = new Action();
 

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -144,6 +144,8 @@ export function sGroupAttributeAction(id, attrs) {
 }
 
 export function fromSgroupDeletion(restruct, id) {
+  console.log('fromSgroupAddition');
+
   let action = new Action();
   const struct = restruct.molecule;
 
@@ -194,6 +196,8 @@ export function fromSgroupAddition(
   name?,
   oldSgroup?,
 ) {
+  console.log('fromSgroupAddition');
+
   // eslint-disable-line
   let action = new Action();
 
@@ -519,7 +523,10 @@ function findAttachmentPoints(
           const sgroupAtom = structAtoms.get(sgroupAtomId);
 
           sgroupAtom?.neighbors.forEach((sgroupNeighbor) => {
-            if (sgroupNeighbor === structNeighbor + 1) {
+            if (
+              sgroupNeighbor === structNeighbor + 1 ||
+              sgroupNeighbor === structNeighbor - 1
+            ) {
               attachmentPoints.push(
                 new SGroupAttachmentPoint(sgroupAtomId, undefined, undefined),
               );

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -24,7 +24,7 @@ import {
   SGroupDelete,
   SGroupRemoveFromHierarchy,
 } from '../operations';
-import { Pile, SGroup, SGroupAttachmentPoint, Struct } from 'domain/entities';
+import { Pile, SGroup } from 'domain/entities';
 import { atomGetAttr, atomGetDegree, atomGetSGroups } from './utils';
 
 import { Action } from './action';
@@ -45,8 +45,7 @@ export function fromSeveralSgroupAddition(
   atoms,
   attrs,
 ) {
-  const struct = restruct.molecule;
-  const attachmentPoints = findAttachmentPoints(struct, atoms);
+  const attachmentPoints = [];
 
   const descriptors = attrs.fieldValue;
   if (typeof descriptors === 'string' || type !== 'DAT') {
@@ -507,35 +506,4 @@ function getAtomsFromBonds(struct, bonds) {
     acc = acc.concat([bond.begin, bond.end]);
     return acc;
   }, []);
-}
-
-function findAttachmentPoints(
-  struct: Struct,
-  sgroupAtoms: number[],
-): SGroupAttachmentPoint[] {
-  const attachmentPoints: SGroupAttachmentPoint[] = [];
-  const structAtoms = struct.atoms;
-
-  structAtoms.forEach((value, key) => {
-    if (!sgroupAtoms.includes(key)) {
-      value.neighbors.forEach((structNeighbor) => {
-        sgroupAtoms.forEach((sgroupAtomId) => {
-          const sgroupAtom = structAtoms.get(sgroupAtomId);
-
-          sgroupAtom?.neighbors.forEach((sgroupNeighbor) => {
-            if (
-              sgroupNeighbor === structNeighbor + 1 ||
-              sgroupNeighbor === structNeighbor - 1
-            ) {
-              attachmentPoints.push(
-                new SGroupAttachmentPoint(sgroupAtomId, undefined, undefined),
-              );
-            }
-          });
-        });
-      });
-    }
-  });
-
-  return attachmentPoints;
 }


### PR DESCRIPTION
- add findAttachmentPoints function
- add addAttachmentPoint function
- add removeAttachmentPoint function

## How the feature works?

https://github.com/epam/ketcher/assets/117748331/18dfee12-94e4-4d4a-9fa7-92e8c621c3e1

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request