### PR TITLE
#4172 - Macro: 'leavingGroup' section does not contain information about number of atoms

### DIFF
--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -408,7 +408,10 @@ export abstract class BaseMonomer extends DrawingEntity {
       monomerDefinitionAttachmentPoints.push({
         attachmentAtom: attachmentAtomId,
         leavingGroup: {
-          atoms: leavingGroupsAtomId ? [leavingGroupsAtomId] : [],
+          atoms:
+            leavingGroupsAtomId === 0 || leavingGroupsAtomId
+              ? [leavingGroupsAtomId]
+              : [],
         },
         type:
           this.attachmentPointNumberToType[leavingGroupsAtom.rglabel] ||


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
After adding a monomer and saving as .ket, the monomer's leavingGroup wasn't showing up specifically for the ones whose leavingGroup was at 0 index. Added a check for atom id so that if the leavingGroup is at 0 index, that also will be visible.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request