### PR TITLE
Fix viewing 3D molecules in Miew (issue #3501)

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/helpers.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/helpers.ts
@@ -41,11 +41,12 @@ const rotateCoordAxisBy180Degrees = (position: Vec2, axis: Axises): Vec2 => {
   const rotatedPosition = {
     x: position.x,
     y: position.y,
+    z: position.z,
   };
 
   rotatedPosition[axis] = -rotatedPosition[axis];
 
-  return new Vec2(rotatedPosition.x, rotatedPosition.y);
+  return new Vec2(rotatedPosition.x, rotatedPosition.y, rotatedPosition.z);
 };
 
 /**


### PR DESCRIPTION
- Rotation was missing z coordinate when switching into chemistry coordinate system.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request