### PR TITLE
#4507 - Macro: When expanding structures, added to the canvas via Clipboard, an error appears in the Console

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev:standalone": "cross-env MODE=standalone vite",
+    "dev:standalone:macro": "cross-env ENABLE_POLYMER_EDITOR=true MODE=standalone vite",
     "dev:remote": "cross-env MODE=remote vite",
     "start:standalone": "cross-env MODE=standalone react-app-rewired start",
     "start:remote": "cross-env MODE=remote react-app-rewired start",

--- a/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
+++ b/packages/ketcher-core/src/application/editor/tools/SelectRectangle.ts
@@ -231,7 +231,7 @@ class SelectRectangle implements BaseTool {
 
   mouseup(event) {
     const renderer = event.target.__data__;
-    if (this.moveStarted && renderer.drawingEntity?.selected) {
+    if (this.moveStarted && renderer?.drawingEntity?.selected) {
       this.moveStarted = false;
 
       if (


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Closes [#4507](https://github.com/epam/ketcher/issues/4507)

 - When Select Rectangle Tool is used and elements frantically moved mouseup event could be fired and some time it looses renderer object, so check for it is needed.
 - Added possibility to run development with Polymer editor by script 'dev:standalone:macro'.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request