### PR TITLE
Backmerge: #4508 – Macro: In the Text-editing mode, when selecting nucleotides linked through phosphates R2-R2, an error appears in the Console

### DIFF
--- a/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/BaseMonomer.ts
@@ -480,10 +480,6 @@ export abstract class BaseMonomer extends DrawingEntity {
     return this.SubChainConstructor !== monomerToChain.SubChainConstructor;
   }
 
-  public get isPartOfRna() {
-    return false;
-  }
-
   public get isModification() {
     return this.monomerItem.props.MonomerNaturalAnalogCode !== this.label;
   }

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -1713,7 +1713,7 @@ export class DrawingEntitiesManager {
     ) {
       return { command, drawingEntities };
     }
-    if (drawingEntity.isPartOfRna && drawingEntity instanceof Sugar) {
+    if (drawingEntity instanceof Sugar && drawingEntity.isPartOfRNA) {
       const sugar = drawingEntity;
       if (isValidNucleoside(sugar)) {
         const nucleoside = Nucleoside.fromSugar(sugar);

--- a/packages/ketcher-core/src/domain/entities/DrawingEntity.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntity.ts
@@ -79,8 +79,4 @@ export abstract class DrawingEntity {
   public setBaseRenderer(renderer: BaseRenderer) {
     this.baseRenderer = renderer;
   }
-
-  public get isPartOfRna() {
-    return false;
-  }
 }

--- a/packages/ketcher-core/src/domain/entities/Phosphate.ts
+++ b/packages/ketcher-core/src/domain/entities/Phosphate.ts
@@ -2,7 +2,6 @@ import { BaseMonomer } from './BaseMonomer';
 import { AttachmentPointName, MonomerItemType } from 'domain/types';
 import { Vec2 } from './vec2';
 import { Sugar } from './Sugar';
-import { RNABase } from 'domain/entities/RNABase';
 import { PhosphateSubChain } from 'domain/entities/monomer-chains/PhosphateSubChain';
 import { SubChainNode } from 'domain/entities/monomer-chains/types';
 import { RnaSubChain } from 'domain/entities/monomer-chains/RnaSubChain';
@@ -92,22 +91,5 @@ export class Phosphate extends BaseMonomer {
 
   public get SubChainConstructor() {
     return PhosphateSubChain;
-  }
-
-  get isPartOfRna() {
-    const previousMonomer =
-      this.attachmentPointsToBonds.R1?.getAnotherMonomer(this);
-    const isPreviousMonomerSugar = previousMonomer instanceof Sugar;
-    const isSugarConnectedToBase =
-      previousMonomer?.attachmentPointsToBonds.R3?.getAnotherMonomer(
-        previousMonomer,
-      ) instanceof RNABase;
-    const nextMonomer =
-      this.attachmentPointsToBonds.R2?.getAnotherMonomer(this);
-    const isNextMonomerRna = nextMonomer?.isPartOfRna;
-
-    // isNextMonomerRna used here because we need to interpret last phosphate of rna chain
-    // as not a part of nucleoTide but as phosphate connected to nucleoSide
-    return isPreviousMonomerSugar && isSugarConnectedToBase && isNextMonomerRna;
   }
 }

--- a/packages/ketcher-core/src/domain/entities/PolymerBond.ts
+++ b/packages/ketcher-core/src/domain/entities/PolymerBond.ts
@@ -63,7 +63,7 @@ export class PolymerBond extends DrawingEntity {
     return this.position;
   }
 
-  public getAnotherMonomer(monomer: BaseMonomer) {
+  public getAnotherMonomer(monomer: BaseMonomer): BaseMonomer | undefined {
     return this.firstMonomer === monomer
       ? this.secondMonomer
       : this.firstMonomer;

--- a/packages/ketcher-core/src/domain/entities/RNABase.ts
+++ b/packages/ketcher-core/src/domain/entities/RNABase.ts
@@ -1,5 +1,4 @@
 import { BaseMonomer } from 'domain/entities/BaseMonomer';
-import { Sugar } from 'domain/entities/Sugar';
 import { ChemSubChain } from 'domain/entities/monomer-chains/ChemSubChain';
 
 export class RNABase extends BaseMonomer {
@@ -19,11 +18,5 @@ export class RNABase extends BaseMonomer {
 
   public get SubChainConstructor() {
     return ChemSubChain;
-  }
-
-  public get isPartOfRna(): boolean {
-    return (
-      this.attachmentPointsToBonds.R1?.getAnotherMonomer(this) instanceof Sugar
-    );
   }
 }

--- a/packages/ketcher-core/src/domain/entities/Sugar.ts
+++ b/packages/ketcher-core/src/domain/entities/Sugar.ts
@@ -105,7 +105,7 @@ export class Sugar extends BaseMonomer {
     );
   }
 
-  public get isPartOfRna(): boolean {
+  public get isPartOfRNA(): boolean {
     return (
       this.attachmentPointsToBonds.R3?.getAnotherMonomer(this) instanceof
       RNABase


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request