### PR TITLE
#4491 macro escape button unselect nucleotides if a sequence in modify in rna builder mode

### DIFF
--- a/packages/ketcher-macromolecules/src/components/contextMenu/SequenceItemContextMenu/SequenceItemContextMenu.tsx
+++ b/packages/ketcher-macromolecules/src/components/contextMenu/SequenceItemContextMenu/SequenceItemContextMenu.tsx
@@ -1,5 +1,5 @@
 import { Item, ItemParams } from 'react-contexify';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect } from 'react';
 import { CONTEXT_MENU_ID } from '../types';
 import { StyledMenu } from '../styles';
 import { createPortal } from 'react-dom';
@@ -146,6 +146,23 @@ export const SequenceItemContextMenu = ({
   const ketcherEditorRootElement = document.querySelector(
     KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR,
   );
+
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      const unselectButtons =
+        event.key === 'Escape' || (event.shiftKey && event.key === 'Tab');
+      if (unselectButtons && isSequenceEditInRNABuilderMode) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyPress, true);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress, true);
+    };
+  }, [isSequenceEditInRNABuilderMode]);
 
   return ketcherEditorRootElement && !isSequenceEditInRNABuilderMode
     ? createPortal(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

1. link to an issue --> https://github.com/epam/ketcher/issues/4491
2. now the'Escape' vs 'Shift + Tab' buttons while in rna modifying mode doesn't trigger unselection of the sequences.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request