### PR TITLE
#4509 - In the Text-editing mode, when inserting a fragment after pressing Ctrl+V twice, the cursor is moved to another row

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -838,23 +838,14 @@ export class SequenceMode extends BaseMode {
 
     const currentSequence = SequenceRenderer.currentChain;
 
-    const currentSequenceHasPhosphate = currentSequence?.lastNonEmptyNode
-      ? this.hasPhosphateAtEndOfSequence(
-          currentSequence.lastNonEmptyNode.monomer,
-        )
-      : false;
-
-    const newSequenceHasPhosphate = chainsCollection.lastNode
-      ? this.hasPhosphateAtEndOfSequence(chainsCollection.lastNode.monomer)
-      : false;
+    const currentSequenceHasPhosphate =
+      currentSequence.lastNonEmptyNode?.monomer?.monomerItem?.props?.Name ===
+      'Phosphate';
 
     let nextCaretPosition =
       SequenceRenderer.caretPosition + chainsCollection.length;
 
-    if (
-      (currentSequenceHasPhosphate && newSequenceHasPhosphate) ||
-      currentSequenceHasPhosphate
-    ) {
+    if (currentSequenceHasPhosphate) {
       nextCaretPosition -= 1;
     }
 
@@ -870,14 +861,6 @@ export class SequenceMode extends BaseMode {
     );
 
     return modelChanges;
-  }
-
-  private hasPhosphateAtEndOfSequence(monomer: BaseMonomer): boolean {
-    if (!monomer) return false;
-    if (!monomer.monomerItem || !monomer.monomerItem.props) {
-      return false;
-    }
-    return monomer.monomerItem.props.Name === 'Phosphate';
   }
 
   private insertNewSequenceItem(editor: CoreEditor, enteredSymbol: string) {

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -838,7 +838,7 @@ export class SequenceMode extends BaseMode {
 
     const currentSequence = SequenceRenderer.currentChain;
 
-    const currentSequenceHasPhosphate = currentSequence.lastNonEmptyNode
+    const currentSequenceHasPhosphate = currentSequence?.lastNonEmptyNode
       ? this.hasPhosphateAtEndOfSequence(
           currentSequence.lastNonEmptyNode.monomer,
         )

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -839,7 +839,7 @@ export class SequenceMode extends BaseMode {
     const currentSequence = SequenceRenderer.currentChain;
 
     const currentSequenceHasPhosphate =
-      currentSequence.lastNonEmptyNode?.monomer?.monomerItem?.props?.Name ===
+      currentSequence?.lastNonEmptyNode?.monomer?.monomerItem?.props?.Name ===
       'Phosphate';
 
     let nextCaretPosition =


### PR DESCRIPTION
## Overview
This pull request addresses the issue where, in Text-editing mode, the cursor moves to another row after inserting a fragment by pressing Ctrl+V twice.

## Solution
The problem has been resolved by implementing a check for the presence of phosphate in the current sequence and the inserted sequence. 

## Testing
Manual testing has been performed to validate the fix in various scenarios within the Text-editing mode.

## Impact
This fix improves the user experience by preventing the cursor from inadvertently moving to another row after inserting a fragment. It enhances the overall usability and reliability of the Text-editing mode.

## References
[In the Text-editing mode, when inserting a fragment after pressing Ctrl+V twice, the cursor is moved to another row #4509](https://github.com/epam/ketcher/issues/4509)

## Check list
- [ ] unit-tests written
- [ ]  e2e-tests written
- [ ]  documentation updated
- [x]  PR name follows the pattern `#1234 – issue name`
- [x]  branch name doesn't contain '#'
- [x]  PR is linked with the issue
- [x]  base branch (master or release/xx) is correct
- [x]  task status changed to "Code review"
- [x]  reviewers are notified about the pull request