### PR TITLE
Backmerge: #4730 - System doubles number of pasted monomers after switching from flex to sequence

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -80,6 +80,8 @@ export class CoreEditor {
   public sequenceTypeEnterMode = SequenceType.RNA;
   private micromoleculesEditor: Editor;
   private hotKeyEventHandler: (event: unknown) => void = () => {};
+  private copyEventHandler: (event: ClipboardEvent) => void = () => {};
+  private pasteEventHandler: (event: ClipboardEvent) => void = () => {};
 
   constructor({ theme, canvas }: ICoreEditorConstructorParams) {
     this.theme = theme;
@@ -167,12 +169,14 @@ export class CoreEditor {
   }
 
   private setupCopyPasteEvent() {
-    document.addEventListener('copy', (event: ClipboardEvent) => {
+    this.copyEventHandler = (event: ClipboardEvent) => {
       this.mode.onCopy(event);
-    });
-    document.addEventListener('paste', (event: ClipboardEvent) => {
+    };
+    this.pasteEventHandler = (event: ClipboardEvent) => {
       this.mode.onPaste(event);
-    });
+    };
+    document.addEventListener('copy', this.copyEventHandler);
+    document.addEventListener('paste', this.pasteEventHandler);
   }
 
   private setupHotKeysEvents() {
@@ -380,6 +384,8 @@ export class CoreEditor {
       this.events[eventName].handlers = [];
     }
     document.removeEventListener('keydown', this.hotKeyEventHandler);
+    document.removeEventListener('copy', this.copyEventHandler);
+    document.removeEventListener('paste', this.pasteEventHandler);
   }
 
   get trackedDomEvents() {


### PR DESCRIPTION
- added removing of copy/paste event listeners during switching between micro/macro modes

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request