### PR TITLE
Backmerge: #4744 - When changing zoom level in macro mode, there is no percentage indication

### DIFF
--- a/packages/ketcher-macromolecules/src/components/ZoomControls/ZoomControls.tsx
+++ b/packages/ketcher-macromolecules/src/components/ZoomControls/ZoomControls.tsx
@@ -44,7 +44,7 @@ export const ZoomControls = () => {
     ZoomTool?.instance?.subscribeOnZoomEvent(() => {
       setCurrentZoom(Math.round(ZoomTool?.instance?.getZoomLevel() * 100));
     });
-  }, [ZoomTool?.instance?.subscribeOnZoomEvent]);
+  }, [ZoomTool?.instance]);
 
   const onZoomSubmit = useCallback(() => {
     const inputEl = inputRef.current;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed ZoomControls component subscription to ZoomTool instance


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request