### PR TITLE
#4740 - Delete of cycled sequnece from the canvas causes delete of another cycled sequence bond that makes it non-cycled

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -549,17 +549,16 @@ export class SequenceMode extends BaseMode {
 
       if (
         !nodeBeforeSelection ||
-        nodeBeforeSelection instanceof EmptySequenceNode ||
-        nodeBeforeSelection !== nodeInSameChainBeforeSelection ||
-        nodeAfterSelection !== nodeInSameChainAfterSelection
+        nodeBeforeSelection instanceof EmptySequenceNode
       ) {
         return;
       }
 
       if (
+        nodeBeforeSelection === nodeInSameChainBeforeSelection &&
         nodeBeforeSelection instanceof Nucleotide &&
-        !(nodeAfterSelection instanceof Nucleotide) &&
-        !(nodeAfterSelection instanceof Nucleoside)
+        !(nodeInSameChainAfterSelection instanceof Nucleotide) &&
+        !(nodeInSameChainAfterSelection instanceof Nucleoside)
       ) {
         // delete phosphate from last nucleotide
         modelChanges.merge(
@@ -573,7 +572,10 @@ export class SequenceMode extends BaseMode {
 
       if (
         !nodeAfterSelection ||
-        nodeAfterSelection instanceof EmptySequenceNode
+        nodeAfterSelection instanceof EmptySequenceNode ||
+        (!this.isEditMode &&
+          (nodeAfterSelection !== nodeInSameChainAfterSelection ||
+            nodeBeforeSelection !== nodeInSameChainBeforeSelection))
       ) {
         return;
       }

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -531,6 +531,8 @@ export class SequenceMode extends BaseMode {
       const nodeAfterSelection = SequenceRenderer.getNextNode(selectionEndNode);
       const nodeInSameChainBeforeSelection =
         SequenceRenderer.getPreviousNodeInSameChain(selectionStartNode);
+      const nodeInSameChainAfterSelection =
+        SequenceRenderer.getNextNodeInSameChain(selectionEndNode);
 
       if (
         !nodeInSameChainBeforeSelection &&
@@ -547,7 +549,9 @@ export class SequenceMode extends BaseMode {
 
       if (
         !nodeBeforeSelection ||
-        nodeBeforeSelection instanceof EmptySequenceNode
+        nodeBeforeSelection instanceof EmptySequenceNode ||
+        nodeBeforeSelection !== nodeInSameChainBeforeSelection ||
+        nodeAfterSelection !== nodeInSameChainAfterSelection
       ) {
         return;
       }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- skip handling of adding/deleteing phosphates and establishing bonds if selection if on the bound of chain

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request