### PR TITLE
#4777 - Incorrect valence for carbon atom in ring with attachment point after saving and reopening file

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -124,11 +124,6 @@ export function fromPaste(
     );
   });
 
-  pasteItems.atoms.forEach((aid) => {
-    action.addOp(new CalcImplicitH([aid]).perform(restruct));
-    new AtomAttr(aid, 'isPreview', isPreview).perform(restruct);
-  });
-
   pstruct.sgroups.forEach((sg: SGroup) => {
     const newsgid = restruct.molecule.sgroups.newId();
     const sgAtoms = sg.atoms.map((aid) => aidMap.get(aid));
@@ -154,6 +149,11 @@ export function fromPaste(
     sgAction.operations.reverse().forEach((oper) => {
       action.addOp(oper);
     });
+  });
+
+  pasteItems.atoms.forEach((aid) => {
+    action.addOp(new CalcImplicitH([aid]).perform(restruct));
+    new AtomAttr(aid, 'isPreview', isPreview).perform(restruct);
   });
 
   pstruct.rxnArrows.forEach((rxnArrow) => {

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -985,6 +985,10 @@ export class Struct {
   }
 
   calcImplicitHydrogen(aid: number) {
+    if (Atom.isHiddenLeavingGroupAtom(this, aid)) {
+      return;
+    }
+
     const atom = this.atoms.get(aid)!;
     const charge = atom.charge || 0;
     const [conn, isAromatic] = this.calcConn(atom);

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -371,6 +371,11 @@ export class Struct {
     for (let i = 0; i < atom.neighbors.length; ++i) {
       const hb = this.halfBonds.get(atom.neighbors[i])!;
       const bond = this.bonds.get(hb.bid)!;
+
+      if (Bond.isBondToHiddenLeavingGroup(this, bond)) {
+        continue;
+      }
+
       switch (bond.type) {
         case Bond.PATTERN.TYPE.SINGLE:
           conn += 1;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added ignoring of leaving groups connection count for valence warning calculation if there is connection to attachment point

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request