### PR TITLE
Backmerge: #4764 - IDT label is not shown or shown but layout is broken after load sequence from ket

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -571,6 +571,7 @@ export class KetSerializer implements Serializer<Struct> {
             fullName: monomer.monomerItem.props.Name,
             alias: monomer.monomerItem.label,
             attachmentPoints: monomer.monomerItem.attachmentPoints,
+            idtAliases: monomer.monomerItem.props.idtAliases,
           };
           // CHEMs do not have natural analog
           if (monomer.monomerItem.props.MonomerType !== 'CHEM') {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added idtAliases serialisation to ket

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request