### PR TITLE
#4636 - In the Sequence mode, when selecting elements on the canvas, the total number of elements is not displayed in the Right-click menu

### DIFF
--- a/packages/ketcher-macromolecules/src/components/contextMenu/SequenceItemContextMenu/helpers.ts
+++ b/packages/ketcher-macromolecules/src/components/contextMenu/SequenceItemContextMenu/helpers.ts
@@ -53,6 +53,15 @@ const generateLabeledNodes = (
   return labeledNodes;
 };
 
+function isNucleotideNucleosideOrPhosphate(selection: NodeSelection): boolean {
+  const { node } = selection;
+  return (
+    node instanceof Nucleotide ||
+    node instanceof Nucleoside ||
+    node?.monomer instanceof Phosphate
+  );
+}
+
 // Generate menu title if selected:
 // one nucleotide
 // one nucleoside
@@ -112,6 +121,11 @@ export const generateSequenceContextMenuProps = (
       isSelectedOnlyNucleoelements = false;
     }
   }
+  if (countOfSelections > countOfNucleoelements) {
+    if (!selectionsFlatten.every(isNucleotideNucleosideOrPhosphate)) {
+      isSelectedOnlyNucleoelements = false;
+    }
+  }
 
   // Set title based on selected elements
   if (
@@ -120,10 +134,9 @@ export const generateSequenceContextMenuProps = (
   ) {
     title = generateNucleoelementTitle(selectedSequenceLabeledNodes);
   } else {
-    title =
-      countOfSelections === countOfNucleoelements
-        ? `${countOfNucleoelements} nucleotides`
-        : `${countOfSelections} elements`;
+    title = isSelectedOnlyNucleoelements
+      ? `${countOfNucleoelements} nucleotides`
+      : `${countOfSelections} elements`;
   }
 
   return {

--- a/packages/ketcher-macromolecules/src/components/contextMenu/SequenceItemContextMenu/helpers.ts
+++ b/packages/ketcher-macromolecules/src/components/contextMenu/SequenceItemContextMenu/helpers.ts
@@ -120,9 +120,10 @@ export const generateSequenceContextMenuProps = (
   ) {
     title = generateNucleoelementTitle(selectedSequenceLabeledNodes);
   } else {
-    title = isSelectedOnlyNucleoelements
-      ? `${countOfNucleoelements} nucleotides`
-      : `${countOfSelections} elements`;
+    title =
+      countOfSelections === countOfNucleoelements
+        ? `${countOfNucleoelements} nucleotides`
+        : `${countOfSelections} elements`;
   }
 
   return {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?


If the number of selections equal the number of nucleic elements, then we write nucleotides, otherwise elements.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request