### PR TITLE
#4801 - Cut operation for attachment points makes canvas inaccessible/inoperational and delete entire molecule

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/erase.ts
+++ b/packages/ketcher-core/src/application/editor/actions/erase.ts
@@ -149,7 +149,8 @@ export function fromFragmentDeletion(restruct, rawSelection) {
       attachmentPoints.forEach((attachmentPoint) => {
         if (
           attachmentPoint.atomId === atomId &&
-          isNumber(attachmentPoint.leaveAtomId)
+          isNumber(attachmentPoint.leaveAtomId) &&
+          !selection.atoms.includes(attachmentPoint.leaveAtomId)
         ) {
           action.addOp(
             new SGroupAtomRemove(sgroup.id, attachmentPoint.leaveAtomId),

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -476,7 +476,7 @@ export function removeSgroupIfNeeded(action, restruct: Restruct, atoms) {
     const sGroup = restruct.sgroups.get(sid)?.item;
     const sgAtoms = SGroup.getAtoms(restruct.molecule, sGroup);
 
-    if (sgAtoms.length === count) {
+    if (sgAtoms.length === count && !sGroup?.isSuperatomWithoutLabel) {
       // delete whole s-group
       const sgroup = struct.sgroups.get(sid) as SGroup;
       action.mergeWith(sGroupAttributeAction(sid, sgroup.getAttrs()));

--- a/packages/ketcher-core/src/application/editor/operations/bond/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/index.ts
@@ -104,7 +104,13 @@ class BondDelete extends BaseOperation {
 
   constructor(bondId?: any) {
     super(OperationType.BOND_DELETE, OperationPriority.BOND_DELETE);
-    this.data = { bid: bondId, bond: null, begin: null, end: null };
+    this.data = {
+      bid: bondId,
+      bond: null,
+      begin: null,
+      end: null,
+      needInvalidateAtoms: true,
+    };
   }
 
   execute(restruct: ReStruct) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added skipping of implicit leaving group atom deletion in case if it is explicitly selected
- added connected atoms invalidation for undo of bond deletion
- skipped regular logic of sgroup atoms deletion in case of superatoms without labels

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request