### PR TITLE
#4785 - Structure appears distorted after saving and reopening in MOLV2000 format

### DIFF
--- a/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { RGroupAttachmentPoint } from './rgroupAttachmentPoint';
+import { isNumber } from 'lodash';
 
 /**
  * This is data model for Sgrou attachment point.
@@ -39,12 +40,14 @@ export class SGroupAttachmentPoint {
   constructor(
     atomId: number,
     leaveAtomId: number | undefined,
-    attachmentId: string | undefined,
+    attachmentId: string | number | undefined,
     attachmentPointNumber?: number,
   ) {
     this.atomId = atomId;
     this.leaveAtomId = leaveAtomId;
-    this.attachmentId = attachmentId;
+    this.attachmentId = isNumber(attachmentId)
+      ? attachmentId.toString()
+      : attachmentId;
     this.attachmentPointNumber = attachmentPointNumber;
   }
 

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -112,7 +112,7 @@ export class SGroup {
       mul: 1, // multiplication count for MUL group
       connectivity: 'ht', // head-to-head, head-to-tail or either-unknown
       name: '',
-      subscript: 'n',
+      subscript: '',
       expanded: undefined,
       // data s-group fields
       attached: false,

--- a/packages/ketcher-core/src/domain/serializers/mol/common.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/common.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Pile, SGroup } from 'domain/entities';
+import { MonomerMicromolecule, Pile, SGroup } from 'domain/entities';
 
 import utils from './utils';
 import v2000 from './v2000';
@@ -202,9 +202,19 @@ function saveSupToMolfile(sgroup, mol, sgMap, atomMap, bondMap) {
   let lines = [];
   lines = lines.concat(makeAtomBondLines('SAL', idstr, sgroup.atoms, atomMap));
   lines = lines.concat(makeAtomBondLines('SBL', idstr, sgroup.bonds, bondMap));
-  if (sgroup.data.name && sgroup.data.name !== '') {
-    lines.push('M  SMT ' + idstr + ' ' + sgroup.data.name);
+
+  let sgroupName;
+
+  if (sgroup instanceof MonomerMicromolecule) {
+    sgroupName = sgroup.monomer.label;
+  } else if (sgroup.data.name && sgroup.data.name !== '') {
+    sgroupName = sgroup.data.name;
   }
+
+  if (sgroupName) {
+    lines.push('M  SMT ' + idstr + ' ' + sgroupName);
+  }
+
   return lines.join('\n');
 }
 

--- a/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
@@ -25,6 +25,7 @@ import { Elements } from 'domain/constants';
 import common from './common';
 import utils from './utils';
 import { KetcherLogger } from 'utilities';
+import { isNumber } from 'lodash';
 
 const END_V2000 = '2D 1   1.00000     0.00000     0';
 
@@ -658,6 +659,8 @@ export class Molfile {
 
     const attachmentId = attachmentPoint.attachmentId
       ? attachmentPoint.attachmentId.slice(0, 2)
+      : isNumber(attachmentPoint.attachmentPointNumber)
+      ? attachmentPoint.attachmentPointNumber.toString()
       : '  ';
     this.writePadded(attachmentId, 2);
     this.writeCR();

--- a/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.js
@@ -395,11 +395,19 @@ function parseSGroupSAPLineV2000(ctabString) {
       false,
     );
     const atomId = utils.parseDecimalInt(iii) - 1;
+    const attachmentId = utils.parseDecimalInt(cc);
     assert(atomId >= 0);
     const leaveAtomParsedId = utils.parseDecimalInt(ooo);
     const leaveAtomId =
       leaveAtomParsedId > 0 ? leaveAtomParsedId - 1 : undefined;
-    attachmentPoints.push(new SGroupAttachmentPoint(atomId, leaveAtomId, cc));
+    attachmentPoints.push(
+      new SGroupAttachmentPoint(
+        atomId,
+        leaveAtomId,
+        attachmentId,
+        attachmentId,
+      ),
+    );
   }
   return { sGroupId, attachmentPoints };
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed saving superatoms with attachment points without labels in molV2000
- partially fixed saving monomers to molV2000

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request