### PR TITLE
#4823 - In sequence mode, each press adds two characters and when deleted, also removes two

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -82,6 +82,7 @@ export class CoreEditor {
   private hotKeyEventHandler: (event: unknown) => void = () => {};
   private copyEventHandler: (event: ClipboardEvent) => void = () => {};
   private pasteEventHandler: (event: ClipboardEvent) => void = () => {};
+  private keydownEventHandler: (event: KeyboardEvent) => void = () => {};
 
   constructor({ theme, canvas }: ICoreEditorConstructorParams) {
     this.theme = theme;
@@ -163,9 +164,11 @@ export class CoreEditor {
 
   private setupKeyboardEvents() {
     this.setupHotKeysEvents();
-    document.addEventListener('keydown', async (event: KeyboardEvent) => {
+    this.keydownEventHandler = async (event: KeyboardEvent) => {
       await this.mode.onKeyDown(event);
-    });
+    };
+
+    document.addEventListener('keydown', this.keydownEventHandler);
   }
 
   private setupCopyPasteEvent() {
@@ -386,6 +389,7 @@ export class CoreEditor {
     document.removeEventListener('keydown', this.hotKeyEventHandler);
     document.removeEventListener('copy', this.copyEventHandler);
     document.removeEventListener('paste', this.pasteEventHandler);
+    document.removeEventListener('keydown', this.keydownEventHandler);
   }
 
   get trackedDomEvents() {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added removing keydown subscription after editor destroy

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request