### PR TITLE
#4793 - Context menu for attachment point labels should contain only Delete option

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
@@ -171,6 +171,14 @@ const AtomMenuItems: FC<MenuItemsProps> = (props) => {
       ),
   );
 
+  if (isAtomSuperatomLeavingGroup && onlyOneAtomSelected) {
+    return (
+      <Item {...props} onClick={handleDelete}>
+        Delete
+      </Item>
+    );
+  }
+
   return (
     <>
       <Item {...props} onClick={handleEdit}>


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request