### PR TITLE
#4791 - System saves selection states of attachment point labels to KET file (it should not)

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.jsx
@@ -27,6 +27,7 @@ import {
   getPropertiesByImgFormat,
   b64toBlob,
   KetcherLogger,
+  Atom,
 } from 'ketcher-core';
 
 import { Dialog } from '../../../../components';
@@ -202,6 +203,11 @@ class SaveDialog extends Component {
       const getStructFromStringByType = () => {
         if (type === 'ket') {
           const selection = this.props.editor.selection();
+          if (selection?.atoms?.length > 0) {
+            selection.atoms = selection.atoms.filter((selectedAtomId) => {
+              return !Atom.isSuperatomLeavingGroupAtom(struct, selectedAtomId);
+            });
+          }
           return service.getStructureFromStructAsync(
             struct,
             undefined,

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
@@ -82,7 +82,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
     onClear: () => dispatchAction('clear'),
     onFileOpen: () => dispatchAction('open'),
     onSave: () => {
-      dispatchAction('deselect-all');
       dispatch(removeStructAction());
       dispatchAction('save');
     },

--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/TopToolbar.container.ts
@@ -82,6 +82,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
     onClear: () => dispatchAction('clear'),
     onFileOpen: () => dispatchAction('open'),
     onSave: () => {
+      dispatchAction('deselect-all');
       dispatch(removeStructAction());
       dispatchAction('save');
     },


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Deselect before saving

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request