### PR TITLE
#4833 - Support rendering multiple ketcher editors on a page without an iframe

### DIFF
--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -29,7 +29,7 @@ import classes from './Editor.module.less';
 import clsx from 'clsx';
 import { useResizeObserver } from './hooks';
 import {
-  KETCHER_INIT_EVENT_NAME,
+  ketcherInitEventName,
   KETCHER_ROOT_NODE_CLASS_NAME,
 } from './constants';
 import { createRoot } from 'react-dom/client';
@@ -49,7 +49,6 @@ function Editor(props: EditorProps) {
   const { height, width } = useResizeObserver<HTMLDivElement>({
     ref: rootElRef,
   });
-  const ketcherInitEvent = new Event(KETCHER_INIT_EVENT_NAME);
 
   useEffect(() => {
     const appRoot = createRoot(rootElRef.current as HTMLDivElement);
@@ -57,12 +56,21 @@ function Editor(props: EditorProps) {
       ...props,
       element: rootElRef.current,
       appRoot,
-    }).then((ketcher: Ketcher | undefined) => {
-      if (typeof onInit === 'function' && ketcher) {
-        onInit(ketcher);
-        window.dispatchEvent(ketcherInitEvent);
-      }
-    });
+    }).then(
+      ({
+        ketcher,
+        ketcherId,
+      }: {
+        ketcher: Ketcher | undefined;
+        ketcherId: string;
+      }) => {
+        if (typeof onInit === 'function' && ketcher) {
+          onInit(ketcher);
+          const ketcherInitEvent = new Event(ketcherInitEventName(ketcherId));
+          window.dispatchEvent(ketcherInitEvent);
+        }
+      },
+    );
     return () => {
       // setTimeout is used to disable the warn msg from react "Attempted to synchronously unmount a root while React was already rendering"
       setTimeout(() => {

--- a/packages/ketcher-react/src/constants.ts
+++ b/packages/ketcher-react/src/constants.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
-export const ketcherInitEventName = (ketcherId: string) =>
-  `ketcher-init-${ketcherId}`;
+export const ketcherInitEventName = (ketcherId?: string) =>
+  ketcherId ? `ketcher-init-${ketcherId}` : 'ketcher-init';
 
 export const MODES = {
   FG: 'fg',

--- a/packages/ketcher-react/src/constants.ts
+++ b/packages/ketcher-react/src/constants.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
-export const KETCHER_INIT_EVENT_NAME = 'ketcher-init';
+export const ketcherInitEventName = (ketcherId: string) =>
+  `ketcher-init-${ketcherId}`;
 
 export const MODES = {
   FG: 'fg',

--- a/packages/ketcher-react/src/contexts/appContext.tsx
+++ b/packages/ketcher-react/src/contexts/appContext.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 
 export interface IAppContext {
   getKetcherInstance: () => Ketcher;
+  ketcherId: string;
 }
 
 const appContext = React.createContext<IAppContext>({} as IAppContext);

--- a/packages/ketcher-react/src/hooks/useSubscribtionOnEvents.ts
+++ b/packages/ketcher-react/src/hooks/useSubscribtionOnEvents.ts
@@ -19,12 +19,12 @@ import { indigoVerification } from '../script/ui/state/request';
 import { Ketcher, KetcherAsyncEvents } from 'ketcher-core';
 import { useEffect } from 'react';
 import { useAppContext } from './useAppContext';
-import { KETCHER_INIT_EVENT_NAME } from '../constants';
+import { ketcherInitEventName } from '../constants';
 
 export const useSubscriptionOnEvents = () => {
   const dispatch = useDispatch();
 
-  const { getKetcherInstance } = useAppContext();
+  const { getKetcherInstance, ketcherId } = useAppContext();
 
   const loadingHandler = () => {
     dispatch(indigoVerification(true));
@@ -66,10 +66,11 @@ export const useSubscriptionOnEvents = () => {
       unsubscribe(getKetcherInstance());
     };
 
-    window.addEventListener(KETCHER_INIT_EVENT_NAME, subscribeOnInit);
+    const initEventName = ketcherInitEventName(ketcherId);
+    window.addEventListener(initEventName, subscribeOnInit);
     return () => {
       unsubscribeOnUnMount();
-      window.removeEventListener(KETCHER_INIT_EVENT_NAME, subscribeOnInit);
+      window.removeEventListener(initEventName, subscribeOnInit);
     };
   }, []);
 };

--- a/packages/ketcher-react/src/index.tsx
+++ b/packages/ketcher-react/src/index.tsx
@@ -18,3 +18,4 @@ export * from './Editor';
 export * from './script';
 export * from './constants';
 export * from './components';
+export { AppContext } from './contexts';

--- a/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
+++ b/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
@@ -62,10 +62,14 @@ class KetcherBuilder {
     errorHandler: (message: string) => void,
     buttons?: ButtonsConfig,
     togglerComponent?: JSX.Element,
-  ): Promise<void> {
+  ): Promise<{ setKetcher: (ketcher: Ketcher) => void; ketcherId: string }> {
     const { structService } = this;
 
-    const editor = await new Promise<Editor>((resolve) => {
+    const { editor, setKetcher, ketcherId } = await new Promise<{
+      editor: Editor;
+      setKetcher: (ketcher: Ketcher) => void;
+      ketcherId: string;
+    }>((resolve) => {
       initApp(
         element,
         appRoot,
@@ -90,6 +94,7 @@ class KetcherBuilder {
         : // eslint-disable-next-line @typescript-eslint/no-empty-function
           () => {};
     this.formatterFactory = new FormatterFactory(structService!);
+    return { setKetcher, ketcherId };
   }
 
   build() {

--- a/packages/ketcher-react/src/script/index.ts
+++ b/packages/ketcher-react/src/script/index.ts
@@ -42,7 +42,7 @@ async function buildKetcherAsync({
 
   await builder.appendApiAsync(structServiceProvider);
   builder.appendServiceMode(structServiceProvider.mode);
-  await builder.appendUiAsync(
+  const { setKetcher, ketcherId } = await builder.appendUiAsync(
     element,
     appRoot,
     staticResourcesUrl,
@@ -51,7 +51,11 @@ async function buildKetcherAsync({
     togglerComponent,
   );
 
-  return builder.build();
+  const ketcher = builder.build();
+  if (ketcher) {
+    setKetcher(ketcher);
+  }
+  return { ketcher, ketcherId };
 }
 
 export type { Config, ButtonsConfig };

--- a/packages/ketcher-react/src/script/ui/App/initApp.tsx
+++ b/packages/ketcher-react/src/script/ui/App/initApp.tsx
@@ -23,6 +23,7 @@ import { Ketcher, StructService } from 'ketcher-core';
 
 import App from './App.container';
 import { Provider } from 'react-redux';
+import { uniqueId } from 'lodash';
 import { Root } from 'react-dom/client';
 import createStore from '../state';
 import { initKeydownListener } from '../state/hotkeys';
@@ -35,9 +36,21 @@ function initApp(
   staticResourcesUrl: string,
   options: any,
   server: StructService,
-  setEditor: (editor: any) => void,
+  resolve: (args: {
+    editor: any;
+    setKetcher: (ketcher: Ketcher) => void;
+    ketcherId: string;
+  }) => void,
   togglerComponent?: JSX.Element,
 ) {
+  let ketcherRef: Ketcher | null = null;
+  const setKetcher = (ketcher: Ketcher) => {
+    ketcherRef = ketcher;
+  };
+  const ketcherId = uniqueId();
+  const setEditor = (editor) => {
+    resolve({ editor, setKetcher, ketcherId });
+  };
   const store = createStore(options, server, setEditor);
   store.dispatch(initKeydownListener(element));
   store.dispatch(initMouseListener(element));
@@ -49,7 +62,9 @@ function initApp(
         <ErrorsContext.Provider value={{ errorHandler: options.errorHandler }}>
           <AppContext.Provider
             value={{
-              getKetcherInstance: () => (window as any).ketcher as Ketcher,
+              // Expected this is set before load
+              getKetcherInstance: () => ketcherRef as unknown as Ketcher,
+              ketcherId,
             }}
           >
             <App togglerComponent={togglerComponent} />


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Add a ketcherId so that multiple ketcher instances can be added to the same page without using an iframe. Instead of binding each ketcher instance to the iframe, they can now be stored in the React state and easily accessed to obtain the data. 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request