### PR TITLE
#4786 - Keyboard shortcust stops working after adding/removing attachment point

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -697,6 +697,11 @@ class Editor implements KetcherEditor {
   clearMacromoleculeConvertionError() {
     this.macromoleculeConvertionError = null;
   }
+
+  focusCliparea() {
+    const cliparea: HTMLElement | null = document.querySelector('.cliparea');
+    cliparea?.focus();
+  }
 }
 
 /**

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useAddAttachmentPoint.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useAddAttachmentPoint.ts
@@ -80,6 +80,7 @@ const useAddAttachmentPoint = () => {
 
       editor.update(action);
       editor.selection(null);
+      editor.focusCliparea();
     },
     [getKetcherInstance],
   );

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useDelete.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useDelete.ts
@@ -20,6 +20,7 @@ const useDelete = () => {
       editor.update(action);
 
       editor.selection(null);
+      editor.focusCliparea();
     },
     [getKetcherInstance],
   );

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRemoveAttachmentPoint.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRemoveAttachmentPoint.ts
@@ -45,6 +45,7 @@ const useRemoveAttachmentPoint = () => {
 
       editor.update(action);
       editor.selection(null);
+      editor.focusCliparea();
     },
     [getKetcherInstance],
   );


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Add focus function after deleting and adding attachment point

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request