### PR TITLE
#4837 - Library filter does not reset when switching between Micro and Macro mode

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, useEffect, useRef } from 'react';
 import { Tabs } from 'components/shared/Tabs';
 import { tabsContent } from 'components/monomerLibrary/tabsContent';
 import { useAppDispatch, useAppSelector, useLayoutMode } from 'hooks';
@@ -51,13 +51,9 @@ const MonomerLibrary = React.memo((props: MonomerLibraryProps) => {
   const isDisabledTabsPanels =
     isSequenceMode && !isSequenceEditInRNABuilderMode;
 
-  const [firstRender, setFirstRender] = useState(true);
   useEffect(() => {
-    if (firstRender) {
-      setFirstRender(false);
-      dispatch(setSearchFilter(''));
-    }
-  }, [dispatch, firstRender]);
+    dispatch(setSearchFilter(''));
+  }, [dispatch]);
 
   useAppSelector(selectAllPresets, (presets) => {
     presetsRef.current = presets;

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import React, { ChangeEvent, useRef } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { Tabs } from 'components/shared/Tabs';
 import { tabsContent } from 'components/monomerLibrary/tabsContent';
 import { useAppDispatch, useAppSelector, useLayoutMode } from 'hooks';
@@ -50,6 +50,14 @@ const MonomerLibrary = React.memo((props: MonomerLibraryProps) => {
   const isDisabledTabs = isSequenceMode;
   const isDisabledTabsPanels =
     isSequenceMode && !isSequenceEditInRNABuilderMode;
+
+  const [firstRender, setFirstRender] = useState(true);
+  useEffect(() => {
+    if (firstRender) {
+      setFirstRender(false);
+      dispatch(setSearchFilter(''));
+    }
+  }, [dispatch, firstRender]);
 
   useAppSelector(selectAllPresets, (presets) => {
     presetsRef.current = presets;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Adding logic to track the first rendering of a component

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request