### PR TITLE
#4849 - Migrate to Indigo v1.21.0-rc.2 in-browser module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15206,9 +15206,9 @@
       }
     },
     "node_modules/indigo-ketcher": {
-      "version": "1.21.0-rc.1",
-      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.21.0-rc.1.tgz",
-      "integrity": "sha512-W1T5E5fnv62jl7Ib+QyDcUAEJ4fKbeuKvpaCSnYiJwodtQcbmhhvTCh1qO6FxL/pScoJu4GqpIGUl+Y2/rLSUA=="
+      "version": "1.21.0-rc.2",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.21.0-rc.2.tgz",
+      "integrity": "sha512-3ApNWMwISDCjiOwOszWiMESNITc5o+oD73uKmZR1J+oKRj/E4WZ/w30UPTctu77bEXWgaU/35JwiBRA62Q8ZFg=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -31460,7 +31460,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "2.22.0-rc.6",
+      "version": "2.22.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
@@ -31586,7 +31586,7 @@
       "dev": true
     },
     "packages/ketcher-macromolecules": {
-      "version": "2.22.0-rc.6",
+      "version": "2.22.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
@@ -33015,7 +33015,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "2.22.0-rc.6",
+      "version": "2.22.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
@@ -34750,11 +34750,11 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "2.22.0-rc.6",
+      "version": "2.22.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
-        "indigo-ketcher": "1.21.0-rc.1",
+        "indigo-ketcher": "1.21.0-rc.2",
         "ketcher-core": "*"
       },
       "devDependencies": {

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "2.22.0-rc.6",
+  "version": "2.22.0-rc.7",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "2.22.0-rc.6",
+  "version": "2.22.0-rc.7",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "2.22.0-rc.6",
+  "version": "2.22.0-rc.7",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "2.22.0-rc.6",
+  "version": "2.22.0-rc.7",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "indigo-ketcher": "1.21.0-rc.1",
+    "indigo-ketcher": "1.21.0-rc.2",
     "ketcher-core": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
- updated indigo to 1.21.0-rc.2
- updated ketcher to 2.22.0-rc.7

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request