### PR TITLE
#4608 – Incorrect display of linked sugar AP R2 – base AP R1 in the Sequence mode

### DIFF
--- a/packages/ketcher-core/src/domain/entities/PolymerBond.ts
+++ b/packages/ketcher-core/src/domain/entities/PolymerBond.ts
@@ -1,11 +1,14 @@
-import { DrawingEntity } from 'domain/entities/DrawingEntity';
-import { PolymerBondRenderer } from 'application/render/renderers/PolymerBondRenderer';
-import { Vec2 } from 'domain/entities/vec2';
-import { BaseMonomer } from './BaseMonomer';
 import { BaseRenderer } from 'application/render/renderers/BaseRenderer';
-import { AttachmentPointName } from 'domain/types';
+import { PolymerBondRenderer } from 'application/render/renderers/PolymerBondRenderer';
 import { BackBoneBondSequenceRenderer } from 'application/render/renderers/sequence/BackBoneBondSequenceRenderer';
 import { PolymerBondSequenceRenderer } from 'application/render/renderers/sequence/PolymerBondSequenceRenderer';
+import { BaseMonomer } from 'domain/entities/BaseMonomer';
+import { DrawingEntity } from 'domain/entities/DrawingEntity';
+import { Phosphate } from 'domain/entities/Phosphate';
+import { RNABase } from 'domain/entities/RNABase';
+import { Sugar } from 'domain/entities/Sugar';
+import { Vec2 } from 'domain/entities/vec2';
+import { AttachmentPointName } from 'domain/types';
 
 export class PolymerBond extends DrawingEntity {
   public secondMonomer?: BaseMonomer;
@@ -75,33 +78,56 @@ export class PolymerBond extends DrawingEntity {
       : this.firstMonomer;
   }
 
-  public static get backBoneChainAttachmentPoints() {
-    return [AttachmentPointName.R1, AttachmentPointName.R2];
-  }
+  public get isBackboneChainConnection(): boolean {
+    // Variants:
+    // • Sugar [R2] — [R1] Phosphate
+    // • Sugar [R1] — [R2] Phosphate
+    // • Phosphate [R2] — [R1] Sugar
+    // • Phosphate [R1] — [R2] Sugar
+    // • Sugar [R3] — [R1] RNA base
+    // • RNA base [R1] — [R3] Sugar
+    if (!this.secondMonomer) {
+      return true;
+    }
 
-  public get isBackBoneChainConnection() {
-    return !this.isSideChainConnection;
-  }
-
-  public get isSideChainConnection() {
-    const firstMonomerAttachmentPoint =
-      this.firstMonomer.getAttachmentPointByBond(this);
-    const secondMonomerAttachmentPoint =
-      this.secondMonomer?.getAttachmentPointByBond(this);
-
-    if (!firstMonomerAttachmentPoint || !secondMonomerAttachmentPoint) {
+    let sugarMonomer: Sugar;
+    let anotherMonomer: BaseMonomer;
+    if (this.firstMonomer instanceof Sugar) {
+      sugarMonomer = this.firstMonomer;
+      anotherMonomer = this.secondMonomer;
+    } else if (this.secondMonomer instanceof Sugar) {
+      sugarMonomer = this.secondMonomer;
+      anotherMonomer = this.firstMonomer;
+    } else {
       return false;
     }
 
+    const sugarMonomerAttachmentPoint =
+      sugarMonomer.getAttachmentPointByBond(this);
+    const anotherMonomerAttachmentPoint =
+      anotherMonomer.getAttachmentPointByBond(this);
+    if (!sugarMonomerAttachmentPoint || !anotherMonomerAttachmentPoint) {
+      return true;
+    }
+
+    const thereArePhosphateAndSugar = anotherMonomer instanceof Phosphate;
+    const thereAreR1AndR2 =
+      (sugarMonomerAttachmentPoint === AttachmentPointName.R2 &&
+        anotherMonomerAttachmentPoint === AttachmentPointName.R1) ||
+      (sugarMonomerAttachmentPoint === AttachmentPointName.R1 &&
+        anotherMonomerAttachmentPoint === AttachmentPointName.R2);
+    if (thereArePhosphateAndSugar && thereAreR1AndR2) {
+      return true;
+    }
+
     return (
-      !(
-        PolymerBond.backBoneChainAttachmentPoints.includes(
-          firstMonomerAttachmentPoint,
-        ) &&
-        PolymerBond.backBoneChainAttachmentPoints.includes(
-          secondMonomerAttachmentPoint,
-        )
-      ) || firstMonomerAttachmentPoint === secondMonomerAttachmentPoint
+      sugarMonomerAttachmentPoint === AttachmentPointName.R3 &&
+      anotherMonomer instanceof RNABase &&
+      anotherMonomerAttachmentPoint === AttachmentPointName.R1
     );
+  }
+
+  public get isSideChainConnection(): boolean {
+    return !this.isBackboneChainConnection;
   }
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request