### PR TITLE
#4927 - Able to change attachment point label to an atom if it is selected first

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -64,7 +64,11 @@ class AtomTool implements Tool {
         const updatedAtoms = editorSelection?.atoms?.filter(
           (selectAtomId) =>
             !deletedAtomsInSGroups?.includes(selectAtomId) &&
-            struct.atoms.has(selectAtomId),
+            struct.atoms.has(selectAtomId) &&
+            !Atom.isSuperatomLeavingGroupAtom(
+              this.editor.render.ctab.molecule,
+              selectAtomId,
+            ),
         );
         action.mergeWith(fromAtomsAttrs(struct, updatedAtoms, atomProps, true));
         editor.update(action);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
added a check for "attachment point" to the filter function

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request