### PR TITLE
#4929 - System allow to change atoms inside S-group without removing abbreviation

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -56,6 +56,17 @@ class AtomTool implements Tool {
         const selectedSGroupsId =
           editorSelection &&
           getGroupIdsFromItemArrays(struct.molecule, editorSelection);
+        const sgroups = struct.molecule.functionalGroups;
+        const atomsInFunctionalGroup = editorSelection.atoms.map((atom) => {
+          return FunctionalGroup.atomsInFunctionalGroup(sgroups, atom);
+        });
+        if (atomsInFunctionalGroup.some((atom) => atom !== null)) {
+          editor.event.removeFG.dispatch({ fgIds: [...selectedSGroupsId] });
+          this.editor.hoverIcon.hide();
+          this.isNotActiveTool = true;
+          return;
+        }
+
         const deletedAtomsInSGroups = deleteFunctionalGroups(
           selectedSGroupsId,
           struct,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
added check for selected atoms in the functional group

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request