### PR TITLE
#4973 - Connection between molecule and monomer lost after opening and saving to ket

### DIFF
--- a/packages/ketcher-core/src/domain/entities/monomerMicromolecule.ts
+++ b/packages/ketcher-core/src/domain/entities/monomerMicromolecule.ts
@@ -30,13 +30,18 @@ export class MonomerMicromolecule extends SGroup {
     return { position: this.pp, atomId: sgroupContractedPosition.atomId };
   }
 
-  public static clone(monomerMicromolecule: MonomerMicromolecule) {
+  public static clone(
+    monomerMicromolecule: MonomerMicromolecule,
+    atomIdMap?: Map<number, number>,
+  ) {
     const monomerMicromoleculeClone = new MonomerMicromolecule(
       monomerMicromolecule.type,
       monomerMicromolecule.monomer,
     );
     monomerMicromoleculeClone.pp = monomerMicromolecule.pp;
-    monomerMicromoleculeClone.atoms = monomerMicromolecule.atoms;
+    monomerMicromoleculeClone.atoms = atomIdMap
+      ? monomerMicromolecule.atoms.map((elem) => atomIdMap.get(elem))
+      : monomerMicromolecule.atoms;
 
     return monomerMicromoleculeClone;
   }

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -293,7 +293,7 @@ export class Struct {
 
       sg =
         oldSgroup instanceof MonomerMicromolecule
-          ? MonomerMicromolecule.clone(oldSgroup)
+          ? MonomerMicromolecule.clone(oldSgroup, aidMap!)
           : SGroup.clone(sg, aidMap!);
 
       const id = cp.sgroups.add(sg);

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -644,6 +644,10 @@ export class KetSerializer implements Serializer<Struct> {
 
     struct.sgroups.forEach((sgroup) => {
       const attachmentPoints = sgroup.getAttachmentPoints();
+      const attachmentPointsToReplace: Map<
+        SGroupAttachmentPoint,
+        SGroupAttachmentPoint
+      > = new Map();
       attachmentPoints.forEach((attachmentPoint) => {
         if (
           isNumber(attachmentPoint.leaveAtomId) &&
@@ -655,14 +659,19 @@ export class KetSerializer implements Serializer<Struct> {
             attachmentPoint.attachmentId,
             attachmentPoint.attachmentPointNumber,
           );
-          sgroup.removeAttachmentPoint(attachmentPoint);
-          sgroup.addAttachmentPoint(attachmentPointClone);
+          attachmentPointsToReplace.set(attachmentPoint, attachmentPointClone);
           sgroup.atoms.splice(
             sgroup.atoms.indexOf(attachmentPoint.leaveAtomId),
             1,
           );
         }
       });
+      attachmentPointsToReplace.forEach(
+        (attachmentPointToAdd, attachmentPointToDelete) => {
+          sgroup.removeAttachmentPoint(attachmentPointToDelete);
+          sgroup.addAttachmentPoint(attachmentPointToAdd);
+        },
+      );
     });
 
     return struct;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed monomer atoms ids mapping during struct clone

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request