### PR TITLE
#5005 - Use ketcher-standalone with separate indigo wasm file by default in ketcher example

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,8 +27,15 @@ let structServiceProvider: StructServiceProvider =
     process.env.API_PATH || process.env.REACT_APP_API_PATH,
   );
 if (process.env.MODE === 'standalone') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { StandaloneStructServiceProvider } = require('ketcher-standalone');
+  // It is possible to use just 'ketcher-standalone' instead of ketcher-standalone/dist/binaryWasm
+  // however, it will increase the size of the bundle more than two times because wasm will be
+  // included in ketcher bundle as base64 string.
+  // In case of usage ketcher-standalone/dist/binaryWasm additional build configuration required
+  // to copy .wasm files in build folder. Please check /example/config/webpack.config.js.
+  const {
+    StandaloneStructServiceProvider,
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+  } = require('ketcher-standalone/dist/binaryWasm');
   structServiceProvider =
     new StandaloneStructServiceProvider() as StructServiceProvider;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request