### PR TITLE
Backmerge: #4932 - Preview: Unsplit nucleotide without natural analog should be displayed as '@' symbol 

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/UnsplitNucleotideSequenceItemRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/UnsplitNucleotideSequenceItemRenderer.ts
@@ -2,7 +2,10 @@ import { BaseSequenceItemRenderer } from 'application/render/renderers/sequence/
 
 export class UnsplitNucleotideSequenceItemRenderer extends BaseSequenceItemRenderer {
   get symbolToDisplay(): string {
-    return this.node.monomer.monomerItem.props.MonomerNaturalAnalogCode || '@';
+    const naturalAnalogue =
+      this.node.monomer.monomerItem.props.MonomerNaturalAnalogCode;
+
+    return naturalAnalogue && naturalAnalogue !== 'X' ? naturalAnalogue : '@';
   }
 
   protected drawModification(): void {

--- a/packages/ketcher-core/src/application/render/renderers/sequence/UnsplitNucleotideSequenceItemRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/UnsplitNucleotideSequenceItemRenderer.ts
@@ -1,11 +1,14 @@
 import { BaseSequenceItemRenderer } from 'application/render/renderers/sequence/BaseSequenceItemRenderer';
+import { NO_NATURAL_ANALOGUE } from 'domain/constants/monomers';
 
 export class UnsplitNucleotideSequenceItemRenderer extends BaseSequenceItemRenderer {
   get symbolToDisplay(): string {
     const naturalAnalogue =
       this.node.monomer.monomerItem.props.MonomerNaturalAnalogCode;
 
-    return naturalAnalogue && naturalAnalogue !== 'X' ? naturalAnalogue : '@';
+    return naturalAnalogue && naturalAnalogue !== NO_NATURAL_ANALOGUE
+      ? naturalAnalogue
+      : '@';
   }
 
   protected drawModification(): void {

--- a/packages/ketcher-core/src/domain/constants/monomers.ts
+++ b/packages/ketcher-core/src/domain/constants/monomers.ts
@@ -27,3 +27,5 @@ export const peptideNaturalAnalogues = [
   'W',
   'Y',
 ];
+
+export const NO_NATURAL_ANALOGUE = 'X';


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request