### PR TITLE
Backmerge: #4920 - Preview: Unable to load IDT codes for unsplit monomers we have in the library

### DIFF
--- a/packages/ketcher-core/src/application/editor/data/monomers.ket
+++ b/packages/ketcher-core/src/application/editor/data/monomers.ket
@@ -2236,25 +2236,25 @@
         "$ref": "monomerGroupTemplate-dR(U)P"
       },
       {
-        "$ref": "monomerTemplate-5AmdA___5' 2, 6-Diaminopurine"
+        "$ref": "monomerTemplate-AmdA___2, 6-Diaminopurine"
       },
       {
-        "$ref": "monomerTemplate-55HydMe-dC___5' 5-Hydroxymethyl dC"
+        "$ref": "monomerTemplate-5HydMe-dC___5-Hydroxymethyl dC"
       },
       {
-        "$ref": "monomerTemplate-5Super-dG___5' Super G"
+        "$ref": "monomerTemplate-Super-dG___Super G"
       },
       {
-        "$ref": "monomerTemplate-5Super-dT___5' Super T"
+        "$ref": "monomerTemplate-Super-dT___Super T"
       },
       {
-        "$ref": "monomerTemplate-55Br-dU___5' 5-Bromo dU"
+        "$ref": "monomerTemplate-5Br-dU___5-Bromo dU"
       },
       {
-        "$ref": "monomerTemplate-55NitInd___5' 5-Nitroindole"
+        "$ref": "monomerTemplate-5NitInd___5-Nitroindole"
       },
       {
-        "$ref": "monomerTemplate-iAmMC6T___Int Amino Modifier C6 dT"
+        "$ref": "monomerTemplate-AmMC6T___Amino Modifier C6 dT"
       },
       {
         "$ref": "monomerTemplate-4aPEGMal___4-Arm PEG-Maleimide"
@@ -169971,15 +169971,20 @@
       }
     ]
   },
-  "monomerTemplate-5AmdA___5' 2, 6-Diaminopurine": {
+  "monomerTemplate-AmdA___2, 6-Diaminopurine": {
     "type": "monomerTemplate",
-    "id": "5AmdA___5' 2, 6-Diaminopurine",
-    "fullName": "5' 2, 6-Diaminopurine",
-    "alias": "5AmdA",
+    "id": "AmdA___2, 6-Diaminopurine",
+    "fullName": "2,6-Diaminopurine",
+    "alias": "2-Amino-dA",
     "naturalAnalogShort": "A",
     "class": "RNA",
     "idtAliases": {
-      "base": "5AmdA"
+      "base": "AmdA",
+      "modifications": {
+        "endpoint5": "5AmdA",
+        "internal": "i6diPr",
+        "endpoint3": "3AmdA"
+      }
     },
     "atoms": [
       {
@@ -170386,15 +170391,15 @@
       }
     ]
   },
-  "monomerTemplate-55HydMe-dC___5' 5-Hydroxymethyl dC": {
+  "monomerTemplate-5HydMe-dC___5-Hydroxymethyl dC": {
     "type": "monomerTemplate",
-    "id": "55HydMe-dC___5' 5-Hydroxymethyl dC",
-    "fullName": "5' 5-Hydroxymethyl dC",
-    "alias": "55HydMe-dC",
+    "id": "5HydMe-dC___5-Hydroxymethyl dC",
+    "fullName": "Hydroxymethyl dC",
+    "alias": "5HydMe-dC",
     "naturalAnalogShort": "C",
     "class": "RNA",
     "idtAliases": {
-      "base": "55HydMe-dC"
+      "base": "5HydMe-dC"
     },
     "atoms": [
       {
@@ -170779,15 +170784,15 @@
       }
     ]
   },
-  "monomerTemplate-5Super-dG___5' Super G": {
+  "monomerTemplate-Super-dG___Super G": {
     "type": "monomerTemplate",
-    "id": "5Super-dG___5' Super G",
-    "fullName": "5' Super G",
-    "alias": "5Super-dG",
+    "id": "Super-dG___Super G",
+    "fullName": "8-aza-7-deazaguanosine",
+    "alias": "Super G",
     "naturalAnalogShort": "G",
     "class": "RNA",
     "idtAliases": {
-      "base": "5Super-dG"
+      "base": "Super-dG"
     },
     "atoms": [
       {
@@ -171194,15 +171199,15 @@
       }
     ]
   },
-  "monomerTemplate-5Super-dT___5' Super T": {
+  "monomerTemplate-Super-dT___Super T": {
     "type": "monomerTemplate",
-    "id": "5Super-dT___5' Super T",
-    "fullName": "5' Super T",
-    "alias": "5Super-dT",
+    "id": "Super-dT___Super T",
+    "fullName": "5-hydroxybutynl-2’-deoxyuridine",
+    "alias": "Super T",
     "naturalAnalogShort": "T",
     "class": "RNA",
     "idtAliases": {
-      "base": "5Super-dT"
+      "base": "Super-dT"
     },
     "atoms": [
       {
@@ -171632,15 +171637,19 @@
       }
     ]
   },
-  "monomerTemplate-55Br-dU___5' 5-Bromo dU": {
+  "monomerTemplate-5Br-dU___5-Bromo dU": {
     "type": "monomerTemplate",
-    "id": "55Br-dU___5' 5-Bromo dU",
-    "fullName": "5' 5-Bromo dU",
-    "alias": "55Br-dU",
+    "id": "5Br-dU___5-Bromo dU",
+    "fullName": "5-Bromo-deoxyuridine",
+    "alias": "5-Bromo dU",
     "naturalAnalogShort": "U",
     "class": "RNA",
     "idtAliases": {
-      "base": "55Br-dU"
+      "base": "5Br-dU",
+      "modifications":  {
+        "endpoint5": "55Br-dU",
+        "internal": "i5Br-dU"
+      }
     },
     "atoms": [
       {
@@ -172010,15 +172019,15 @@
       }
     ]
   },
-  "monomerTemplate-55NitInd___5' 5-Nitroindole": {
+  "monomerTemplate-5NitInd___5-Nitroindole": {
     "type": "monomerTemplate",
-    "id": "55NitInd___5' 5-Nitroindole",
-    "fullName": "5' 5-Nitroindole",
-    "alias": "55NitInd",
+    "id": "5NitInd___5-Nitroindole",
+    "fullName": "5-Nitroindole",
+    "alias": "5NitInd",
     "naturalAnalogShort": "X",
     "class": "RNA",
     "idtAliases": {
-      "base": "55NitInd"
+      "base": "5NitInd"
     },
     "atoms": [
       {
@@ -172442,15 +172451,15 @@
       }
     ]
   },
-  "monomerTemplate-iAmMC6T___Int Amino Modifier C6 dT": {
+  "monomerTemplate-AmMC6T___Amino Modifier C6 dT": {
     "type": "monomerTemplate",
-    "id": "iAmMC6T___Int Amino Modifier C6 dT",
-    "fullName": "Int Amino Modifier C6 dT",
-    "alias": "iAmMC6T",
+    "id": "AmMC6T___Amino Modifier C6 dT",
+    "fullName": "Amino Modifier C6 dT",
+    "alias": "AmMC6T",
     "naturalAnalogShort": "T",
     "class": "RNA",
     "idtAliases": {
-      "base": "iAmMC6T"
+      "base": "AmMC6T"
     },
     "atoms": [
       {

--- a/packages/ketcher-core/src/application/render/renderers/UnsplitNucleotideRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/UnsplitNucleotideRenderer.ts
@@ -36,13 +36,23 @@ export class UnsplitNucleotideRenderer extends BaseMonomerRenderer {
 
   protected appendLabel(rootElement: D3SvgElementSelection<SVGGElement, void>) {
     const fontSize = 6;
+    const Y_OFFSET_FROM_MIDDLE = -2;
+
     rootElement
       .append('foreignObject')
       .attr('width', this.width)
-      .attr('height', this.height)
+      .attr('height', this.height - this.height / 3)
       .html(
         `
-        <div style="padding: 0 4px; text-align: center; color: ${this.textColor}">
+        <div style="
+            padding: 0 4px;
+            text-align: center;
+            color: ${this.textColor};
+            display: flex;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+        ">
           ${this.monomer.label}
         </div>
       `,
@@ -54,7 +64,7 @@ export class UnsplitNucleotideRenderer extends BaseMonomerRenderer {
       .style('user-select', 'none')
       .attr('pointer-events', 'none')
       .attr('x', '4px')
-      .attr('y', this.height / 2);
+      .attr('y', this.height / 2 + Y_OFFSET_FROM_MIDDLE);
   }
 
   protected get enumerationElementPosition() {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed nucleotides definition in library
- fixed unsplit nucleotides label styles

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request