### PR TITLE
Backmerge: #4934 - Preview: Enumeration counters remain unchanged after bond being deleted

### DIFF
--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -4,6 +4,7 @@ import {
   Phosphate,
   RNABase,
   Sugar,
+  UnsplitNucleotide,
 } from 'domain/entities';
 import { AttachmentPointName, MonomerItemType } from 'domain/types';
 
@@ -66,7 +67,9 @@ export function getPhosphateFromSugar(monomer?: BaseMonomer) {
 
 export function isMonomerBeginningOfChain(
   monomer: BaseMonomer,
-  MonomerTypes: Array<typeof Peptide | typeof Phosphate | typeof Sugar>,
+  MonomerTypes: Array<
+    typeof Peptide | typeof Phosphate | typeof Sugar | typeof UnsplitNucleotide
+  >,
 ) {
   const r1PolymerBond = monomer.attachmentPointsToBonds.R1;
   const previousMonomer = r1PolymerBond?.getAnotherMonomer(monomer);
@@ -77,9 +80,12 @@ export function isMonomerBeginningOfChain(
     r1PolymerBond &&
     previousMonomer?.getAttachmentPointByBond(r1PolymerBond) !== 'R2';
 
+  // For single monomers we check that monomer has bonds, but for UnsplitNucleotide we don't
+  // to be consistent with rna triplets (we show enumeration for single triplet)
   return (
-    monomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) ||
-    !monomer.hasAttachmentPoint(AttachmentPointName.R1) ||
+    ((monomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) ||
+      !monomer.hasAttachmentPoint(AttachmentPointName.R1)) &&
+      (monomer.hasBonds || monomer instanceof UnsplitNucleotide)) ||
     previousConnectionNotR2 ||
     isPreviousMonomerPartOfChain
   );

--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -78,9 +78,8 @@ export function isMonomerBeginningOfChain(
     previousMonomer?.getAttachmentPointByBond(r1PolymerBond) !== 'R2';
 
   return (
-    ((monomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) ||
-      !monomer.hasAttachmentPoint(AttachmentPointName.R1)) &&
-      monomer.hasBonds) ||
+    monomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) ||
+    !monomer.hasAttachmentPoint(AttachmentPointName.R1) ||
     previousConnectionNotR2 ||
     isPreviousMonomerPartOfChain
   );


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed check of chain beginning

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request