### PR TITLE
Backmerge: #4924 - RNA Preset without Base causes constant crash after switching to Macromolecules mode

### DIFF
--- a/packages/ketcher-macromolecules/src/helpers/getPreset.ts
+++ b/packages/ketcher-macromolecules/src/helpers/getPreset.ts
@@ -53,10 +53,16 @@ export const getPresets = (
       ) as MonomerItemType;
 
       const result: IRnaPreset = {
-        base: { ...rnaBase, label: rnaBase.props.MonomerName },
+        base: rnaBase
+          ? { ...rnaBase, label: rnaBase.props.MonomerName }
+          : undefined,
         name: rnaPresetsTemplate.name,
-        phosphate: { ...phosphate, label: phosphate.props.MonomerName },
-        sugar: { ...ribose, label: ribose.props.MonomerName },
+        phosphate: phosphate
+          ? { ...phosphate, label: phosphate.props.MonomerName }
+          : undefined,
+        sugar: ribose
+          ? { ...ribose, label: ribose.props.MonomerName }
+          : undefined,
         favorite: rnaPresetsTemplate.favorite,
         default: isDefault || rnaPresetsTemplate.default,
       };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added safety checks in rna presets getter

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request