### PR TITLE
Backmerge: #4889 - After using "Clear Canvas" in the Sequence mode and entering new sequence, extra structures are shown in Flex and Snake modes

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/types.ts
+++ b/packages/ketcher-core/src/application/editor/modes/types.ts
@@ -1,6 +1,13 @@
+import { BaseMode } from 'application/editor/modes/BaseMode';
+import { SequenceMode } from 'application/editor';
+
 export type LayoutMode =
   | 'flex-layout-mode'
   | 'snake-layout-mode'
   | 'sequence-layout-mode';
 
 export const DEFAULT_LAYOUT_MODE: LayoutMode = 'sequence-layout-mode';
+
+export function isSequenceMode(mode: BaseMode): mode is SequenceMode {
+  return mode instanceof SequenceMode;
+}

--- a/packages/ketcher-core/src/application/editor/tools/Clear.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Clear.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 import { CoreEditor, EditorHistory } from 'application/editor/internal';
-import { SequenceMode } from 'application/editor/modes';
+import { isSequenceMode } from 'application/editor/modes';
 import { BaseTool } from 'application/editor/tools/Tool';
 import { ReinitializeModeOperation } from 'application/editor/operations/modes';
 
@@ -24,15 +24,22 @@ class ClearTool implements BaseTool {
   constructor(private editor: CoreEditor) {
     this.editor = editor;
     this.history = new EditorHistory(editor);
+    const mode = editor.mode;
+    const isCurrentModeSequence = isSequenceMode(mode);
+    const isSequenceEditMode = isCurrentModeSequence && mode.isEditMode;
 
     const modelChanges = this.editor.drawingEntitiesManager.deleteAllEntities();
-    this.editor.renderersContainer.update(modelChanges);
 
-    if (editor.mode instanceof SequenceMode) {
+    if (isCurrentModeSequence) {
       modelChanges.addOperation(new ReinitializeModeOperation());
     }
 
+    this.editor.renderersContainer.update(modelChanges);
     this.history.update(modelChanges);
+
+    if (isSequenceEditMode) {
+      mode.startNewSequence();
+    }
   }
 
   destroy() {}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed clear tool for sequence mode

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request