### PR TITLE
#4950 - Preview: Switching to Molecules mode causes crash if unknown monomer is on the canvas

### DIFF
--- a/packages/ketcher-core/src/application/formatters/types/ket.ts
+++ b/packages/ketcher-core/src/application/formatters/types/ket.ts
@@ -125,6 +125,8 @@ export interface IKetMonomerTemplate {
   name?: string;
   idtAliases?: IKetIdtAliases;
   unresolved?: boolean;
+  atoms: [];
+  bonds: [];
 }
 
 export interface IKetMonomerTemplateRef {

--- a/packages/ketcher-core/src/domain/entities/UnresolvedMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/UnresolvedMonomer.ts
@@ -1,4 +1,5 @@
-import { BaseMonomer, Peptide } from 'domain/entities';
+import { Peptide } from 'domain/entities';
+import { BaseMonomer } from './BaseMonomer';
 import { ChemSubChain } from 'domain/entities/monomer-chains/ChemSubChain';
 import { PeptideSubChain } from 'domain/entities/monomer-chains/PeptideSubChain';
 import { SubChainNode } from 'domain/entities/monomer-chains/types';

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerToDrawingEntity.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerToDrawingEntity.ts
@@ -5,6 +5,7 @@ import {
 import { Struct, Vec2 } from 'domain/entities';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
 import { switchIntoChemistryCoordSystem } from 'domain/serializers/ket/helpers';
+import { KetSerializer } from 'domain/serializers';
 
 export function templateToMonomerProps(template: IKetMonomerTemplate) {
   return {
@@ -37,7 +38,7 @@ export function monomerToDrawingEntity(
       colorScheme: undefined,
       favorite: false,
       props: templateToMonomerProps(template),
-      attachmentPoints: template.attachmentPoints,
+      attachmentPoints: KetSerializer.getTemplateAttachmentPoints(template),
       seqId: node.seqid,
     },
     position,

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -19,6 +19,7 @@ import {
   Bond,
   SGroupAttachmentPoint,
   Struct,
+  UnresolvedMonomer,
   Vec2,
 } from 'domain/entities';
 import { arrowToKet, plusToKet } from './toKet/rxnToKet';
@@ -298,7 +299,22 @@ export class KetSerializer implements Serializer<Struct> {
     return fileContentForMicromolecules;
   }
 
+  public static getTemplateAttachmentPoints(template: IKetMonomerTemplate) {
+    return template.unresolved
+      ? template.attachmentPoints?.map((_, index) => {
+          return {
+            attachmentAtom: index,
+            leavingGroup: {
+              atoms: [],
+            },
+          };
+        })
+      : template.attachmentPoints;
+  }
+
   public convertMonomerTemplateToStruct(template: IKetMonomerTemplate) {
+    const attachmentPoints = template.attachmentPoints || [];
+
     return this.fillStruct({
       root: {
         nodes: [{ $ref: 'mol0' }],
@@ -306,6 +322,30 @@ export class KetSerializer implements Serializer<Struct> {
       mol0: {
         ...template,
         type: 'molecule',
+        atoms: template.unresolved
+          ? attachmentPoints?.map((_, index) => {
+              return {
+                label: 'C',
+                location: [index, index, index],
+              };
+            })
+          : template.atoms,
+        bonds: template.unresolved
+          ? attachmentPoints?.map((_, index) => {
+              if (index === attachmentPoints.length - 1) {
+                return {
+                  type: 1,
+                  atoms: [0, attachmentPoints.length - 1],
+                };
+              }
+
+              return {
+                type: 1,
+                atoms: [index, index + 1],
+              };
+            })
+          : template.bonds,
+        attachmentPoints: KetSerializer.getTemplateAttachmentPoints(template),
       },
       header: {
         moleculeName: template.fullName,
@@ -320,7 +360,7 @@ export class KetSerializer implements Serializer<Struct> {
       label: template.alias || template.id,
       struct: this.convertMonomerTemplateToStruct(template),
       props: templateToMonomerProps(template),
-      attachmentPoints: template.attachmentPoints,
+      attachmentPoints: KetSerializer.getTemplateAttachmentPoints(template),
     };
     this.fillStructRgLabelsByMonomerTemplate(template, monomerLibraryItem);
 
@@ -582,6 +622,7 @@ export class KetSerializer implements Serializer<Struct> {
             alias: monomer.monomerItem.label,
             attachmentPoints: monomer.monomerItem.attachmentPoints,
             idtAliases: monomer.monomerItem.props.idtAliases,
+            unresolved: monomer instanceof UnresolvedMonomer,
           };
           // CHEMs do not have natural analog
           if (monomer.monomerItem.props.MonomerType !== 'CHEM') {

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -622,7 +622,7 @@ export class KetSerializer implements Serializer<Struct> {
             alias: monomer.monomerItem.label,
             attachmentPoints: monomer.monomerItem.attachmentPoints,
             idtAliases: monomer.monomerItem.props.idtAliases,
-            unresolved: monomer instanceof UnresolvedMonomer,
+            unresolved: monomer instanceof UnresolvedMonomer ? true : undefined,
           };
           // CHEMs do not have natural analog
           if (monomer.monomerItem.props.MonomerType !== 'CHEM') {

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -1,5 +1,11 @@
 import assert from 'assert';
-import { Bond, MonomerMicromolecule, SGroup, Struct } from 'ketcher-core';
+import {
+  Bond,
+  MonomerMicromolecule,
+  SGroup,
+  Struct,
+  UnresolvedMonomer,
+} from 'ketcher-core';
 import Editor from '../Editor';
 
 let showTooltipTimer: ReturnType<typeof setTimeout> | null = null;
@@ -112,6 +118,13 @@ function hideTooltip(editor: Editor) {
 
 function showTooltip(editor: Editor, infoPanelData: InfoPanelData | null) {
   hideTooltip(editor);
+
+  if (
+    infoPanelData?.sGroup instanceof MonomerMicromolecule &&
+    infoPanelData.sGroup.monomer instanceof UnresolvedMonomer
+  ) {
+    return;
+  }
 
   showTooltipTimer = setTimeout(() => {
     editor.event.showInfo.dispatch(infoPanelData);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added filling of unresolved monomers by fake structure

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request