### PR TITLE
#5005 - Use ketcher-standalone with separate indigo wasm file by default in ketcher example

### DIFF
--- a/.github/workflows/playwright-macromolecules.yml
+++ b/.github/workflows/playwright-macromolecules.yml
@@ -18,6 +18,7 @@ env:
   IGNORE_UNSTABLE_TESTS: true
   CI_ENVIRONMENT: true
   ENABLE_POLYMER_EDITOR: true
+  USE_SEPARATE_INDIGO_WASM: true
 jobs:
   playwright_tests:
     timeout-minutes: 120
@@ -44,6 +45,7 @@ jobs:
           echo "IGNORE_UNSTABLE_TESTS=$IGNORE_UNSTABLE_TESTS" >> .env
           echo "CI_ENVIRONMENT=$CI_ENVIRONMENT" >> .env
           echo "ENABLE_POLYMER_EDITOR=$ENABLE_POLYMER_EDITOR" >> .env
+          echo "USE_SEPARATE_INDIGO_WASM=$USE_SEPARATE_INDIGO_WASM" >> .env
       - name: Build autotests for docker
         run: cd ketcher-autotests && npm run docker:build
       - name: Run playwright tests in docker

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,7 @@ env:
   DOCKER: true
   IGNORE_UNSTABLE_TESTS: true
   CI_ENVIRONMENT: true
+  USE_SEPARATE_INDIGO_WASM: true
 jobs:
   playwright_tests:
     timeout-minutes: 150
@@ -42,6 +43,7 @@ jobs:
           echo "MODE=$MODE" >> .env
           echo "IGNORE_UNSTABLE_TESTS=$IGNORE_UNSTABLE_TESTS" >> .env
           echo "CI_ENVIRONMENT=$CI_ENVIRONMENT" >> .env
+          echo "USE_SEPARATE_INDIGO_WASM=$USE_SEPARATE_INDIGO_WASM" >> .env
       - name: Build autotests for docker
         run: cd ketcher-autotests && npm run docker:build
       - name: Run playwright tests in docker

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,8 +9,6 @@ import {
 } from 'ketcher-core';
 import { ModeControl } from './ModeControl';
 
-const isProduction = process.env.NODE_ENV === 'production';
-
 const getHiddenButtonsConfig = (): ButtonsConfig => {
   const searchParams = new URLSearchParams(window.location.search);
   const hiddenButtons = searchParams.get('hiddenControls');
@@ -29,7 +27,7 @@ let structServiceProvider: StructServiceProvider =
     process.env.API_PATH || process.env.REACT_APP_API_PATH,
   );
 if (process.env.MODE === 'standalone') {
-  if (isProduction) {
+  if (process.env.USE_SEPARATE_INDIGO_WASM === 'true') {
     // It is possible to use just 'ketcher-standalone' instead of ketcher-standalone/dist/binaryWasm
     // however, it will increase the size of the bundle more than two times because wasm will be
     // included in ketcher bundle as base64 string.


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- make build with separate wasm under env variable

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request