### PR TITLE
#4683 Improve labels for SRU polymer S-groups

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/resgroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.ts
@@ -96,10 +96,9 @@ class ReSGroup extends ReObject {
         }
         case 'SRU': {
           let connectivity: string = sgroup.data.connectivity || 'eu';
-          if (connectivity === 'ht') connectivity = '';
           const subscript = sgroup.data.subscript || 'n';
           SGroupdrawBracketsOptions.lowerIndexText = subscript;
-          SGroupdrawBracketsOptions.upperIndexText = connectivity;
+          SGroupdrawBracketsOptions.upperIndexText = connectivity.toUpperCase();
           break;
         }
         case 'SUP': {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Issue: https://github.com/epam/ketcher/issues/4683

Currently, the if you have an SRU polymer, with repeat pattern "Head-to-tail", it doesn't display the repeat pattern next to the brackets. From the code, it looks like this might have been intentional, but is there a reason for this? Also, is it possible to change the labels to be capitalized?

### Before
<img width="500" alt="Screenshot 2024-07-18 at 11 46 36 AM" src="https://github.com/user-attachments/assets/bebb069b-6a0d-4362-b711-346f57cf437b">
<img width="500" alt="Screenshot 2024-07-18 at 11 49 57 AM" src="https://github.com/user-attachments/assets/d2030162-6ff8-4396-91ba-92d2a9f938d7">


### After
<img width="500" alt="Screenshot 2024-07-18 at 11 45 54 AM" src="https://github.com/user-attachments/assets/f6a10563-fbfb-4dda-a4aa-e00568059088">


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request