### PR TITLE
WIP #5078 IDT alias is displayed outside the information window in the library after viewing on the main diagram

### DIFF
--- a/packages/ketcher-macromolecules/src/components/shared/MonomerWithIDTAliasesPreview/styles.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/MonomerWithIDTAliasesPreview/styles.ts
@@ -37,7 +37,6 @@ export const MonomerName = styled.p`
 `;
 
 export const StyledStructRender = styled(StructRender)`
-  flex-grow: 1;
-  overflow: auto;
+  height: 85%;
   width: 100%;
 `;

--- a/packages/ketcher-macromolecules/src/components/shared/MonomerWithIDTAliasesPreview/styles.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/MonomerWithIDTAliasesPreview/styles.ts
@@ -37,6 +37,7 @@ export const MonomerName = styled.p`
 `;
 
 export const StyledStructRender = styled(StructRender)`
-  height: 100%;
+  flex-grow: 1;
+  overflow: auto;
   width: 100%;
 `;


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/5078

Past behavior

- IDT alias is displayed outside the information window

Actual behavior

- IDT alias is displayed in the information window


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request