### PR TITLE
#5126 - The error appears in the Console, when connecting two unsplit nucleotides in Snake mode

### DIFF
--- a/packages/ketcher-core/src/domain/entities/canvas-matrix/CanvasMatrix.ts
+++ b/packages/ketcher-core/src/domain/entities/canvas-matrix/CanvasMatrix.ts
@@ -201,7 +201,7 @@ export class CanvasMatrix {
           }
 
           const initialMatrixRowLength =
-            this.matrixConfig.initialMatrix.getRow(rowNumber).length;
+            this.matrixConfig.initialMatrix?.getRow(rowNumber)?.length || 0;
 
           if (columnNumber >= initialMatrixRowLength) {
             let emptyCellsAmount = this.initialMatrixWidth - columnNumber;


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/5126

Past behavior

Console error when connecting two unsplit nucleotides in snake mode.

Actual behavior

No console error shown.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request