### PR TITLE
#4806 - It is allowed to change bond type between micro and macro

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -26,7 +26,7 @@ const BondMenuItems: FC<MenuItemsProps> = (props) => {
   } as ItemEventParams);
   return (
     <>
-      <Item {...props} onClick={handleEdit}>
+      <Item {...props} onClick={handleEdit} disabled={isDisabled}>
         {props.propsFromTrigger?.extraItemsSelected
           ? 'Edit selected bonds...'
           : 'Edit...'}


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/4806 

Past Behavior

- [ ]  It is possible to change bond type via Bond properties edit

Actual Behavior

- [x] It is not possible to change bond type via Bond properties edit


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request