### PR TITLE
#3951 - Aromatizing causes NULL in export to MDL Molfile V2000 format file 

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
@@ -138,8 +138,11 @@ export class Molfile {
   ) {
     // eslint-disable-line max-statements
     /* saver */
+
+    const null2empty = (arg: string) => arg || '';
+
     this.reaction = molecule.hasRxnArrow();
-    this.molfile = '' + molecule.name;
+    this.molfile = null2empty(molecule.name);
     if (this.reaction) {
       if (molecule.rgroups.size > 0) {
         throw new Error(
@@ -153,7 +156,7 @@ export class Molfile {
       const all = reactants.concat(products);
       this.molfile =
         '$RXN\n' +
-        molecule.name +
+        null2empty(molecule.name) +
         '\n\n\n' +
         utils.paddedNum(reactants.length, 3) +
         utils.paddedNum(products.length, 3) +
@@ -177,7 +180,9 @@ export class Molfile {
           molecule.rgroups,
         );
         this.molfile =
-          '$MDL  REV  1\n$MOL\n$HDR\n' + molecule.name + '\n\n\n$END HDR\n';
+          '$MDL  REV  1\n$MOL\n$HDR\n' +
+          null2empty(molecule.name) +
+          '\n\n\n$END HDR\n';
         this.molfile += '$CTAB\n' + scaffold + '$END CTAB\n';
 
         molecule.rgroups.forEach((rg, rgid) => {


### PR DESCRIPTION
Issue => [3951](https://github.com/epam/ketcher/issues/3951)
## How did you fix the issue?
When a molecule name is null we now don't print out 'null' but print an empty string instead.

This is in accordance with the specification https://www.nonlinear.com/progenesis/sdf-studio/v0.9/faq/sdf-file-format-guidance.aspx#:~:text=Molfiles%20are%20text%20files%20which,libraries%20of%20compound%20structure%20data. :
"A compound record contains several distinct sections. First, there is a three-line header block. These three lines may contain:
1. The name of the molecule
2. Details of the software used to generate the compound structure 
3. A comment

Alternatively, any (or all) of these lines may be left blank."


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request