### PR TITLE
#5190 - Include indigo without render module into ketcher-standalone build process

### DIFF
--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -205,6 +205,10 @@ export default defineConfig({
         find: 'web-worker:./indigoWorker',
         replacement: './indigoWorker?worker',
       },
+      {
+        find: '_indigo-ketcher-import-alias_',
+        replacement: 'indigo-ketcher',
+      },
     ],
   },
   customLogger: logger,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35280,6 +35280,7 @@
         "@rollup/plugin-babel": "^5.2.1",
         "@rollup/plugin-commonjs": "^16.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-replace": "^5.0.7",
         "@rollup/plugin-strip": "^2.0.0",
         "@types/jest": "^27.0.3",
         "@types/node": "^16.11.12",
@@ -35302,6 +35303,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "packages/ketcher-standalone/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
     },
     "packages/ketcher-standalone/node_modules/@rollup/plugin-node-resolve": {
       "version": "15.2.3",
@@ -35350,6 +35357,49 @@
         }
       }
     },
+    "packages/ketcher-standalone/node_modules/@rollup/plugin-replace": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.7.tgz",
+      "integrity": "sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ketcher-standalone/node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "packages/ketcher-standalone/node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -35361,6 +35411,15 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true
+    },
+    "packages/ketcher-standalone/node_modules/magic-string": {
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     }
   }
 }

--- a/packages/ketcher-core/src/domain/services/struct/structService.types.ts
+++ b/packages/ketcher-core/src/domain/services/struct/structService.types.ts
@@ -204,4 +204,5 @@ export interface StructService {
     data: ExplicitHydrogensData,
     options?: StructServiceOptions,
   ) => Promise<ExplicitHydrogensResult>;
+  destroy?: () => void;
 }

--- a/packages/ketcher-react/src/constants.ts
+++ b/packages/ketcher-react/src/constants.ts
@@ -31,3 +31,6 @@ export const KETCHER_ROOT_NODE_CSS_SELECTOR = `.${KETCHER_ROOT_NODE_CLASS_NAME}`
 
 export const EditorClassName = 'Ketcher-polymer-editor-root';
 export const KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR = `.${EditorClassName}`;
+export const STRUCT_SERVICE_NO_RENDER_INITIALIZED_EVENT =
+  'struct-service-no-render-initialized';
+export const STRUCT_SERVICE_INITIALIZED_EVENT = 'struct-service-initialized';

--- a/packages/ketcher-react/src/script/api.ts
+++ b/packages/ketcher-react/src/script/api.ts
@@ -49,6 +49,7 @@ function createApi(
     getInChIKey: structService.getInChIKey.bind(structService),
     toggleExplicitHydrogens:
       structService.toggleExplicitHydrogens.bind(structService),
+    destroy: structService.destroy?.bind(structService),
   });
 }
 

--- a/packages/ketcher-react/src/script/index.ts
+++ b/packages/ketcher-react/src/script/index.ts
@@ -42,20 +42,21 @@ async function buildKetcherAsync({
 
   await builder.appendApiAsync(structServiceProvider);
   builder.appendServiceMode(structServiceProvider.mode);
-  const { setKetcher, ketcherId, cleanup } = await builder.appendUiAsync(
-    element,
-    appRoot,
-    staticResourcesUrl,
-    errorHandler,
-    buttons,
-    togglerComponent,
-  );
+  const { setKetcher, ketcherId, cleanup, setServer } =
+    await builder.appendUiAsync(
+      element,
+      appRoot,
+      staticResourcesUrl,
+      errorHandler,
+      buttons,
+      togglerComponent,
+    );
 
   const ketcher = builder.build();
   if (ketcher) {
     setKetcher(ketcher);
   }
-  return { ketcher, ketcherId, cleanup };
+  return { ketcher, ketcherId, cleanup, builder, setServer };
 }
 
 export type { Config, ButtonsConfig };

--- a/packages/ketcher-react/src/script/ui/App/initApp.tsx
+++ b/packages/ketcher-react/src/script/ui/App/initApp.tsx
@@ -51,6 +51,7 @@ function initApp(
   const ketcherId = uniqueId();
   // hack to return server setter to Editor.tsx
   // because it does not have access to store
+  // eslint-disable-next-line prefer-const
   let getServerSetter: () => (structService: StructService) => void;
 
   const setEditor = (editor) => {

--- a/packages/ketcher-react/src/script/ui/App/initApp.tsx
+++ b/packages/ketcher-react/src/script/ui/App/initApp.tsx
@@ -25,7 +25,7 @@ import App from './App.container';
 import { Provider } from 'react-redux';
 import { uniqueId } from 'lodash';
 import { Root } from 'react-dom/client';
-import createStore from '../state';
+import createStore, { setServer } from '../state';
 import { initKeydownListener, removeKeydownListener } from '../state/hotkeys';
 import { initResize } from '../state/toolbar';
 import { initMouseListener, removeMouseListeners } from '../state/mouse';
@@ -40,6 +40,7 @@ function initApp(
     editor: any;
     setKetcher: (ketcher: Ketcher) => void;
     ketcherId: string;
+    setServer: (server: StructService) => void;
   }) => void,
   togglerComponent?: JSX.Element,
 ) {
@@ -48,10 +49,21 @@ function initApp(
     ketcherRef = ketcher;
   };
   const ketcherId = uniqueId();
+  // hack to return server setter to Editor.tsx
+  // because it does not have access to store
+  let getServerSetter: () => (structService: StructService) => void;
+
   const setEditor = (editor) => {
-    resolve({ editor, setKetcher, ketcherId });
+    const setServer = getServerSetter();
+    resolve({ editor, setKetcher, ketcherId, setServer });
   };
   const store = createStore(options, server, setEditor);
+
+  getServerSetter = () => {
+    return (structService: StructService) => {
+      store.dispatch(setServer(structService));
+    };
+  };
 
   store.dispatch(initKeydownListener(element));
   store.dispatch(initMouseListener(element));

--- a/packages/ketcher-react/src/script/ui/state/index.js
+++ b/packages/ketcher-react/src/script/ui/state/index.js
@@ -34,6 +34,8 @@ import floatingToolsReducer from './floatingTools';
 
 export { onAction, load };
 
+export const SET_SERVER = 'SET_SERVER';
+
 const shared = combineReducers({
   common: commonReducer,
   actionState: actionStateReducer,
@@ -68,6 +70,13 @@ function getRootReducer(setEditor) {
           ...data
         } = action;
         if (data) state = { ...state, ...data };
+      }
+
+      case SET_SERVER: {
+        state = {
+          ...state,
+          server: action.server || state.server,
+        };
       }
     }
     /* eslint-enable no-fallthrough */
@@ -114,4 +123,11 @@ export default function (options, server, setEditor) {
 
   const rootReducer = getRootReducer(setEditor);
   return createStore(rootReducer, initState, applyMiddleware(...middleware));
+}
+
+export function setServer(server) {
+  return {
+    type: SET_SERVER,
+    server,
+  };
 }

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -29,7 +29,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "cross-env NODE_ENV=production rollup -c -m true && cross-env NODE_ENV=production BINARY_WASM=true rollup -c -m true",
+    "build": "cross-env NODE_ENV=production rollup -c -m true && cross-env NODE_ENV=production INDIGO_MODULE_NAME=wasm rollup -c -m true && cross-env NODE_ENV=production INDIGO_MODULE_NAME=base64WithoutRender SEPARATE_INDIGO_RENDER=true rollup -c -m true && cross-env NODE_ENV=production INDIGO_MODULE_NAME=wasmWithoutRender SEPARATE_INDIGO_RENDER=true rollup -c -m true",
     "start": "cross-env NODE_ENV=development rollup -c -m true -w",
     "test": "run-s test:prettier test:eslint:quiet test:types test:unit",
     "test:eslint": "eslint . --ext .ts,.js",
@@ -54,6 +54,7 @@
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^16.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-strip": "^2.0.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.12",
@@ -84,6 +85,14 @@
     "./dist/binaryWasm": {
       "import": "./dist/binaryWasm/index.modern.js",
       "require": "./dist/binaryWasm/index.js"
+    },
+    "./dist/jsNoRender": {
+      "import": "./dist/jsNoRender/index.modern.js",
+      "require": "./dist/jsNoRender/index.js"
+    },
+    "./dist/binaryWasmNoRender": {
+      "import": "./dist/binaryWasmNoRender/index.modern.js",
+      "require": "./dist/binaryWasmNoRender/index.js"
     }
   }
 }

--- a/packages/ketcher-standalone/src/index.ts
+++ b/packages/ketcher-standalone/src/index.ts
@@ -14,9 +14,4 @@
  * limitations under the License.
  ***************************************************************************/
 
-import {
-  StandaloneStructService,
-  StandaloneStructServiceProvider,
-} from './infrastructure/services';
-
-export { StandaloneStructServiceProvider, StandaloneStructService };
+export * from './infrastructure/services';

--- a/packages/ketcher-standalone/src/infrastructure/services/index.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/index.ts
@@ -20,3 +20,4 @@ import {
 } from './struct';
 
 export { StandaloneStructServiceProvider, StandaloneStructService };
+export * from './struct/constants';

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/constants.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/constants.ts
@@ -1,0 +1,3 @@
+export const STRUCT_SERVICE_NO_RENDER_INITIALIZED_EVENT =
+  'struct-service-no-render-initialized';
+export const STRUCT_SERVICE_INITIALIZED_EVENT = 'struct-service-initialized';

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/index.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/index.ts
@@ -18,3 +18,4 @@ import StandaloneStructService from './standaloneStructService';
 import StandaloneStructServiceProvider from './standaloneStructServiceProvider';
 
 export { StandaloneStructService, StandaloneStructServiceProvider };
+export * from './constants';

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts
@@ -113,8 +113,6 @@ self.onmessage = (e: MessageEvent<InputMessage<CommandData>>) => {
 
     case Command.Layout: {
       const data: LayoutCommandData = message.data as LayoutCommandData;
-      // eslint-disable-next-line no-debugger
-      console.info('hew');
       handle(
         (indigo, indigoOptions) => {
           const response = indigo.layout(

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts
@@ -38,7 +38,7 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import indigoModuleFn from 'indigo-ketcher';
+import indigoModuleFn from '_indigo-ketcher-import-alias_';
 
 interface IndigoOptions {
   set: (key: string, value: string) => void;
@@ -113,6 +113,8 @@ self.onmessage = (e: MessageEvent<InputMessage<CommandData>>) => {
 
     case Command.Layout: {
       const data: LayoutCommandData = message.data as LayoutCommandData;
+      // eslint-disable-next-line no-debugger
+      console.info('hew');
       handle(
         (indigo, indigoOptions) => {
           const response = indigo.layout(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added ketcher-standalone builds for indigo without render module
- added structService reinitialization

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request