### PR TITLE
#4935 - Preview: Enumeration is missing for cycled unsplit nucleotides after load from file (KET/MOL doesn't matter)

### DIFF
--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -1,11 +1,4 @@
-import {
-  BaseMonomer,
-  Peptide,
-  Phosphate,
-  RNABase,
-  Sugar,
-  UnsplitNucleotide,
-} from 'domain/entities';
+import { BaseMonomer, Phosphate, RNABase, Sugar } from 'domain/entities';
 import { AttachmentPointName, MonomerItemType } from 'domain/types';
 import { PolymerBond } from 'domain/entities/PolymerBond';
 
@@ -124,32 +117,6 @@ export function getPhosphateFromSugar(monomer?: BaseMonomer) {
   return nextMonomerInChain instanceof Phosphate
     ? nextMonomerInChain
     : undefined;
-}
-
-export function isMonomerBeginningOfChain(
-  monomer: BaseMonomer,
-  MonomerTypes: Array<
-    typeof Peptide | typeof Phosphate | typeof Sugar | typeof UnsplitNucleotide
-  >,
-) {
-  const r1PolymerBond = monomer.attachmentPointsToBonds.R1;
-  const previousMonomer = r1PolymerBond?.getAnotherMonomer(monomer);
-  const isPreviousMonomerPartOfChain =
-    previousMonomer &&
-    !MonomerTypes.some((MonomerType) => previousMonomer instanceof MonomerType);
-  const previousConnectionNotR2 =
-    r1PolymerBond &&
-    previousMonomer?.getAttachmentPointByBond(r1PolymerBond) !== 'R2';
-
-  // For single monomers we check that monomer has bonds, but for UnsplitNucleotide we don't
-  // to be consistent with rna triplets (we show enumeration for single triplet)
-  return (
-    ((monomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) ||
-      !monomer.hasAttachmentPoint(AttachmentPointName.R1)) &&
-      (monomer.hasBonds || monomer instanceof UnsplitNucleotide)) ||
-    previousConnectionNotR2 ||
-    isPreviousMonomerPartOfChain
-  );
 }
 
 export function isValidNucleotide(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request