### PR TITLE
Backmerge: #5242 - Replace phosphate at the end with petide causes cycled polymer

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1088,8 +1088,11 @@ export class SequenceMode extends BaseMode {
     const editor = CoreEditor.provideEditorInstance();
     const nextNode = SequenceRenderer.getNextNodeInSameChain(selection.node);
     const position = selection.node.monomer.position;
-
     const sideChainConnections = this.preserveSideChainConnections(selection);
+    const hasPreviousNodeInChain =
+      selection.node.firstMonomerInNode.attachmentPointsToBonds.R1;
+    const hasNextNodeInChain =
+      selection.node.lastMonomerInNode.attachmentPointsToBonds.R2;
 
     selection.node.monomers.forEach((monomer) => {
       modelChanges.merge(editor.drawingEntitiesManager.deleteMonomer(monomer));
@@ -1113,6 +1116,8 @@ export class SequenceMode extends BaseMode {
         newMonomerSequenceNode,
         nextNode || null,
         previousSelectionNode,
+        Boolean(hasPreviousNodeInChain),
+        Boolean(hasNextNodeInChain),
       ),
     );
 
@@ -1161,6 +1166,10 @@ export class SequenceMode extends BaseMode {
       );
 
       selectionRange.forEach((nodeSelection) => {
+        if (nodeSelection.node instanceof EmptySequenceNode) {
+          return;
+        }
+
         previousReplacedNode = this.replaceSelectionWithMonomer(
           monomerItem,
           nodeSelection,
@@ -1364,6 +1373,10 @@ export class SequenceMode extends BaseMode {
     const editor = CoreEditor.provideEditorInstance();
     const nextNode = SequenceRenderer.getNextNodeInSameChain(selection.node);
     const position = selection.node.monomer.position;
+    const hasPreviousNodeInChain =
+      selection.node.firstMonomerInNode.attachmentPointsToBonds.R1;
+    const hasNextNodeInChain =
+      selection.node.lastMonomerInNode.attachmentPointsToBonds.R2;
 
     const sideChainConnections = this.preserveSideChainConnections(selection);
 
@@ -1419,6 +1432,8 @@ export class SequenceMode extends BaseMode {
         newPresetNode,
         nextNode || null,
         previousSelectionNode,
+        Boolean(hasPreviousNodeInChain),
+        Boolean(hasNextNodeInChain),
       ),
     );
 
@@ -1470,6 +1485,10 @@ export class SequenceMode extends BaseMode {
       );
 
       selectionRange.forEach((nodeSelection) => {
+        if (nodeSelection.node instanceof EmptySequenceNode) {
+          return;
+        }
+
         previousReplacedNode = this.replaceSelectionWithPreset(
           preset,
           nodeSelection,
@@ -1631,6 +1650,8 @@ export class SequenceMode extends BaseMode {
     chainsCollectionOrNode: ChainsCollection | SubChainNode,
     nextNodeToConnect?: SubChainNode | null,
     previousNodeToConnect?: SubChainNode,
+    needConnectWithPreviousNodeInChain = true,
+    needConnectWithNextNodeInChain = true,
   ) {
     const chainsCollection =
       chainsCollectionOrNode instanceof ChainsCollection
@@ -1651,20 +1672,24 @@ export class SequenceMode extends BaseMode {
 
     this.deleteBondToNextNodeInChain(previousNodeInSameChain, modelChanges);
 
-    this.connectNodes(
-      previousNodeInSameChain,
-      firstNodeOfNewFragment,
-      modelChanges,
-      newNodePosition,
-      currentNode,
-    );
+    if (needConnectWithPreviousNodeInChain) {
+      this.connectNodes(
+        previousNodeInSameChain,
+        firstNodeOfNewFragment,
+        modelChanges,
+        newNodePosition,
+        currentNode,
+      );
+    }
 
-    this.connectNodes(
-      lastNodeOfNewFragment,
-      currentNode,
-      modelChanges,
-      newNodePosition,
-    );
+    if (needConnectWithNextNodeInChain) {
+      this.connectNodes(
+        lastNodeOfNewFragment,
+        currentNode,
+        modelChanges,
+        newNodePosition,
+      );
+    }
 
     return modelChanges;
   }

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1086,7 +1086,7 @@ export class SequenceMode extends BaseMode {
     previousSelectionNode?: SubChainNode,
   ) {
     const editor = CoreEditor.provideEditorInstance();
-    const nextNode = SequenceRenderer.getNextNode(selection.node);
+    const nextNode = SequenceRenderer.getNextNodeInSameChain(selection.node);
     const position = selection.node.monomer.position;
 
     const sideChainConnections = this.preserveSideChainConnections(selection);
@@ -1111,7 +1111,7 @@ export class SequenceMode extends BaseMode {
     modelChanges.merge(
       this.insertNewSequenceFragment(
         newMonomerSequenceNode,
-        nextNode,
+        nextNode || null,
         previousSelectionNode,
       ),
     );
@@ -1156,8 +1156,8 @@ export class SequenceMode extends BaseMode {
     const modelChanges = new Command();
 
     selections.forEach((selectionRange) => {
-      let previousReplacedNode = SequenceRenderer.getNodeByPointer(
-        selectionRange[0].nodeIndexOverall - 1,
+      let previousReplacedNode = SequenceRenderer.getPreviousNodeInSameChain(
+        selectionRange[0].node,
       );
 
       selectionRange.forEach((nodeSelection) => {
@@ -1362,7 +1362,7 @@ export class SequenceMode extends BaseMode {
     previousSelectionNode?: SubChainNode,
   ) {
     const editor = CoreEditor.provideEditorInstance();
-    const nextNode = SequenceRenderer.getNextNode(selection.node);
+    const nextNode = SequenceRenderer.getNextNodeInSameChain(selection.node);
     const position = selection.node.monomer.position;
 
     const sideChainConnections = this.preserveSideChainConnections(selection);
@@ -1417,7 +1417,7 @@ export class SequenceMode extends BaseMode {
     modelChanges.merge(
       this.insertNewSequenceFragment(
         newPresetNode,
-        nextNode,
+        nextNode || null,
         previousSelectionNode,
       ),
     );
@@ -1465,8 +1465,8 @@ export class SequenceMode extends BaseMode {
     const modelChanges = new Command();
 
     selections.forEach((selectionRange) => {
-      let previousReplacedNode = SequenceRenderer.getNodeByPointer(
-        selectionRange[0].nodeIndexOverall - 1,
+      let previousReplacedNode = SequenceRenderer.getPreviousNodeInSameChain(
+        selectionRange[0].node,
       );
 
       selectionRange.forEach((nodeSelection) => {
@@ -1629,7 +1629,7 @@ export class SequenceMode extends BaseMode {
 
   private insertNewSequenceFragment(
     chainsCollectionOrNode: ChainsCollection | SubChainNode,
-    nextNodeToConnect?: SubChainNode,
+    nextNodeToConnect?: SubChainNode | null,
     previousNodeToConnect?: SubChainNode,
   ) {
     const chainsCollection =
@@ -1639,7 +1639,9 @@ export class SequenceMode extends BaseMode {
             new Chain().addNode(chainsCollectionOrNode),
           );
     const currentNode =
-      nextNodeToConnect || SequenceRenderer.currentEdittingNode;
+      nextNodeToConnect === null
+        ? undefined
+        : nextNodeToConnect || SequenceRenderer.currentEdittingNode;
     const previousNodeInSameChain =
       previousNodeToConnect || SequenceRenderer.previousNodeInSameChain;
     const modelChanges = new Command();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- changed usage of previous/next node to previous/next node in same chain for replacing sequence items through the library

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request