### PR TITLE
 #5202 - Updated visuals in Right-click context menu

### DIFF
--- a/packages/ketcher-react/src/components/ToggleButtonGroup/ToggleButtonGroup.module.less
+++ b/packages/ketcher-react/src/components/ToggleButtonGroup/ToggleButtonGroup.module.less
@@ -14,33 +14,71 @@
  * limitations under the License.
  ***************************************************************************/
 
-@import '../../style/mixins.less';
-@import '../../style/variables.less';
+ @import '../../style/mixins.less';
+ @import '../../style/variables.less';
 
-.button {
-  .btn();
-
-  cursor: pointer;
-  height: 24px;
-  white-space: nowrap;
-  font-size: 12px;
-  color: @color-grey-6!important;
-  border-color: @color-grey-6!important;
-  text-transform: none!important;
-
-  &:hover {
-    color: @color-spec-button-primary-hover!important;
-  }
-}
-
-.button.selected,
-.button:active {
-  background: @color-primary!important;
-  color: #fff!important;
-
-  &:hover {
-    background-color: @color-spec-button-primary-hover!important;
-  }
-}
-
-
+ .button {
+   .btn();
+ 
+   cursor: pointer;
+   height: 28px!important;
+   white-space: nowrap;
+   font-size: 12px;
+   color: @color-grey-6!important;
+   background-color: #F3F8F9!important;
+   text-transform: none!important;
+   margin: 2px!important;
+   border-color: transparent!important;
+ 
+   &:hover {
+     background-color:  #E1E5EA!important;
+   }
+ }
+ 
+ .button.selected,
+ .button:active {
+   background: @color-primary!important;
+   color: #fff!important;
+ 
+   &:hover {
+     background-color: @color-spec-button-primary-hover!important;
+   }
+ }
+ 
+ 
+ .buttonGroupContainer {
+   display: inline-flex!important;
+   flex-direction: column!important;
+   align-items: start!important;
+   padding: 2px!important;
+   box-sizing: border-box!important;
+ }
+ 
+ .textButtonGroupColumn {
+   flex-direction: column;
+   width: 101px!important;
+ }
+ 
+ .textButtonGroupRow {
+   flex-direction: row;
+ }
+ 
+ .buttonGroupContainerSpecific {
+   width: auto!important;
+   box-sizing: border-box!important;
+ }
+ 
+ .buttonSpecific {
+   height: 28px!important;
+ }
+ 
+ .contexify {
+   min-width: 0 !important;
+ }
+ 
+ .contexify_submenu[data-target-label-submenu="true"] {
+   min-width: 0 !important;
+   width: 109px !important;
+   padding: 4px;
+ }
+ 

--- a/packages/ketcher-react/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/ketcher-react/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,7 +1,14 @@
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import classes from './ToggleButtonGroup.module.less';
 import clsx from 'clsx';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useContextMenu } from 'react-contexify';
+
+const STRICT_TARGET_LABELS = [
+  ['Unsaturated', 'Saturated'],
+  ['none', 'aromatic', 'aliphatic'],
+  ['none', 'anticlockwise', 'clockwise'],
+];
 
 export default function ButtonGroup<T>({
   buttons,
@@ -12,36 +19,145 @@ export default function ButtonGroup<T>({
   onClick: (value: T) => void;
   defaultValue: T;
 }) {
-  const [value, setValue] = useState(defaultValue);
+  useContextMenu({ id: 'context-menu-id' });
+
+  const [value, setValue] = useState<T>(defaultValue);
 
   const handleChange = useCallback(
-    (event: React.MouseEvent<HTMLElement>, value: T) => {
+    (event: React.MouseEvent<HTMLElement>, newValue: T) => {
       event.stopPropagation();
-      onClick(value);
-      setValue(value);
+      onClick(newValue);
+      setValue(newValue);
     },
     [onClick],
   );
 
+  const filterTextButtons = (buttons: { label: string; value: T }[]) =>
+    buttons.filter(
+      ({ label }) => isNaN(Number(label.trim())) || label.trim() === '',
+    );
+
+  const filterNumericButtons = (buttons: { label: string; value: T }[]) =>
+    buttons.filter(
+      ({ label }) => !isNaN(Number(label.trim())) && label.trim() !== '',
+    );
+
+  const textButtons = filterTextButtons(buttons);
+  const numericButtons = filterNumericButtons(buttons);
+
+  const getButtonClass = (buttonValue: T) =>
+    clsx(classes.button, {
+      [classes.buttonSpecific]:
+        textButtons.length > 0 && numericButtons.length === 0,
+      [classes.textButton]: textButtons.some(
+        ({ value }) => value === buttonValue,
+      ),
+      [classes.numericButton]: numericButtons.some(
+        ({ value }) => value === buttonValue,
+      ),
+      [classes.selected]: buttonValue === value,
+    });
+
+  const applyStylesToTargetLabelSubmenus = () => {
+    const submenus = document.querySelectorAll('.contexify_submenu');
+    submenus.forEach((submenu) => {
+      const items = Array.from(submenu.querySelectorAll('.MuiButtonBase-root'));
+      const itemLabels = items
+        .map((item) => item.textContent?.trim())
+        .filter((label): label is string => !!label);
+
+      const isTargetSubmenu = STRICT_TARGET_LABELS.some(
+        (targetLabels) =>
+          targetLabels.length === itemLabels.length &&
+          targetLabels.every((label, index) => label === itemLabels[index]),
+      );
+
+      if (isTargetSubmenu) {
+        const submenuElement = submenu as HTMLElement;
+        submenuElement.setAttribute('data-target-label-submenu', 'true');
+        submenuElement.style.setProperty('min-width', '0px', 'important');
+      }
+    });
+  };
+
+  useEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.addedNodes.length) {
+          applyStylesToTargetLabelSubmenus();
+        }
+      });
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [textButtons, numericButtons]);
+
+  useEffect(() => {
+    const contextMenuHandler = () => {
+      applyStylesToTargetLabelSubmenus();
+    };
+
+    document.addEventListener('contextmenu', contextMenuHandler);
+
+    return () => {
+      document.removeEventListener('contextmenu', contextMenuHandler);
+    };
+  }, []);
+
   return (
-    <ToggleButtonGroup
-      exclusive
-      style={{ overflowX: 'hidden', flexWrap: 'wrap' }}
+    <div
+      className={clsx(classes.buttonGroupContainer, {
+        [classes.buttonGroupContainerWithNumeric]:
+          textButtons.length > 0 && numericButtons.length > 0,
+        [classes.buttonGroupContainerOnlyText]:
+          textButtons.length > 0 && numericButtons.length === 0,
+      })}
+      id="context-menu-id"
     >
-      {buttons.map(({ label, value: buttonValue }) => (
-        <ToggleButton
-          data-testid={label + '-option'}
-          key={label}
-          value={Number(buttonValue) || ''}
-          onClick={(event) => handleChange(event, buttonValue)}
-          className={clsx(classes.button, {
-            [classes.selected]: buttonValue === value,
-          })}
-          style={{ flex: '1 0 25%', margin: '2px', borderRadius: '3px' }}
-        >
-          {label || 'none'}
-        </ToggleButton>
-      ))}
-    </ToggleButtonGroup>
+      <ToggleButtonGroup
+        exclusive
+        className={clsx(classes.textButtonGroup, {
+          [classes.textButtonGroupColumn]:
+            textButtons.length > 0 && numericButtons.length === 0,
+          [classes.textButtonGroupRow]: numericButtons.length > 0,
+        })}
+        value={value}
+        onChange={(_, newValue) => newValue !== null && setValue(newValue)}
+      >
+        {textButtons.map(({ label, value: buttonValue }) => (
+          <ToggleButton
+            data-testid={label + '-option'}
+            key={label || 'empty'}
+            value={buttonValue ?? ''}
+            onClick={(event) =>
+              buttonValue !== undefined && handleChange(event, buttonValue)
+            }
+            className={getButtonClass(buttonValue)}
+            style={{ margin: '3px', borderRadius: '3px' }}
+          >
+            {label || 'none'}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+      <div className={classes.numericButtonsContainer}>
+        {numericButtons.map(({ label, value: buttonValue }) => (
+          <ToggleButton
+            data-testid={label + '-option'}
+            key={label}
+            value={buttonValue ?? ''}
+            onClick={(event) =>
+              buttonValue !== undefined && handleChange(event, buttonValue)
+            }
+            className={getButtonClass(buttonValue)}
+          >
+            {label}
+          </ToggleButton>
+        ))}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/5202

- [ ] Past behavior 

- Need to fix context menu styles according to the layout

- [x] Actual behavior

-  Fix context menu styles according to the layout

<img width="558" alt="Снимок экрана 2024-08-09 в 00 48 19" src="https://github.com/user-attachments/assets/3a8981ab-a3c7-4eb6-8235-2cadbca21a0e">

<img width="558" alt="Снимок экрана 2024-08-09 в 00 48 35" src="https://github.com/user-attachments/assets/1fd97708-cc10-4c84-bae0-858773794bc8">
<img width="558" alt="Снимок экрана 2024-08-09 в 00 48 52" src="https://github.com/user-attachments/assets/64525e16-cdab-4a4e-8b5f-523faacf327b">
<img width="558" alt="Снимок экрана 2024-08-09 в 00 49 08" src="https://github.com/user-attachments/assets/c4279eb5-d5f1-43fa-a69e-86a81b45feb2">


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request