### PR TITLE
#5228 - System insert monomer from the library to the canvas even if it shouldn't (and error message is wrong)

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -937,7 +937,7 @@ export class SequenceMode extends BaseMode {
     return entity?.firstMonomerInNode?.attachmentPointsToBonds?.R1 === null;
   }
 
-  private isR2Free(entity: SubChainNode | BaseMonomer): boolean {
+  private isR2Free(entity?: SubChainNode | BaseMonomer): boolean {
     if (entity instanceof BaseMonomer) {
       return entity.attachmentPointsToBonds.R2 === null;
     }
@@ -1305,6 +1305,12 @@ export class SequenceMode extends BaseMode {
     const history = new EditorHistory(editor);
     const modelChanges = new Command();
     const selections = SequenceRenderer.selections;
+    const previousNodeInSameChain = SequenceRenderer.previousNodeInSameChain;
+    const nextNodeInSameChain = SequenceRenderer.nextNodeInSameChain;
+    const newMonomerAttachmentPoints =
+      BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
+        monomerItem.attachmentPoints || [],
+      );
 
     if (selections.length > 0) {
       if (
@@ -1342,6 +1348,17 @@ export class SequenceMode extends BaseMode {
       } else {
         this.replaceSelectionsWithMonomer(selections, monomerItem);
       }
+    } else if (
+      (previousNodeInSameChain?.lastMonomerInNode.attachmentPointsToBonds.R2 &&
+        !newMonomerAttachmentPoints.attachmentPointsList.includes(
+          AttachmentPointName.R1,
+        )) ||
+      (nextNodeInSameChain?.firstMonomerInNode.attachmentPointsToBonds.R1 &&
+        !newMonomerAttachmentPoints.attachmentPointsList.includes(
+          AttachmentPointName.R2,
+        ))
+    ) {
+      this.showMergeWarningModal();
     } else {
       const newNodePosition = this.getNewNodePosition();
 

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1349,14 +1349,20 @@ export class SequenceMode extends BaseMode {
         this.replaceSelectionsWithMonomer(selections, monomerItem);
       }
     } else if (
-      (previousNodeInSameChain?.lastMonomerInNode.attachmentPointsToBonds.R2 &&
-        !newMonomerAttachmentPoints.attachmentPointsList.includes(
-          AttachmentPointName.R1,
-        )) ||
-      (nextNodeInSameChain?.firstMonomerInNode.attachmentPointsToBonds.R1 &&
-        !newMonomerAttachmentPoints.attachmentPointsList.includes(
+      (previousNodeInSameChain &&
+        (!previousNodeInSameChain?.lastMonomerInNode.hasAttachmentPoint(
           AttachmentPointName.R2,
-        ))
+        ) ||
+          !newMonomerAttachmentPoints.attachmentPointsList.includes(
+            AttachmentPointName.R1,
+          ))) ||
+      (nextNodeInSameChain &&
+        (!nextNodeInSameChain?.firstMonomerInNode.hasAttachmentPoint(
+          AttachmentPointName.R1,
+        ) ||
+          !newMonomerAttachmentPoints.attachmentPointsList.includes(
+            AttachmentPointName.R2,
+          )))
     ) {
       this.showMergeWarningModal();
     } else {

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -592,7 +592,7 @@ export class SequenceRenderer {
     );
   }
 
-  public static get nextNodeInSameChain() {
+  public static get nextNodeInSameChain(): SubChainNode | undefined {
     if (SequenceRenderer.nextCaretPosition !== SequenceRenderer.caretPosition) {
       return;
     }
@@ -653,7 +653,9 @@ export class SequenceRenderer {
     );
   }
 
-  public static getPreviousNodeInSameChain(nodeToCompare: SubChainNode) {
+  public static getPreviousNodeInSameChain(
+    nodeToCompare: SubChainNode,
+  ): SubChainNode | undefined {
     let previousNode;
     let previousNodeChainIndex = -1;
     let nodeToReturn;
@@ -669,7 +671,9 @@ export class SequenceRenderer {
     return nodeToReturn;
   }
 
-  public static getNextNodeInSameChain(nodeToCompare: SubChainNode) {
+  public static getNextNodeInSameChain(
+    nodeToCompare: SubChainNode,
+  ): SubChainNode {
     let previousNode;
     let previousNodeChainIndex = -1;
     let nodeToReturn;

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -593,7 +593,7 @@ export class SequenceRenderer {
   }
 
   public static get nextNodeInSameChain(): SubChainNode | undefined {
-    if (SequenceRenderer.nextCaretPosition !== SequenceRenderer.caretPosition) {
+    if (SequenceRenderer.nextCaretPosition === SequenceRenderer.caretPosition) {
       return;
     }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed case with adding new sequence items using replace from library in case if there is no attachment points

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request