### PR TITLE
Backmerge: #5245 - Replacement of peptide at the end of sequence on preset w/out base works wrong 

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1290,6 +1290,7 @@ export class SequenceMode extends BaseMode {
       selectionRange.some((nodeSelection) =>
         [preset.sugar, preset.base, preset.phosphate].some(
           (monomer) =>
+            monomer &&
             !this.checkIfNewMonomerCouldEstablishConnections(
               nodeSelection,
               monomer,
@@ -1364,6 +1365,52 @@ export class SequenceMode extends BaseMode {
     }
   }
 
+  private createRnaPresetNode(preset: IRnaPreset, position: Vec2) {
+    const editor = CoreEditor.provideEditorInstance();
+    const { base: rnaBase, sugar, phosphate } = preset;
+
+    if (!sugar) {
+      return;
+    }
+
+    const rnaPresetAddResult = editor.drawingEntitiesManager.addRnaPreset({
+      sugar,
+      sugarPosition: position,
+      rnaBase,
+      rnaBasePosition: position,
+      phosphate,
+      phosphatePosition: position,
+    });
+
+    const sugarMonomer = rnaPresetAddResult.monomers.find(
+      (monomer) => monomer instanceof Sugar,
+    ) as Sugar;
+    const rnaBaseMonomer = rnaPresetAddResult.monomers.find(
+      (monomer) => monomer instanceof RNABase,
+    ) as RNABase;
+    const phosphateMonomer = rnaPresetAddResult.monomers.find(
+      (monomer) => monomer instanceof Phosphate,
+    ) as Phosphate;
+
+    let newPresetNode: Nucleotide | Nucleoside | LinkerSequenceNode;
+    if (phosphateMonomer) {
+      newPresetNode = new Nucleotide(
+        sugarMonomer,
+        rnaBaseMonomer,
+        phosphateMonomer,
+      );
+    } else if (rnaBase) {
+      newPresetNode = new Nucleoside(sugarMonomer, rnaBaseMonomer);
+    } else {
+      newPresetNode = new LinkerSequenceNode(sugarMonomer);
+    }
+
+    return {
+      newPresetNode,
+      rnaPresetAddModelChanges: rnaPresetAddResult.command,
+    };
+  }
+
   private replaceSelectionWithPreset(
     preset: IRnaPreset,
     selection: NodeSelection,
@@ -1389,44 +1436,15 @@ export class SequenceMode extends BaseMode {
       });
     });
 
-    const { base: rnaBase, sugar, phosphate } = preset;
+    const rnaAdditionResult = this.createRnaPresetNode(preset, position);
 
-    if (!rnaBase || !sugar) {
+    if (!rnaAdditionResult) {
       return;
     }
 
-    const monomerAddCommand = editor.drawingEntitiesManager.addRnaPreset({
-      sugar,
-      sugarPosition: position,
-      rnaBase,
-      rnaBasePosition: position,
-      phosphate,
-      phosphatePosition: position,
-    });
+    const { newPresetNode, rnaPresetAddModelChanges } = rnaAdditionResult;
 
-    const sugarMonomer = monomerAddCommand.monomers.find(
-      (monomer) => monomer instanceof Sugar,
-    ) as Sugar;
-    const rnaBaseMonomer = monomerAddCommand.monomers.find(
-      (monomer) => monomer instanceof RNABase,
-    ) as RNABase;
-    const phosphateMonomer = monomerAddCommand.monomers.find(
-      (monomer) => monomer instanceof Phosphate,
-    ) as Phosphate;
-
-    modelChanges.merge(monomerAddCommand.command);
-
-    let newPresetNode: Nucleotide | Nucleoside;
-    if (phosphateMonomer) {
-      newPresetNode = new Nucleotide(
-        sugarMonomer,
-        rnaBaseMonomer,
-        phosphateMonomer,
-      );
-    } else {
-      newPresetNode = new Nucleoside(sugarMonomer, rnaBaseMonomer);
-    }
-
+    modelChanges.merge(rnaPresetAddModelChanges);
     modelChanges.merge(
       this.insertNewSequenceFragment(
         newPresetNode,
@@ -1439,7 +1457,11 @@ export class SequenceMode extends BaseMode {
 
     // TODO: This check breaks some side chains (e.g. Sugar-to-Sugar for Nucleotides), need another way of preserving connections
     const monomerForSideConnections =
-      newPresetNode instanceof Nucleotide ? phosphateMonomer : sugarMonomer;
+      newPresetNode instanceof Nucleotide
+        ? newPresetNode.phosphate
+        : newPresetNode instanceof Nucleoside
+        ? newPresetNode.sugar
+        : newPresetNode.monomer;
 
     sideChainConnections?.forEach((sideConnectionData) => {
       const {
@@ -1545,45 +1567,19 @@ export class SequenceMode extends BaseMode {
     } else {
       const newNodePosition = this.getNewNodePosition();
 
-      const { base: rnaBase, sugar, phosphate } = preset;
+      const rnaAdditionResult = this.createRnaPresetNode(
+        preset,
+        newNodePosition,
+      );
 
-      if (!rnaBase || !sugar) {
+      if (!rnaAdditionResult) {
         return;
       }
 
-      const monomerAddCommand = editor.drawingEntitiesManager.addRnaPreset({
-        sugar,
-        sugarPosition: newNodePosition,
-        rnaBase,
-        rnaBasePosition: newNodePosition,
-        phosphate,
-        phosphatePosition: newNodePosition,
-      });
-
-      const sugarMonomer = monomerAddCommand.monomers.find(
-        (monomer) => monomer instanceof Sugar,
-      ) as Sugar;
-      const rnaBaseMonomer = monomerAddCommand.monomers.find(
-        (monomer) => monomer instanceof RNABase,
-      ) as RNABase;
-      const phosphateMonomer = monomerAddCommand.monomers.find(
-        (monomer) => monomer instanceof Phosphate,
-      ) as Phosphate;
-
-      modelChanges.merge(monomerAddCommand.command);
-
-      let newPresetNode: Nucleotide | Nucleoside;
-      if (phosphateMonomer) {
-        newPresetNode = new Nucleotide(
-          sugarMonomer,
-          rnaBaseMonomer,
-          phosphateMonomer,
-        );
-      } else {
-        newPresetNode = new Nucleoside(sugarMonomer, rnaBaseMonomer);
-      }
-
-      modelChanges.merge(this.insertNewSequenceFragment(newPresetNode));
+      modelChanges.merge(rnaAdditionResult.rnaPresetAddModelChanges);
+      modelChanges.merge(
+        this.insertNewSequenceFragment(rnaAdditionResult.newPresetNode),
+      );
 
       modelChanges.addOperation(new ReinitializeModeOperation());
       editor.renderersContainer.update(modelChanges);

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1393,16 +1393,17 @@ export class SequenceMode extends BaseMode {
     ) as Phosphate;
 
     let newPresetNode: Nucleotide | Nucleoside | LinkerSequenceNode;
-    if (phosphateMonomer) {
+
+    if (!rnaBase) {
+      newPresetNode = new LinkerSequenceNode(sugarMonomer);
+    } else if (!phosphateMonomer) {
+      newPresetNode = new Nucleoside(sugarMonomer, rnaBaseMonomer);
+    } else {
       newPresetNode = new Nucleotide(
         sugarMonomer,
         rnaBaseMonomer,
         phosphateMonomer,
       );
-    } else if (rnaBase) {
-      newPresetNode = new Nucleoside(sugarMonomer, rnaBaseMonomer);
-    } else {
-      newPresetNode = new LinkerSequenceNode(sugarMonomer);
     }
 
     return {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- moved rna node addition in sequence mode to separate function
- removed restriction of insertion/replacing rna without base

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request