### PR TITLE
#5195-Preview: Some content problems in monomer library

### DIFF
--- a/packages/ketcher-core/src/application/editor/data/monomers.ket
+++ b/packages/ketcher-core/src/application/editor/data/monomers.ket
@@ -59590,7 +59590,7 @@
     "class": "AminoAcid",
     "classHELM": "PEPTIDE",
     "id": "D-OAla___D-lactic acid",
-    "fullName": "D-lactic acid",
+    "fullName": "D-Lactic acid",
     "alias": "D-OAla",
     "attachmentPoints": [
       {


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/5195

- [ ] Past behavior 

-  Label in preview tooltip for D-OAla peptide is wrong - D-lactic acid

<img width="221" alt="Снимок экрана 2024-08-13 в 16 06 21" src="https://github.com/user-attachments/assets/9e47ac87-637a-4bf1-b40f-2ee0ef15ae99">

- [x] Actual behavior 

- Label in preview tooltip  changed - D-Lactic acid


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request