### PR TITLE
Backmerge: #5335 - The application crashes when selecting Enhanced Stereochemistry from the right-click menu

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/rergroup.js
+++ b/packages/ketcher-core/src/application/render/restruct/rergroup.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Box2Abs, Vec2 } from 'domain/entities';
-
+import { Box2Abs } from 'domain/entities/box2Abs';
+import { Vec2 } from 'domain/entities/vec2';
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/utils.ts
+++ b/packages/ketcher-core/src/application/utils.ts
@@ -57,6 +57,7 @@ export async function prepareStructToRender(
   struct.initHalfBonds();
   struct.initNeighbors();
   struct.setImplicitHydrogen();
+  struct.setStereoLabelsToAtoms();
   struct.markFragments();
 
   return struct;

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -16,7 +16,7 @@
 
 import assert from 'assert';
 import { Atom, radicalElectrons } from './atom';
-import { EditorSelection } from 'application/editor';
+import { EditorSelection, getStereoAtomsMap } from 'application/editor';
 import { Bond } from './bond';
 import { Box2Abs } from './box2Abs';
 import { Elements } from 'domain/constants';
@@ -1071,6 +1071,26 @@ export class Struct {
         }
       });
     }
+  }
+
+  public setStereoLabelsToAtoms() {
+    const stereAtomsMap = getStereoAtomsMap(
+      this,
+      Array.from(this.bonds.values()),
+    );
+
+    this.atoms.forEach((atom, id) => {
+      if (this?.atomGetNeighbors(id)?.length === 0) {
+        atom.stereoLabel = null;
+        atom.stereoParity = 0;
+      } else {
+        const stereoProp = stereAtomsMap.get(id);
+        if (stereoProp) {
+          atom.stereoLabel = stereoProp.stereoLabel;
+          atom.stereoParity = stereoProp.stereoParity;
+        }
+      }
+    });
   }
 
   atomGetNeighbors(aid: number): Array<Neighbor> | undefined {

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -18,7 +18,6 @@ import {
   FormatterFactory,
   Pile,
   SGroup,
-  getStereoAtomsMap,
   identifyStructFormat,
   Struct,
   SupportedFormat,
@@ -186,25 +185,7 @@ export function load(struct: Struct, options?) {
 
       parsedStruct.findConnectedComponents();
       parsedStruct.setImplicitHydrogen();
-
-      const stereAtomsMap = getStereoAtomsMap(
-        parsedStruct,
-        Array.from(parsedStruct.bonds.values()),
-      );
-
-      parsedStruct.atoms.forEach((atom, id) => {
-        if (parsedStruct?.atomGetNeighbors(id)?.length === 0) {
-          atom.stereoLabel = null;
-          atom.stereoParity = 0;
-        } else {
-          const stereoProp = stereAtomsMap.get(id);
-          if (stereoProp) {
-            atom.stereoLabel = stereoProp.stereoLabel;
-            atom.stereoParity = stereoProp.stereoParity;
-          }
-        }
-      });
-
+      parsedStruct.setStereoLabelsToAtoms();
       parsedStruct.markFragments();
 
       if (fragment) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added set stereo labels to atoms to setMolecule

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request