### PR TITLE
Backmerge: #5335 - The application crashes when selecting Enhanced Stereochemistry from the right-click menu

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -15,11 +15,7 @@
  ***************************************************************************/
 
 import {
-  Atom,
   Bond,
-  Neighbor,
-  StereoLabel,
-  Struct,
   Vec2,
   AtomAttributes,
   BondAttributes,
@@ -47,9 +43,9 @@ import {
 
 import { Action } from './action';
 import { ReSGroup, ReStruct } from '../../render';
-import { StereoValidator } from 'domain/helpers';
 import utils from '../shared/utils';
 import { fromSgroupAttachmentPointRemove } from 'application/editor';
+import { getStereoAtomsMap } from 'application/editor/actions/helpers';
 
 export function fromBondAddition(
   reStruct: ReStruct,
@@ -327,95 +323,6 @@ export function fromBondStereoUpdate(
   });
 
   return action;
-}
-
-export function getStereoAtomsMap(
-  struct: Struct,
-  bonds: Array<Bond>,
-  bond?: Bond,
-) {
-  const stereoAtomsMap = new Map();
-  const correctAtomIds: Array<number> = [];
-
-  bonds.forEach((bond: Bond | undefined) => {
-    if (bond) {
-      const beginNeighs: Array<Neighbor> | undefined = struct.atomGetNeighbors(
-        bond.begin,
-      );
-      const endNeighs: Array<Neighbor> | undefined = struct.atomGetNeighbors(
-        bond.end,
-      );
-
-      if (
-        StereoValidator.isCorrectStereoCenter(
-          bond,
-          beginNeighs,
-          endNeighs,
-          struct,
-        )
-      ) {
-        const stereoLabel = struct.atoms.get(bond.begin)?.stereoLabel;
-        if (
-          stereoLabel == null ||
-          stereoAtomsMap.get(bond.begin)?.stereoLabel == null
-        ) {
-          stereoAtomsMap.set(bond.begin, {
-            stereoParity: getStereoParity(bond.stereo),
-            stereoLabel: stereoLabel || `${StereoLabel.Abs}`,
-          });
-        }
-        correctAtomIds.push(bond.begin);
-      } else {
-        if (!correctAtomIds.includes(bond.begin)) {
-          stereoAtomsMap.set(bond.begin, {
-            stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-            stereoLabel: null,
-          });
-        }
-        if (!correctAtomIds.includes(bond.end)) {
-          stereoAtomsMap.set(bond.end, {
-            stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-            stereoLabel: null,
-          });
-        }
-      }
-    }
-  });
-
-  // in case the stereo band is flipped, changed or removed
-  // TODO the duplication of the code below should be fixed, mayby by function
-  if (bond) {
-    if (!correctAtomIds.includes(bond.begin)) {
-      stereoAtomsMap.set(bond.begin, {
-        stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-        stereoLabel: null,
-      });
-    }
-    if (!correctAtomIds.includes(bond.end)) {
-      stereoAtomsMap.set(bond.end, {
-        stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-        stereoLabel: null,
-      });
-    }
-  }
-
-  return stereoAtomsMap;
-}
-
-function getStereoParity(stereo: number): number | null {
-  let newAtomParity: number | null = null;
-  switch (stereo) {
-    case Bond.PATTERN.STEREO.UP:
-      newAtomParity = Atom.PATTERN.STEREO_PARITY.ODD;
-      break;
-    case Bond.PATTERN.STEREO.EITHER:
-      newAtomParity = Atom.PATTERN.STEREO_PARITY.EITHER;
-      break;
-    case Bond.PATTERN.STEREO.DOWN:
-      newAtomParity = Atom.PATTERN.STEREO_PARITY.EVEN;
-      break;
-  }
-  return newAtomParity;
 }
 
 const plainBondTypes = [

--- a/packages/ketcher-core/src/application/editor/actions/helpers.ts
+++ b/packages/ketcher-core/src/application/editor/actions/helpers.ts
@@ -1,0 +1,91 @@
+import { Atom, Bond, Neighbor, StereoLabel, Struct } from 'domain/entities';
+import { StereoValidator } from 'domain/helpers';
+
+export function getStereoAtomsMap(
+  struct: Struct,
+  bonds: Array<Bond>,
+  bond?: Bond,
+) {
+  const stereoAtomsMap = new Map();
+  const correctAtomIds: Array<number> = [];
+
+  bonds.forEach((bond: Bond | undefined) => {
+    if (bond) {
+      const beginNeighs: Array<Neighbor> | undefined = struct.atomGetNeighbors(
+        bond.begin,
+      );
+      const endNeighs: Array<Neighbor> | undefined = struct.atomGetNeighbors(
+        bond.end,
+      );
+
+      if (
+        StereoValidator.isCorrectStereoCenter(
+          bond,
+          beginNeighs,
+          endNeighs,
+          struct,
+        )
+      ) {
+        const stereoLabel = struct.atoms.get(bond.begin)?.stereoLabel;
+        if (
+          stereoLabel == null ||
+          stereoAtomsMap.get(bond.begin)?.stereoLabel == null
+        ) {
+          stereoAtomsMap.set(bond.begin, {
+            stereoParity: getStereoParity(bond.stereo),
+            stereoLabel: stereoLabel || `${StereoLabel.Abs}`,
+          });
+        }
+        correctAtomIds.push(bond.begin);
+      } else {
+        if (!correctAtomIds.includes(bond.begin)) {
+          stereoAtomsMap.set(bond.begin, {
+            stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
+            stereoLabel: null,
+          });
+        }
+        if (!correctAtomIds.includes(bond.end)) {
+          stereoAtomsMap.set(bond.end, {
+            stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
+            stereoLabel: null,
+          });
+        }
+      }
+    }
+  });
+
+  // in case the stereo band is flipped, changed or removed
+  // TODO the duplication of the code below should be fixed, mayby by function
+  if (bond) {
+    if (!correctAtomIds.includes(bond.begin)) {
+      stereoAtomsMap.set(bond.begin, {
+        stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
+        stereoLabel: null,
+      });
+    }
+    if (!correctAtomIds.includes(bond.end)) {
+      stereoAtomsMap.set(bond.end, {
+        stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
+        stereoLabel: null,
+      });
+    }
+  }
+
+  return stereoAtomsMap;
+}
+
+function getStereoParity(stereo: number): number | null {
+  let newAtomParity: number | null = null;
+  switch (stereo) {
+    case Bond.PATTERN.STEREO.UP:
+      newAtomParity = Atom.PATTERN.STEREO_PARITY.ODD;
+      break;
+    case Bond.PATTERN.STEREO.EITHER:
+      newAtomParity = Atom.PATTERN.STEREO_PARITY.EITHER;
+      break;
+    case Bond.PATTERN.STEREO.DOWN:
+      newAtomParity = Atom.PATTERN.STEREO_PARITY.EVEN;
+      break;
+  }
+  return newAtomParity;
+}

--- a/packages/ketcher-core/src/application/render/restruct/rergroup.js
+++ b/packages/ketcher-core/src/application/render/restruct/rergroup.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Box2Abs, Vec2 } from 'domain/entities';
-
+import { Box2Abs } from 'domain/entities/box2Abs';
+import { Vec2 } from 'domain/entities/vec2';
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/utils.ts
+++ b/packages/ketcher-core/src/application/utils.ts
@@ -57,6 +57,7 @@ export async function prepareStructToRender(
   struct.initHalfBonds();
   struct.initNeighbors();
   struct.setImplicitHydrogen();
+  struct.setStereoLabelsToAtoms();
   struct.markFragments();
 
   return struct;

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -16,7 +16,7 @@
 
 import assert from 'assert';
 import { Atom, radicalElectrons } from './atom';
-import { EditorSelection, getStereoAtomsMap } from 'application/editor';
+import { EditorSelection } from 'application/editor';
 import { Bond } from './bond';
 import { Box2Abs } from './box2Abs';
 import { Elements } from 'domain/constants';
@@ -39,6 +39,7 @@ import { RGroupAttachmentPoint } from './rgroupAttachmentPoint';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import { isNumber } from 'lodash';
 import { Image } from './image';
+import { getStereoAtomsMap } from 'application/editor/actions/helpers';
 
 export type Neighbor = {
   aid: number;

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -16,7 +16,7 @@
 
 import assert from 'assert';
 import { Atom, radicalElectrons } from './atom';
-import { EditorSelection } from 'application/editor';
+import { EditorSelection, getStereoAtomsMap } from 'application/editor';
 import { Bond } from './bond';
 import { Box2Abs } from './box2Abs';
 import { Elements } from 'domain/constants';
@@ -1071,6 +1071,26 @@ export class Struct {
         }
       });
     }
+  }
+
+  public setStereoLabelsToAtoms() {
+    const stereAtomsMap = getStereoAtomsMap(
+      this,
+      Array.from(this.bonds.values()),
+    );
+
+    this.atoms.forEach((atom, id) => {
+      if (this?.atomGetNeighbors(id)?.length === 0) {
+        atom.stereoLabel = null;
+        atom.stereoParity = 0;
+      } else {
+        const stereoProp = stereAtomsMap.get(id);
+        if (stereoProp) {
+          atom.stereoLabel = stereoProp.stereoLabel;
+          atom.stereoParity = stereoProp.stereoParity;
+        }
+      }
+    });
   }
 
   atomGetNeighbors(aid: number): Array<Neighbor> | undefined {

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -18,7 +18,6 @@ import {
   FormatterFactory,
   Pile,
   SGroup,
-  getStereoAtomsMap,
   identifyStructFormat,
   Struct,
   SupportedFormat,
@@ -186,25 +185,7 @@ export function load(struct: Struct, options?) {
 
       parsedStruct.findConnectedComponents();
       parsedStruct.setImplicitHydrogen();
-
-      const stereAtomsMap = getStereoAtomsMap(
-        parsedStruct,
-        Array.from(parsedStruct.bonds.values()),
-      );
-
-      parsedStruct.atoms.forEach((atom, id) => {
-        if (parsedStruct?.atomGetNeighbors(id)?.length === 0) {
-          atom.stereoLabel = null;
-          atom.stereoParity = 0;
-        } else {
-          const stereoProp = stereAtomsMap.get(id);
-          if (stereoProp) {
-            atom.stereoLabel = stereoProp.stereoLabel;
-            atom.stereoParity = stereoProp.stereoParity;
-          }
-        }
-      });
-
+      parsedStruct.setStereoLabelsToAtoms();
       parsedStruct.markFragments();
 
       if (fragment) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added set stereo labels to atoms to setMolecule

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request