### PR TITLE
#5396 - Refactor KET import and save tests for optimized execution

### DIFF
--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import {
   TopPanelButton,
   moveMouseAway,
@@ -21,16 +21,34 @@ import {
   clickUndo,
   dragMouseTo,
 } from '@utils';
+import { pageReload } from '@utils/common/helpers';
 import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
 import { Peptides } from '@utils/selectors/macromoleculeEditor';
+import {
+  markResetToDefaultState,
+  processResetToDefaultState,
+} from '@utils/testAnnotations/resetToDefaultState';
+
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  page = await context.newPage();
+  await waitForPageInit(page);
+  await turnOnMacromoleculesEditor(page);
+});
+
+test.afterEach(async ({ context: _ }, testInfo) => {
+  await selectClearCanvasTool(page);
+  await processResetToDefaultState(testInfo, page);
+});
+
+test.afterAll(async ({ browser }) => {
+  await Promise.all(browser.contexts().map((context) => context.close()));
+});
 
 test.describe('Import-Saving .ket Files', () => {
-  test.beforeEach(async ({ page }) => {
-    await waitForPageInit(page);
-    await turnOnMacromoleculesEditor(page);
-  });
-
-  test('Open ket file with monomers and bonds', async ({ page }) => {
+  test('Open ket file with monomers and bonds', async () => {
     /*
     Test case: #3230 - Support parsing KET file for macromolecules on ketcher side
     Description: Ket Deserialize
@@ -40,15 +58,16 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check save and open of file with 50 monomers saved in KET format', async ({
-    page,
-  }) => {
+  test('Check save and open of file with 50 monomers saved in KET format', async () => {
     /*
     Test case: Import/Saving files
     Description: Structure in center of canvas after opening
     The structure does not fit on the canvas when opened, and to
     see the whole picture in this test and in future ones, zoom is used
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+
     await openFileAndAddToCanvasMacro('KET/fifty-monomers.ket', page);
     const expectedFile = await getKet(page);
     await saveToFile('KET/fifty-monomers-expected.ket', expectedFile);
@@ -71,13 +90,14 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check save and open of file with 100 monomers saved in KET format', async ({
-    page,
-  }) => {
+  test('Check save and open of file with 100 monomers saved in KET format', async () => {
     /*
     Test case: Import/Saving files
     Description: Structure in center of canvas after opening
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+
     await openFileAndAddToCanvasMacro('KET/hundred-monomers.ket', page);
     const expectedFile = await getKet(page);
     await saveToFile('KET/hundred-monomers-expected.ket', expectedFile);
@@ -100,9 +120,7 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check that empty file can be saved in .ket format', async ({
-    page,
-  }) => {
+  test('Check that empty file can be saved in .ket format', async () => {
     /*
     Test case: Import/Saving files
     Description: Empty file can be saved in .ket format
@@ -118,13 +136,14 @@ test.describe('Import-Saving .ket Files', () => {
     expect(ketFile).toEqual(ketFileExpected);
   });
 
-  test('Validate that saving to .ket file of any monomer from our Library does not change after loading it back from .ket file to canvas', async ({
-    page,
-  }) => {
+  test('Validate that saving to .ket file of any monomer from our Library does not change after loading it back from .ket file to canvas', async () => {
     /*
     Test case: Import/Saving files #3827 #3757
     Description: The monomer name is present in the preview after opening the saved file. 
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+
     await page.getByTestId(Peptides.BetaAlanine).click();
     await clickInTheMiddleOfTheScreen(page);
     const expectedFile = await getKet(page);
@@ -142,9 +161,7 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check that after loading from a file and then pressing undo, it does not break the selection/moving functionality', async ({
-    page,
-  }) => {
+  test('Check that after loading from a file and then pressing undo, it does not break the selection/moving functionality', async () => {
     /*
     Test case: Import/Saving files #3756
     Description: After pressing Undo not break the selection/moving functionality. 
@@ -167,13 +184,15 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check that fields "class" and "classHELM" are presents into .ket file', async ({
-    page,
-  }) => {
+  test('Check that fields "class" and "classHELM" are presents into .ket file', async () => {
     /*
     Test case: Import/Saving files #3846
     Description: Fields "class" and "classHELM" are presents into .ket file. 
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+    markResetToDefaultState('tabSelection');
+
     test.slow();
     await page.getByTestId('RNA-TAB').click();
     await page.getByTestId('summary-Sugars').click();
@@ -190,13 +209,14 @@ test.describe('Import-Saving .ket Files', () => {
     expect(ketFile).toEqual(ketFileExpected);
   });
 
-  test('Check .ket file that "leavingGroup" section contain information about number of atoms', async ({
-    page,
-  }) => {
+  test('Check .ket file that "leavingGroup" section contain information about number of atoms', async () => {
     /*
     Test case: Import/Saving files #4172
     Description: "leavingGroup" section contain information about number of atoms. 
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+
     await page.getByTestId(Peptides.D2Nal).click();
     await clickInTheMiddleOfTheScreen(page);
     const expectedFile = await getKet(page);
@@ -210,9 +230,7 @@ test.describe('Import-Saving .ket Files', () => {
     expect(ketFile).toEqual(ketFileExpected);
   });
 
-  test('Check that system does not let importing empty .ket file', async ({
-    page,
-  }) => {
+  test('Check that system does not let importing empty .ket file', async () => {
     /*
     Test case: Import/Saving files
     Description: System does not let importing empty .ket file
@@ -222,9 +240,7 @@ test.describe('Import-Saving .ket Files', () => {
     await page.getByText('Add to Canvas').isDisabled();
   });
 
-  test('Check that system does not let uploading corrupted .ket file', async ({
-    page,
-  }) => {
+  test('Check that system does not let uploading corrupted .ket file', async () => {
     /*
     Test case: Import/Saving files
     Description: System does not let uploading corrupted .ket file
@@ -235,21 +251,19 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Validate correct displaying of snake viewed peptide chain loaded from .ket file format', async ({
-    page,
-  }) => {
+  test('Validate correct displaying of snake viewed peptide chain loaded from .ket file format', async () => {
     /*
     Test case: Import/Saving files
     Description: Sequence of Peptides displaying according to snake view mockup.
     */
+    markResetToDefaultState('defaultLayout');
+
     await openFileAndAddToCanvasMacro('KET/snake-mode-peptides.ket', page);
     await selectSnakeLayoutModeTool(page);
     await takeEditorScreenshot(page);
   });
 
-  test('Check that .ket file with macro structures is imported correctly in macro mode when saving it in micro mode', async ({
-    page,
-  }) => {
+  test('Check that .ket file with macro structures is imported correctly in macro mode when saving it in micro mode', async () => {
     /*
     Test case: Import/Saving files
     Description: .ket file with macro structures is imported correctly in macro mode when saving it in micro mode
@@ -261,21 +275,19 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check that macro .ket file can be imported in micro mode', async ({
-    page,
-  }) => {
+  test('Check that macro .ket file can be imported in micro mode', async () => {
     /*
     Test case: Import/Saving files
     Description: .ket file imported in micro mode
     */
+    markResetToDefaultState('macromoleculesEditor');
+
     await turnOnMicromoleculesEditor(page);
     await openFileAndAddToCanvas('KET/monomers-saved-in-macro-mode.ket', page);
     await takeEditorScreenshot(page);
   });
 
-  test('Check that RNA preset in not changing after saving and importing it as .ket file', async ({
-    page,
-  }) => {
+  test('Check that RNA preset in not changing after saving and importing it as .ket file', async () => {
     /*
     Test case: Import/Saving files
     Description: .ket file with macro structures is imported correctly in macro mode
@@ -284,9 +296,7 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check that CHEMs in not changing after saving and importing it as .ket file', async ({
-    page,
-  }) => {
+  test('Check that CHEMs in not changing after saving and importing it as .ket file', async () => {
     /*
     Test case: Import/Saving files
     Description: .ket file with macro structures is imported correctly in macro mode.
@@ -295,13 +305,14 @@ test.describe('Import-Saving .ket Files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Check save and open of file with unresolved monomers in KET format', async ({
-    page,
-  }) => {
+  test('Check save and open of file with unresolved monomers in KET format', async () => {
     /*
     Test case: Import/Saving files
     Description: There should be possible to load monomers which not found in Monomer library
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+
     await openFileAndAddToCanvasMacro('KET/unresolved-monomers.ket', page);
     const expectedFile = await getKet(page);
     await saveToFile('KET/unresolved-monomers-expected.ket', expectedFile);
@@ -315,13 +326,14 @@ test.describe('Import-Saving .ket Files', () => {
     expect(ketFile).toEqual(ketFileExpected);
   });
 
-  test('Validate that unsplit nucleotides connected with another monomers could be saved to ket file and loaded back', async ({
-    page,
-  }) => {
+  test('Validate that unsplit nucleotides connected with another monomers could be saved to ket file and loaded back', async () => {
     /*
     Test case: Import/Saving files
     Description: .ket file with macro structures is exported and imported correctly .
     */
+    // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+    await pageReload(page);
+
     await openFileAndAddToCanvasMacro(
       'KET/unsplit-nucleotides-connected-with-another-monomers.ket',
       page,
@@ -349,11 +361,6 @@ test.describe('Base monomers on the canvas, their connection points and preview 
     (Base) from ket file, correctly show them on canvas (name, shape, color),
     shows correct number or connections and shows correct preview tooltip
   */
-  test.beforeEach(async ({ page }) => {
-    await waitForPageInit(page);
-    await turnOnMacromoleculesEditor(page);
-  });
-
   const fileNames = [
     '01 - (R1) - Left only',
     '04 - (R1,R2) - R3 gap',
@@ -366,7 +373,10 @@ test.describe('Base monomers on the canvas, their connection points and preview 
   ];
 
   for (const fileName of fileNames) {
-    test(`for ${fileName}`, async ({ page }) => {
+    test(`for ${fileName}`, async () => {
+      // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(
         `KET/Base-Templates/${fileName}.ket`,
         page,
@@ -398,11 +408,6 @@ test.describe('CHEM monomers on the canvas, their connection points and preview 
     (CHEM) from ket file, correctly show them on canvas (name, shape, color),
     shows correct number or connections and shows correct preview tooltip
   */
-  test.beforeEach(async ({ page }) => {
-    await waitForPageInit(page);
-    await turnOnMacromoleculesEditor(page);
-  });
-
   const fileNames = [
     '01 - (R1) - Left only',
     '02 - (R2) - Right only',
@@ -422,7 +427,10 @@ test.describe('CHEM monomers on the canvas, their connection points and preview 
   ];
 
   for (const fileName of fileNames) {
-    test(`for ${fileName}`, async ({ page }) => {
+    test(`for ${fileName}`, async () => {
+      // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(
         `KET/CHEM-Templates/${fileName}.ket`,
         page,
@@ -454,11 +462,6 @@ test.describe('Peptide monomers on the canvas, their connection points and previ
     (Peptide) from ket file, correctly show them on canvas (name, shape, color),
     shows correct number or connections and shows correct preview tooltip
   */
-  test.beforeEach(async ({ page }) => {
-    await waitForPageInit(page);
-    await turnOnMacromoleculesEditor(page);
-  });
-
   const fileNames = [
     '01 - (R1) - Left only',
     '02 - (R2) - Right only',
@@ -478,7 +481,10 @@ test.describe('Peptide monomers on the canvas, their connection points and previ
   ];
 
   for (const fileName of fileNames) {
-    test(`for ${fileName}`, async ({ page }) => {
+    test(`for ${fileName}`, async () => {
+      // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(
         `KET/Peptide-Templates/${fileName}.ket`,
         page,
@@ -510,11 +516,6 @@ test.describe('Phosphate monomers on the canvas, their connection points and pre
     (Phosphate) from ket file, correctly show them on canvas (name, shape, color),
     shows correct number or connections and shows correct preview tooltip
   */
-  test.beforeEach(async ({ page }) => {
-    await waitForPageInit(page);
-    await turnOnMacromoleculesEditor(page);
-  });
-
   const fileNames = [
     '01 - (R1) - Left only',
     '02 - (R2) - Right only',
@@ -534,7 +535,10 @@ test.describe('Phosphate monomers on the canvas, their connection points and pre
   ];
 
   for (const fileName of fileNames) {
-    test(`for ${fileName}`, async ({ page }) => {
+    test(`for ${fileName}`, async () => {
+      // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(
         `KET/Phosphate-Templates/${fileName}.ket`,
         page,
@@ -566,11 +570,6 @@ test.describe('Sugar monomers on the canvas, their connection points and preview
     (Sugar) from ket file, correctly show them on canvas (name, shape, color),
     shows correct number or connections and shows correct preview tooltip
   */
-  test.beforeEach(async ({ page }) => {
-    await waitForPageInit(page);
-    await turnOnMacromoleculesEditor(page);
-  });
-
   const fileNames = [
     '01 - (R1) - Left only',
     '02 - (R2) - Right only',
@@ -590,7 +589,10 @@ test.describe('Sugar monomers on the canvas, their connection points and preview
   ];
 
   for (const fileName of fileNames) {
-    test(`for ${fileName}`, async ({ page }) => {
+    test(`for ${fileName}`, async () => {
+      // Reload needed as monomer IDs increment in prior tests, affecting data comparasion
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(
         `KET/Sugar-Templates/${fileName}.ket`,
         page,


### PR DESCRIPTION
## Overview
This pull request refines and optimizes the test suite for KET import and saving by clearing the canvas after each test in accordance with [this task](https://github.com/epam/ketcher/issues/5396).

Since many tests involve checking the contents of generated files, a page reload has been added for them.

## How the feature works? / How did you fix the issue?
The modifications have resulted in a reduction in the maximum execution time on a single worker — down to approximately 115 seconds (on my PC) from the previous ~145 seconds using the older page reload method. For tests where it is still necessary to reload the page, clear comments have been added to explain the rationale.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request