### PR TITLE
#5430 - Fix ESLint error in selectClearCanvasTool function

### DIFF
--- a/ketcher-autotests/tests/utils/canvas/tools/helpers.ts
+++ b/ketcher-autotests/tests/utils/canvas/tools/helpers.ts
@@ -144,13 +144,10 @@ export async function selectImageTool(page: Page) {
  * If the maximum number of attempts is not provided, it defaults to 10.
  *
  * @param {Page} page - The Playwright page instance where the button is located.
- * @param {number} [maxAttempts=5] - The maximum number of retry attempts to click the button.
+ * @param {number} [maxAttempts=10] - The maximum number of retry attempts to click the button.
  * @throws {Error} Throws an error if the button cannot be clicked after the specified number of attempts.
  */
-export async function selectClearCanvasTool(
-  page: Page,
-  maxAttempts: number = 10,
-) {
+export async function selectClearCanvasTool(page: Page, maxAttempts = 10) {
   const clearCanvasButton = page.getByTestId('clear-canvas');
   let attempts = 0;
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
- Removed the `number` type in the parameter declaration of the `selectClearCanvasTool` function in accordance with [this task](https://github.com/epam/ketcher/issues/5430).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request