### PR TITLE
#5313 - Creation preset without phosphate causes R3less sugars disabled in the library FOREVER

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
@@ -109,7 +109,7 @@ export const RnaAccordion = ({ libraryName, duplicatePreset, editPreset }) => {
     } else {
       setExpandedAccordion(rnaBuilderItem);
       const { sugarValidations, phosphateValidations, baseValidations } =
-        getValidations(newPreset);
+        getValidations(newPreset, isEditMode);
 
       dispatch(setSugarValidations(sugarValidations));
       dispatch(setPhosphateValidations(phosphateValidations));

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditor.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditor.tsx
@@ -31,10 +31,14 @@ import {
   selectIsEditMode,
   selectPresetFullName,
   setActiveRnaBuilderItem,
+  setBaseValidations,
   setIsEditMode,
+  setPhosphateValidations,
+  setSugarValidations,
 } from 'state/rna-builder';
 import { scrollToElement } from 'helpers/dom';
 import { selectIsSequenceEditInRNABuilderMode } from 'state/common';
+import { getValidations } from 'helpers/rnaValidations';
 
 export const scrollToSelectedPreset = (presetName) => {
   scrollToElement(`[data-rna-preset-item-name="${presetName}"]`);
@@ -65,6 +69,15 @@ export const RnaEditor = ({ duplicatePreset }) => {
     dispatch(createNewPreset());
     dispatch(setActiveRnaBuilderItem(RnaBuilderPresetsItem.Presets));
   }, [activePreset]);
+
+  useEffect(() => {
+    const { sugarValidations, phosphateValidations, baseValidations } =
+      getValidations(activePreset, isEditMode);
+
+    dispatch(setSugarValidations(sugarValidations));
+    dispatch(setPhosphateValidations(phosphateValidations));
+    dispatch(setBaseValidations(baseValidations));
+  }, [isEditMode]);
 
   const expandEditor = () => {
     setExpanded(!expanded);

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -225,7 +225,7 @@ export const RnaEditorExpanded = ({
     dispatch(setActiveRnaBuilderItem(selectedGroup));
 
     const { sugarValidations, phosphateValidations, baseValidations } =
-      getValidations(newPreset);
+      getValidations(newPreset, isEditMode);
 
     dispatch(setSugarValidations(sugarValidations));
     dispatch(setPhosphateValidations(phosphateValidations));

--- a/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
+++ b/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
@@ -2,6 +2,7 @@ import { IRnaPreset } from 'components/monomerLibrary/RnaBuilder/types';
 
 export const getValidations = (
   newPreset: IRnaPreset,
+  isEditMode: boolean,
 ): {
   sugarValidations: string[];
   phosphateValidations: string[];
@@ -10,6 +11,14 @@ export const getValidations = (
   const sugarValidations: string[] = [];
   const phosphateValidations: string[] = [];
   const baseValidations: string[] = [];
+
+  if (!isEditMode) {
+    return {
+      sugarValidations,
+      phosphateValidations,
+      baseValidations,
+    };
+  }
 
   if (newPreset?.phosphate) {
     sugarValidations.push('R2');


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request