### PR TITLE
#5427 - Preview tooltip for mixture ambiguous monomer shows wrong percentages

### DIFF
--- a/packages/ketcher-react/src/components/MonomerPreview/AmbiguousMonomerPreview/AmbiguousMonomerPreview.tsx
+++ b/packages/ketcher-react/src/components/MonomerPreview/AmbiguousMonomerPreview/AmbiguousMonomerPreview.tsx
@@ -78,6 +78,16 @@ const UnstyledAmbiguousMonomerPreview = ({ className, preview }: Props) => {
         return b.ratio - a.ratio;
       }
     });
+    if (!isAlternatives) {
+      const overallRatio = sortedData.reduce(
+        (acc, item) => acc + (item.ratio || 1),
+        0,
+      );
+
+      sortedData.forEach((entry) => {
+        entry.ratio = Math.round(((entry.ratio || 1) / overallRatio) * 100);
+      });
+    }
 
     return sortedData.slice(0, 5);
   }, [previewData, isAlternatives]);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request