### PR TITLE
Backmerge: #5470 - Export of diffrent mixed and alternatives peptides (with diffrent proportions and percents) works wrong

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -714,11 +714,13 @@ export class KetSerializer implements Serializer<Struct> {
         );
 
         if (monomer instanceof AmbiguousMonomer) {
-          templateId = monomer.monomers.reduce(
-            (templateId, monomer) =>
-              templateId + '_' + getMonomerUniqueKey(monomer.monomerItem),
-            '',
-          );
+          templateId =
+            monomer.variantMonomerItem.id ||
+            monomer.monomers.reduce(
+              (templateId, monomer) =>
+                templateId + '_' + getMonomerUniqueKey(monomer.monomerItem),
+              '',
+            );
         } else {
           templateId =
             monomer.monomerItem.props.id ||


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request