### PR TITLE
Backmerge: #5313 - Creation preset without phosphate causes R3less sugars disabled in the library FOREVER

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
@@ -42,6 +42,7 @@ import {
 import { Summary } from './Summary';
 import {
   createNewPreset,
+  recalculateRnaBuilderValidations,
   RnaBuilderItem,
   RnaBuilderPresetsItem,
   selectActivePreset,
@@ -51,10 +52,7 @@ import {
   selectIsEditMode,
   setActivePresetMonomerGroup,
   setActiveRnaBuilderItem,
-  setBaseValidations,
   setIsEditMode,
-  setPhosphateValidations,
-  setSugarValidations,
 } from 'state/rna-builder';
 import { useDispatch } from 'react-redux';
 import { IRnaPreset } from '../types';
@@ -68,7 +66,6 @@ import {
   selectIsSequenceEditInRNABuilderMode,
 } from 'state/common';
 import { RnaPresetGroup } from 'components/monomerLibrary/RnaPresetGroup/RnaPresetGroup';
-import { getValidations } from 'helpers/rnaValidations';
 
 interface IGroupsDataItem {
   groupName: MonomerGroups | RnaBuilderPresetsItem;
@@ -108,12 +105,9 @@ export const RnaAccordion = ({ libraryName, duplicatePreset, editPreset }) => {
       setExpandedAccordion(null);
     } else {
       setExpandedAccordion(rnaBuilderItem);
-      const { sugarValidations, phosphateValidations, baseValidations } =
-        getValidations(newPreset, isEditMode);
-
-      dispatch(setSugarValidations(sugarValidations));
-      dispatch(setPhosphateValidations(phosphateValidations));
-      dispatch(setBaseValidations(baseValidations));
+      dispatch(
+        recalculateRnaBuilderValidations({ rnaPreset: newPreset, isEditMode }),
+      );
     }
   };
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaAccordion/RnaAccordion.tsx
@@ -109,7 +109,7 @@ export const RnaAccordion = ({ libraryName, duplicatePreset, editPreset }) => {
     } else {
       setExpandedAccordion(rnaBuilderItem);
       const { sugarValidations, phosphateValidations, baseValidations } =
-        getValidations(newPreset);
+        getValidations(newPreset, isEditMode);
 
       dispatch(setSugarValidations(sugarValidations));
       dispatch(setPhosphateValidations(phosphateValidations));

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditor.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditor.tsx
@@ -26,19 +26,16 @@ import {
 import { useAppDispatch, useAppSelector } from 'hooks';
 import {
   createNewPreset,
+  recalculateRnaBuilderValidations,
   RnaBuilderPresetsItem,
   selectActivePreset,
   selectIsEditMode,
   selectPresetFullName,
   setActiveRnaBuilderItem,
-  setBaseValidations,
   setIsEditMode,
-  setPhosphateValidations,
-  setSugarValidations,
 } from 'state/rna-builder';
 import { scrollToElement } from 'helpers/dom';
 import { selectIsSequenceEditInRNABuilderMode } from 'state/common';
-import { getValidations } from 'helpers/rnaValidations';
 
 export const scrollToSelectedPreset = (presetName) => {
   scrollToElement(`[data-rna-preset-item-name="${presetName}"]`);
@@ -71,12 +68,9 @@ export const RnaEditor = ({ duplicatePreset }) => {
   }, [activePreset]);
 
   useEffect(() => {
-    const { sugarValidations, phosphateValidations, baseValidations } =
-      getValidations(activePreset, isEditMode);
-
-    dispatch(setSugarValidations(sugarValidations));
-    dispatch(setPhosphateValidations(phosphateValidations));
-    dispatch(setBaseValidations(baseValidations));
+    dispatch(
+      recalculateRnaBuilderValidations({ rnaPreset: activePreset, isEditMode }),
+    );
   }, [isEditMode]);
 
   const expandEditor = () => {

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditor.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditor.tsx
@@ -31,10 +31,14 @@ import {
   selectIsEditMode,
   selectPresetFullName,
   setActiveRnaBuilderItem,
+  setBaseValidations,
   setIsEditMode,
+  setPhosphateValidations,
+  setSugarValidations,
 } from 'state/rna-builder';
 import { scrollToElement } from 'helpers/dom';
 import { selectIsSequenceEditInRNABuilderMode } from 'state/common';
+import { getValidations } from 'helpers/rnaValidations';
 
 export const scrollToSelectedPreset = (presetName) => {
   scrollToElement(`[data-rna-preset-item-name="${presetName}"]`);
@@ -65,6 +69,15 @@ export const RnaEditor = ({ duplicatePreset }) => {
     dispatch(createNewPreset());
     dispatch(setActiveRnaBuilderItem(RnaBuilderPresetsItem.Presets));
   }, [activePreset]);
+
+  useEffect(() => {
+    const { sugarValidations, phosphateValidations, baseValidations } =
+      getValidations(activePreset, isEditMode);
+
+    dispatch(setSugarValidations(sugarValidations));
+    dispatch(setPhosphateValidations(phosphateValidations));
+    dispatch(setBaseValidations(baseValidations));
+  }, [isEditMode]);
 
   const expandEditor = () => {
     setExpanded(!expanded);

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -43,15 +43,13 @@ import {
   selectAllPresets,
   setActivePreset,
   setActiveRnaBuilderItem,
-  setSugarValidations,
-  setBaseValidations,
-  setPhosphateValidations,
   setIsEditMode,
   selectPresetFullName,
   setUniqueNameError,
   setSequenceSelection,
   setSequenceSelectionName,
   selectIsActivePresetNewAndEmpty,
+  recalculateRnaBuilderValidations,
 } from 'state/rna-builder';
 import { useAppSelector, useLayoutMode } from 'hooks';
 import {
@@ -72,7 +70,6 @@ import {
 } from 'components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/helpers';
 import { openModal } from 'state/modal';
 import { getCountOfNucleoelements } from 'helpers/countNucleoelents';
-import { getValidations } from 'helpers/rnaValidations';
 
 type SequenceSelectionGroupNames = {
   [MonomerGroups.SUGARS]: string;
@@ -224,12 +221,9 @@ export const RnaEditorExpanded = ({
     scrollToActiveItemInLibrary(selectedGroup);
     dispatch(setActiveRnaBuilderItem(selectedGroup));
 
-    const { sugarValidations, phosphateValidations, baseValidations } =
-      getValidations(newPreset, isEditMode);
-
-    dispatch(setSugarValidations(sugarValidations));
-    dispatch(setPhosphateValidations(phosphateValidations));
-    dispatch(setBaseValidations(baseValidations));
+    dispatch(
+      recalculateRnaBuilderValidations({ rnaPreset: newPreset, isEditMode }),
+    );
   };
 
   const onChangeName = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -225,7 +225,7 @@ export const RnaEditorExpanded = ({
     dispatch(setActiveRnaBuilderItem(selectedGroup));
 
     const { sugarValidations, phosphateValidations, baseValidations } =
-      getValidations(newPreset);
+      getValidations(newPreset, isEditMode);
 
     dispatch(setSugarValidations(sugarValidations));
     dispatch(setPhosphateValidations(phosphateValidations));

--- a/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
+++ b/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
@@ -2,6 +2,7 @@ import { IRnaPreset } from 'components/monomerLibrary/RnaBuilder/types';
 
 export const getValidations = (
   newPreset: IRnaPreset,
+  isEditMode: boolean,
 ): {
   sugarValidations: string[];
   phosphateValidations: string[];
@@ -10,6 +11,14 @@ export const getValidations = (
   const sugarValidations: string[] = [];
   const phosphateValidations: string[] = [];
   const baseValidations: string[] = [];
+
+  if (!isEditMode) {
+    return {
+      sugarValidations,
+      phosphateValidations,
+      baseValidations,
+    };
+  }
 
   if (newPreset?.phosphate) {
     sugarValidations.push('R2');

--- a/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
+++ b/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
@@ -12,7 +12,10 @@ export const getValidations = (
   const phosphateValidations: string[] = [];
   const baseValidations: string[] = [];
 
-  if (!isEditMode) {
+  if (
+    !isEditMode ||
+    (!newPreset?.sugar && !newPreset?.phosphate && !newPreset?.base)
+  ) {
     return {
       sugarValidations,
       phosphateValidations,

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -32,6 +32,7 @@ import {
 import { transformRnaPresetToRnaLabeledPreset } from './rnaBuilderSlice.helper';
 import { selectEditorPosition } from 'state/common';
 import { PresetPosition } from 'ketcher-react';
+import { getValidations } from 'helpers/rnaValidations';
 
 export enum RnaBuilderPresetsItem {
   Presets = 'Presets',
@@ -141,14 +142,17 @@ export const rnaBuilderSlice = createSlice({
     ) => {
       state.activeRnaBuilderItem = action.payload;
     },
-    setSugarValidations: (state, action: PayloadAction<string[]>) => {
-      state.groupItemValidations[MonomerGroups.SUGARS] = action.payload;
-    },
-    setBaseValidations: (state, action: PayloadAction<string[]>) => {
-      state.groupItemValidations[MonomerGroups.BASES] = action.payload;
-    },
-    setPhosphateValidations: (state, action: PayloadAction<string[]>) => {
-      state.groupItemValidations[MonomerGroups.PHOSPHATES] = action.payload;
+    recalculateRnaBuilderValidations: (
+      state,
+      action: PayloadAction<{ rnaPreset: IRnaPreset; isEditMode: boolean }>,
+    ) => {
+      const { sugarValidations, phosphateValidations, baseValidations } =
+        getValidations(action.payload.rnaPreset, action.payload.isEditMode);
+
+      state.groupItemValidations[MonomerGroups.SUGARS] = sugarValidations;
+      state.groupItemValidations[MonomerGroups.BASES] = baseValidations;
+      state.groupItemValidations[MonomerGroups.PHOSPHATES] =
+        phosphateValidations;
     },
     setActivePresetMonomerGroup: (
       state,
@@ -506,9 +510,7 @@ export const {
   setIsSequenceFirstsOnlyNucleoelementsSelected,
   setActivePresetName,
   setActiveRnaBuilderItem,
-  setSugarValidations,
-  setBaseValidations,
-  setPhosphateValidations,
+  recalculateRnaBuilderValidations,
   setActivePresetMonomerGroup,
   savePreset,
   deletePreset,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added clearing of rna components validations in case of NOT edit mode

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request