### PR TITLE
#4982-Choose both directions of wedged/hashed bonds from right-clicking the bond

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -270,7 +270,7 @@ export function fromBondsMerge(
   return action;
 }
 
-function fromBondFlipping(restruct: ReStruct, id: number): Action {
+export function fromBondFlipping(restruct: ReStruct, id: number): Action {
   const bond = restruct.molecule.bonds.get(id);
 
   const action = new Action();

--- a/packages/ketcher-core/src/domain/entities/bond.ts
+++ b/packages/ketcher-core/src/domain/entities/bond.ts
@@ -323,14 +323,6 @@ export class Bond extends BaseMicromoleculeEntity {
     return sGroupsWithBeginAtom?.intersection(sGroupsWithEndAtom);
   }
 
-  changeDirection() {
-    if (this.stereo === Bond.PATTERN.STEREO.UP) {
-      this.stereo = Bond.PATTERN.STEREO.DOWN;
-    } else if (this.stereo === Bond.PATTERN.STEREO.DOWN) {
-      this.stereo = Bond.PATTERN.STEREO.UP;
-    }
-  }
-
   public static isBondToHiddenLeavingGroup(struct: Struct, bond: Bond) {
     const beginSuperatomAttachmentPoint =
       Atom.getSuperAtomAttachmentPointByLeavingGroup(struct, bond.begin);

--- a/packages/ketcher-core/src/domain/entities/bond.ts
+++ b/packages/ketcher-core/src/domain/entities/bond.ts
@@ -99,7 +99,7 @@ export class Bond extends BaseMicromoleculeEntity {
   end: number;
   readonly type: number;
   readonly xxx: string;
-  readonly stereo: number;
+  stereo: number;
   readonly topology: number | null;
   readonly reactingCenterStatus: number | null;
   customQuery: string | null;
@@ -321,6 +321,14 @@ export class Bond extends BaseMicromoleculeEntity {
       struct.atoms.get(this.begin)?.sgs || new Pile();
     const sGroupsWithEndAtom = struct.atoms.get(this.end)?.sgs || new Pile();
     return sGroupsWithBeginAtom?.intersection(sGroupsWithEndAtom);
+  }
+
+  changeDirection() {
+    if (this.stereo === Bond.PATTERN.STEREO.UP) {
+      this.stereo = Bond.PATTERN.STEREO.DOWN;
+    } else if (this.stereo === Bond.PATTERN.STEREO.DOWN) {
+      this.stereo = Bond.PATTERN.STEREO.UP;
+    }
   }
 
   public static isBondToHiddenLeavingGroup(struct: Struct, bond: Bond) {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useChangeBondDirection.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useChangeBondDirection.ts
@@ -1,0 +1,27 @@
+import { useAppContext } from 'src/hooks';
+
+export const useChangeBondDirection = (props) => {
+  const { getKetcherInstance } = useAppContext();
+
+  const changeDirection = () => {
+    const editor = getKetcherInstance()?.editor;
+    const bondIds = props.propsFromTrigger?.bondIds || [];
+    const bondId = bondIds[0];
+    const molecule = editor?.render.ctab.molecule;
+
+    if (!molecule || !bondId) return;
+
+    const bond = molecule.bonds.get(bondId);
+    if (!bond) return;
+
+    const atomBegin = bond.begin;
+    const atomEnd = bond.end;
+
+    bond.begin = atomEnd;
+    bond.end = atomBegin;
+
+    editor.update(true);
+  };
+
+  return { changeDirection };
+};

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useChangeBondDirection.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useChangeBondDirection.ts
@@ -1,4 +1,5 @@
 import { useAppContext } from 'src/hooks';
+import { fromBondFlipping } from 'ketcher-core';
 
 export const useChangeBondDirection = (props) => {
   const { getKetcherInstance } = useAppContext();
@@ -14,13 +15,9 @@ export const useChangeBondDirection = (props) => {
     const bond = molecule.bonds.get(bondId);
     if (!bond) return;
 
-    const atomBegin = bond.begin;
-    const atomEnd = bond.end;
+    const action = fromBondFlipping(editor?.render.ctab, bondId);
 
-    bond.begin = atomEnd;
-    bond.end = atomBegin;
-
-    editor.update(true);
+    editor.update(action);
   };
 
   return { changeDirection };

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Item, Submenu } from 'react-contexify';
 import tools from 'src/script/ui/action/tools';
 import styles from '../ContextMenu.module.less';
@@ -14,12 +14,19 @@ import {
   MenuItemsProps,
 } from '../contextMenu.types';
 import { getIconName, Icon } from 'components';
+import { useChangeBondDirection } from '../hooks/useChangeBondDirection';
+import { useAppContext } from 'src/hooks/useAppContext';
 
 type Params = ItemEventParams<BondsContextMenuProps>;
 
 const nonQueryBondNames = getNonQueryBondNames(tools);
 
 const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
+  const { getKetcherInstance } = useAppContext();
+  const [bondData, setBondData] = useState<{
+    type: number;
+    stereo: number;
+  } | null>(null);
   const [handleEdit] = useBondEdit();
   const [handleTypeChange, disabled] = useBondTypeChange();
   const [handleSGroupAttach, sGroupAttachHidden] = useBondSGroupAttach();
@@ -30,6 +37,27 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
   const isDisabled = disabled({
     props: props.propsFromTrigger,
   } as Params);
+  const { changeDirection } = useChangeBondDirection(props as ItemEventParams);
+  useEffect(() => {
+    const editor = getKetcherInstance()?.editor;
+    const bondIds = props.propsFromTrigger?.bondIds || [];
+
+    if (bondIds.length > 0 && editor) {
+      const bond = editor.render.ctab.molecule.bonds.get(bondIds[0]);
+      if (bond) {
+        setBondData({ type: bond.type, stereo: bond.stereo });
+      } else {
+        setBondData(null);
+      }
+    }
+  }, [props.propsFromTrigger, getKetcherInstance]);
+
+  const shouldShowChangeDirection =
+    bondData &&
+    ((bondData.type === 9 && bondData.stereo === 0) ||
+      (bondData.type === 1 && bondData.stereo === 1) ||
+      (bondData.type === 1 && bondData.stereo === 6) ||
+      (bondData.type === 1 && bondData.stereo === 4));
   return (
     <>
       <Item {...props} onClick={handleEdit} disabled={isDisabled}>
@@ -77,6 +105,11 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
         })}
       </Submenu>
 
+      {shouldShowChangeDirection && (
+        <Item {...props} onClick={changeDirection}>
+          Change direction
+        </Item>
+      )}
       <Item {...props} hidden={sGroupAttachHidden} onClick={handleSGroupAttach}>
         Attach S-Group...
       </Item>


### PR DESCRIPTION
- [x] User can be able to change the direction of a directed bond on canvas via bond context menu. For this purpose a new menu item 'Change direction'  added to the bond context menu. 


https://github.com/user-attachments/assets/056ed2da-d8f1-4553-a2d6-4dee98adfb0d


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request