### PR TITLE
Backmerge: #5512 - System saves mixture ambiguous monomers as alternatives ambiguous monomers

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -715,10 +715,15 @@ export class KetSerializer implements Serializer<Struct> {
 
         if (monomer instanceof AmbiguousMonomer) {
           templateId =
-            monomer.variantMonomerItem.id ||
-            monomer.monomers.reduce(
-              (templateId, monomer) =>
-                templateId + '_' + getMonomerUniqueKey(monomer.monomerItem),
+            monomer.variantMonomerItem.subtype +
+            '_' +
+            monomer.variantMonomerItem.options.reduce(
+              (templateId, option) =>
+                templateId +
+                '_' +
+                option.templateId +
+                '_' +
+                (option.probability || option.ratio || ''),
               '',
             );
         } else {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed template id generation for ambiguous monomers

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request