### PR TITLE
#5521 - Sugar color is wrong if loaded from HELM with inline SMILES

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/PhosphateRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/PhosphateRenderer.ts
@@ -3,6 +3,7 @@ import { Phosphate } from 'domain/entities/Phosphate';
 import { BaseMonomerRenderer } from 'application/render/renderers/BaseMonomerRenderer';
 import { MONOMER_SYMBOLS_IDS } from 'application/render/renderers/constants';
 import { KetMonomerClass } from 'application/formatters';
+import { RNA_DNA_NON_MODIFIED_PART } from 'domain/constants/monomers';
 
 const PHOSPHATE_SELECTED_ELEMENT_ID =
   MONOMER_SYMBOLS_IDS[KetMonomerClass.Phosphate].selected;
@@ -18,6 +19,10 @@ export class PhosphateRenderer extends BaseMonomerRenderer {
       PHOSPHATE_SYMBOL_ELEMENT_ID,
       scale,
     );
+  }
+
+  protected getMonomerColor(theme) {
+    return theme.monomer.color[RNA_DNA_NON_MODIFIED_PART.PHOSPHATE].regular;
   }
 
   protected appendBody(

--- a/packages/ketcher-core/src/application/render/renderers/SugarRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/SugarRenderer.ts
@@ -3,6 +3,7 @@ import { Sugar } from 'domain/entities/Sugar';
 import { BaseMonomerRenderer } from 'application/render/renderers/BaseMonomerRenderer';
 import { MONOMER_SYMBOLS_IDS } from 'application/render/renderers/constants';
 import { KetMonomerClass } from 'application/formatters';
+import { RNA_DNA_NON_MODIFIED_PART } from 'domain/constants/monomers';
 
 const SUGAR_SELECTED_ELEMENT_ID =
   MONOMER_SYMBOLS_IDS[KetMonomerClass.Sugar].selected;
@@ -19,6 +20,14 @@ export class SugarRenderer extends BaseMonomerRenderer {
       SUGAR_SYMBOL_ELEMENT_ID,
       scale,
     );
+  }
+
+  public get textColor() {
+    return '#fff';
+  }
+
+  protected getMonomerColor(theme) {
+    return theme.monomer.color[RNA_DNA_NON_MODIFIED_PART.SUGAR_RNA].regular;
   }
 
   protected appendBody(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request