### PR TITLE
#5651 – The reaction can't save to MDL RXN V3000 (returns RXN V2000 instead)

### DIFF
--- a/packages/ketcher-core/src/application/formatters/formatProperties.ts
+++ b/packages/ketcher-core/src/application/formatters/formatProperties.ts
@@ -168,6 +168,7 @@ const formatProperties: FormatPropertiesMap = {
     ChemicalMimeType.RDF,
     ['.rdf'],
     true,
+    { 'molfile-saving-mode': '3000' },
   ),
 };
 

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -342,6 +342,7 @@ class IndigoService implements StructService {
           options?.['reaction-component-margin-size'],
         'image-resolution': options?.['image-resolution'],
         'input-format': inputFormat,
+        'molfile-saving-mode': options?.['molfile-saving-mode'],
         monomerLibrary,
       };
 


### PR DESCRIPTION
#5651 - The reaction can't save to MDL RXN V3000 (returns RXN V2000 instead)

#5652 - Export to SDF V3000 returns SDF V2000

#5653 - The reaction can't save to MOL V3000 (returns MOL V2000 instead)

## How the feature works? / How did you fix the issue?
This PR updates Ketcher to pass the `molfile-saving-mode` option to Indigo

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request