### PR TITLE
Backmerge: #5615 - Overlapping UI elements in Query Properties right-click menu

### DIFF
--- a/packages/ketcher-react/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/ketcher-react/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -37,7 +37,12 @@ export default function ButtonGroup<T>({
           className={clsx(classes.button, {
             [classes.selected]: buttonValue === value,
           })}
-          style={{ flex: '1 0 25%', margin: '2px', borderRadius: '3px' }}
+          style={{
+            display: 'flex',
+            flex: '1 0 25%',
+            margin: '2px',
+            borderRadius: '3px',
+          }}
         >
           {label || 'none'}
         </ToggleButton>


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request