### PR TITLE
#5651 – The reaction can't save to MDL RXN V3000 (returns RXN V2000 instead)

### DIFF
--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files.spec.ts
@@ -199,39 +199,34 @@ test('Open and Save file - Open/Save V3000 *.mol file contains abbreviation 1/2 
   await takeEditorScreenshot(page);
 });
 
-test.fail(
-  'Open and Save file - Open/Save V3000 *.mol file contains abbreviation 2/2 - save',
-  async ({ page }) => {
-    /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-     * Test case: EPMLSOPKET-1859(2)
-     * Description: v3000 mol file with abbreviation is opened and saved correctly
-     */
-    await waitForPageInit(page);
+test('Open and Save file - Open/Save V3000 *.mol file contains abbreviation 2/2 - save', async ({
+  page,
+}) => {
+  /*
+   * Test case: EPMLSOPKET-1859(2)
+   * Description: v3000 mol file with abbreviation is opened and saved correctly
+   */
+  await waitForPageInit(page);
 
-    await openFileAndAddToCanvas(
-      'Molfiles-V3000/sec-butyl-abr-V3000.mol',
+  await openFileAndAddToCanvas('Molfiles-V3000/sec-butyl-abr-V3000.mol', page);
+  const expectedFile = await getMolfile(page, 'v3000');
+  await saveToFile(
+    'Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
+    expectedFile,
+  );
+  const METADATA_STRING_INDEX = [1];
+
+  const { fileExpected: molFileExpected, file: molFile } =
+    await receiveFileComparisonData({
       page,
-    );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
-      'Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
-      expectedFile,
-    );
-    const METADATA_STRING_INDEX = [1];
+      expectedFileName:
+        'tests/test-data/Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
+      fileFormat: 'v3000',
+      metaDataIndexes: METADATA_STRING_INDEX,
+    });
 
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
-  },
-);
+  expect(molFile).toEqual(molFileExpected);
+});
 
 test('Open and Save file - Open/Save file with R-Groups 1/2 - open', async ({
   page,
@@ -332,39 +327,34 @@ test('Open and Save file - Open/Save V3000 mol file contains attached data 1/2 -
   await takeEditorScreenshot(page);
 });
 
-test.fail(
-  'Open and Save file - Open/Save V3000 mol file contains attached data 2/2 - save',
-  async ({ page }) => {
-    /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-     * Test case: EPMLSOPKET-1882(2)
-     * Description: Structure with attached data is saved to mol file correctly
-     */
-    await waitForPageInit(page);
+test('Open and Save file - Open/Save V3000 mol file contains attached data 2/2 - save', async ({
+  page,
+}) => {
+  /*
+   * Test case: EPMLSOPKET-1882(2)
+   * Description: Structure with attached data is saved to mol file correctly
+   */
+  await waitForPageInit(page);
 
-    await openFileAndAddToCanvas(
-      'Molfiles-V3000/attached-data-V3000.mol',
+  await openFileAndAddToCanvas('Molfiles-V3000/attached-data-V3000.mol', page);
+  const expectedFile = await getMolfile(page, 'v3000');
+  await saveToFile(
+    'Molfiles-V3000/attached-data-V3000-expected.mol',
+    expectedFile,
+  );
+  const METADATA_STRING_INDEX = [1];
+
+  const { fileExpected: molFileExpected, file: molFile } =
+    await receiveFileComparisonData({
       page,
-    );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
-      'Molfiles-V3000/attached-data-V3000-expected.mol',
-      expectedFile,
-    );
-    const METADATA_STRING_INDEX = [1];
+      expectedFileName:
+        'tests/test-data/Molfiles-V3000/attached-data-V3000-expected.mol',
+      fileFormat: 'v3000',
+      metaDataIndexes: METADATA_STRING_INDEX,
+    });
 
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/attached-data-V3000-expected.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
-  },
-);
+  expect(molFile).toEqual(molFileExpected);
+});
 
 test('Open and Save file - V3000 *.mol file contains Heteroatoms 1/2 - open', async ({
   page,
@@ -380,36 +370,34 @@ test('Open and Save file - V3000 *.mol file contains Heteroatoms 1/2 - open', as
   await takeEditorScreenshot(page);
 });
 
-test.fail(
-  'Open and Save file - V3000 *.mol file contains Heteroatoms 2/2 - save',
-  async ({ page }) => {
-    /**
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-     * Test case: EPMLSOPKET-1879(2)
-     * Description: Structure with heteroatoms is saved correctly to mol file
-     */
-    await waitForPageInit(page);
+test('Open and Save file - V3000 *.mol file contains Heteroatoms 2/2 - save', async ({
+  page,
+}) => {
+  /**
+   * Test case: EPMLSOPKET-1879(2)
+   * Description: Structure with heteroatoms is saved correctly to mol file
+   */
+  await waitForPageInit(page);
 
-    await openFileAndAddToCanvas('Molfiles-V3000/heteroatoms-V3000.mol', page);
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
-      'Molfiles-V3000/heteroatoms-V3000-expected.mol',
-      expectedFile,
-    );
-    const METADATA_STRING_INDEX = [1];
+  await openFileAndAddToCanvas('Molfiles-V3000/heteroatoms-V3000.mol', page);
+  const expectedFile = await getMolfile(page, 'v3000');
+  await saveToFile(
+    'Molfiles-V3000/heteroatoms-V3000-expected.mol',
+    expectedFile,
+  );
+  const METADATA_STRING_INDEX = [1];
 
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/heteroatoms-V3000-expected.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
+  const { fileExpected: molFileExpected, file: molFile } =
+    await receiveFileComparisonData({
+      page,
+      expectedFileName:
+        'tests/test-data/Molfiles-V3000/heteroatoms-V3000-expected.mol',
+      fileFormat: 'v3000',
+      metaDataIndexes: METADATA_STRING_INDEX,
+    });
 
-    expect(molFile).toEqual(molFileExpected);
-  },
-);
+  expect(molFile).toEqual(molFileExpected);
+});
 
 test('Open and Save file - Open/Save file with Attached data 1/2 - open', async ({
   page,
@@ -504,61 +492,56 @@ test('Open and Save file - Open/Save V3000 mol file contains abs stereochemistry
   await takeEditorScreenshot(page);
 });
 
-test.fail(
-  'Open and Save file - Open/Save V3000 mol file contains abs stereochemistry 2/2 - save',
-  async ({ page }) => {
-    /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-     * Test case: EPMLSOPKET-1884(2)
-     * Description: Structure with abs stereochemistry is saved correctly to mol file
-     */
-    await waitForPageInit(page);
+test('Open and Save file - Open/Save V3000 mol file contains abs stereochemistry 2/2 - save', async ({
+  page,
+}) => {
+  /*
+   * Test case: EPMLSOPKET-1884(2)
+   * Description: Structure with abs stereochemistry is saved correctly to mol file
+   */
+  await waitForPageInit(page);
 
-    await openFileAndAddToCanvas('Molfiles-V3000/V3000-abs.mol', page);
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile('Molfiles-V3000/V3000-abs-expected.mol', expectedFile);
-    const METADATA_STRING_INDEX = [1];
+  await openFileAndAddToCanvas('Molfiles-V3000/V3000-abs.mol', page);
+  const expectedFile = await getMolfile(page, 'v3000');
+  await saveToFile('Molfiles-V3000/V3000-abs-expected.mol', expectedFile);
+  const METADATA_STRING_INDEX = [1];
 
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/V3000-abs-expected.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
+  const { fileExpected: molFileExpected, file: molFile } =
+    await receiveFileComparisonData({
+      page,
+      expectedFileName: 'tests/test-data/Molfiles-V3000/V3000-abs-expected.mol',
+      fileFormat: 'v3000',
+      metaDataIndexes: METADATA_STRING_INDEX,
+    });
 
-    expect(molFile).toEqual(molFileExpected);
-  },
-);
+  expect(molFile).toEqual(molFileExpected);
+});
 
-test.fail(
-  'Open and Save file - Save V2000 molfile as V3000 molfile',
-  async ({ page }) => {
-    /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-     * Test case: EPMLSOPKET-1985
-     * Description: Structure opened from V2000 molfile can be saved to V3000 molfile
-     */
-    await waitForPageInit(page);
+test('Open and Save file - Save V2000 molfile as V3000 molfile', async ({
+  page,
+}) => {
+  /*
+   * Test case: EPMLSOPKET-1985
+   * Description: Structure opened from V2000 molfile can be saved to V3000 molfile
+   */
+  await waitForPageInit(page);
 
-    await openFileAndAddToCanvas('Molfiles-V2000/spiro2.mol', page);
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile('Molfiles-V3000/spiro-expected.mol', expectedFile);
+  await openFileAndAddToCanvas('Molfiles-V2000/spiro2.mol', page);
+  const expectedFile = await getMolfile(page, 'v3000');
+  await saveToFile('Molfiles-V3000/spiro-expected.mol', expectedFile);
 
-    const METADATA_STRINGS_INDEXES = [1, 3];
+  const METADATA_STRINGS_INDEXES = [1, 3];
 
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName: 'tests/test-data/Molfiles-V3000/spiro-expected.mol',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
+  const { fileExpected: molFileExpected, file: molFile } =
+    await receiveFileComparisonData({
+      page,
+      expectedFileName: 'tests/test-data/Molfiles-V3000/spiro-expected.mol',
+      metaDataIndexes: METADATA_STRINGS_INDEXES,
+      fileFormat: 'v3000',
+    });
 
-    expect(molFile).toEqual(molFileExpected);
-  },
-);
+  expect(molFile).toEqual(molFileExpected);
+});
 
 test('Open and Save file - Save V3000 molfile as V2000 molfile', async ({
   page,
@@ -730,8 +713,6 @@ test.describe('Open and Save file', () => {
 
     for (const file of files) {
       test(`${file.testName}`, async ({ page }) => {
-        // IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-        if (file.format === 'v3000') test.fail();
         await openFileAndAddToCanvas(file.pathToOpen, page);
 
         const expectedFile = await getMolfile(

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Rxn-Files/rxn-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Rxn-Files/rxn-files.spec.ts
@@ -356,36 +356,31 @@ test.describe('Tests for Open and Save RXN file operations', () => {
     await takeEditorScreenshot(page);
   });
 
-  test.fail(
-    'Open and Save file - V3000 rxn file contains Rgroup 2/2 - save',
-    async ({ page }) => {
-      /**
-       * * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
-       * Test case: EPMLSOPKET-1902(2)
-       * Description: Reaction can be saved correctly to rxn V3000 file
-       */
-      await openFileAndAddToCanvas('Rxn-V3000/r-group-V3000.rxn', page);
-      const expectedFile = await getRxn(page, 'v3000');
-      await saveToFile(
-        'Rxn-V3000/r-group-V3000-expectedV3000.rxn',
-        expectedFile,
-      );
+  test('Open and Save file - V3000 rxn file contains Rgroup 2/2 - save', async ({
+    page,
+  }) => {
+    /**
+     * Test case: EPMLSOPKET-1902(2)
+     * Description: Reaction can be saved correctly to rxn V3000 file
+     */
+    await openFileAndAddToCanvas('Rxn-V3000/r-group-V3000.rxn', page);
+    const expectedFile = await getRxn(page, 'v3000');
+    await saveToFile('Rxn-V3000/r-group-V3000-expectedV3000.rxn', expectedFile);
 
-      // eslint-disable-next-line no-magic-numbers
-      const METADATA_STRINGS_INDEXES = [2];
+    // eslint-disable-next-line no-magic-numbers
+    const METADATA_STRINGS_INDEXES = [2];
 
-      const { fileExpected: rxnFileExpected, file: rxnFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/Rxn-V3000/r-group-V3000-expectedV3000.rxn',
-          metaDataIndexes: METADATA_STRINGS_INDEXES,
-          fileFormat: 'v3000',
-        });
+    const { fileExpected: rxnFileExpected, file: rxnFile } =
+      await receiveFileComparisonData({
+        page,
+        expectedFileName:
+          'tests/test-data/Rxn-V3000/r-group-V3000-expectedV3000.rxn',
+        metaDataIndexes: METADATA_STRINGS_INDEXES,
+        fileFormat: 'v3000',
+      });
 
-      expect(rxnFile).toEqual(rxnFileExpected);
-    },
-  );
+    expect(rxnFile).toEqual(rxnFileExpected);
+  });
 
   test('Validate that unsplit nucleotides connected with phosphates could be saved to rxn2000 file and loaded back', async ({
     page,

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/SDF-Files/sdf-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/SDF-Files/sdf-files.spec.ts
@@ -40,10 +40,7 @@ test.describe('CDF files', () => {
     await takeEditorScreenshot(page);
   });
 
-  test.fail('Open SDF v3000 file and save it', async ({ page }) => {
-    /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2477
-     */
+  test('Open SDF v3000 file and save it', async ({ page }) => {
     await openFileAndAddToCanvas('SDF/sdf-v3000-to-open.sdf', page);
     try {
       const expectedFile = await getSdf(page, 'v3000');

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Save-File/save-file.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Save-File/save-file.spec.ts
@@ -293,32 +293,28 @@ test.describe('Save files', () => {
     expect(molFile).toEqual(molFileExpected);
   });
 
-  test.fail(
-    'Support for exporting to "SDF V3000" file format',
-    async ({ page }) => {
-      /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2477
+  test('Support for exporting to "SDF V3000" file format', async ({ page }) => {
+    /*
       Test case: EPMLSOPKET-18031
       Description: Structure saves in SDF V3000 format
     */
-      await openFileAndAddToCanvas('KET/chain.ket', page);
+    await openFileAndAddToCanvas('KET/chain.ket', page);
 
-      const expectedFile = await getSdf(page, 'v3000');
-      await saveToFile('SDF/chain-expectedV3000.sdf', expectedFile);
+    const expectedFile = await getSdf(page, 'v3000');
+    await saveToFile('SDF/chain-expectedV3000.sdf', expectedFile);
 
-      const METADATA_STRING_INDEX = [1];
+    const METADATA_STRING_INDEX = [1];
 
-      const { fileExpected: molFileExpected, file: molFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName: 'tests/test-data/SDF/chain-expectedV3000.sdf',
-          fileFormat: 'v3000',
-          metaDataIndexes: METADATA_STRING_INDEX,
-        });
+    const { fileExpected: molFileExpected, file: molFile } =
+      await receiveFileComparisonData({
+        page,
+        expectedFileName: 'tests/test-data/SDF/chain-expectedV3000.sdf',
+        fileFormat: 'v3000',
+        metaDataIndexes: METADATA_STRING_INDEX,
+      });
 
-      expect(molFile).toEqual(molFileExpected);
-    },
-  );
+    expect(molFile).toEqual(molFileExpected);
+  });
 });
 
 test.describe('Open/Save/Paste files', () => {

--- a/ketcher-autotests/tests/Indigo-Tools/Aromatize-Dearomatize/aromatize-dearomatize.spec.ts
+++ b/ketcher-autotests/tests/Indigo-Tools/Aromatize-Dearomatize/aromatize-dearomatize.spec.ts
@@ -239,41 +239,39 @@ test.describe('Aromatize/Dearomatize Tool', () => {
     await takeEditorScreenshot(page);
   });
 
-  test.fail(
-    '(MolV3000) Save cyclic structures with a circle inside the cycle',
-    async ({ page }) => {
-      /*
-       * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-       * Test case: EPMLSOPKET-1877
-       * Description: The structures are saved as mol-file.
-       * The saved mol-file is opened correctly. In Ketcher the saved structures appear
-       * with the circle inside the cycles.
-       */
-      await openFileAndAddToCanvas(
-        'Molfiles-V3000/aromatic-benzene-v3000.mol',
+  test('(MolV3000) Save cyclic structures with a circle inside the cycle', async ({
+    page,
+  }) => {
+    /*
+     * Test case: EPMLSOPKET-1877
+     * Description: The structures are saved as mol-file.
+     * The saved mol-file is opened correctly. In Ketcher the saved structures appear
+     * with the circle inside the cycles.
+     */
+    await openFileAndAddToCanvas(
+      'Molfiles-V3000/aromatic-benzene-v3000.mol',
+      page,
+    );
+    const expectedFile = await getMolfile(page, 'v3000');
+    await saveToFile(
+      'Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
+      expectedFile,
+    );
+
+    const METADATA_STRING_INDEX = [1];
+
+    const { fileExpected: molFileExpected, file: molFile } =
+      await receiveFileComparisonData({
         page,
-      );
-      const expectedFile = await getMolfile(page, 'v3000');
-      await saveToFile(
-        'Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
-        expectedFile,
-      );
+        expectedFileName:
+          'tests/test-data/Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
+        metaDataIndexes: METADATA_STRING_INDEX,
+        fileFormat: 'v3000',
+      });
 
-      const METADATA_STRING_INDEX = [1];
-
-      const { fileExpected: molFileExpected, file: molFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
-          metaDataIndexes: METADATA_STRING_INDEX,
-          fileFormat: 'v3000',
-        });
-
-      expect(molFile).toEqual(molFileExpected);
-      await takeEditorScreenshot(page);
-    },
-  );
+    expect(molFile).toEqual(molFileExpected);
+    await takeEditorScreenshot(page);
+  });
 
   test('(Smiles) Save cyclic structures with a circle inside the cycle', async ({
     page,

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -1709,44 +1709,39 @@ test.describe('Macro-Micro-Switcher', () => {
     await takeEditorScreenshot(page);
   });
 
-  test.fail(
-    'Verify presence and correctness of attachment points (SAP) in the SGROUP segment of SDF V3000 molecular structure files',
-    async () => {
-      /*
+  test('Verify presence and correctness of attachment points (SAP) in the SGROUP segment of SDF V3000 molecular structure files', async () => {
+    /*
     Test case: #4530
     Description: Attachment points and leaving groups are correctly represented in SDF V3000 format.
-    
-    IMPORTANT: This test fails because of https://github.com/epam/Indigo/issues/2477 issue
     */
-      await openFileAndAddToCanvas(
-        'KET/one-attachment-point-added-in-micro-mode.ket',
+    await openFileAndAddToCanvas(
+      'KET/one-attachment-point-added-in-micro-mode.ket',
+      page,
+    );
+    const expectedFile = await getSdf(page, 'v3000');
+    await saveToFile(
+      'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
+      expectedFile,
+    );
+
+    const METADATA_STRINGS_INDEXES = [1];
+
+    const { fileExpected: molFileExpected, file: molFile } =
+      await receiveFileComparisonData({
         page,
-      );
-      const expectedFile = await getSdf(page, 'v3000');
-      await saveToFile(
-        'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
-        expectedFile,
-      );
+        expectedFileName:
+          'tests/test-data/SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
+        metaDataIndexes: METADATA_STRINGS_INDEXES,
+        fileFormat: 'v3000',
+      });
 
-      const METADATA_STRINGS_INDEXES = [1];
-
-      const { fileExpected: molFileExpected, file: molFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
-          metaDataIndexes: METADATA_STRINGS_INDEXES,
-          fileFormat: 'v3000',
-        });
-
-      expect(molFile).toEqual(molFileExpected);
-      await openFileAndAddToCanvasAsNewProject(
-        'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
-        page,
-      );
-      await takeEditorScreenshot(page);
-    },
-  );
+    expect(molFile).toEqual(molFileExpected);
+    await openFileAndAddToCanvasAsNewProject(
+      'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
+      page,
+    );
+    await takeEditorScreenshot(page);
+  });
 
   test('Verify presence and correctness of attachment points (SAP) in the SGROUP segment of CDX molecular structure files', async () => {
     /* 

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
@@ -204,45 +204,41 @@ test.describe('Macro-Micro-Switcher2', () => {
     expect(molFile).toEqual(molFileExpected);
   });
 
-  test.fail(
-    'Check that attachment points and leaving groups are correctly represented in Mol V3000 format',
-    async ({ page }) => {
-      /*
+  test('Check that attachment points and leaving groups are correctly represented in Mol V3000 format', async ({
+    page,
+  }) => {
+    /*
       Test case: #4530
       Description: Attachment points and leaving groups are correctly represented in Mol V3000 format.
-
-      IMPORTANT: This test fails because of https://github.com/epam/Indigo/issues/2477 issue.
-      After fix we need to update screenshot.
       */
-      await openFileAndAddToCanvas(
-        'KET/one-attachment-point-added-in-micro-mode.ket',
+    await openFileAndAddToCanvas(
+      'KET/one-attachment-point-added-in-micro-mode.ket',
+      page,
+    );
+    const expectedFile = await getMolfile(page, 'v3000');
+    await saveToFile(
+      'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
+      expectedFile,
+    );
+
+    const METADATA_STRINGS_INDEXES = [1];
+
+    const { fileExpected: molFileExpected, file: molFile } =
+      await receiveFileComparisonData({
         page,
-      );
-      const expectedFile = await getMolfile(page, 'v3000');
-      await saveToFile(
-        'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
-        expectedFile,
-      );
+        expectedFileName:
+          'tests/test-data/Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
+        metaDataIndexes: METADATA_STRINGS_INDEXES,
+        fileFormat: 'v3000',
+      });
 
-      const METADATA_STRINGS_INDEXES = [1];
-
-      const { fileExpected: molFileExpected, file: molFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
-          metaDataIndexes: METADATA_STRINGS_INDEXES,
-          fileFormat: 'v3000',
-        });
-
-      expect(molFile).toEqual(molFileExpected);
-      await openFileAndAddToCanvasAsNewProject(
-        'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
-        page,
-      );
-      await takeEditorScreenshot(page);
-    },
-  );
+    expect(molFile).toEqual(molFileExpected);
+    await openFileAndAddToCanvasAsNewProject(
+      'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
+      page,
+    );
+    await takeEditorScreenshot(page);
+  });
 
   test('Connection one molecule to another one by drugging one over another - result indicate existence of AP label and it remain back after delete connection', async ({
     page,

--- a/ketcher-autotests/tests/Reactions/Reaction-Validation/reaction-validation.spec.ts
+++ b/ketcher-autotests/tests/Reactions/Reaction-Validation/reaction-validation.spec.ts
@@ -43,35 +43,33 @@ test.describe('Reaction validation', () => {
     expect(rxnFile).toEqual(rxnFileExpected);
   });
 
-  test.fail(
-    'Saving reaction with more than one pluses RXN V3000',
-    async ({ page }) => {
-      /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
+  test('Saving reaction with more than one pluses RXN V3000', async ({
+    page,
+  }) => {
+    /*
     Test case: EPMLSOPKET-1488
     Description: Structures are on the canvas, pluses and arrows
     */
-      await openFileAndAddToCanvas('KET/plus-and-reaction-arrow.ket', page);
-      const expectedFile = await getRxn(page, 'v3000');
-      await saveToFile(
-        'Rxn-V3000/plus-and-reaction-arrow-expected.rxn',
-        expectedFile,
-      );
+    await openFileAndAddToCanvas('KET/plus-and-reaction-arrow.ket', page);
+    const expectedFile = await getRxn(page, 'v3000');
+    await saveToFile(
+      'Rxn-V3000/plus-and-reaction-arrow-expected.rxn',
+      expectedFile,
+    );
 
-      const METADATA_STRING_INDEX = [2];
+    const METADATA_STRING_INDEX = [2];
 
-      const { fileExpected: rxnFileExpected, file: rxnFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/Rxn-V3000/plus-and-reaction-arrow-expected.rxn',
-          metaDataIndexes: METADATA_STRING_INDEX,
-          fileFormat: 'v3000',
-        });
+    const { fileExpected: rxnFileExpected, file: rxnFile } =
+      await receiveFileComparisonData({
+        page,
+        expectedFileName:
+          'tests/test-data/Rxn-V3000/plus-and-reaction-arrow-expected.rxn',
+        metaDataIndexes: METADATA_STRING_INDEX,
+        fileFormat: 'v3000',
+      });
 
-      expect(rxnFile).toEqual(rxnFileExpected);
-    },
-  );
+    expect(rxnFile).toEqual(rxnFileExpected);
+  });
 
   test('Only one structure is on canvas and reaction arrow', async ({
     page,
@@ -101,35 +99,33 @@ test.describe('Reaction validation', () => {
     expect(rxnFile).toEqual(rxnFileExpected);
   });
 
-  test.fail(
-    'Only one structure is on canvas and reaction arrow RXN V3000',
-    async ({ page }) => {
-      /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
+  test('Only one structure is on canvas and reaction arrow RXN V3000', async ({
+    page,
+  }) => {
+    /*
     Test case: EPMLSOPKET-1489
     Description: Benzene structure is on the canvas and arrow
     */
-      await openFileAndAddToCanvas('KET/benzene-and-one-arrow.ket', page);
-      const expectedFile = await getRxn(page, 'v3000');
-      await saveToFile(
-        'Rxn-V3000/benzene-and-one-arrow-expected.rxn',
-        expectedFile,
-      );
+    await openFileAndAddToCanvas('KET/benzene-and-one-arrow.ket', page);
+    const expectedFile = await getRxn(page, 'v3000');
+    await saveToFile(
+      'Rxn-V3000/benzene-and-one-arrow-expected.rxn',
+      expectedFile,
+    );
 
-      const METADATA_STRING_INDEX = [2];
+    const METADATA_STRING_INDEX = [2];
 
-      const { fileExpected: rxnFileExpected, file: rxnFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/Rxn-V3000/benzene-and-one-arrow-expected.rxn',
-          metaDataIndexes: METADATA_STRING_INDEX,
-          fileFormat: 'v3000',
-        });
+    const { fileExpected: rxnFileExpected, file: rxnFile } =
+      await receiveFileComparisonData({
+        page,
+        expectedFileName:
+          'tests/test-data/Rxn-V3000/benzene-and-one-arrow-expected.rxn',
+        metaDataIndexes: METADATA_STRING_INDEX,
+        fileFormat: 'v3000',
+      });
 
-      expect(rxnFile).toEqual(rxnFileExpected);
-    },
-  );
+    expect(rxnFile).toEqual(rxnFileExpected);
+  });
 
   test('Reaction can have a combination of reactants', async ({ page }) => {
     /*
@@ -157,9 +153,8 @@ test.describe('Reaction validation', () => {
     expect(rxnFile).toEqual(rxnFileExpected);
   });
 
-  test.fail('Reaction can have a combination of products', async ({ page }) => {
+  test('Reaction can have a combination of products', async ({ page }) => {
     /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
     Test case: EPMLSOPKET-1491
     Description: Structures are saved as .rxn v3000
     */

--- a/ketcher-autotests/tests/Reagents/RXN-Format/reagents-rxn-format.spec.ts
+++ b/ketcher-autotests/tests/Reagents/RXN-Format/reagents-rxn-format.spec.ts
@@ -88,44 +88,39 @@ test.describe('Reagents RXN format', () => {
     expect(actualComparableData).toEqual(expectedComparableData);
   });
 
-  test.fail(
-    'Detection molecule as reagent and write reagent information in "MDL rxnfile V3000" format',
-    async ({ page }) => {
-      /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
+  test('Detection molecule as reagent and write reagent information in "MDL rxnfile V3000" format', async ({
+    page,
+  }) => {
+    /*
     Test case: EPMLSOPKET-4672
     Description: Files are compared for reagent presence
     */
-      await openFileAndAddToCanvas(
-        'KET/benzene-arrow-benzene-reagent-nh3.ket',
-        page,
-      );
-      const expectedFile = await getRxn(page, 'v3000');
-      await saveToFile(
-        'Rxn-V3000/mdl-rxnfile-v3000-expected.rxn',
-        expectedFile,
-      );
+    await openFileAndAddToCanvas(
+      'KET/benzene-arrow-benzene-reagent-nh3.ket',
+      page,
+    );
+    const expectedFile = await getRxn(page, 'v3000');
+    await saveToFile('Rxn-V3000/mdl-rxnfile-v3000-expected.rxn', expectedFile);
 
-      const rxnFileExpected = await readFileContents(
-        'tests/test-data/Rxn-V3000/mdl-rxnfile-v3000-expected.rxn',
-      );
-      const COMPARABLE_DATA_START = 5;
-      const COMPARABLE_DATA_END = 58;
-      const rxnFile = await getRxn(page, 'v3000');
+    const rxnFileExpected = await readFileContents(
+      'tests/test-data/Rxn-V3000/mdl-rxnfile-v3000-expected.rxn',
+    );
+    const COMPARABLE_DATA_START = 5;
+    const COMPARABLE_DATA_END = 58;
+    const rxnFile = await getRxn(page, 'v3000');
 
-      const actualComparableData = getComparableDataFromRxn(
-        rxnFile,
-        COMPARABLE_DATA_START,
-        COMPARABLE_DATA_END,
-      );
-      const expectedComparableData = getComparableDataFromRxn(
-        rxnFileExpected,
-        COMPARABLE_DATA_START,
-        COMPARABLE_DATA_END,
-      );
-      expect(actualComparableData).toEqual(expectedComparableData);
-    },
-  );
+    const actualComparableData = getComparableDataFromRxn(
+      rxnFile,
+      COMPARABLE_DATA_START,
+      COMPARABLE_DATA_END,
+    );
+    const expectedComparableData = getComparableDataFromRxn(
+      rxnFileExpected,
+      COMPARABLE_DATA_START,
+      COMPARABLE_DATA_END,
+    );
+    expect(actualComparableData).toEqual(expectedComparableData);
+  });
 
   test('File saves in "MDL rxnfile V2000" format', async ({ page }) => {
     /*
@@ -162,9 +157,8 @@ test.describe('Reagents RXN format', () => {
     await page.getByRole('button', { name: 'Save', exact: true }).click();
   });
 
-  test.fail('File saves in "MDL rxnfile V3000" format', async ({ page }) => {
+  test('File saves in "MDL rxnfile V3000" format', async ({ page }) => {
     /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
     Test case: EPMLSOPKET-4676
     Description: File saved in format (e.g. "ketcher.rxn")
     */

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Attachment-Point-Tool/attachment-point-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Attachment-Point-Tool/attachment-point-tool.spec.ts
@@ -428,9 +428,8 @@ test.describe('Attachment Point Tool', () => {
     await takeEditorScreenshot(page);
   });
 
-  test.fail('Save as *.mol file V3000', async ({ page }) => {
+  test('Save as *.mol file V3000', async ({ page }) => {
     /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
      * Test case: EPMLSOPKET-1651
      * Description: Structure with attachment points saved as .mol file V3000
      */

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-fragment-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-fragment-tool.spec.ts
@@ -352,9 +352,8 @@ test.describe('R-Group Fragment Tool', () => {
     expect(molFile).toEqual(molFileExpected);
   });
 
-  test.fail('Save as *.mol V3000 file', async ({ page }) => {
+  test('Save as *.mol V3000 file', async ({ page }) => {
     /*
-     * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
      * Test case: EPMLSOPKET-1603
      * Description: All R-group members, R-group definition, occurrence,
      * brackets are rendered correctly after saving as *.mol V3000 file.

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-label-dialog.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-label-dialog.spec.ts
@@ -506,9 +506,8 @@ test.describe('R-Group Label Tool', () => {
     expect(rxnFile).toEqual(rxnFileExpected);
   });
 
-  test.fail('Save as *.rxn V3000 file', async ({ page }) => {
+  test('Save as *.rxn V3000 file', async ({ page }) => {
     /*
-    * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2476
     Test case: EPMLSOPKET-1567
     Description: User is able to save the structure with R-group label as .rxn V3000 file
     */

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-tool.spec.ts
@@ -98,37 +98,33 @@ test.describe('R-Group', () => {
     await takeEditorScreenshot(page);
   });
 
-  test.fail(
-    'Save as .mol V3000 file with R-Group features',
-    async ({ page }) => {
-      /*
-       * IMPORTANT: Test fails because we have bug https://github.com/epam/Indigo/issues/2490
-       * Test case: EPMLSOPKET-1672
-       * Description: The file is saved as .mol V3000 file.
-       */
-      await openFileAndAddToCanvas(
-        'Molfiles-V2000/r-group-with-allkind-attachment-points.mol',
+  test('Save as .mol V3000 file with R-Group features', async ({ page }) => {
+    /*
+     * Test case: EPMLSOPKET-1672
+     * Description: The file is saved as .mol V3000 file.
+     */
+    await openFileAndAddToCanvas(
+      'Molfiles-V2000/r-group-with-allkind-attachment-points.mol',
+      page,
+    );
+    const expectedFile = await getMolfile(page, 'v3000');
+    await saveToFile(
+      'Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
+      expectedFile,
+    );
+    const METADATA_STRING_INDEX = [1];
+    const { file: molFile, fileExpected: molFileExpected } =
+      await receiveFileComparisonData({
         page,
-      );
-      const expectedFile = await getMolfile(page, 'v3000');
-      await saveToFile(
-        'Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
-        expectedFile,
-      );
-      const METADATA_STRING_INDEX = [1];
-      const { file: molFile, fileExpected: molFileExpected } =
-        await receiveFileComparisonData({
-          page,
-          metaDataIndexes: METADATA_STRING_INDEX,
-          expectedFileName:
-            'tests/test-data/Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
-          fileFormat: 'v3000',
-        });
+        metaDataIndexes: METADATA_STRING_INDEX,
+        expectedFileName:
+          'tests/test-data/Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
+        fileFormat: 'v3000',
+      });
 
-      expect(molFile).toEqual(molFileExpected);
-      await takeEditorScreenshot(page);
-    },
-  );
+    expect(molFile).toEqual(molFileExpected);
+    await takeEditorScreenshot(page);
+  });
 
   test('Open .smi file with R-Group features', async ({ page }) => {
     /*

--- a/packages/ketcher-core/src/application/formatters/formatProperties.ts
+++ b/packages/ketcher-core/src/application/formatters/formatProperties.ts
@@ -168,6 +168,7 @@ const formatProperties: FormatPropertiesMap = {
     ChemicalMimeType.RDF,
     ['.rdf'],
     true,
+    { 'molfile-saving-mode': '3000' },
   ),
 };
 

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -342,6 +342,7 @@ class IndigoService implements StructService {
           options?.['reaction-component-margin-size'],
         'image-resolution': options?.['image-resolution'],
         'input-format': inputFormat,
+        'molfile-saving-mode': options?.['molfile-saving-mode'],
         monomerLibrary,
       };
 


### PR DESCRIPTION
https://github.com/epam/ketcher/issues/5651 - The reaction can't save to MDL RXN V3000 (returns RXN V2000 instead)

https://github.com/epam/ketcher/issues/5652 - Export to SDF V3000 returns SDF V2000

https://github.com/epam/ketcher/issues/5653 - The reaction can't save to MOL V3000 (returns MOL V2000 instead)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request