### PR TITLE
Backmerge: #5672 - Multiple duplicate items

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -155,7 +155,7 @@ class SelectTool implements Tool {
       };
     }
 
-    if (!ci || ci.map === 'atoms') {
+    if (!ci || (ci.map === 'atoms' && !event.ctrlKey)) {
       atomLongtapEvent(this, rnd);
     }
 
@@ -346,6 +346,7 @@ class SelectTool implements Tool {
       return;
     }
     this.isMouseDown = false;
+    this.isReadyForCopy = false;
 
     const editor = this.editor;
     const selected = editor.selection();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
+ Stop copying if mouse up event handled
+ fixed on MacOs issue, cannot open menu when ctrl+click to atom (because long tap functionality)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request