### PR TITLE
#5649 - Default values for bond settings (at least for bond) got corrupted and become wrong after ver 2.26 version installed

### DIFF
--- a/packages/ketcher-core/src/utilities/SettingsManager.ts
+++ b/packages/ketcher-core/src/utilities/SettingsManager.ts
@@ -56,9 +56,21 @@ export class SettingsManager {
 
   static getOptions(): SavedOptions {
     try {
-      return JSON.parse(
+      const optionsFromLocalStorage = JSON.parse(
         localStorage.getItem(KETCHER_SAVED_OPTIONS_KEY) || '{}',
       );
+
+      // In 2.25 default bondLength was set to 2.1 by mistake.
+      // Current code reset it to 40px
+      // Can be removed in future versions
+      if (
+        optionsFromLocalStorage.bondLength === 2.1 &&
+        optionsFromLocalStorage.bondLengthUnit === 'px'
+      ) {
+        optionsFromLocalStorage.bondLength = 40;
+      }
+
+      return optionsFromLocalStorage;
     } catch (e) {
       KetcherLogger.error('SettingsManager.ts::SettingsManager::getOptions', e);
       return {} as SavedOptions;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request