### PR TITLE
Backmerge: Only bonds highlighting created when select bonds + atoms together

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
@@ -31,9 +31,10 @@ const SelectionMenuItems: FC<MenuItemsProps<SelectionContextMenuProps>> = (
   const handleDelete = useDelete();
   const highlightBondWithColor = (color: string) => {
     const bondIds = props.propsFromTrigger?.bondIds || [];
+    const atomIds = props.propsFromTrigger?.atomIds || [];
 
     editor.highlights.create({
-      atoms: [],
+      atoms: atomIds,
       bonds: bondIds,
       color: color === '' ? 'transparent' : color,
     });


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
When select bonds + atoms together and create highlight, highlight create now for both: bonds and atoms

<img width="338" alt="Screenshot 2024-10-14 at 20 12 51" src="https://github.com/user-attachments/assets/6002b1d9-5b19-4b27-b73f-7778dd1c395e">
<img width="220" alt="Screenshot 2024-10-14 at 20 13 34" src="https://github.com/user-attachments/assets/bf642838-2eb7-47ab-b94c-842d69d2e506">


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request