### PR TITLE
#5685 - The diagonal bond in the molecule is displayed incorrect with  ACS style

### DIFF
--- a/packages/ketcher-react/src/constants.ts
+++ b/packages/ketcher-react/src/constants.ts
@@ -44,7 +44,7 @@ export const ACS_STYLE_DEFAULT_SETTINGS = {
   reactionComponentMarginSize: 1.6,
   reactionComponentMarginSizeUnit: 'pt',
   imageResolution: '600',
-  bondLength: 14.4,
+  bondLength: 30,
   bondLengthUnit: 'pt',
   bondSpacing: 18,
   bondThickness: 0.6,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request