### PR TITLE
Revert "#5685 - The diagonal bond in the molecule is displayed incorrect with ACS style (#5787)"

### DIFF
--- a/packages/ketcher-react/src/constants.ts
+++ b/packages/ketcher-react/src/constants.ts
@@ -44,7 +44,7 @@ export const ACS_STYLE_DEFAULT_SETTINGS = {
   reactionComponentMarginSize: 1.6,
   reactionComponentMarginSizeUnit: 'pt',
   imageResolution: '600',
-  bondLength: 30,
+  bondLength: 14.4,
   bondLengthUnit: 'pt',
   bondSpacing: 18,
   bondThickness: 0.6,


### PR DESCRIPTION
This reverts commit 72172ab3c78c37fc6a4a93c18df2e5a1f2f39b60.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request