### PR TITLE
Backmerge: #5800 - Application crashes with white screen in Macro mode when loading local storage data from a previous version 

### DIFF
--- a/packages/ketcher-macromolecules/src/helpers/getPreset.ts
+++ b/packages/ketcher-macromolecules/src/helpers/getPreset.ts
@@ -29,17 +29,24 @@ export const getPresets = (
     }),
   );
 
-  return rnaPresetsTemplates.map(
-    (rnaPresetsTemplate: RnaPresetsTemplatesType): IRnaPreset => {
+  return rnaPresetsTemplates
+    .filter((rnaPresetsTemplate) => {
+      return rnaPresetsTemplate.templates.every((rnaPartsMonomerTemplateRef) =>
+        Boolean(
+          monomerLibraryItemByMonomerIDMap.get(rnaPartsMonomerTemplateRef.$ref),
+        ),
+      );
+    })
+    .map((rnaPresetsTemplate: RnaPresetsTemplatesType): IRnaPreset => {
       const rnaPartsMonomerLibraryItemByMonomerClassMap = new Map<
         KetMonomerClass,
         MonomerItemType
       >(
         rnaPresetsTemplate.templates.map((rnaPartsMonomerTemplateRef) => {
-          // TODO: Do we need to check for existence? Suddenly there is `undefined`.
           const monomer = monomerLibraryItemByMonomerIDMap.get(
             rnaPartsMonomerTemplateRef.$ref,
           ) as MonomerItemType;
+
           const [, , monomerClass] = monomerFactory(monomer);
 
           return [monomerClass, monomer];
@@ -76,6 +83,5 @@ export const getPresets = (
         ...result,
         idtAliases: rnaPresetsTemplate.idtAliases,
       };
-    },
-  );
+    });
 };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added filtration of rna preset from local storage if its part does not exist in library

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request