### PR TITLE
Backmerge: #5659 - Moving of selected microstructures on macro canvas works wrong

### DIFF
--- a/packages/ketcher-core/src/application/editor/EditorHistory.ts
+++ b/packages/ketcher-core/src/application/editor/EditorHistory.ts
@@ -76,6 +76,7 @@ export class EditorHistory {
 
     const lastCommand = this.historyStack[this.historyPointer];
     lastCommand.execute(this.editor.renderersContainer);
+    lastCommand.executeAfterAllOperations(this.editor.renderersContainer);
     this.historyPointer++;
   }
 

--- a/packages/ketcher-core/src/application/editor/operations/drawingEntity/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/drawingEntity/index.ts
@@ -31,10 +31,15 @@ export class DrawingEntityMoveOperation implements Operation {
     private drawingEntity: DrawingEntity,
   ) {}
 
-  public execute(renderersManager: RenderersManager) {
+  public execute() {
     this.wasInverted
       ? this.redoDrawingEntityChangeModel()
       : this.moveDrawingEntityChangeModel();
+  }
+
+  public invert(renderersManager: RenderersManager) {
+    this.invertMoveDrawingEntityChangeModel();
+
     if (
       this.drawingEntity instanceof PolymerBond ||
       this.drawingEntity instanceof MonomerToAtomBond
@@ -43,11 +48,11 @@ export class DrawingEntityMoveOperation implements Operation {
     } else {
       renderersManager.moveDrawingEntity(this.drawingEntity);
     }
+
+    this.wasInverted = true;
   }
 
-  public invert(renderersManager: RenderersManager) {
-    this.invertMoveDrawingEntityChangeModel();
-
+  public executeAfterAllOperations(renderersManager: RenderersManager) {
     // Redraw Polymer bonds instead of moving needed here because
     // they have two drawing modes: straight and curved.
     // During switching snake/flex layout modes and undo/redo
@@ -60,10 +65,9 @@ export class DrawingEntityMoveOperation implements Operation {
     } else {
       renderersManager.moveDrawingEntity(this.drawingEntity);
     }
-
-    this.wasInverted = true;
   }
 }
+
 export class DrawingEntityRedrawOperation implements Operation {
   constructor(
     private drawingEntityRedrawModelChange: () => DrawingEntity,

--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -436,7 +436,13 @@ export class RenderersManager {
   }
 
   public update(modelChanges?: Command) {
+    const editor = CoreEditor.provideEditorInstance();
+    const viewModel = editor.viewModel;
+
     modelChanges?.execute(this);
+    viewModel.initialize([...editor.drawingEntitiesManager.bonds.values()]);
+    modelChanges?.executeAfterAllOperations(this);
+
     this.runPostRenderMethods();
     notifyRenderComplete();
   }

--- a/packages/ketcher-core/src/domain/entities/Command.ts
+++ b/packages/ketcher-core/src/domain/entities/Command.ts
@@ -43,6 +43,14 @@ export class Command {
     renderersManagers.runPostRenderMethods();
   }
 
+  public executeAfterAllOperations(renderersManagers: RenderersManager) {
+    this.operations.forEach((operation) => {
+      if (operation.executeAfterAllOperations) {
+        operation.executeAfterAllOperations(renderersManagers);
+      }
+    });
+  }
+
   public clear() {
     this.operations = [];
   }

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -348,11 +348,7 @@ export class DrawingEntitiesManager {
     if (drawingEntity instanceof PolymerBond) {
       drawingEntity.moveToLinkedMonomers();
     } else if (drawingEntity instanceof Bond) {
-      const editor = CoreEditor.provideEditorInstance();
-      const viewModel = editor.viewModel;
-
       drawingEntity.moveToLinkedAtoms();
-      viewModel.initialize([...this.bonds.values()]);
     } else if (drawingEntity instanceof MonomerToAtomBond) {
       drawingEntity.moveToLinkedMonomerAndAtom();
     } else {
@@ -389,6 +385,14 @@ export class DrawingEntitiesManager {
 
     [...this.atoms.values(), ...this.monomers.values()].forEach(
       (drawingEntity) => {
+        if (
+          drawingEntity instanceof BaseMonomer &&
+          drawingEntity.monomerItem.props.isMicromoleculeFragment &&
+          !isMonomerSgroupWithAttachmentPoints(drawingEntity)
+        ) {
+          return;
+        }
+
         if (drawingEntity.selected) {
           command.merge(
             this.createDrawingEntityMovingCommand(

--- a/packages/ketcher-core/src/domain/entities/Operation.ts
+++ b/packages/ketcher-core/src/domain/entities/Operation.ts
@@ -14,4 +14,5 @@ export interface Operation {
   polymerBond?: PolymerBond;
   execute(renderersManager: RenderersManager): void;
   invert(renderersManager: RenderersManager): void;
+  executeAfterAllOperations?(renderersManager: RenderersManager): void;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- removed hidden chems created for molecules in model from selection
- fixed performance by collecting moving

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request