### PR TITLE
#5703 Added tooltip for image resolution option

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/meta/Settings/Settings.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/meta/Settings/Settings.tsx
@@ -175,6 +175,7 @@ const SettingsDialog = (props: Props) => {
         />
         <Field
           name="imageResolution"
+          tooltip="option applicable to PNG/SVG pictures renderer"
           component={Select}
           options={getSelectOptionsFromSchema(settingsProps?.imageResolution)}
         />


### PR DESCRIPTION
<img width="421" alt="Screenshot 2024-10-18 at 19 11 15" src="https://github.com/user-attachments/assets/4b407ad6-a8b2-4d92-8c5f-fb3b91fcf465">



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request