### PR TITLE
Backmerge: #5665 – Show remove abbreviation dialog when trying to erase expanded monomer

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/eraser.ts
+++ b/packages/ketcher-react/src/script/editor/tool/eraser.ts
@@ -30,6 +30,7 @@ import {
   IMAGE_KEY,
   MULTITAIL_ARROW_KEY,
   fromMultitailArrowDeletion,
+  MonomerMicromolecule,
 } from 'ketcher-core';
 
 import LassoHelper from './helper/lasso';
@@ -359,7 +360,10 @@ class EraserTool implements Tool {
     } else if (ci.map === 'sgroups' || ci.map === 'sgroupData') {
       const sGroup = sgroups.get(ci.id);
 
-      if (FunctionalGroup.isFunctionalGroup(sGroup?.item)) {
+      if (
+        FunctionalGroup.isFunctionalGroup(sGroup?.item) ||
+        sGroup?.item instanceof MonomerMicromolecule
+      ) {
         this.editor.event.removeFG.dispatch({ fgIds: [ci.id] });
       } else {
         this.editor.update(fromSgroupDeletion(restruct, ci.id));


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request