### PR TITLE
Importing functional groups (e.g. Boc, Bn, CF3) ignores drawing settings

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -274,12 +274,18 @@ class ReAtom extends ReObject {
             : this.a.pp,
           render.options,
         );
+        const fontFamily = options.font.substr(
+          options.font.indexOf(' ') + 1,
+          options.font.length,
+        );
         const path = render.paper
           .text(position.x, position.y, sgroup.data.name)
           .attr({
             'font-weight': 700,
-            'font-size': 14,
+            'font-size': options.fontszInPx,
+            'font-family': fontFamily,
           });
+
         restruct.addReObjectPath(
           LayerMap.data,
           this.visel,

--- a/packages/ketcher-react/src/script/ui/component/form/systemfonts.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/systemfonts.jsx
@@ -75,6 +75,7 @@ function SystemFonts(props) {
       const fonts = results
         .filter((i) => i !== null)
         .map((font) => {
+          // TODO remove font-size from here
           return { value: `30px ${font}`, label: font };
         });
       if (mounted) {


### PR DESCRIPTION

<img width="514" alt="Screenshot 2024-10-26 at 10 19 37" src="https://github.com/user-attachments/assets/966d8989-dfbe-4fc5-adf4-a91119ee3d76">

Now it applies font size and font family


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request