### PR TITLE
Backmerge: #5836 - R-group fragment labels font size doesnt defined by sub font  size property at settings 

### DIFF
--- a/packages/ketcher-core/src/application/render/options.ts
+++ b/packages/ketcher-core/src/application/render/options.ts
@@ -66,12 +66,12 @@ function defaultOptions(renderOptions: RenderOptions): RenderOptions {
     lineWidth: scaleFactorMicro / 20,
     bondSpace: options.bondSpacingInPx || scaleFactorMicro / 7,
     stereoBond: options.stereoBondWidthInPx || scaleFactorMicro / 7,
-    subFontSize,
+    subFontSize: options.fontszsubInPx || subFontSize,
     font: '30px Arial',
-    fontszInPx: labelFontSize,
-    fontszsubInPx: subFontSize,
-    fontRLabel: labelFontSize * 1.2,
-    fontRLogic: labelFontSize * 0.7,
+    fontszInPx: options.fontszInPx || labelFontSize,
+    fontszsubInPx: options.fontszsubInPx || subFontSize,
+    fontRLabel: (options.fontszInPx || labelFontSize) * 1.2,
+    fontRLogic: (options.fontszInPx || labelFontSize) * 0.7,
 
     radiusScaleFactor: 0.38,
 
@@ -122,7 +122,7 @@ function defaultOptions(renderOptions: RenderOptions): RenderOptions {
     movingStyle: {
       cursor: 'all-scroll',
     },
-    atomSelectionPlateRadius: labelFontSize,
+    atomSelectionPlateRadius: options.fontszInPx || labelFontSize,
     contractedFunctionalGroupSize: 50,
 
     previewOpacity: 0.5,

--- a/packages/ketcher-core/src/application/render/restruct/resgroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.ts
@@ -380,7 +380,7 @@ function showValue(
 ): any {
   const text = paper.text(pos?.x, pos?.y, sgroup.data.fieldValue).attr({
     font: options.font,
-    'font-size': options.fontszInPx,
+    'font-size': options.fontszsubInPx,
   });
   const box = text.getBBox();
   let rect = paper.rect(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request