### PR TITLE
Backmerge: #5809 – Open correct context menu for expanded monomer while clicking on bond or atom

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.utils.ts
@@ -54,16 +54,28 @@ export function getMenuPropsForClosestItem(
         true,
       );
 
-      return functionalGroup === null ||
-        functionalGroup?.relatedSGroup.isSuperatomWithoutLabel
-        ? {
-            id: CONTEXT_MENU_ID.FOR_BONDS,
-            bondIds: [closestItem.id],
-          }
-        : {
-            id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-            functionalGroups: [functionalGroup],
-          };
+      const noFunctionalGroup =
+        functionalGroup === null ||
+        functionalGroup?.relatedSGroup.isSuperatomWithoutLabel;
+      const isMonomer =
+        functionalGroup?.relatedSGroup instanceof MonomerMicromolecule;
+
+      if (noFunctionalGroup) {
+        return {
+          id: CONTEXT_MENU_ID.FOR_BONDS,
+          bondIds: [closestItem.id],
+        };
+      } else if (isMonomer) {
+        return {
+          id: CONTEXT_MENU_ID.FOR_MACROMOLECULE,
+          functionalGroups: [functionalGroup],
+        };
+      } else {
+        return {
+          id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+          functionalGroups: [functionalGroup],
+        };
+      }
     }
 
     case 'atoms': {
@@ -73,16 +85,28 @@ export function getMenuPropsForClosestItem(
         true,
       );
 
-      return functionalGroup === null ||
-        functionalGroup?.relatedSGroup.isSuperatomWithoutLabel
-        ? {
-            id: CONTEXT_MENU_ID.FOR_ATOMS,
-            atomIds: [closestItem.id],
-          }
-        : {
-            id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
-            functionalGroups: [functionalGroup],
-          };
+      const noFunctionalGroup =
+        functionalGroup === null ||
+        functionalGroup?.relatedSGroup.isSuperatomWithoutLabel;
+      const isMonomer =
+        functionalGroup?.relatedSGroup instanceof MonomerMicromolecule;
+
+      if (noFunctionalGroup) {
+        return {
+          id: CONTEXT_MENU_ID.FOR_ATOMS,
+          atomIds: [closestItem.id],
+        };
+      } else if (isMonomer) {
+        return {
+          id: CONTEXT_MENU_ID.FOR_MACROMOLECULE,
+          functionalGroups: [functionalGroup],
+        };
+      } else {
+        return {
+          id: CONTEXT_MENU_ID.FOR_FUNCTIONAL_GROUPS,
+          functionalGroups: [functionalGroup],
+        };
+      }
     }
 
     case 'sgroups':


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request