### PR TITLE
#5887 - After save and load a MOL V3000 file in macro and micro mode, bond connections are changed, and the microstructures are shifted

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -858,7 +858,7 @@ export class KetSerializer implements Serializer<Struct> {
         } as IKetConnectionEndPoint,
         endpoint2: {
           moleculeId: `mol${struct.atoms.get(globalAtomId)?.fragment}`,
-          atomId: monomerToAtomBond.atom.atomIdInMicroMode,
+          atomId: String(monomerToAtomBond.atom.atomIdInMicroMode),
         } as IKetConnectionEndPoint,
       });
     });


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- made conversion of atomId to string for monomer to atom connections

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request