### PR TITLE
#5814 - On Remote environment, the reaction/molecule can't be saved to V3000 formats (returns V2000 instead): MOL, RXN, SDF, RDF

### DIFF
--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -231,6 +231,7 @@ export class RemoteStructService implements StructService {
       'reaction-component-margin-size':
         options?.['reaction-component-margin-size'],
       'image-resolution': options?.['image-resolution'],
+      'molfile-saving-mode': options?.['molfile-saving-mode'],
     };
 
     return indigoCall(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request