### PR TITLE
5988 - perform s-group attribute action when an s-group is deleted

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -312,11 +312,11 @@ export function fromSgroupDeletion(restruct, id, needPerform = true) {
 
   action.addOp(new SGroupDelete(id));
 
+  action.mergeWith(sGroupAttributeAction(id, attrs));
+
   if (needPerform) {
     action = action.perform(restruct);
   }
-
-  action.mergeWith(sGroupAttributeAction(id, attrs));
 
   return action;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
In issue https://github.com/epam/ketcher/issues/5988, the structure in the canvas disappeared when the editor was configured with a custom change subscription and a functional group was replaced with a different atom.
The error thrown is that the `_inverted` field on the s-group attribute operations are undefined, but assumed to be defined here:
https://github.com/epam/ketcher/blob/f87331811d1b3eba7f93a804dee2b75706f7d8aa/packages/ketcher-react/src/script/editor/utils/customOnChangeHandler.ts#L46
An operation's `_inverted` field is only set after the `perform` function is executed here:
https://github.com/epam/ketcher/blob/f87331811d1b3eba7f93a804dee2b75706f7d8aa/packages/ketcher-core/src/application/editor/operations/base.ts#L41-L48
The change in this PR moves the `perform` function execution from before the s-group attribute operations were added to after, such that those operations also have their `_inverted` field set. 
I tested the same behavior as in the issue locally and this change solves the issue:
https://github.com/user-attachments/assets/8b9764a3-1074-40de-a821-9e44cb16a9d9

Note that the `_inverted` field still can be undefined in the `customOnChangeHandler` for other operations and this PR does not address that issue.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request