### PR TITLE
#5974 – Paste to canvas recogniton logic should be changed

### DIFF
--- a/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
+++ b/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
@@ -107,7 +107,15 @@ export function identifyStructFormat(
     return SupportedFormat.fasta;
   }
 
-  if (/^[a-zA-Z\s\n]*$/.test(sanitizedString)) {
+  const isSequence = /^[a-zA-Z\s\n]*$/.test(sanitizedString);
+  const isThreeLetter = /^(?:(?:[A-Z][a-z]{2})\s?)+$/.test(sanitizedString);
+  const isIdt = /^([a-zA-Z0-9\\*/+-]+(?:\/[a-zA-Z0-9\\*/+-]+)*)$/.test(
+    sanitizedString,
+  );
+
+  if (!isThreeLetter && isIdt) {
+    return SupportedFormat.idt;
+  } else if (isSequence) {
     return SupportedFormat.sequence;
   }
 

--- a/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
+++ b/packages/ketcher-core/src/application/formatters/identifyStructFormat.ts
@@ -109,9 +109,7 @@ export function identifyStructFormat(
 
   const isSequence = /^[a-zA-Z\s\n]*$/.test(sanitizedString);
   const isThreeLetter = /^(?:(?:[A-Z][a-z]{2})\s?)+$/.test(sanitizedString);
-  const isIdt = /^([a-zA-Z0-9\\*/+-]+(?:\/[a-zA-Z0-9\\*/+-]+)*)$/.test(
-    sanitizedString,
-  );
+  const isIdt = /([a-zA-Z0-9]+)\/*([a-zA-Z0-9*-]+)/.test(sanitizedString);
 
   if (!isThreeLetter && isIdt) {
     return SupportedFormat.idt;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
In this PR, conditions are added to check the pasted expression in macromolecules mode for compliance with the IDT format. The check is performed in the order: 3-letter - IDT - 1-letter


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request