### PR TITLE
Backmerge: #5969 - Load from file having only micro structures on macro canvas causes unnecessary zoom up to 200% and shift molecule to top left angle

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -790,7 +790,8 @@ export class CoreEditor {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       window._ketcher_isAutozoomDisabled ||
-      !this.isCurrentModeWithAutozoom()
+      !this.isCurrentModeWithAutozoom() ||
+      !this.drawingEntitiesManager.hasMonomers
     ) {
       return;
     }

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -166,6 +166,16 @@ export class DrawingEntitiesManager {
     return this.allEntities.length !== 0;
   }
 
+  public get hasMonomers() {
+    const monomers = [...this.monomers.values()].filter(
+      (monomer) =>
+        !monomer.monomerItem.props.isMicromoleculeFragment ||
+        isMonomerSgroupWithAttachmentPoints(monomer),
+    );
+
+    return monomers.length !== 0;
+  }
+
   public get allBondsToMonomers() {
     return [
       ...(this.polymerBonds as Map<number, PolymerBond>),


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request