### PR TITLE
#6068 - Same chain configuration imported by different HELM layouted differently (anyway - both are wrong)

### DIFF
--- a/packages/ketcher-core/src/application/editor/tools/Erase.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Erase.ts
@@ -30,6 +30,9 @@ class EraserTool implements BaseTool {
     ) {
       const modelChanges =
         this.editor.drawingEntitiesManager.deleteSelectedEntities();
+      modelChanges.merge(
+        this.editor.drawingEntitiesManager.recalculateAntisenseChains(),
+      );
       this.history.update(modelChanges);
       this.editor.renderersContainer.update(modelChanges);
     }
@@ -47,6 +50,9 @@ class EraserTool implements BaseTool {
         this.editor.drawingEntitiesManager.deleteDrawingEntity(
           selectedItemRenderer.drawingEntity,
         );
+      modelChanges.merge(
+        this.editor.drawingEntitiesManager.recalculateAntisenseChains(),
+      );
       this.history.update(modelChanges);
       this.editor.renderersContainer.update(modelChanges);
     }

--- a/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer.ts
@@ -225,7 +225,17 @@ export class SnakeModePolymerBondRenderer extends BaseRenderer {
     ) as Connection;
     const isVerticalConnection = firstCellConnection.isVertical;
     const isStraightVerticalConnection =
-      cells.length === 2 && isVerticalConnection;
+      (cells.length === 2 ||
+        cells.reduce(
+          (isStraight: boolean, cell: Cell, index: number): boolean => {
+            if (!isStraight || index === 0 || index === cells.length - 1) {
+              return isStraight;
+            }
+            return cell.x === firstCell.x && !cell.monomer;
+          },
+          true,
+        )) &&
+      isVerticalConnection;
     const isFirstMonomerOfBondInFirstCell = firstCell.node?.monomers.includes(
       this.polymerBond.firstMonomer,
     );

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -2679,11 +2679,12 @@ export class DrawingEntitiesManager {
       const chainsToCheck = new Set<Chain>();
 
       complimentaryChainsWithData.forEach((complimentaryChainWithData) => {
-        const hasHadrogenBondWithRnaBase =
+        const hasHydrogenBondWithRnaBase =
           complimentaryChainWithData.complimentaryChain.monomers.some(
             (monomer) => {
               return (
                 (monomer instanceof RNABase &&
+                  Boolean(getSugarFromRnaBase(monomer)) &&
                   monomer.hydrogenBonds.length > 0) ||
                 monomer.hydrogenBonds.some((hydrogenBond) => {
                   const anotherMonomer =
@@ -2698,7 +2699,7 @@ export class DrawingEntitiesManager {
             },
           );
 
-        if (hasHadrogenBondWithRnaBase) {
+        if (hasHydrogenBondWithRnaBase) {
           chainsToCheck.add(complimentaryChainWithData.complimentaryChain);
         }
       });

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -4,7 +4,6 @@ import assert from 'assert';
 import {
   getNextMonomerInChain,
   getRnaBaseFromSugar,
-  getSugarFromRnaBase,
   isValidNucleoside,
   isValidNucleotide,
 } from 'domain/helpers/monomers';
@@ -125,22 +124,5 @@ export class Nucleoside {
     return (
       this.rnaBase.isModification || this.sugar.isModification || isNotLastNode
     );
-  }
-
-  public getFirstAntisenseMonomer() {
-    for (let i = 0; i < this.monomers.length; i++) {
-      const monomer = this.monomers[i];
-      const hydrogenBondToRnaBase = monomer.hydrogenBonds.find(
-        (hydrogenBond) =>
-          hydrogenBond.firstMonomer instanceof RNABase ||
-          hydrogenBond.secondMonomer instanceof RNABase,
-      );
-
-      if (hydrogenBondToRnaBase) {
-        return hydrogenBondToRnaBase.getAnotherMonomer(monomer);
-      }
-    }
-
-    return undefined;
   }
 }

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -127,21 +127,20 @@ export class Nucleoside {
     );
   }
 
-  public getAntisenseRnaBase() {
-    const hydrogenBondToAntisenseNode = this.rnaBase.hydrogenBonds.find(
-      (hydrogenBond) => {
-        const anotherMonomer = hydrogenBond.getAnotherMonomer(this.rnaBase);
+  public getFirstAntisenseMonomer() {
+    for (let i = 0; i < this.monomers.length; i++) {
+      const monomer = this.monomers[i];
+      const hydrogenBondToRnaBase = monomer.hydrogenBonds.find(
+        (hydrogenBond) =>
+          hydrogenBond.firstMonomer instanceof RNABase ||
+          hydrogenBond.secondMonomer instanceof RNABase,
+      );
 
-        return (
-          anotherMonomer instanceof RNABase &&
-          getSugarFromRnaBase(anotherMonomer)
-        );
-      },
-    );
-    const antisenseRnaBase = hydrogenBondToAntisenseNode?.getAnotherMonomer(
-      this.rnaBase,
-    );
+      if (hydrogenBondToRnaBase) {
+        return hydrogenBondToRnaBase.getAnotherMonomer(monomer);
+      }
+    }
 
-    return antisenseRnaBase;
+    return undefined;
   }
 }

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -125,7 +125,7 @@ export class Nucleotide {
     );
   }
 
-  public getAntisenseRnaBase() {
-    return Nucleoside.prototype.getAntisenseRnaBase.call(this);
+  public getFirstAntisenseMonomer() {
+    return Nucleoside.prototype.getFirstAntisenseMonomer.call(this);
   }
 }

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -18,7 +18,6 @@ import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { RNA_MONOMER_DISTANCE } from 'application/editor/tools/RnaPreset';
 import { SugarRenderer } from 'application/render';
 import { SNAKE_LAYOUT_CELL_WIDTH } from 'domain/entities/DrawingEntitiesManager';
-import { Nucleoside } from 'domain/entities/Nucleoside';
 
 export class Nucleotide {
   constructor(
@@ -123,9 +122,5 @@ export class Nucleotide {
       this.sugar.isModification ||
       this.phosphate.isModification
     );
-  }
-
-  public getFirstAntisenseMonomer() {
-    return Nucleoside.prototype.getFirstAntisenseMonomer.call(this);
   }
 }

--- a/packages/ketcher-core/src/domain/entities/monomer-chains/ChainsCollection.ts
+++ b/packages/ketcher-core/src/domain/entities/monomer-chains/ChainsCollection.ts
@@ -4,8 +4,6 @@ import {
   BaseMonomer,
   Chem,
   IsChainCycled,
-  Nucleoside,
-  Nucleotide,
   Peptide,
   Phosphate,
   RNABase,
@@ -312,17 +310,26 @@ export class ChainsCollection {
     });
   }
 
+  private getFirstAntisenseMonomerInNode(node: SubChainNode) {
+    for (let i = 0; i < node.monomers.length; i++) {
+      const monomer = node.monomers[i];
+      const hydrogenBond = monomer.hydrogenBonds[0];
+
+      if (hydrogenBond) {
+        return hydrogenBond.getAnotherMonomer(monomer);
+      }
+    }
+
+    return undefined;
+  }
+
   public getComplimentaryChainsWithData(chain: Chain) {
     const complimentaryChainsWithData: ComplimentaryChainsWithData[] = [];
     const handledChains = new Set<Chain>();
     const monomerToChain = this.monomerToChain;
 
     chain.forEachNode(({ node }) => {
-      if (!(node instanceof Nucleotide || node instanceof Nucleoside)) {
-        return;
-      }
-
-      const complimentaryMonomer = node.getFirstAntisenseMonomer();
+      const complimentaryMonomer = this.getFirstAntisenseMonomerInNode(node);
       const complimentaryNode =
         complimentaryMonomer && this.monomerToNode.get(complimentaryMonomer);
       const complimentaryChain =


### PR DESCRIPTION
Closes:

- #6068 
- #6074 
- #6080
- #6081 
- #6087 
- #6077 
- #6076 
- #6075 
- #6070 
- #6067 
- #6061 

## How the feature works? / How did you fix the issue?
- handled case if antisense chain starts from the left of snake layout starting point
- fixed logic of sense/antisense chains calculation. Applied correct business rules. Handled not only rna base to rna base hydrogen connections, but rna base to any monomer.
- added antisense chains recalculation after adding/removing bonds

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request