### PR TITLE
feat: Chain displays the total number of C atoms during mouseMove

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/chain.ts
+++ b/packages/ketcher-core/src/application/editor/actions/chain.ts
@@ -21,7 +21,14 @@ import { Vec2 } from 'domain/entities';
 import { atomGetAttr } from './utils';
 import { fromBondAddition } from './bond';
 
-export function fromChain(restruct, p0, v, nSect, atomId) {
+export function fromChain(
+  restruct,
+  p0,
+  v,
+  nSect,
+  atomId,
+  isShowSectCount = false,
+) {
   // eslint-disable-line max-params
   const dx = Math.cos(Math.PI / 6);
   const dy = Math.sin(Math.PI / 6);
@@ -53,11 +60,17 @@ export function fromChain(restruct, p0, v, nSect, atomId) {
   for (let i = 0; i < nSect; i++) {
     const pos = new Vec2(dx * (i + 1), i & 1 ? 0 : dy).rotate(v).add(p0);
 
+    let label = 'C';
+
+    if (isShowSectCount && i === nSect - 1) {
+      label = `${nSect + 1}`;
+    }
+
     const ret = fromBondAddition(
       restruct,
       {},
       id0,
-      { label: 'C' },
+      { label: label },
       undefined,
       pos,
     );

--- a/packages/ketcher-react/src/script/editor/tool/chain.ts
+++ b/packages/ketcher-react/src/script/editor/tool/chain.ts
@@ -35,6 +35,7 @@ import { isBondingWithMacroMolecule } from './helper/isMacroMolecule';
 class ChainTool implements Tool {
   private readonly editor: Editor;
   private dragCtx: any;
+  private sectCount?: number;
 
   constructor(editor) {
     this.editor = editor;
@@ -46,6 +47,7 @@ class ChainTool implements Tool {
     if (isBondingWithMacroMolecule(this.editor, event)) {
       return;
     }
+    this.sectCount = 0;
     const struct = this.editor.render.ctab;
     const molecule = struct.molecule;
     const functionalGroups = molecule.functionalGroups;
@@ -146,7 +148,7 @@ class ChainTool implements Tool {
     return true;
   }
 
-  mousemove(event) {
+  mousemove(event, isShowSectCount = true) {
     const editor = this.editor;
     const restruct = editor.render.ctab;
     const dragCtx = this.dragCtx;
@@ -177,6 +179,7 @@ class ChainTool implements Tool {
 
       const pos1 = editor.render.page2obj(event);
       const sectCount = Math.ceil(Vec2.diff(pos1, pos0).length());
+      this.sectCount = sectCount;
 
       const angle = event.ctrlKey
         ? vectorUtils.calcAngle(pos0, pos1)
@@ -188,6 +191,7 @@ class ChainTool implements Tool {
         angle,
         sectCount,
         dragCtx.item ? dragCtx.item.id : null,
+        isShowSectCount,
       );
 
       editor.event.message.dispatch({
@@ -213,6 +217,10 @@ class ChainTool implements Tool {
     let atom;
     const atomResult: Array<number> = [];
     const result: Array<number> = [];
+
+    if (this.sectCount && this.dragCtx) {
+      this.mousemove(event, false);
+    }
 
     if (this.dragCtx && this.dragCtx.mergeItems && functionalGroups.size) {
       atom = this.dragCtx.mergeItems.atoms.values().next().value;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

The chain displays the total number of C atoms during mouseMove, and follows the original logic during mouseUp because we need to know the length of the chain, otherwise we have to count them one by one

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request