### PR TITLE
#5949 - Delete of micromolecules bonds works wrong (or doesn't work)

### DIFF
--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -477,7 +477,7 @@ export class MacromoleculesConverter {
           );
         });
 
-        monomer.monomerItem.struct.bonds.forEach((bond) => {
+        monomer.monomerItem.struct.bonds.forEach((bond, bondId) => {
           const firstAtom = atomsMap.get(bond.begin);
           const secondAtom = atomsMap.get(bond.end);
 
@@ -491,6 +491,7 @@ export class MacromoleculesConverter {
               secondAtom,
               bond.type,
               bond.stereo,
+              bondId,
             ),
           );
         });

--- a/packages/ketcher-core/src/application/editor/operations/coreAtom/atom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/coreAtom/atom.ts
@@ -19,12 +19,75 @@
 import { RenderersManager } from 'application/render/renderers/RenderersManager';
 import { Operation } from 'domain/entities/Operation';
 import { Atom } from 'domain/entities/CoreAtom';
+import {
+  Bond as MicromoleculesBond,
+  Atom as MicromoleculesAtom,
+} from 'domain/entities';
+import { KetcherLogger } from 'utilities';
 
+interface BondWithIdInMicromolecules {
+  bondId: number;
+  bond: MicromoleculesBond;
+}
+
+interface DeletedMoleculeStructItems {
+  atomInMoleculeStruct: MicromoleculesAtom;
+  bondsInMoleculeStruct: BondWithIdInMicromolecules[];
+}
+
+function addAtomToMoleculeStruct(
+  atom: Atom,
+  atomInMoleculeStruct: MicromoleculesAtom,
+  bondsInMoleculeStruct: BondWithIdInMicromolecules[] = [],
+) {
+  const moleculeStruct = atom.monomer.monomerItem.struct;
+
+  moleculeStruct.atoms.set(atom.atomIdInMicroMode, atomInMoleculeStruct);
+
+  bondsInMoleculeStruct.forEach(({ bondId, bond }) => {
+    moleculeStruct.bonds.set(bondId, bond);
+  });
+}
+
+function deleteAtomFromMoleculeStruct(atom: Atom) {
+  const moleculeStruct = atom.monomer.monomerItem.struct;
+  const atomInMoleculeStruct = moleculeStruct.atoms.get(atom.atomIdInMicroMode);
+
+  if (!atomInMoleculeStruct) {
+    KetcherLogger.warn('Atom is not found in molecule struct during deletion');
+
+    return;
+  }
+
+  const bondsInMoleculeStruct = moleculeStruct.bonds.filter((_, bond) => {
+    return (
+      bond.begin === atom.atomIdInMicroMode ||
+      bond.end === atom.atomIdInMicroMode
+    );
+  });
+
+  moleculeStruct.atoms.delete(atom.atomIdInMicroMode);
+
+  bondsInMoleculeStruct.forEach((_, bondId) => {
+    moleculeStruct.bonds.delete(bondId);
+  });
+
+  return {
+    atomInMoleculeStruct,
+    bondsInMoleculeStruct: [...bondsInMoleculeStruct.entries()].map(
+      ([bondId, bond]) => {
+        return { bondId, bond };
+      },
+    ),
+  };
+}
 export class AtomAddOperation implements Operation {
   public atom: Atom;
+  private deletedMoleculeStructItems?: DeletedMoleculeStructItems;
+
   constructor(
     public addAtomChangeModel: (atom?: Atom) => Atom,
-    public deleteAtomChangeModel: () => void,
+    public deleteAtomChangeModel: (atom: Atom) => void,
   ) {
     this.atom = this.addAtomChangeModel();
   }
@@ -32,17 +95,29 @@ export class AtomAddOperation implements Operation {
   public execute(renderersManager: RenderersManager) {
     this.atom = this.addAtomChangeModel(this.atom);
     renderersManager.addAtom(this.atom);
+
+    if (this.deletedMoleculeStructItems) {
+      addAtomToMoleculeStruct(
+        this.atom,
+        this.deletedMoleculeStructItems.atomInMoleculeStruct,
+        this.deletedMoleculeStructItems.bondsInMoleculeStruct,
+      );
+    }
   }
 
   public invert(renderersManager: RenderersManager) {
     if (this.atom) {
-      this.deleteAtomChangeModel();
+      this.deleteAtomChangeModel(this.atom);
       renderersManager.deleteAtom(this.atom);
     }
+
+    this.deletedMoleculeStructItems = deleteAtomFromMoleculeStruct(this.atom);
   }
 }
 
 export class AtomDeleteOperation implements Operation {
+  private deletedMoleculeStructItems?: DeletedMoleculeStructItems;
+
   constructor(
     public atom: Atom,
     public deleteAtomChangeModel: () => void,
@@ -52,10 +127,23 @@ export class AtomDeleteOperation implements Operation {
   public execute(renderersManager: RenderersManager) {
     this.deleteAtomChangeModel();
     renderersManager.deleteAtom(this.atom);
+
+    this.deletedMoleculeStructItems = deleteAtomFromMoleculeStruct(this.atom);
   }
 
-  public invert(renderersManager: RenderersManager) {
+  public invert() {
     this.addAtomChangeModel(this.atom);
+
+    if (this.deletedMoleculeStructItems) {
+      addAtomToMoleculeStruct(
+        this.atom,
+        this.deletedMoleculeStructItems.atomInMoleculeStruct,
+        this.deletedMoleculeStructItems.bondsInMoleculeStruct,
+      );
+    }
+  }
+
+  public invertAfterAllOperations(renderersManager: RenderersManager) {
     renderersManager.addAtom(this.atom);
   }
 }

--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -435,12 +435,16 @@ export class RenderersManager {
     monomer.renderer?.updateAttachmentPoints();
   }
 
-  public update(modelChanges?: Command) {
+  public reinitializeViewModel() {
     const editor = CoreEditor.provideEditorInstance();
     const viewModel = editor.viewModel;
 
-    modelChanges?.execute(this);
     viewModel.initialize([...editor.drawingEntitiesManager.bonds.values()]);
+  }
+
+  public update(modelChanges?: Command) {
+    this.reinitializeViewModel();
+    modelChanges?.execute(this);
     modelChanges?.executeAfterAllOperations(this);
 
     this.runPostRenderMethods();

--- a/packages/ketcher-core/src/domain/entities/Command.ts
+++ b/packages/ketcher-core/src/domain/entities/Command.ts
@@ -33,6 +33,8 @@ export class Command {
     }
 
     operations.forEach((operation) => operation.invert(renderersManagers));
+    renderersManagers.reinitializeViewModel();
+    this.invertAfterAllOperations(renderersManagers, operations);
     renderersManagers.runPostRenderMethods();
   }
 
@@ -43,10 +45,24 @@ export class Command {
     renderersManagers.runPostRenderMethods();
   }
 
-  public executeAfterAllOperations(renderersManagers: RenderersManager) {
-    this.operations.forEach((operation) => {
+  public executeAfterAllOperations(
+    renderersManagers: RenderersManager,
+    operations = this.operations,
+  ) {
+    operations.forEach((operation) => {
       if (operation.executeAfterAllOperations) {
         operation.executeAfterAllOperations(renderersManagers);
+      }
+    });
+  }
+
+  public invertAfterAllOperations(
+    renderersManagers: RenderersManager,
+    operations = this.operations,
+  ) {
+    operations.forEach((operation) => {
+      if (operation.invertAfterAllOperations) {
+        operation.invertAfterAllOperations(renderersManagers);
       }
     });
   }

--- a/packages/ketcher-core/src/domain/entities/CoreBond.ts
+++ b/packages/ketcher-core/src/domain/entities/CoreBond.ts
@@ -11,6 +11,7 @@ export class Bond extends DrawingEntity {
   constructor(
     public firstAtom: Atom,
     public secondAtom: Atom,
+    public bondIdInMicroMode,
     public type = 1,
     public stereo = 0,
   ) {

--- a/packages/ketcher-core/src/domain/entities/Operation.ts
+++ b/packages/ketcher-core/src/domain/entities/Operation.ts
@@ -15,4 +15,5 @@ export interface Operation {
   execute(renderersManager: RenderersManager): void;
   invert(renderersManager: RenderersManager): void;
   executeAfterAllOperations?(renderersManager: RenderersManager): void;
+  invertAfterAllOperations?(renderersManager: RenderersManager): void;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added invertAfterAllOperations method to atom and bonds operations to allow renderers rely on final state of model before rendering
- added deleting of atoms and bonds from molecules struct to synchronize molecules and macromolecules modes

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request