### PR TITLE
Backmerge: #6068 - Same chain configuration imported by different HELM layouted differently (anyway - both are wrong)

### DIFF
--- a/ketcher-autotests/tests/Reagents/CML-format/CML-format.spec.ts
+++ b/ketcher-autotests/tests/Reagents/CML-format/CML-format.spec.ts
@@ -10,6 +10,7 @@ import {
   pasteFromClipboardAndAddToCanvas,
   selectTopPanelButton,
   TopPanelButton,
+  moveMouseAway,
 } from '@utils';
 import { clickOnFileFormatDropdown, getCml } from '@utils/formats';
 
@@ -76,6 +77,7 @@ test.describe('Reagents CML format', () => {
       page,
     );
     await saveFileAsCmlFormat(page);
+    await moveMouseAway(page);
     await takeEditorScreenshot(page);
   });
 

--- a/packages/ketcher-core/src/application/editor/tools/Erase.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Erase.ts
@@ -30,6 +30,9 @@ class EraserTool implements BaseTool {
     ) {
       const modelChanges =
         this.editor.drawingEntitiesManager.deleteSelectedEntities();
+      modelChanges.merge(
+        this.editor.drawingEntitiesManager.recalculateAntisenseChains(),
+      );
       this.history.update(modelChanges);
       this.editor.renderersContainer.update(modelChanges);
     }
@@ -47,6 +50,9 @@ class EraserTool implements BaseTool {
         this.editor.drawingEntitiesManager.deleteDrawingEntity(
           selectedItemRenderer.drawingEntity,
         );
+      modelChanges.merge(
+        this.editor.drawingEntitiesManager.recalculateAntisenseChains(),
+      );
       this.history.update(modelChanges);
       this.editor.renderersContainer.update(modelChanges);
     }

--- a/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer.ts
@@ -225,7 +225,17 @@ export class SnakeModePolymerBondRenderer extends BaseRenderer {
     ) as Connection;
     const isVerticalConnection = firstCellConnection.isVertical;
     const isStraightVerticalConnection =
-      cells.length === 2 && isVerticalConnection;
+      (cells.length === 2 ||
+        cells.reduce(
+          (isStraight: boolean, cell: Cell, index: number): boolean => {
+            if (!isStraight || index === 0 || index === cells.length - 1) {
+              return isStraight;
+            }
+            return cell.x === firstCell.x && !cell.monomer;
+          },
+          true,
+        )) &&
+      isVerticalConnection;
     const isFirstMonomerOfBondInFirstCell = firstCell.node?.monomers.includes(
       this.polymerBond.firstMonomer,
     );

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -4,7 +4,6 @@ import assert from 'assert';
 import {
   getNextMonomerInChain,
   getRnaBaseFromSugar,
-  getSugarFromRnaBase,
   isValidNucleoside,
   isValidNucleotide,
 } from 'domain/helpers/monomers';
@@ -125,23 +124,5 @@ export class Nucleoside {
     return (
       this.rnaBase.isModification || this.sugar.isModification || isNotLastNode
     );
-  }
-
-  public getAntisenseRnaBase() {
-    const hydrogenBondToAntisenseNode = this.rnaBase.hydrogenBonds.find(
-      (hydrogenBond) => {
-        const anotherMonomer = hydrogenBond.getAnotherMonomer(this.rnaBase);
-
-        return (
-          anotherMonomer instanceof RNABase &&
-          getSugarFromRnaBase(anotherMonomer)
-        );
-      },
-    );
-    const antisenseRnaBase = hydrogenBondToAntisenseNode?.getAnotherMonomer(
-      this.rnaBase,
-    );
-
-    return antisenseRnaBase;
   }
 }

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -18,7 +18,6 @@ import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { RNA_MONOMER_DISTANCE } from 'application/editor/tools/RnaPreset';
 import { SugarRenderer } from 'application/render';
 import { SNAKE_LAYOUT_CELL_WIDTH } from 'domain/entities/DrawingEntitiesManager';
-import { Nucleoside } from 'domain/entities/Nucleoside';
 
 export class Nucleotide {
   constructor(
@@ -123,9 +122,5 @@ export class Nucleotide {
       this.sugar.isModification ||
       this.phosphate.isModification
     );
-  }
-
-  public getAntisenseRnaBase() {
-    return Nucleoside.prototype.getAntisenseRnaBase.call(this);
   }
 }


### PR DESCRIPTION
#6074 - System doesn't flip chain if connected to monomer but not to base (2)

#6068 - Same chain configuration imported by different HELM layouted differently (anyway - both are wrong)

#6080 - System doesn't flip chain if connected to monomer but not to base (3)

#6081 - Smaller chain should be at the bottom

#6087 - Antisense layout is wrong for any ambiguouse base from the library

#6077 - H-bond is not alligned to Snake mode view in some cases

#6076 - Two-to-one base H-bond connection layouted wrong

#6075 - In case of multipal H-bonds system should arrange antisence chain to first base of bottom chain

#6070 - System doesn't flip chain if connected to monomer but not to base

#6067 - Two chains connected by H-bond arranged wrong if third bond present on the canvas

#6061 - RNA chain remain flipped after hydrogen bond removal

## How the feature works? / How did you fix the issue?

- reworked antisense chains calculation

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request