### PR TITLE
#6109 - Antisense of layout doesn't work on flex mode after load

### DIFF
--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "2.28.0-rc.1",
+  "version": "2.28.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -41,7 +41,12 @@ import assert from 'assert';
 import { SequenceType, Struct, Vec2 } from 'domain/entities';
 import { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { Command } from 'domain/entities/Command';
-import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
+import {
+  DrawingEntitiesManager,
+  MONOMER_START_X_POSITION,
+  MONOMER_START_Y_POSITION,
+  SNAKE_LAYOUT_CELL_WIDTH,
+} from 'domain/entities/DrawingEntitiesManager';
 import { PolymerBond } from 'domain/entities/PolymerBond';
 import { KetSerializer } from 'domain/serializers';
 import { AttachmentPointName, MonomerItemType } from 'domain/types';
@@ -429,6 +434,7 @@ export class CoreEditor {
 
     this.renderersContainer.update(modelChanges);
     history.update(modelChanges);
+    this.scrollToTopLeftCorner();
   }
 
   private onSelectMonomer(monomer: MonomerItemType) {
@@ -798,5 +804,18 @@ export class CoreEditor {
     const structureBbox = RenderersManager.getRenderedStructuresBbox();
 
     ZoomTool.instance.zoomStructureToFitHalfOfCanvas(structureBbox);
+  }
+
+  public scrollToTopLeftCorner() {
+    const drawnEntitiesBoundingBox =
+      RenderersManager.getRenderedStructuresBbox();
+
+    ZoomTool.instance.scrollTo(
+      new Vec2(drawnEntitiesBoundingBox.left, drawnEntitiesBoundingBox.top),
+      false,
+      MONOMER_START_X_POSITION - SNAKE_LAYOUT_CELL_WIDTH / 4,
+      MONOMER_START_Y_POSITION - SNAKE_LAYOUT_CELL_WIDTH / 4,
+      false,
+    );
   }
 }

--- a/packages/ketcher-core/src/application/editor/modes/FlexMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/FlexMode.ts
@@ -30,7 +30,25 @@ export class FlexMode extends BaseMode {
   }
 
   applyAdditionalPasteOperations() {
-    return new Command();
+    const command = new Command();
+    const editor = CoreEditor.provideEditorInstance();
+
+    editor.drawingEntitiesManager.recalculateAntisenseChains();
+
+    if (!editor.drawingEntitiesManager.hasAntisenseChains) {
+      return command;
+    }
+
+    command.merge(
+      editor.drawingEntitiesManager.applySnakeLayout(
+        editor.canvas.width.baseVal.value,
+        true,
+        true,
+        true,
+      ),
+    );
+
+    return command;
   }
 
   isPasteAllowedByMode(): boolean {

--- a/packages/ketcher-core/src/application/editor/modes/SnakeMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SnakeMode.ts
@@ -7,11 +7,6 @@ import { Command } from 'domain/entities/Command';
 import { ReinitializeModeOperation } from 'application/editor/operations/modes';
 import { Vec2 } from 'domain/entities';
 import { RenderersManager } from 'application/render/renderers/RenderersManager';
-import {
-  MONOMER_START_X_POSITION,
-  MONOMER_START_Y_POSITION,
-  SNAKE_LAYOUT_CELL_WIDTH,
-} from 'domain/entities/DrawingEntitiesManager';
 
 export class SnakeMode extends BaseMode {
   constructor(previousMode?: LayoutMode) {
@@ -33,22 +28,10 @@ export class SnakeMode extends BaseMode {
         );
 
     editor.drawingEntitiesManager.applyFlexLayoutMode();
-
     command.merge(modelChanges);
     editor.renderersContainer.update(modelChanges);
     command.setUndoOperationReverse();
-
-    const drawnEntitiesBoundingBox =
-      RenderersManager.getRenderedStructuresBbox();
-    const zoom = ZoomTool.instance;
-
-    zoom.scrollTo(
-      new Vec2(drawnEntitiesBoundingBox.left, drawnEntitiesBoundingBox.top),
-      false,
-      MONOMER_START_X_POSITION - SNAKE_LAYOUT_CELL_WIDTH / 4,
-      MONOMER_START_Y_POSITION - SNAKE_LAYOUT_CELL_WIDTH / 4,
-      false,
-    );
+    editor.scrollToTopLeftCorner();
 
     return command;
   }

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -2794,6 +2794,12 @@ export class DrawingEntitiesManager {
     return command;
   }
 
+  public get hasAntisenseChains() {
+    return [...this.monomers.values()].some(
+      (monomer) => monomer.monomerItem.isAntisense,
+    );
+  }
+
   private getAntisenseBaseLabel(rnaBase: RNABase | AmbiguousMonomer) {
     return this.antisenseChainBasesMap[
       rnaBase instanceof AmbiguousMonomer

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "2.28.0-rc.1",
+  "version": "2.28.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/src/components/modal/Open/Open.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/Open/Open.tsx
@@ -29,6 +29,7 @@ import {
   macromoleculesFilesInputFormats,
   ModeTypes,
   SnakeMode,
+  FlexMode,
 } from 'ketcher-core';
 import { IndigoProvider } from 'ketcher-react';
 import { RequiredModalProps } from '../modalContainer';
@@ -175,6 +176,24 @@ const addToCanvas = ({
   const editorHistory = new EditorHistory(editor);
   const isSequenceMode = editor.mode instanceof SequenceMode;
   const isSnakeMode = editor.mode instanceof SnakeMode;
+  const isFlexMode = editor.mode instanceof FlexMode;
+
+  if (isFlexMode) {
+    editor.drawingEntitiesManager.recalculateAntisenseChains();
+
+    if (!editor.drawingEntitiesManager.hasAntisenseChains) {
+      return;
+    }
+
+    modelChanges.merge(
+      editor.drawingEntitiesManager.applySnakeLayout(
+        editor.canvas.width.baseVal.value,
+        true,
+        true,
+        true,
+      ),
+    );
+  }
 
   editor.renderersContainer.update(modelChanges);
   editorHistory.update(modelChanges);

--- a/packages/ketcher-macromolecules/src/components/modal/Open/Open.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/Open/Open.tsx
@@ -181,18 +181,16 @@ const addToCanvas = ({
   if (isFlexMode) {
     editor.drawingEntitiesManager.recalculateAntisenseChains();
 
-    if (!editor.drawingEntitiesManager.hasAntisenseChains) {
-      return;
+    if (editor.drawingEntitiesManager.hasAntisenseChains) {
+      modelChanges.merge(
+        editor.drawingEntitiesManager.applySnakeLayout(
+          editor.canvas.width.baseVal.value,
+          true,
+          true,
+          true,
+        ),
+      );
     }
-
-    modelChanges.merge(
-      editor.drawingEntitiesManager.applySnakeLayout(
-        editor.canvas.width.baseVal.value,
-        true,
-        true,
-        true,
-      ),
-    );
   }
 
   editor.renderersContainer.update(modelChanges);

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "2.28.0-rc.1",
+  "version": "2.28.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "2.28.0-rc.1",
+  "version": "2.28.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- applied snake layout in flex mode if open/paste file with antisense chain
- applied zoom to left top corner of the structures after antisense chains creation

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request