### PR TITLE
#6107 - Create Antisense Strand doesn't work in some cases

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -2616,7 +2616,7 @@ export class DrawingEntitiesManager {
 
   private get antisenseChainBasesMap() {
     return {
-      [RnaDnaNaturalAnaloguesEnum.ADENINE]: RnaDnaNaturalAnaloguesEnum.THYMINE,
+      [RnaDnaNaturalAnaloguesEnum.ADENINE]: RnaDnaNaturalAnaloguesEnum.URACIL,
       [RnaDnaNaturalAnaloguesEnum.CYTOSINE]: RnaDnaNaturalAnaloguesEnum.GUANINE,
       [RnaDnaNaturalAnaloguesEnum.GUANINE]: RnaDnaNaturalAnaloguesEnum.CYTOSINE,
       [RnaDnaNaturalAnaloguesEnum.THYMINE]: RnaDnaNaturalAnaloguesEnum.ADENINE,

--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -73,6 +73,24 @@ export function isMonomerConnectedToR2RnaBase(monomer?: BaseMonomer) {
   );
 }
 
+export function getPreviousMonomerInChain(monomer: BaseMonomer) {
+  const r1PolymerBond = monomer.attachmentPointsToBonds.R1;
+  const previousMonomer =
+    r1PolymerBond instanceof PolymerBond
+      ? r1PolymerBond?.getAnotherMonomer(monomer)
+      : undefined;
+
+  if (!previousMonomer || !(r1PolymerBond instanceof PolymerBond)) {
+    return undefined;
+  }
+
+  return previousMonomer &&
+    previousMonomer.getAttachmentPointByBond(r1PolymerBond) ===
+      AttachmentPointName.R2
+    ? previousMonomer
+    : undefined;
+}
+
 export function getNextMonomerInChain(
   monomer?: BaseMonomer,
   firstMonomer?: BaseMonomer | null,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- changed implementation of searching first monomers in selection (in this case monomer can be in the middle of the chain and does not have free r1 attachment point)
- changed antisense base for Adenine

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request