### PR TITLE
#6086 - Unable to create antisense chains for ambiguous monomers from the library

### DIFF
--- a/packages/ketcher-core/src/domain/constants/monomers.ts
+++ b/packages/ketcher-core/src/domain/constants/monomers.ts
@@ -22,6 +22,20 @@ export enum RnaDnaNaturalAnaloguesEnum {
   URACIL = 'U',
 }
 
+export enum StandardAmbiguousRnaBase {
+  N = 'N',
+  B = 'B',
+  V = 'V',
+  D = 'D',
+  H = 'H',
+  K = 'K',
+  M = 'M',
+  W = 'W',
+  Y = 'Y',
+  R = 'R',
+  S = 'S',
+}
+
 export const rnaDnaNaturalAnalogues = [
   RnaDnaNaturalAnaloguesEnum.ADENINE,
   RnaDnaNaturalAnaloguesEnum.THYMINE,

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -18,6 +18,7 @@ import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { RNA_MONOMER_DISTANCE } from 'application/editor/tools/RnaPreset';
 import { SugarRenderer } from 'application/render';
 import { RNA_DNA_NON_MODIFIED_PART } from 'domain/constants/monomers';
+import { KetMonomerClass } from 'application/formatters';
 
 export class Nucleoside {
   constructor(
@@ -46,8 +47,16 @@ export class Nucleoside {
     isAntisense = false,
   ) {
     const editor = CoreEditor.provideEditorInstance();
-    const rnaBaseLibraryItem = getRnaPartLibraryItem(editor, rnaBaseName);
-    const sugarLibraryItem = getRnaPartLibraryItem(editor, sugarName);
+    const rnaBaseLibraryItem = getRnaPartLibraryItem(
+      editor,
+      rnaBaseName,
+      KetMonomerClass.Base,
+    );
+    const sugarLibraryItem = getRnaPartLibraryItem(
+      editor,
+      sugarName,
+      KetMonomerClass.Sugar,
+    );
 
     assert(sugarLibraryItem);
     assert(rnaBaseLibraryItem);

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -18,6 +18,7 @@ import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { RNA_MONOMER_DISTANCE } from 'application/editor/tools/RnaPreset';
 import { SugarRenderer } from 'application/render';
 import { SNAKE_LAYOUT_CELL_WIDTH } from 'domain/entities/DrawingEntitiesManager';
+import { KetMonomerClass } from 'application/formatters';
 
 export class Nucleotide {
   constructor(
@@ -53,12 +54,20 @@ export class Nucleotide {
     sugarName: RNA_DNA_NON_MODIFIED_PART = RNA_DNA_NON_MODIFIED_PART.SUGAR_RNA,
   ) {
     const editor = CoreEditor.provideEditorInstance();
-    const rnaBaseLibraryItem = getRnaPartLibraryItem(editor, rnaBaseName);
+    const rnaBaseLibraryItem = getRnaPartLibraryItem(
+      editor,
+      rnaBaseName,
+      KetMonomerClass.Base,
+    );
     const phosphateLibraryItem = getRnaPartLibraryItem(
       editor,
       RNA_DNA_NON_MODIFIED_PART.PHOSPHATE,
     );
-    const sugarLibraryItem = getRnaPartLibraryItem(editor, sugarName);
+    const sugarLibraryItem = getRnaPartLibraryItem(
+      editor,
+      sugarName,
+      KetMonomerClass.Sugar,
+    );
 
     assert(sugarLibraryItem);
     assert(rnaBaseLibraryItem);

--- a/packages/ketcher-core/src/domain/helpers/rna.ts
+++ b/packages/ketcher-core/src/domain/helpers/rna.ts
@@ -1,13 +1,23 @@
 import { CoreEditor } from 'application/editor/internal';
-import { SequenceType } from 'domain/entities';
+import { AmbiguousMonomer, SequenceType } from 'domain/entities';
 import { RNA_DNA_NON_MODIFIED_PART } from 'domain/constants/monomers';
 import { MONOMER_CONST } from 'application/editor';
+import { isAmbiguousMonomerLibraryItem } from 'domain/helpers/monomers';
+import { KetMonomerClass } from 'application/formatters';
 
-export function getRnaPartLibraryItem(editor: CoreEditor, rnaBaseName: string) {
-  return editor.monomersLibrary.find(
-    (libraryItem) =>
-      libraryItem.props.MonomerType === MONOMER_CONST.RNA &&
-      libraryItem.props.MonomerName === rnaBaseName,
+export function getRnaPartLibraryItem(
+  editor: CoreEditor,
+  rnaBaseName: string,
+  monomerClass?: KetMonomerClass,
+) {
+  return editor.monomersLibrary.find((libraryItem) =>
+    isAmbiguousMonomerLibraryItem(libraryItem)
+      ? (!monomerClass ||
+          AmbiguousMonomer.getMonomerClass(libraryItem.monomers) ===
+            monomerClass) &&
+        libraryItem.label === rnaBaseName
+      : (!monomerClass || libraryItem.props.MonomerClass === monomerClass) &&
+        libraryItem.props.MonomerName === rnaBaseName,
   );
 }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added antisense creation for chains with ambiguous bases

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request