### PR TITLE
#5476 - Copy/Cut and Paste using Ctrl+C/X and Ctrl+V doesn't work for static elements in Mozilla Firefox

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.jsx
+++ b/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.jsx
@@ -214,6 +214,7 @@ async function copy(data) {
 
     const clipboardItem = new ClipboardItem(clipboardItemData);
 
+    // Chrome: clipboardItem.presentationStyle is undefined
     if (
       clipboardItem.presentationStyle &&
       clipboardItem.presentationStyle === 'unspecified'
@@ -228,7 +229,7 @@ async function copy(data) {
     }
   } catch (e) {
     KetcherLogger.error('cliparea.jsx::copy', e);
-    console.info(`Could not write exact type ${data && data.toString()}`);
+    console.info(`Could not write exact type ${JSON.stringify(data)}`);
   }
 }
 

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -397,7 +397,7 @@ async function clipData(editor: Editor) {
       ? ChemicalMimeType.Mol
       : ChemicalMimeType.Rxn;
 
-    res['text/plain'] = data;
+    res['text/plain'] = ket;
     res[type] = data;
 
     return res;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
- Use KET format to save in Clipboard instead of RXN
- Firefox doesn't support MIME types other than text/plain in ClipboardItem, and RXN format saved by default to text/plain supports only chemical elements
- When reading from Clipboard Firefox reads only chemical elements as text/plain saved to it is in RXN format

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request