### PR TITLE
Backmerge: #6096 - Antisense creation works wrong in case of partial selection

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -18,6 +18,7 @@ import {
   RNABase,
   SGroupForest,
   Struct,
+  SubChainNode,
   Sugar,
 } from 'domain/entities';
 import {
@@ -2800,12 +2801,45 @@ export class DrawingEntitiesManager {
         );
       },
     );
+    const selectedPiecesInChains: SubChainNode[][] = [];
+
+    chainsForAntisenseCreation.forEach((chain) => {
+      let selectedPiece: SubChainNode[] = [];
+      let hasRnaInPiece = false;
+
+      chain.nodes.forEach((node) => {
+        const hasSelectedMonomerInNode = node.monomers.some(
+          (monomer) => monomer.selected,
+        );
+
+        if (!hasSelectedMonomerInNode) {
+          if (hasRnaInPiece) {
+            selectedPiecesInChains.push(selectedPiece);
+          }
+          selectedPiece = [];
+          hasRnaInPiece = false;
+        } else {
+          selectedPiece.push(node);
+        }
+
+        if (node instanceof Nucleoside || node instanceof Nucleotide) {
+          hasRnaInPiece = true;
+        }
+      });
+
+      if (hasRnaInPiece) {
+        selectedPiecesInChains.push(selectedPiece);
+      }
+
+      selectedPiece = [];
+      hasRnaInPiece = false;
+    });
 
     let lastAddedNode;
     let lastAddedMonomer;
 
-    chainsForAntisenseCreation.forEach((chain) => {
-      chain.forEachNode(({ node }) => {
+    selectedPiecesInChains.forEach((selectedPiece) => {
+      selectedPiece.forEach((node) => {
         if (!node.monomer.selected) {
           lastAddedMonomer = undefined;
           lastAddedNode = undefined;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed creation of antisense for partial selection by several pieces in one chain

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request