### PR TITLE
Backmerge: #5949 - Delete of micromolecules bonds works wrong (or doesn't work)

### DIFF
--- a/packages/ketcher-core/src/application/editor/EditorHistory.ts
+++ b/packages/ketcher-core/src/application/editor/EditorHistory.ts
@@ -77,7 +77,6 @@ export class EditorHistory {
 
     const lastCommand = this.historyStack[this.historyPointer];
     lastCommand.execute(this.editor.renderersContainer);
-    lastCommand.executeAfterAllOperations(this.editor.renderersContainer);
     this.historyPointer++;
   }
 

--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -477,7 +477,7 @@ export class MacromoleculesConverter {
           );
         });
 
-        monomer.monomerItem.struct.bonds.forEach((bond) => {
+        monomer.monomerItem.struct.bonds.forEach((bond, bondId) => {
           const firstAtom = atomsMap.get(bond.begin);
           const secondAtom = atomsMap.get(bond.end);
 
@@ -491,6 +491,7 @@ export class MacromoleculesConverter {
               secondAtom,
               bond.type,
               bond.stereo,
+              bondId,
             ),
           );
         });

--- a/packages/ketcher-core/src/application/editor/operations/coreAtom/atom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/coreAtom/atom.ts
@@ -84,6 +84,7 @@ function deleteAtomFromMoleculeStruct(atom: Atom) {
 export class AtomAddOperation implements Operation {
   public atom: Atom;
   private deletedMoleculeStructItems?: DeletedMoleculeStructItems;
+  public priority = 2;
 
   constructor(
     public addAtomChangeModel: (atom?: Atom) => Atom,
@@ -92,9 +93,8 @@ export class AtomAddOperation implements Operation {
     this.atom = this.addAtomChangeModel();
   }
 
-  public execute(renderersManager: RenderersManager) {
+  public execute() {
     this.atom = this.addAtomChangeModel(this.atom);
-    renderersManager.addAtom(this.atom);
 
     if (this.deletedMoleculeStructItems) {
       addAtomToMoleculeStruct(
@@ -105,18 +105,26 @@ export class AtomAddOperation implements Operation {
     }
   }
 
-  public invert(renderersManager: RenderersManager) {
+  public invert() {
     if (this.atom) {
       this.deleteAtomChangeModel(this.atom);
-      renderersManager.deleteAtom(this.atom);
     }
 
     this.deletedMoleculeStructItems = deleteAtomFromMoleculeStruct(this.atom);
+  }
+
+  public executeAfterAllOperations(renderersManager: RenderersManager) {
+    renderersManager.addAtom(this.atom);
+  }
+
+  public invertAfterAllOperations(renderersManager: RenderersManager) {
+    renderersManager.deleteAtom(this.atom);
   }
 }
 
 export class AtomDeleteOperation implements Operation {
   private deletedMoleculeStructItems?: DeletedMoleculeStructItems;
+  public priority = 2;
 
   constructor(
     public atom: Atom,
@@ -124,9 +132,8 @@ export class AtomDeleteOperation implements Operation {
     public addAtomChangeModel: (atom?: Atom) => Atom,
   ) {}
 
-  public execute(renderersManager: RenderersManager) {
+  public execute() {
     this.deleteAtomChangeModel();
-    renderersManager.deleteAtom(this.atom);
 
     this.deletedMoleculeStructItems = deleteAtomFromMoleculeStruct(this.atom);
   }
@@ -145,5 +152,9 @@ export class AtomDeleteOperation implements Operation {
 
   public invertAfterAllOperations(renderersManager: RenderersManager) {
     renderersManager.addAtom(this.atom);
+  }
+
+  public executeAfterAllOperations(renderersManager: RenderersManager) {
+    renderersManager.deleteAtom(this.atom);
   }
 }

--- a/packages/ketcher-core/src/application/editor/operations/coreAtom/atom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/coreAtom/atom.ts
@@ -19,12 +19,75 @@
 import { RenderersManager } from 'application/render/renderers/RenderersManager';
 import { Operation } from 'domain/entities/Operation';
 import { Atom } from 'domain/entities/CoreAtom';
+import {
+  Bond as MicromoleculesBond,
+  Atom as MicromoleculesAtom,
+} from 'domain/entities';
+import { KetcherLogger } from 'utilities';
 
+interface BondWithIdInMicromolecules {
+  bondId: number;
+  bond: MicromoleculesBond;
+}
+
+interface DeletedMoleculeStructItems {
+  atomInMoleculeStruct: MicromoleculesAtom;
+  bondsInMoleculeStruct: BondWithIdInMicromolecules[];
+}
+
+function addAtomToMoleculeStruct(
+  atom: Atom,
+  atomInMoleculeStruct: MicromoleculesAtom,
+  bondsInMoleculeStruct: BondWithIdInMicromolecules[] = [],
+) {
+  const moleculeStruct = atom.monomer.monomerItem.struct;
+
+  moleculeStruct.atoms.set(atom.atomIdInMicroMode, atomInMoleculeStruct);
+
+  bondsInMoleculeStruct.forEach(({ bondId, bond }) => {
+    moleculeStruct.bonds.set(bondId, bond);
+  });
+}
+
+function deleteAtomFromMoleculeStruct(atom: Atom) {
+  const moleculeStruct = atom.monomer.monomerItem.struct;
+  const atomInMoleculeStruct = moleculeStruct.atoms.get(atom.atomIdInMicroMode);
+
+  if (!atomInMoleculeStruct) {
+    KetcherLogger.warn('Atom is not found in molecule struct during deletion');
+
+    return;
+  }
+
+  const bondsInMoleculeStruct = moleculeStruct.bonds.filter((_, bond) => {
+    return (
+      bond.begin === atom.atomIdInMicroMode ||
+      bond.end === atom.atomIdInMicroMode
+    );
+  });
+
+  moleculeStruct.atoms.delete(atom.atomIdInMicroMode);
+
+  bondsInMoleculeStruct.forEach((_, bondId) => {
+    moleculeStruct.bonds.delete(bondId);
+  });
+
+  return {
+    atomInMoleculeStruct,
+    bondsInMoleculeStruct: [...bondsInMoleculeStruct.entries()].map(
+      ([bondId, bond]) => {
+        return { bondId, bond };
+      },
+    ),
+  };
+}
 export class AtomAddOperation implements Operation {
   public atom: Atom;
+  private deletedMoleculeStructItems?: DeletedMoleculeStructItems;
+
   constructor(
     public addAtomChangeModel: (atom?: Atom) => Atom,
-    public deleteAtomChangeModel: () => void,
+    public deleteAtomChangeModel: (atom: Atom) => void,
   ) {
     this.atom = this.addAtomChangeModel();
   }
@@ -32,17 +95,29 @@ export class AtomAddOperation implements Operation {
   public execute(renderersManager: RenderersManager) {
     this.atom = this.addAtomChangeModel(this.atom);
     renderersManager.addAtom(this.atom);
+
+    if (this.deletedMoleculeStructItems) {
+      addAtomToMoleculeStruct(
+        this.atom,
+        this.deletedMoleculeStructItems.atomInMoleculeStruct,
+        this.deletedMoleculeStructItems.bondsInMoleculeStruct,
+      );
+    }
   }
 
   public invert(renderersManager: RenderersManager) {
     if (this.atom) {
-      this.deleteAtomChangeModel();
+      this.deleteAtomChangeModel(this.atom);
       renderersManager.deleteAtom(this.atom);
     }
+
+    this.deletedMoleculeStructItems = deleteAtomFromMoleculeStruct(this.atom);
   }
 }
 
 export class AtomDeleteOperation implements Operation {
+  private deletedMoleculeStructItems?: DeletedMoleculeStructItems;
+
   constructor(
     public atom: Atom,
     public deleteAtomChangeModel: () => void,
@@ -52,10 +127,23 @@ export class AtomDeleteOperation implements Operation {
   public execute(renderersManager: RenderersManager) {
     this.deleteAtomChangeModel();
     renderersManager.deleteAtom(this.atom);
+
+    this.deletedMoleculeStructItems = deleteAtomFromMoleculeStruct(this.atom);
   }
 
-  public invert(renderersManager: RenderersManager) {
+  public invert() {
     this.addAtomChangeModel(this.atom);
+
+    if (this.deletedMoleculeStructItems) {
+      addAtomToMoleculeStruct(
+        this.atom,
+        this.deletedMoleculeStructItems.atomInMoleculeStruct,
+        this.deletedMoleculeStructItems.bondsInMoleculeStruct,
+      );
+    }
+  }
+
+  public invertAfterAllOperations(renderersManager: RenderersManager) {
     renderersManager.addAtom(this.atom);
   }
 }

--- a/packages/ketcher-core/src/application/editor/operations/coreBond/bond.ts
+++ b/packages/ketcher-core/src/application/editor/operations/coreBond/bond.ts
@@ -42,6 +42,7 @@ function deleteBondFromMoleculeStruct(bond: Bond) {
 export class BondAddOperation implements Operation {
   public bond: Bond;
   private bondInMoleculeStruct?: MicromoleculesBond;
+  public priority = 1;
   constructor(
     public addBondChangeModel: (bond?: Bond) => Bond,
     public deleteBondChangeModel: (bond: Bond) => void,
@@ -49,27 +50,34 @@ export class BondAddOperation implements Operation {
     this.bond = this.addBondChangeModel();
   }
 
-  public execute(renderersManager: RenderersManager) {
+  public execute() {
     this.bond = this.addBondChangeModel(this.bond);
-    renderersManager.addBond(this.bond);
 
     if (this.bondInMoleculeStruct) {
       addBondToMoleculeStruct(this.bond, this.bondInMoleculeStruct);
     }
   }
 
-  public invert(renderersManager: RenderersManager) {
+  public invert() {
     if (this.bond) {
       this.deleteBondChangeModel(this.bond);
-      renderersManager.deleteBond(this.bond);
     }
 
     this.bondInMoleculeStruct = deleteBondFromMoleculeStruct(this.bond);
+  }
+
+  public executeAfterAllOperations(renderersManager: RenderersManager) {
+    renderersManager.addBond(this.bond);
+  }
+
+  public invertAfterAllOperations(renderersManager: RenderersManager) {
+    renderersManager.deleteBond(this.bond);
   }
 }
 
 export class BondDeleteOperation implements Operation {
   private bondInMoleculeStruct?: MicromoleculesBond;
+  public priority = 1;
 
   constructor(
     public bond: Bond,
@@ -77,9 +85,8 @@ export class BondDeleteOperation implements Operation {
     public addBondChangeModel: (bond: Bond) => Bond,
   ) {}
 
-  public execute(renderersManager: RenderersManager) {
+  public execute() {
     this.deleteBondChangeModel(this.bond);
-    renderersManager.deleteBond(this.bond);
 
     this.bondInMoleculeStruct = deleteBondFromMoleculeStruct(this.bond);
   }
@@ -90,6 +97,10 @@ export class BondDeleteOperation implements Operation {
     if (this.bondInMoleculeStruct) {
       addBondToMoleculeStruct(this.bond, this.bondInMoleculeStruct);
     }
+  }
+
+  public executeAfterAllOperations(renderersManager: RenderersManager) {
+    renderersManager.deleteBond(this.bond);
   }
 
   public invertAfterAllOperations(renderersManager: RenderersManager) {

--- a/packages/ketcher-core/src/application/editor/operations/drawingEntity/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/drawingEntity/index.ts
@@ -36,15 +36,8 @@ export class DrawingEntityMoveOperation implements Operation {
       : this.moveDrawingEntityChangeModel();
   }
 
-  public invert(renderersManager: RenderersManager) {
+  public invert() {
     this.invertMoveDrawingEntityChangeModel();
-
-    if (this.drawingEntity instanceof BaseBond) {
-      renderersManager.redrawDrawingEntity(this.drawingEntity);
-    } else {
-      renderersManager.moveDrawingEntity(this.drawingEntity);
-    }
-
     this.wasInverted = true;
   }
 
@@ -53,6 +46,14 @@ export class DrawingEntityMoveOperation implements Operation {
     // they have two drawing modes: straight and curved.
     // During switching snake/flex layout modes and undo/redo
     // we need to redraw them to apply the correct drawing mode.
+    if (this.drawingEntity instanceof BaseBond) {
+      renderersManager.redrawDrawingEntity(this.drawingEntity);
+    } else {
+      renderersManager.moveDrawingEntity(this.drawingEntity);
+    }
+  }
+
+  public invertAfterAllOperations(renderersManager: RenderersManager) {
     if (this.drawingEntity instanceof BaseBond) {
       renderersManager.redrawDrawingEntity(this.drawingEntity);
     } else {

--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -305,12 +305,16 @@ export class RenderersManager {
     monomer.renderer?.updateAttachmentPoints();
   }
 
-  public update(modelChanges?: Command) {
+  public reinitializeViewModel() {
     const editor = CoreEditor.provideEditorInstance();
     const viewModel = editor.viewModel;
 
-    modelChanges?.execute(this);
     viewModel.initialize([...editor.drawingEntitiesManager.bonds.values()]);
+  }
+
+  public update(modelChanges?: Command) {
+    this.reinitializeViewModel();
+    modelChanges?.execute(this);
     modelChanges?.executeAfterAllOperations(this);
 
     this.runPostRenderMethods();

--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -315,8 +315,6 @@ export class RenderersManager {
   public update(modelChanges?: Command) {
     this.reinitializeViewModel();
     modelChanges?.execute(this);
-    modelChanges?.executeAfterAllOperations(this);
-
     this.runPostRenderMethods();
     notifyRenderComplete();
   }

--- a/packages/ketcher-core/src/domain/entities/Command.ts
+++ b/packages/ketcher-core/src/domain/entities/Command.ts
@@ -42,6 +42,8 @@ export class Command {
     this.operations.forEach((operation) =>
       operation.execute(renderersManagers),
     );
+    renderersManagers.reinitializeViewModel();
+    this.executeAfterAllOperations(renderersManagers);
     renderersManagers.runPostRenderMethods();
   }
 

--- a/packages/ketcher-core/src/domain/entities/Command.ts
+++ b/packages/ketcher-core/src/domain/entities/Command.ts
@@ -33,6 +33,8 @@ export class Command {
     }
 
     operations.forEach((operation) => operation.invert(renderersManagers));
+    renderersManagers.reinitializeViewModel();
+    this.invertAfterAllOperations(renderersManagers, operations);
     renderersManagers.runPostRenderMethods();
   }
 
@@ -43,10 +45,24 @@ export class Command {
     renderersManagers.runPostRenderMethods();
   }
 
-  public executeAfterAllOperations(renderersManagers: RenderersManager) {
-    this.operations.forEach((operation) => {
+  public executeAfterAllOperations(
+    renderersManagers: RenderersManager,
+    operations = this.operations,
+  ) {
+    operations.forEach((operation) => {
       if (operation.executeAfterAllOperations) {
         operation.executeAfterAllOperations(renderersManagers);
+      }
+    });
+  }
+
+  public invertAfterAllOperations(
+    renderersManagers: RenderersManager,
+    operations = this.operations,
+  ) {
+    operations.forEach((operation) => {
+      if (operation.invertAfterAllOperations) {
+        operation.invertAfterAllOperations(renderersManagers);
       }
     });
   }

--- a/packages/ketcher-core/src/domain/entities/CoreBond.ts
+++ b/packages/ketcher-core/src/domain/entities/CoreBond.ts
@@ -11,6 +11,7 @@ export class Bond extends DrawingEntity {
   constructor(
     public firstAtom: Atom,
     public secondAtom: Atom,
+    public bondIdInMicroMode,
     public type = 1,
     public stereo = 0,
   ) {

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -2004,9 +2004,9 @@ export class DrawingEntitiesManager {
       const bondAddCommand = targetDrawingEntitiesManager.addBond(
         newFirstAtom,
         newSecondAtom,
-        bond.bondIdInMicroMode,
         bond.type,
         bond.stereo,
+        bond.bondIdInMicroMode,
       );
       const addedBond = bondAddCommand.operations[0].bond as Bond;
 
@@ -2442,6 +2442,12 @@ export class DrawingEntitiesManager {
 
         command.merge(this.deleteBond(bond));
       });
+
+      this.monomerToAtomBonds.forEach((monomerToAtomBond) => {
+        if (monomerToAtomBond.atom === atom && !monomerToAtomBond.selected) {
+          command.merge(this.deleteMonomerToAtomBond(monomerToAtomBond));
+        }
+      });
     }
 
     return command;
@@ -2519,9 +2525,9 @@ export class DrawingEntitiesManager {
           this.addBondChangeModel(
             bond.firstAtom,
             bond.secondAtom,
-            bond.bondIdInMicroMode,
             bond.type,
             bond.stereo,
+            bond.bondIdInMicroMode,
             bond,
           ),
       ),

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -284,7 +284,7 @@ export class DrawingEntitiesManager {
     } else if (drawingEntity instanceof Bond) {
       return this.deleteBond(drawingEntity);
     } else if (drawingEntity instanceof Atom) {
-      return this.deleteAtom(drawingEntity);
+      return this.deleteAtom(drawingEntity, needToDeleteConnectedEntities);
     } else {
       return new Command();
     }
@@ -2004,6 +2004,7 @@ export class DrawingEntitiesManager {
       const bondAddCommand = targetDrawingEntitiesManager.addBond(
         newFirstAtom,
         newSecondAtom,
+        bond.bondIdInMicroMode,
         bond.type,
         bond.stereo,
       );
@@ -2402,13 +2403,7 @@ export class DrawingEntitiesManager {
         atomIdInMicroMode,
         label,
       ),
-      this.addAtomChangeModel.bind(
-        this,
-        position,
-        monomer,
-        atomIdInMicroMode,
-        label,
-      ),
+      this.deleteAtomChangeModel.bind(this),
     );
 
     command.addOperation(atomAddOperation);
@@ -2422,7 +2417,7 @@ export class DrawingEntitiesManager {
     return atom;
   }
 
-  private deleteAtom(atom: Atom) {
+  private deleteAtom(atom: Atom, needToDeleteConnectedEntities = true) {
     const command = new Command();
 
     command.addOperation(
@@ -2439,6 +2434,16 @@ export class DrawingEntitiesManager {
       ),
     );
 
+    if (needToDeleteConnectedEntities) {
+      atom.bonds.forEach((bond) => {
+        if (bond.selected) {
+          return;
+        }
+
+        command.merge(this.deleteBond(bond));
+      });
+    }
+
     return command;
   }
 
@@ -2447,6 +2452,7 @@ export class DrawingEntitiesManager {
     secondAtom: Atom,
     type: number,
     stereo: number,
+    bondIdInMicroMode: number,
     _bond?: Bond,
   ) {
     if (_bond) {
@@ -2455,7 +2461,13 @@ export class DrawingEntitiesManager {
       return _bond;
     }
 
-    const bond = new Bond(firstAtom, secondAtom, type, stereo);
+    const bond = new Bond(
+      firstAtom,
+      secondAtom,
+      bondIdInMicroMode,
+      type,
+      stereo,
+    );
 
     this.bonds.set(bond.id, bond);
     firstAtom.addBond(bond);
@@ -2469,11 +2481,20 @@ export class DrawingEntitiesManager {
     secondAtom: Atom,
     type: number,
     stereo: number,
+    bondIdInMicroMode: number,
   ) {
     const command = new Command();
     const bondAddOperation = new BondAddOperation(
-      this.addBondChangeModel.bind(this, firstAtom, secondAtom, type, stereo),
-      this.addBondChangeModel.bind(this, firstAtom, secondAtom, type, stereo),
+      (bond?: Bond) =>
+        this.addBondChangeModel(
+          firstAtom,
+          secondAtom,
+          type,
+          stereo,
+          bondIdInMicroMode,
+          bond,
+        ),
+      (bond: Bond) => this.deleteBondChangeModel(bond),
     );
 
     command.addOperation(bondAddOperation);
@@ -2494,13 +2515,15 @@ export class DrawingEntitiesManager {
       new BondDeleteOperation(
         bond,
         this.deleteBondChangeModel.bind(this, bond),
-        this.addBondChangeModel.bind(
-          this,
-          bond.firstAtom,
-          bond.secondAtom,
-          bond.type,
-          bond.stereo,
-        ),
+        (bond: Bond) =>
+          this.addBondChangeModel(
+            bond.firstAtom,
+            bond.secondAtom,
+            bond.bondIdInMicroMode,
+            bond.type,
+            bond.stereo,
+            bond,
+          ),
       ),
     );
 
@@ -2900,6 +2923,19 @@ export class DrawingEntitiesManager {
     command.setUndoOperationsByPriority();
 
     return command;
+  }
+
+  public get monomersArray() {
+    return [...this.monomers.values()];
+  }
+
+  public get molecules() {
+    return this.monomersArray.filter((monomer) => {
+      return (
+        monomer.monomerItem.props.isMicromoleculeFragment &&
+        !isMonomerSgroupWithAttachmentPoints(monomer)
+      );
+    });
   }
 }
 function getFirstPosition(

--- a/packages/ketcher-core/src/domain/entities/Operation.ts
+++ b/packages/ketcher-core/src/domain/entities/Operation.ts
@@ -15,4 +15,5 @@ export interface Operation {
   execute(renderersManager: RenderersManager): void;
   invert(renderersManager: RenderersManager): void;
   executeAfterAllOperations?(renderersManager: RenderersManager): void;
+  invertAfterAllOperations?(renderersManager: RenderersManager): void;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added invertAfterAllOperations method to atom and bonds operations to allow renderers rely on final state of model before rendering
- added deleting of atoms and bonds from molecules struct to synchronize molecules and macromolecules modes

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request