### PR TITLE
#5796 - Indigo functions doesn't work if monomer on micro canvas - system throws an error: Error: Cannot deserialize input JSON.

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -332,6 +332,14 @@ export class KetSerializer implements Serializer<Struct> {
       fileContentForMicromolecules[template.$ref] = undefined;
     });
 
+    Object.entries(
+      fileContentForMicromolecules as IKetMacromoleculesContent,
+    ).forEach(([key, value]) => {
+      if (value?.type === KetTemplateType.AMBIGUOUS_MONOMER_TEMPLATE) {
+        fileContentForMicromolecules[key] = undefined;
+      }
+    });
+
     return fileContentForMicromolecules;
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
### Root cause
The bug was caused by [validation](https://github.com/epam/ketcher/blob/master/packages/ketcher-core/src/domain/serializers/ket/validate.ts) that checks if passed data satisfies rules from [scheme](https://github.com/epam/ketcher/blob/master/packages/ketcher-core/src/domain/serializers/ket/schema.json).

Ambiguous monomers templates weren’t taken into consideration inside [this filtering](https://github.com/epam/ketcher/blob/master/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts#L305-L336) and were passed to the validation that threw an exception from the issue’s description.

### Solution
Added ambiguous monomers to the filter in oder to exclude them from the further processing.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request