### PR TITLE
#5139 - After pressing the Clear Canvas button in sequence-editing view, the Enter button does not start a new sequence but erases it

### DIFF
--- a/packages/ketcher-macromolecules/src/components/menu/menuItem/MenuItem.tsx
+++ b/packages/ketcher-macromolecules/src/components/menu/menuItem/MenuItem.tsx
@@ -17,6 +17,7 @@ import { type IconName } from 'ketcher-react';
 import { useMenuContext } from '../../../hooks/useMenuContext';
 import { useCallback } from 'react';
 import { StyledIconButton } from './styles';
+import { blurActiveElement } from 'helpers/canvas';
 
 type MenuItemProp = {
   itemId: IconName;
@@ -37,6 +38,8 @@ const MenuItem = ({
 
   const onClickCallback = useCallback(() => {
     activate(itemId);
+    blurActiveElement();
+
     if (onClick) {
       onClick();
     }

--- a/packages/ketcher-macromolecules/src/helpers/canvas.ts
+++ b/packages/ketcher-macromolecules/src/helpers/canvas.ts
@@ -1,0 +1,5 @@
+export function blurActiveElement() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  document.activeElement?.blur();
+}


### PR DESCRIPTION
Closes:

#4338 - After Undo/Redo actions Enter repeats these actions.
#5139 - After pressing the Clear Canvas button in sequence-editing view, the Enter button does not start a new sequence but erases it

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request