### PR TITLE
4723-when-pressing-enter-a-user-can-create-new-sequences-in-the-modif…

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -176,6 +176,8 @@ export class SequenceMode extends BaseMode {
   }
 
   public startNewSequence(eventData?: StartNewSequenceEventData) {
+    if (CoreEditor.provideEditorInstance()?.isSequenceEditInRNABuilderMode)
+      return;
     const currentChainIndex = this.isEditMode
       ? SequenceRenderer.currentChainIndex
       : SequenceRenderer.chainsCollection.chains.length - 1;


### PR DESCRIPTION
…y-rna-builder-mode
<img width="828" alt="image" src="https://github.com/user-attachments/assets/add4ab27-ec63-4f57-9a53-8740aacc4125" />

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

now the user cannot create new sequences in the “Modify RNA Builder" mode. But it seems that the functionality in the “Modify RNA Builder” mode is not fully thought out and an audit is needed and then a new task to expand the functionality

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request