### PR TITLE
Backmerge: #6161 - Stereo flags are displayed despite enabling 'Ignore chiral flag' in MOL V2000 files

### DIFF
--- a/documentation/help.md
+++ b/documentation/help.md
@@ -647,7 +647,7 @@ In the _Stereochemistry tab_ in _Settings_ you can:
 
 <img src=images/49_sett_stereon.png width = "440"/>
 
-When option _Ignore the chiral flag_ is _true_ it will affect opening and saving of MDL V2000 and MDL V3000 files, as well as the display of labels at stereogenic centers and stereo flags:
+When option _Ignore the chiral flag_ is _true_ it will affect opening of MDL V2000 and MDL V3000 files, as well as the display of labels at stereogenic centers and stereo flags:
 
 - stereo flags are not displayed
 

--- a/packages/ketcher-core/src/application/utils.ts
+++ b/packages/ketcher-core/src/application/utils.ts
@@ -76,7 +76,7 @@ export function parseStruct(
 
   const service = factory.create(format, {
     'dearomatize-on-load': options['dearomatize-on-load'],
-    'ignore-no-chiral-flag': options.ignoreChiralFlag,
+    ignoreChiralFlag: options.ignoreChiralFlag,
   });
   return service.getStructureFromStringAsync(structStr);
 }

--- a/packages/ketcher-core/src/domain/serializers/mol/molSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/molSerializer.ts
@@ -84,7 +84,6 @@ export class MolSerializer implements Serializer<Struct> {
       this.options.ignoreErrors,
       this.options.noRgroups,
       this.options.preserveIndigoDesc,
-      this.options.ignoreChiralFlag,
     );
   }
 }

--- a/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/molfile.ts
@@ -134,7 +134,6 @@ export class Molfile {
     skipSGroupErrors: boolean,
     norgroups?: boolean,
     preserveIndigoDesc?: boolean,
-    ignoreChiralFlag?: boolean,
   ) {
     // eslint-disable-line max-statements
     /* saver */
@@ -201,7 +200,7 @@ export class Molfile {
     this.prepareSGroups(skipSGroupErrors, preserveIndigoDesc);
 
     this.writeHeader();
-    this.writeCTab2000(undefined, ignoreChiralFlag);
+    this.writeCTab2000(undefined);
 
     return this.molfile;
   }
@@ -268,7 +267,7 @@ export class Molfile {
     this.write(utils.paddedNum(number, width, precision));
   }
 
-  writeCTab2000Header(ignoreChiralFlag) {
+  writeCTab2000Header() {
     /* saver */
     this.writePaddedNumber(this.molecule!.atoms.size, 3);
     this.writePaddedNumber(this.molecule!.bonds.size, 3);
@@ -279,7 +278,7 @@ export class Molfile {
       fr ? fr.enhancedStereoFlag === StereoFlag.Abs : false,
     );
 
-    this.writePaddedNumber(isAbsFlag || ignoreChiralFlag ? 1 : 0, 3);
+    this.writePaddedNumber(isAbsFlag ? 1 : 0, 3);
     this.writePaddedNumber(0, 3);
     this.writePaddedNumber(0, 3);
     this.writePaddedNumber(0, 3);
@@ -289,10 +288,10 @@ export class Molfile {
     this.writeCR(' V2000');
   }
 
-  writeCTab2000(rgroups?: Map<any, any>, ignoreChiralFlag?: boolean) {
+  writeCTab2000(rgroups?: Map<any, any>) {
     // eslint-disable-line max-statements
     /* saver */
-    this.writeCTab2000Header(ignoreChiralFlag);
+    this.writeCTab2000Header();
 
     this.mapping = {};
     let i = 1;

--- a/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
+++ b/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
@@ -334,6 +334,7 @@ const server: {
   'gross-formula-add-rsites': ExtendedSchema;
   'gross-formula-add-isotopes': ExtendedSchema;
   'dearomatize-on-load': ExtendedSchema;
+  ignoreChiralFlag: ExtendedSchema;
 } = {
   'dearomatize-on-load': {
     title: 'dearomatize-on-load',
@@ -346,6 +347,12 @@ const server: {
     type: 'boolean',
     description: 'slider',
     default: true,
+  },
+  ignoreChiralFlag: {
+    title: 'Ignore the chiral flag',
+    type: 'boolean',
+    description: 'slider',
+    default: false,
   },
   'ignore-stereochemistry-errors': {
     title: 'Ignore stereochemistry errors',


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added ignoreChiralFlag parameter to be used in mol v2000 deserialization during setMolecule and openning files methods
- removed ignoreChiralFlag parameter from serialization

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request