### PR TITLE
#5341 - Replacing all monomers (or part of them) in edit mode - works wrong - system cuts sequence on two

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1784,9 +1784,8 @@ export class SequenceMode extends BaseMode {
     const firstNodeOfNewFragment = chainsCollection.firstNode;
     const newNodePosition = this.getNewNodePosition();
 
-    this.deleteBondToNextNodeInChain(previousNodeInSameChain, modelChanges);
-
     if (needConnectWithPreviousNodeInChain) {
+      this.deleteBondToNextNodeInChain(previousNodeInSameChain, modelChanges);
       this.connectNodes(
         previousNodeInSameChain,
         firstNodeOfNewFragment,


### PR DESCRIPTION
When (the first/all) monomer(s) is replaced with one from the palette, the bond from the previous node will not be deleted while there is not the previous node.

Fixes #5341

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request