### PR TITLE
Autotests: #6043 - autotests replace file comparison for cdxml files only operations with valid helper functions verifyfileexport

### DIFF
--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Enhanced-Stereochemistry/cdxml-enhanced-stereochemistry.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Enhanced-Stereochemistry/cdxml-enhanced-stereochemistry.spec.ts
@@ -1,17 +1,18 @@
-import { Page, expect, test } from '@playwright/test';
+import { Page, test } from '@playwright/test';
 import {
   takeEditorScreenshot,
   openFileAndAddToCanvas,
   LeftPanelButton,
   pressButton,
   selectLeftPanelButton,
-  receiveFileComparisonData,
-  saveToFile,
   clickOnAtom,
   waitForPageInit,
   waitForRender,
 } from '@utils';
-import { getCdxml } from '@utils/formats';
+import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
 
 async function selectRadioButtonForNewGroup(
   page: Page,
@@ -92,17 +93,12 @@ test.describe('CDXML Enhanced Stereochemistry', () => {
     All enhanced stereochemistry features are present after opening.
     */
     await openFileAndAddToCanvas('CDXML/stereo-and-structure.cdxml', page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile('CDXML/stereo-and-structure-expected.cdxml', expectedFile);
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/stereo-and-structure-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
+    await verifyFileExport(
+      page,
+      'CDXML/stereo-and-structure-expected.cdxml',
+      FileType.CDXML,
+    );
   });
 
   test('OR stereo marks - Save as *.cdxml file', async ({ page }) => {
@@ -112,17 +108,12 @@ test.describe('CDXML Enhanced Stereochemistry', () => {
     All enhanced stereochemistry features are present after opening.
     */
     await openFileAndAddToCanvas('CDXML/stereo-or-structure.cdxml', page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile('CDXML/stereo-or-structure-expected.cdxml', expectedFile);
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/stereo-or-structure-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
+    await verifyFileExport(
+      page,
+      'CDXML/stereo-or-structure-expected.cdxml',
+      FileType.CDXML,
+    );
   });
 
   test('Mixed AND stereo marks - Save as *.cdxml file', async ({ page }) => {
@@ -132,20 +123,12 @@ test.describe('CDXML Enhanced Stereochemistry', () => {
     All enhanced stereochemistry features are present after opening.
     */
     await openFileAndAddToCanvas('CDXML/mixed-and-stereo-marks.cdxml', page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/mixed-and-stereo-marks-expected.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/mixed-and-stereo-marks-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
   });
 
   test('Mixed OR stereo marks - Save as *.cdxml file', async ({ page }) => {
@@ -155,20 +138,12 @@ test.describe('CDXML Enhanced Stereochemistry', () => {
     All enhanced stereochemistry features are present after opening.
     */
     await openFileAndAddToCanvas('CDXML/mixed-or-stereo-marks.cdxml', page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/mixed-or-stereo-marks-expected.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/mixed-or-stereo-marks-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
   });
 
   test('Mixed stereo marks - Save as *.cdxml file', async ({ page }) => {
@@ -178,16 +153,11 @@ test.describe('CDXML Enhanced Stereochemistry', () => {
     All enhanced stereochemistry features are present after opening.
     */
     await openFileAndAddToCanvas('CDXML/mixed-stereo-marks.cdxml', page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile('CDXML/mixed-stereo-marks-expected.cdxml', expectedFile);
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/mixed-stereo-marks-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
+    await verifyFileExport(
+      page,
+      'CDXML/mixed-stereo-marks.cdxml',
+      FileType.CDXML,
+    );
   });
 });

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Enhanced-Stereochemistry/cdxml-enhanced-stereochemistry.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Enhanced-Stereochemistry/cdxml-enhanced-stereochemistry.spec.ts
@@ -156,7 +156,7 @@ test.describe('CDXML Enhanced Stereochemistry', () => {
 
     await verifyFileExport(
       page,
-      'CDXML/mixed-stereo-marks.cdxml',
+      'CDXML/mixed-stereo-marks-expected.cdxml',
       FileType.CDXML,
     );
   });

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Files/cdxml-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Files/cdxml-files.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import {
   AtomButton,
   clickInTheMiddleOfTheScreen,
@@ -9,8 +9,6 @@ import {
   selectAtomInToolbar,
   selectLeftPanelButton,
   LeftPanelButton,
-  receiveFileComparisonData,
-  saveToFile,
   waitForPageInit,
   openFileAndAddToCanvasAsNewProject,
   bondsSettings,
@@ -28,7 +26,6 @@ import {
   FileType,
   verifyFileExport,
 } from '@utils/files/receiveFileComparisonData';
-import { getCdxml } from '@utils/formats';
 import { pressUndoButton } from '@utils/macromolecules/topToolBar';
 
 test.describe('Tests for API setMolecule/getMolecule', () => {
@@ -154,16 +151,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
      * Description: Open/Import structure CDXML file
      */
     await openFileAndAddToCanvas('CDXML/cdxml-6969.cdxml', page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile('CDXML/cdxml-6969-expected.cdxml', expectedFile);
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName: 'tests/test-data/CDXML/cdxml-6969-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
+    await verifyFileExport(
+      page,
+      'CDXML/cdxml-6969-expected.cdxml',
+      FileType.CDXML,
+    );
     await takeEditorScreenshot(page);
   });
 
@@ -179,20 +172,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/unsplit-nucleotides-connected-with-nucleotides.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/unsplit-nucleotides-connected-with-nucleotides.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/unsplit-nucleotides-connected-with-nucleotides.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
   });
 
   test('Validate that unsplit nucleotides connected with chems could be saved to Cdxml file and loaded back', async ({
@@ -207,20 +192,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/unsplit-nucleotides-connected-with-chems.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/unsplit-nucleotides-connected-with-chems.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/unsplit-nucleotides-connected-with-chems.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await takeEditorScreenshot(page);
   });
 
@@ -236,20 +213,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/unsplit-nucleotides-connected-with-bases.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/unsplit-nucleotides-connected-with-bases.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/unsplit-nucleotides-connected-with-bases.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await takeEditorScreenshot(page);
   });
 
@@ -265,20 +234,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/unsplit-nucleotides-connected-with-sugars.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/unsplit-nucleotides-connected-with-sugars.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/unsplit-nucleotides-connected-with-sugars.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await takeEditorScreenshot(page);
   });
 
@@ -294,20 +255,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/unsplit-nucleotides-connected-with-phosphates.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/unsplit-nucleotides-connected-with-phosphates.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/unsplit-nucleotides-connected-with-phosphates.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await takeEditorScreenshot(page);
   });
 
@@ -323,20 +276,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/unsplit-nucleotides-connected-with-peptides.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/unsplit-nucleotides-connected-with-peptides.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/unsplit-nucleotides-connected-with-peptides.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await takeEditorScreenshot(page);
   });
 
@@ -352,20 +297,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/simple-schema-with-retrosynthetic-arrow.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/simple-schema-with-retrosynthetic-arrow.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/simple-schema-with-retrosynthetic-arrow.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
 
     await openFileAndAddToCanvasAsNewProject(
       'CDXML/simple-schema-with-retrosynthetic-arrow.cdxml',
@@ -388,20 +325,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/schema-with-retrosynthetic-angel-arrows-and-plus.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/schema-with-retrosynthetic-angel-arrows-and-plus.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/schema-with-retrosynthetic-angel-arrows-and-plus.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
 
     await openFileAndAddToCanvasAsNewProject(
       'CDXML/schema-with-retrosynthetic-angel-arrows-and-plus.cdxml',
@@ -422,20 +351,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'KET/schema-with-two-retrosynthetic-arrows.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/schema-with-two-retrosynthetic-arrows.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
-
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/schema-with-two-retrosynthetic-arrows.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
 
     await openFileAndAddToCanvasAsNewProject(
       'CDXML/schema-with-two-retrosynthetic-arrows.cdxml',
@@ -459,20 +380,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
         'KET/schema-with-reverse-retrosynthetic-arrow-and-pluses.ket',
         page,
       );
-      const expectedFile = await getCdxml(page);
-      await saveToFile(
+
+      await verifyFileExport(
+        page,
         'CDXML/schema-with-reverse-retrosynthetic-arrow-and-pluses.cdxml',
-        expectedFile,
+        FileType.CDXML,
       );
-
-      const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/CDXML/schema-with-reverse-retrosynthetic-arrow-and-pluses.cdxml',
-        });
-
-      expect(cdxmlFile).toEqual(cdxmlFileExpected);
 
       await openFileAndAddToCanvasAsNewProject(
         'CDXML/schema-with-reverse-retrosynthetic-arrow-and-pluses.cdxml',
@@ -497,20 +410,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
         'KET/schema-with-vertical-retrosynthetic-arrow.ket',
         page,
       );
-      const expectedFile = await getCdxml(page);
-      await saveToFile(
+
+      await verifyFileExport(
+        page,
         'CDXML/schema-with-vertical-retrosynthetic-arrow.cdxml',
-        expectedFile,
+        FileType.CDXML,
       );
-
-      const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/CDXML/schema-with-vertical-retrosynthetic-arrow.cdxml',
-        });
-
-      expect(cdxmlFile).toEqual(cdxmlFileExpected);
 
       await openFileAndAddToCanvasAsNewProject(
         'CDXML/schema-with-vertical-retrosynthetic-arrow.cdxml',
@@ -535,20 +440,12 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
         'KET/schema-with-diagonal-retrosynthetic-arrow.ket',
         page,
       );
-      const expectedFile = await getCdxml(page);
-      await saveToFile(
+
+      await verifyFileExport(
+        page,
         'CDXML/schema-with-diagonal-retrosynthetic-arrow.cdxml',
-        expectedFile,
+        FileType.CDXML,
       );
-
-      const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/CDXML/schema-with-diagonal-retrosynthetic-arrow.cdxml',
-        });
-
-      expect(cdxmlFile).toEqual(cdxmlFileExpected);
 
       await openFileAndAddToCanvasAsNewProject(
         'CDXML/schema-with-diagonal-retrosynthetic-arrow.cdxml',
@@ -574,20 +471,13 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
     await pressButton(page, 'Apply');
     await selectLayoutTool(page);
     await takeEditorScreenshot(page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/layout-with-catalyst-pt-bond-lengh.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/layout-with-catalyst-pt-bond-lengh.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'CDXML/layout-with-catalyst-pt-bond-lengh.cdxml',
       page,
@@ -611,20 +501,13 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
     await pressButton(page, 'OK');
     await selectLayoutTool(page);
     await takeEditorScreenshot(page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/layout-with-catalyst-px-margin-size.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/layout-with-catalyst-px-margin-size.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'CDXML/layout-with-catalyst-px-margin-size.cdxml',
       page,
@@ -648,20 +531,13 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
     await pressButton(page, 'OK');
     await selectLayoutTool(page);
     await takeEditorScreenshot(page);
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/layout-with-dif-elements-acs-style.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/layout-with-dif-elements-acs-style.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'CDXML/layout-with-dif-elements-acs-style.cdxml',
       page,

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -52,7 +52,6 @@ import {
   openFileAndAddToCanvasAsNewProject,
   getSdf,
   openFile,
-  getCdxml,
   getCml,
   clickOnFileFormatDropdown,
   takeTopToolbarScreenshot,
@@ -1758,20 +1757,13 @@ test.describe('Macro-Micro-Switcher', () => {
       'KET/one-attachment-point-added-in-micro-mode.ket',
       page,
     );
-    const expectedFile = await getCdxml(page);
-    await saveToFile(
+
+    await verifyFileExport(
+      page,
       'CDXML/one-attachment-point-added-in-micro-mode-expected.cdxml',
-      expectedFile,
+      FileType.CDXML,
     );
 
-    const { fileExpected: cdxmlFileExpected, file: cdxmlFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/CDXML/one-attachment-point-added-in-micro-mode-expected.cdxml',
-      });
-
-    expect(cdxmlFile).toEqual(cdxmlFileExpected);
     await openCdxmlFile(page);
     await takeEditorScreenshot(page);
   });


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request