### PR TITLE
#3627 - Ketcher requires unsafe-eval in order to run, which contradicts content security policy best practises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ yarn-error.log*
 nohup.out
 ketcher-autotests/results.json
 
+# ajv validation file generated with npm run ajv
+/packages/ketcher-core/src/domain/serializers/ket/compiledSchema.js
+
 .pnp.*
 .yarn/*
 tests/test-data/KET/Nucleotide-Templates/01 - (R1) - Left only.ket

--- a/package-lock.json
+++ b/package-lock.json
@@ -8305,6 +8305,33 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ajv": "dist/index.js"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -14028,6 +14055,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -19124,6 +19171,16 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -32028,7 +32085,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
-        "ajv": "^8.10.0",
         "assert": "^2.0.0",
         "d3": "^7.8.5",
         "file-saver": "^2.0.5",
@@ -32052,6 +32108,7 @@
         "@types/jest": "^27.0.3",
         "@types/node": "^16.11.12",
         "@zerollup/ts-transform-paths": "^1.7.18",
+        "ajv-cli": "^5.0.0",
         "babel-jest": "26.6.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.44.0",

--- a/packages/ketcher-core/.eslintignore
+++ b/packages/ketcher-core/.eslintignore
@@ -1,3 +1,6 @@
 dist/
 docs/
 node_modules/
+
+# ajv validation file generated with npm run ajv
+src/domain/serializers/ket/compiledSchema.js

--- a/packages/ketcher-core/.prettierignore
+++ b/packages/ketcher-core/.prettierignore
@@ -1,3 +1,5 @@
 dist/
 docs/
 node_modules/
+
+src/domain/serializers/ket/compiledSchema.js

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -32,6 +32,7 @@
     "ajv": "ajv compile -s src/domain/serializers/ket/schema.json -o src/domain/serializers/ket/compiledSchema.js",
     "prebuild": "npm run ajv",
     "build": "cross-env NODE_ENV=production rollup -c -m true",
+    "prestart": "npm run ajv",
     "start": "cross-env NODE_ENV=development rollup -c -m true -w",
     "test": "run-s test:prettier test:eslint:quiet test:types test:unit",
     "test:eslint": "eslint . --ext .ts,.js",

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -29,6 +29,8 @@
     "node": ">=14"
   },
   "scripts": {
+    "ajv": "ajv compile -s src/domain/serializers/ket/schema.json -o src/domain/serializers/ket/compiledSchema.js",
+    "prebuild": "npm run ajv",
     "build": "cross-env NODE_ENV=production rollup -c -m true",
     "start": "cross-env NODE_ENV=development rollup -c -m true -w",
     "test": "run-s test:prettier test:eslint:quiet test:types test:unit",
@@ -44,7 +46,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "ajv": "^8.10.0",
     "assert": "^2.0.0",
     "d3": "^7.8.5",
     "file-saver": "^2.0.5",
@@ -68,6 +69,7 @@
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.12",
     "@zerollup/ts-transform-paths": "^1.7.18",
+    "ajv-cli": "^5.0.0",
     "babel-jest": "26.6.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.44.0",

--- a/packages/ketcher-core/src/domain/serializers/ket/validate.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/validate.ts
@@ -14,13 +14,10 @@
  * limitations under the License.
  ***************************************************************************/
 
-import Ajv from 'ajv';
-import schema from './schema.json';
+import compiledSchema from './compiledSchema';
 import { validateMultitailArrows } from './multitailArrowsValidator';
 
 export function validate(ket: any): boolean {
-  const ajv = new Ajv();
-  const validate = ajv.compile(schema);
-  const result = validate(ket);
+  const result = compiledSchema(ket);
   return result ? validateMultitailArrows(ket) : result;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Fix the issue mentioned in:
- #3627
- #853

Supersedes:
- #4749
Referring to [rrodionov91's comment](https://github.com/epam/ketcher/pull/4749#issuecomment-2149694336) , it was preferred to provide a solution using ajv, to avoid switching to jsonschema.

This PR uses ajv-cli to pre-compile the validation schema and allow ketcher to run under restrictive CSP header.
Ajv is removed from ketcher-core dependencies as not used anymore, replaced by ajv-cli only.
Ajv persists in ketcher-react as it is used and doesn't need pre-compilation.

This change has been successfully used in production without any issues. Please consider merging this change so all projects with restrictive Content Security Policies can also benefit from this excellent piece of software. =)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request