### PR TITLE
#5696-Adding Attachment point to microstructure already connected to monomer - causes problems

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
@@ -171,7 +171,6 @@ const AtomMenuItems: FC<MenuItemsProps<AtomContextMenuProps>> = (props) => {
             attachmentPoint.attachmentPointNumber,
       ),
   );
-
   const highlightAtomWithColor = (color: string) => {
     const atomIds = props.propsFromTrigger?.atomIds || [];
     editor.highlights.create({
@@ -181,6 +180,22 @@ const AtomMenuItems: FC<MenuItemsProps<AtomContextMenuProps>> = (props) => {
       color: color === '' ? 'transparent' : color,
     });
   };
+
+  const isAddAttachmentPointDisabled =
+    !onlyOneAtomSelected ||
+    (() => {
+      if (!isNumber(selectedAtomId)) return true;
+
+      const connectedComponents = struct.findConnectedComponent(selectedAtomId);
+      for (const connectedAtomId of connectedComponents) {
+        const connectedGroup = struct.getGroupFromAtomId(connectedAtomId);
+        if (connectedGroup?.isMonomer) {
+          return true;
+        }
+      }
+
+      return false;
+    })();
 
   if (isAtomSuperatomLeavingGroup && onlyOneAtomSelected) {
     return (
@@ -231,7 +246,11 @@ const AtomMenuItems: FC<MenuItemsProps<AtomContextMenuProps>> = (props) => {
         !atomInSgroupWithLabel &&
         !maxAttachmentPointsAmount &&
         !isAtomSuperatomLeavingGroup && (
-          <Item {...props} onClick={handleAddAttachmentPoint}>
+          <Item
+            {...props}
+            onClick={handleAddAttachmentPoint}
+            disabled={isAddAttachmentPointDisabled}
+          >
             Add attachment point
           </Item>
         )}


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/5696

- **Description of Changes**
Added logic to prevent adding attachment points to a molecule if it is already connected to a monomer.
This decision was made based on a discussion with @rrodionov91 , where it was concluded that this implementation aligns better with the current functionality.

- **Done**
Implemented a check for monomer connections when adding attachment points.
Disabled the "Add Attachment Point" button if a molecule is connected to a monomer.


https://github.com/user-attachments/assets/1acc41ad-b308-4b8c-b4a8-72179e141f0e



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request