### PR TITLE
Autotests: #6346 - autotests replace file comparison for mol files only operations with valid helper functions verifyfileexport

### DIFF
--- a/ketcher-autotests/tests/API/api-set-get-molecule.spec.ts
+++ b/ketcher-autotests/tests/API/api-set-get-molecule.spec.ts
@@ -20,6 +20,10 @@ import {
 } from '@utils';
 import { getAtomByIndex } from '@utils/canvas/atoms';
 import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
+import {
   addFragment,
   disableQueryElements,
   enableDearomatizeOnLoad,
@@ -202,21 +206,14 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       async () => await setMolecule(page, orEnantiomer),
     );
 
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/test-data-for-enatiomer.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
 
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/test-data-for-enatiomer.mol',
-        metaDataIndexes: [ignoredLineIndigo],
-        fileFormat: 'v3000',
-      });
-    expect(molFile).toEqual(molFileExpected);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/API/api-set-get-molecule.spec.ts
+++ b/ketcher-autotests/tests/API/api-set-get-molecule.spec.ts
@@ -197,7 +197,6 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
     Test case: EPMLSOPKET- 10095
     Description:  Molecule set and get using V3000 format
     */
-    const ignoredLineIndigo = 1;
     const orEnantiomer = await readFileContents(
       'tests/test-data/Molfiles-V3000/or-enantiomer.mol',
     );

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files.spec.ts
@@ -16,6 +16,10 @@ import {
   selectAllStructuresOnCanvas,
   selectLayoutTool,
 } from '@utils';
+import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
 import { getMolfile } from '@utils/formats';
 
 test('Open and Save files - Open/Save structure with atom properties 1/2 - open', async ({
@@ -91,24 +95,13 @@ test('Open and Save file - Open/Save V3000 file with atom and bond properties 2/
     'Molfiles-V3000/marvin-atom-properties-V3000.mol',
     page,
   );
-  const expectedFile = await getMolfile(page, 'v3000');
-  await saveToFile(
+  await verifyFileExport(
+    page,
     'Molfiles-V3000/atom-properties-V3000-expected.mol',
-    expectedFile,
+    FileType.MOL,
+    'v3000',
+    [1],
   );
-
-  const METADATA_STRING_INDEX = [1];
-
-  const { fileExpected: molFileExpected, file: molFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/Molfiles-V3000/atom-properties-V3000-expected.mol',
-      fileFormat: 'v3000',
-      metaDataIndexes: METADATA_STRING_INDEX,
-    });
-
-  expect(molFile).toEqual(molFileExpected);
 });
 
 test('Open and Save file - Open/Save Markush files 1/2 - open', async ({
@@ -216,23 +209,13 @@ test('Open and Save file - Open/Save V3000 *.mol file contains abbreviation 2/2 
   await waitForPageInit(page);
 
   await openFileAndAddToCanvas('Molfiles-V3000/sec-butyl-abr-V3000.mol', page);
-  const expectedFile = await getMolfile(page, 'v3000');
-  await saveToFile(
+  await verifyFileExport(
+    page,
     'Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
-    expectedFile,
+    FileType.MOL,
+    'v3000',
+    [1],
   );
-  const METADATA_STRING_INDEX = [1];
-
-  const { fileExpected: molFileExpected, file: molFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
-      fileFormat: 'v3000',
-      metaDataIndexes: METADATA_STRING_INDEX,
-    });
-
-  expect(molFile).toEqual(molFileExpected);
 });
 
 test('Open and Save file - Open/Save file with R-Groups 1/2 - open', async ({
@@ -344,23 +327,13 @@ test('Open and Save file - Open/Save V3000 mol file contains attached data 2/2 -
   await waitForPageInit(page);
 
   await openFileAndAddToCanvas('Molfiles-V3000/attached-data-V3000.mol', page);
-  const expectedFile = await getMolfile(page, 'v3000');
-  await saveToFile(
+  await verifyFileExport(
+    page,
     'Molfiles-V3000/attached-data-V3000-expected.mol',
-    expectedFile,
+    FileType.MOL,
+    'v3000',
+    [1],
   );
-  const METADATA_STRING_INDEX = [1];
-
-  const { fileExpected: molFileExpected, file: molFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/Molfiles-V3000/attached-data-V3000-expected.mol',
-      fileFormat: 'v3000',
-      metaDataIndexes: METADATA_STRING_INDEX,
-    });
-
-  expect(molFile).toEqual(molFileExpected);
 });
 
 test('Open and Save file - V3000 *.mol file contains Heteroatoms 1/2 - open', async ({
@@ -387,23 +360,13 @@ test('Open and Save file - V3000 *.mol file contains Heteroatoms 2/2 - save', as
   await waitForPageInit(page);
 
   await openFileAndAddToCanvas('Molfiles-V3000/heteroatoms-V3000.mol', page);
-  const expectedFile = await getMolfile(page, 'v3000');
-  await saveToFile(
+  await verifyFileExport(
+    page,
     'Molfiles-V3000/heteroatoms-V3000-expected.mol',
-    expectedFile,
+    FileType.MOL,
+    'v3000',
+    [1],
   );
-  const METADATA_STRING_INDEX = [1];
-
-  const { fileExpected: molFileExpected, file: molFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/Molfiles-V3000/heteroatoms-V3000-expected.mol',
-      fileFormat: 'v3000',
-      metaDataIndexes: METADATA_STRING_INDEX,
-    });
-
-  expect(molFile).toEqual(molFileExpected);
 });
 
 test('Open and Save file - Open/Save file with Attached data 1/2 - open', async ({
@@ -509,19 +472,13 @@ test('Open and Save file - Open/Save V3000 mol file contains abs stereochemistry
   await waitForPageInit(page);
 
   await openFileAndAddToCanvas('Molfiles-V3000/V3000-abs.mol', page);
-  const expectedFile = await getMolfile(page, 'v3000');
-  await saveToFile('Molfiles-V3000/V3000-abs-expected.mol', expectedFile);
-  const METADATA_STRING_INDEX = [1];
-
-  const { fileExpected: molFileExpected, file: molFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName: 'tests/test-data/Molfiles-V3000/V3000-abs-expected.mol',
-      fileFormat: 'v3000',
-      metaDataIndexes: METADATA_STRING_INDEX,
-    });
-
-  expect(molFile).toEqual(molFileExpected);
+  await verifyFileExport(
+    page,
+    'Molfiles-V3000/V3000-abs-expected.mol',
+    FileType.MOL,
+    'v3000',
+    [1],
+  );
 });
 
 test('Open and Save file - Save V2000 molfile as V3000 molfile', async ({
@@ -534,20 +491,13 @@ test('Open and Save file - Save V2000 molfile as V3000 molfile', async ({
   await waitForPageInit(page);
 
   await openFileAndAddToCanvas('Molfiles-V2000/spiro2.mol', page);
-  const expectedFile = await getMolfile(page, 'v3000');
-  await saveToFile('Molfiles-V3000/spiro-expected.mol', expectedFile);
-
-  const METADATA_STRINGS_INDEXES = [1, 3];
-
-  const { fileExpected: molFileExpected, file: molFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName: 'tests/test-data/Molfiles-V3000/spiro-expected.mol',
-      metaDataIndexes: METADATA_STRINGS_INDEXES,
-      fileFormat: 'v3000',
-    });
-
-  expect(molFile).toEqual(molFileExpected);
+  await verifyFileExport(
+    page,
+    'Molfiles-V3000/spiro-expected.mol',
+    FileType.MOL,
+    'v3000',
+    [1, 3],
+  );
 });
 
 test('Open and Save file - Save V3000 molfile as V2000 molfile', async ({
@@ -758,23 +708,13 @@ test.describe('Open and Save file', () => {
         'Molfiles-V3000/more-900-atoms.mol',
         page,
       );
-      const expectedFile = await getMolfile(page, 'v3000');
-      await saveToFile(
+      await verifyFileExport(
+        page,
         'Molfiles-V3000/more-900-atoms-expected.mol',
-        expectedFile,
+        FileType.MOL,
+        'v3000',
+        [1],
       );
-      const METADATA_STRING_INDEX = [1];
-
-      const { fileExpected: molFileExpected, file: molFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/Molfiles-V3000/more-900-atoms-expected.mol',
-          fileFormat: 'v3000',
-          metaDataIndexes: METADATA_STRING_INDEX,
-        });
-
-      expect(molFile).toEqual(molFileExpected);
     },
   );
 
@@ -936,24 +876,13 @@ test.describe('Open and Save file', () => {
     await setBondLengthValue(page, '1.8');
     await pressButton(page, 'Apply');
     await takeEditorScreenshot(page);
-
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/adenosine-triphosphate-cm-bond-lengh.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRING_INDEX = [1];
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/adenosine-triphosphate-cm-bond-lengh.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/adenosine-triphosphate-cm-bond-lengh.mol',
       page,
@@ -1016,24 +945,13 @@ test.describe('Open and Save file', () => {
     await pressButton(page, 'OK');
     await selectLayoutTool(page);
     await takeEditorScreenshot(page);
-
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/adenosine-triphosphate-acs-style.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRING_INDEX = [1];
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/adenosine-triphosphate-acs-style.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/adenosine-triphosphate-acs-style.mol',
       page,

--- a/ketcher-autotests/tests/Indigo-Tools/Aromatize-Dearomatize/aromatize-dearomatize.spec.ts
+++ b/ketcher-autotests/tests/Indigo-Tools/Aromatize-Dearomatize/aromatize-dearomatize.spec.ts
@@ -19,6 +19,10 @@ import {
   takeEditorScreenshot,
   waitForPageInit,
 } from '@utils';
+import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
 import { getCml, getMolfile, getRxn, getSmiles } from '@utils/formats';
 import {
   pressRedoButton,
@@ -230,24 +234,13 @@ test.describe('Aromatize/Dearomatize Tool', () => {
       'Molfiles-V3000/aromatic-benzene-v3000.mol',
       page,
     );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRING_INDEX = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
-        metaDataIndexes: METADATA_STRING_INDEX,
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Indigo-Tools/Calculate-CIP-Tool/calculate-cip-tool.spec.ts
+++ b/ketcher-autotests/tests/Indigo-Tools/Calculate-CIP-Tool/calculate-cip-tool.spec.ts
@@ -545,22 +545,13 @@ test.describe('Indigo Tools - Calculate CIP Tool', () => {
       'Molfiles-V2000/structure-with-stereo-bonds.mol',
       page,
     );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/structure-with-stereo-bonds-expectedV3000.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-    const METADATA_STRING_INDEX = [1];
-    const { file: molFile, fileExpected: molFileExpected } =
-      await receiveFileComparisonData({
-        page,
-        metaDataIndexes: METADATA_STRING_INDEX,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/structure-with-stereo-bonds-expectedV3000.mol',
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
   });
 
   test('Save as .smi file structure with stereo labels', async ({ page }) => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
@@ -3,12 +3,9 @@ import { test, expect } from '@playwright/test';
 import {
   addSingleMonomerToCanvas,
   clickInTheMiddleOfTheScreen,
-  getMolfile,
   moveMouseAway,
   openFileAndAddToCanvasAsNewProject,
   openFileAndAddToCanvasMacro,
-  receiveFileComparisonData,
-  saveToFile,
   selectEraseTool,
   selectPartOfMolecules,
   selectSnakeLayoutModeTool,

--- a/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
@@ -399,23 +399,13 @@ test.describe('Erase Tool', () => {
     await selectEraseTool(page);
     await page.getByText('Bal').locator('..').first().click();
     await page.getByText('D-2Nal').locator('..').first().click();
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/peptides-flex-chain-expected.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-    const METADATA_STRING_INDEX = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/peptides-flex-chain-expected.mol',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await openFileAndAddToCanvasMacro(
       'Molfiles-V3000/peptides-flex-chain-expected.mol',
       page,

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
@@ -9,7 +9,7 @@ import {
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
 } from '@utils/macromolecules';
-import { test, expect, Page } from '@playwright/test';
+import { test, Page } from '@playwright/test';
 import {
   openFileAndAddToCanvas,
   openFileAndAddToCanvasMacro,
@@ -17,9 +17,6 @@ import {
   takeMonomerLibraryScreenshot,
   waitForPageInit,
   selectSnakeLayoutModeTool,
-  saveToFile,
-  receiveFileComparisonData,
-  getMolfile,
   selectLeftPanelButton,
   LeftPanelButton,
   openFileAndAddToCanvasAsNewProject,

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
@@ -208,24 +208,13 @@ test.describe('Macro-Micro-Switcher2', () => {
       'KET/chem-connected-to-micro-structure.ket',
       page,
     );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/chem-connected-to-micro-structure-expected.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRINGS_INDEXES = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/chem-connected-to-micro-structure-expected.mol',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
   });
 
   test('Check that attachment points and leaving groups are correctly represented in Mol V3000 format', async ({
@@ -239,24 +228,13 @@ test.describe('Macro-Micro-Switcher2', () => {
       'KET/one-attachment-point-added-in-micro-mode.ket',
       page,
     );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRINGS_INDEXES = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
       page,
@@ -293,24 +271,13 @@ test.describe('Macro-Micro-Switcher2', () => {
       Description: It is possible to save micro-macro connection to mol v3000 file.
       */
     await openFileAndAddToCanvas('KET/micro-macro-structure.ket', page);
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/micro-macro-structure-expected.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRINGS_INDEXES = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/micro-macro-structure-expected.mol',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/micro-macro-structure-expected.mol',
       page,

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Attachment-Point-Tool/attachment-point-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Attachment-Point-Tool/attachment-point-tool.spec.ts
@@ -37,6 +37,10 @@ import {
 import { getAtomByIndex } from '@utils/canvas/atoms';
 import { getRotationHandleCoordinates } from '@utils/clicks/selectButtonByTitle';
 import { getMolfile, getRxn, getSmiles } from '@utils/formats';
+import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
 
 const CANVAS_CLICK_X = 300;
 const CANVAS_CLICK_Y = 300;
@@ -443,21 +447,13 @@ test.describe('Attachment Point Tool', () => {
      * Description: Structure with attachment points saved as .mol file V3000
      */
     await openFileAndAddToCanvas('KET/chain-with-attachment-points.ket', page);
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/chain-with-attachment-points-expectedV3000.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-    const METADATA_STRING_INDEX = [1];
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        metaDataIndexes: METADATA_STRING_INDEX,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/chain-with-attachment-points-expectedV3000.mol',
-        fileFormat: 'v3000',
-      });
-    expect(molFile).toEqual(molFileExpected);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-fragment-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-fragment-tool.spec.ts
@@ -26,6 +26,10 @@ import {
   selectClearCanvasTool,
   selectLayoutTool,
 } from '@utils';
+import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
 import { getExtendedSmiles, getMolfile } from '@utils/formats';
 import { pressUndoButton } from '@utils/macromolecules/topToolBar';
 
@@ -361,22 +365,13 @@ test.describe('R-Group Fragment Tool', () => {
       'Molfiles-V3000/r1-several-structures-V3000.mol',
       page,
     );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/r1-several-structures-V3000-expected.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-
-    const METADATA_STRING_INDEX = [1];
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        metaDataIndexes: METADATA_STRING_INDEX,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/r1-several-structures-V3000-expected.mol',
-        fileFormat: 'v3000',
-      });
-    expect(molFile).toEqual(molFileExpected);
   });
 
   test('Save as *.cxsmi file', async ({ page }) => {

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-tool.spec.ts
@@ -11,6 +11,10 @@ import {
   takeLeftToolbarScreenshot,
   waitForPageInit,
 } from '@utils';
+import {
+  FileType,
+  verifyFileExport,
+} from '@utils/files/receiveFileComparisonData';
 import { getMolfile } from '@utils/formats';
 
 test.describe('R-Group', () => {
@@ -108,22 +112,13 @@ test.describe('R-Group', () => {
       'Molfiles-V2000/r-group-with-allkind-attachment-points.mol',
       page,
     );
-    const expectedFile = await getMolfile(page, 'v3000');
-    await saveToFile(
+    await verifyFileExport(
+      page,
       'Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
-      expectedFile,
+      FileType.MOL,
+      'v3000',
+      [1],
     );
-    const METADATA_STRING_INDEX = [1];
-    const { file: molFile, fileExpected: molFileExpected } =
-      await receiveFileComparisonData({
-        page,
-        metaDataIndexes: METADATA_STRING_INDEX,
-        expectedFileName:
-          'tests/test-data/Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
     await takeEditorScreenshot(page);
   });
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request