### PR TITLE
Backmerge: #6370 - Inconsistent zoom behavior when inserting a molecule via setMolecule and Paste from Clipboard/Open from File 

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -371,8 +371,9 @@ export class Ketcher {
   }
 
   async setMolecule(structStr: string): Promise<void | undefined> {
-    if (CoreEditor.provideEditorInstance()?.isSequenceEditInRNABuilderMode)
-      return;
+    const macromoleculesEditor = CoreEditor.provideEditorInstance();
+
+    if (macromoleculesEditor?.isSequenceEditInRNABuilderMode) return;
 
     runAsyncAction<void>(async () => {
       assert(typeof structStr === 'string');
@@ -380,6 +381,7 @@ export class Ketcher {
       if (window.isPolymerEditorTurnedOn) {
         deleteAllEntitiesOnCanvas();
         await parseAndAddMacromoleculesOnCanvas(structStr, this.structService);
+        macromoleculesEditor?.zoomToStructuresIfNeeded();
       } else {
         const struct: Struct = await prepareStructToRender(
           structStr,
@@ -411,14 +413,22 @@ export class Ketcher {
   }
 
   async addFragment(structStr: string): Promise<void | undefined> {
-    if (CoreEditor.provideEditorInstance()?.isSequenceEditInRNABuilderMode)
-      return;
+    const macromoleculesEditor = CoreEditor.provideEditorInstance();
+
+    if (macromoleculesEditor?.isSequenceEditInRNABuilderMode) return;
 
     runAsyncAction<void>(async () => {
       assert(typeof structStr === 'string');
 
       if (window.isPolymerEditorTurnedOn) {
+        const isCanvasEmptyBeforeOpenStructure =
+          !macromoleculesEditor.drawingEntitiesManager.hasDrawingEntities;
+
         await parseAndAddMacromoleculesOnCanvas(structStr, this.structService);
+
+        if (isCanvasEmptyBeforeOpenStructure) {
+          macromoleculesEditor?.zoomToStructuresIfNeeded();
+        }
       } else {
         const struct: Struct = await prepareStructToRender(
           structStr,

--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -1,4 +1,4 @@
-import { lazy, StrictMode, Suspense, useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { MicromoleculesEditor, EditorProps } from './MicromoleculesEditor';
 import { ModeControl } from './script/ui/views/toolbars/ModeControl';
 import { LoadingCircles } from './script/ui/views/components';
@@ -36,7 +36,7 @@ export const Editor = (props: Props) => {
   ) : undefined;
 
   return (
-    <StrictMode>
+    <>
       {showPolymerEditor ? (
         <Suspense
           fallback={
@@ -61,6 +61,6 @@ export const Editor = (props: Props) => {
           />
         </Suspense>
       )}
-    </StrictMode>
+    </>
   );
 };


### PR DESCRIPTION
#6370 - Inconsistent zoom behavior when inserting a molecule via setMolecule and Paste from Clipboard/Open from File
- added autozoom for setMolecule and addFragment in macro mode

#6375 - Ketcher renders editor twice in dev mode
- removed react strict mode from editor

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request