### PR TITLE
#6306 - Autotests: Implement "single responsibility" approach for takeElementScreenshot function

### DIFF
--- a/ketcher-autotests/tests/API/view-only-mode.spec.ts
+++ b/ketcher-autotests/tests/API/view-only-mode.spec.ts
@@ -25,9 +25,9 @@ import {
   selectAllStructuresOnCanvas,
   pasteFromClipboardByKeyboard,
   clickOnCanvas,
-  waitForAllStructuresSelected,
 } from '@utils';
 import { closeErrorAndInfoModals } from '@utils/common/helpers';
+import { waitForOpenButtonEnabled } from '@utils/common/loaders/waitForElementState';
 import {
   FileType,
   verifyFileExport,
@@ -321,7 +321,9 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
         await clickInTheMiddleOfTheScreen(page);
         await enableViewOnlyModeBySetOptions(page);
         await selectAllStructuresOnCanvas(page);
-        await waitForAllStructuresSelected(page);
+        // Waiting for all selected elements to lose `display: none` is insufficient
+        // because the "Copy" button becomes enabled last as an indicator of completion.
+        await waitForOpenButtonEnabled(page);
         await waitForSpinnerFinishedWork(
           page,
           async () => await page.keyboard.press(hotkey.keys),

--- a/ketcher-autotests/tests/API/view-only-mode.spec.ts
+++ b/ketcher-autotests/tests/API/view-only-mode.spec.ts
@@ -25,6 +25,7 @@ import {
   selectAllStructuresOnCanvas,
   pasteFromClipboardByKeyboard,
   clickOnCanvas,
+  waitForAllStructuresSelected,
 } from '@utils';
 import { closeErrorAndInfoModals } from '@utils/common/helpers';
 import {
@@ -320,6 +321,7 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
         await clickInTheMiddleOfTheScreen(page);
         await enableViewOnlyModeBySetOptions(page);
         await selectAllStructuresOnCanvas(page);
+        await waitForAllStructuresSelected(page);
         await waitForSpinnerFinishedWork(
           page,
           async () => await page.keyboard.press(hotkey.keys),

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Image-files/image-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Image-files/image-files.spec.ts
@@ -49,6 +49,7 @@ import {
   waitForSpinnerFinishedWork,
 } from '@utils';
 import {
+  clearLocalStorage,
   closeErrorAndInfoModals,
   pageReloadMicro,
 } from '@utils/common/helpers';
@@ -882,7 +883,9 @@ test.describe('Image files', () => {
      * Description: Image is selected then green selection frame is displayed and
      * image can be scaled vertically, horizontally and diagonally.
      */
+    await clearLocalStorage(page);
     await pageReloadMicro(page);
+
     await openImageAndAddToCanvas('Images/image-png.png', page);
     await selectLeftPanelButton(LeftPanelButton.RectangleSelection, page);
     await clickInTheMiddleOfTheScreen(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Antisense-Chains/antisense-chains.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Antisense-Chains/antisense-chains.spec.ts
@@ -3074,6 +3074,9 @@ test(`18. Flipping checks`, async () => {
    */
   test.setTimeout(20000);
 
+  await pageReload(page);
+  await selectSnakeLayoutModeTool(page);
+
   await pasteFromClipboardAndAddToMacromoleculesCanvas(
     page,
     MacroFileType.HELM,

--- a/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/sequence-mode-copy-paste.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/sequence-mode-copy-paste.spec.ts
@@ -22,6 +22,7 @@ import {
 import {
   enterSequence,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import {
   clickOnSequenceSymbol,
@@ -61,6 +62,7 @@ test.describe('Sequence mode copy&paste for view mode', () => {
     await page.keyboard.down('Control');
     await getSequenceSymbolLocator(page, 'G').click();
     await page.keyboard.up('Control');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
     await copyToClipboardByKeyboard(page);
     await pasteFromClipboardByKeyboard(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
@@ -24,6 +24,7 @@ import {
 import { closeErrorMessage, pageReload } from '@utils/common/helpers';
 import {
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
   zoomWithMouseWheel,
 } from '@utils/macromolecules';
 import { clickOnSequenceSymbol } from '@utils/macromolecules/sequence';
@@ -312,6 +313,7 @@ test.describe('Import-Saving .fasta Files', () => {
     await pressButton(page, 'Add to Canvas');
     await selectSequenceLayoutModeTool(page);
     await clickOnSequenceSymbol(page, 'U');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
@@ -267,6 +267,8 @@ test.describe('Import-Saving .fasta Files', () => {
     page,
   }) => {
     test.slow();
+
+    await pageReload(page);
     await selectTopPanelButton(TopPanelButton.Open, page);
 
     const filename = 'FASTA/fasta-rna-musculus-rearranged.fasta';

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
@@ -59,6 +59,7 @@ import {
   Tabs,
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
+  waitForMonomerPreview,
   zoomWithMouseWheel,
 } from '@utils/macromolecules';
 import { goToPeptidesTab } from '@utils/macromolecules/library';
@@ -784,9 +785,11 @@ test.describe('Import-Saving .idt Files', () => {
       `/52MOErA/*/i2MOErC/*/i2MOErG/*/i2MOErC/*/i2MOErG/*/iMe-dC/*G*A*/iMe-dC/*T*A*T*A*/iMe-dC/*G*/i2MOErC/*/i2MOErG/*/i2MOErC/*/i2MOErC/*/32MOErT/`,
     );
     await page.getByText('iMe').locator('..').nth(1).hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
     await selectSequenceLayoutModeTool(page);
     await page.getByText('?').locator('..').nth(1).hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -801,6 +804,7 @@ test.describe('Import-Saving .idt Files', () => {
     );
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('iMe').locator('..').nth(1).hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -826,6 +830,7 @@ test.describe('Import-Saving .idt Files', () => {
     );
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('iMe').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -852,6 +857,7 @@ test.describe('Import-Saving .idt Files', () => {
     );
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('iMe').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
@@ -578,6 +578,7 @@ test.describe('Import-Saving .idt Files', () => {
     const bondLine = page.locator('g[pointer-events="stroke"]').first();
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await bondLine.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
@@ -377,6 +377,8 @@ test.describe('Import-Saving .idt Files', () => {
     */
       markResetToDefaultState('defaultLayout');
 
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(`IDT/${fileName}.idt`, page);
       await takeEditorScreenshot(page);
 
@@ -405,6 +407,8 @@ test.describe('Import-Saving .idt Files', () => {
     Description: Structure is opening
     */
       markResetToDefaultState('defaultLayout');
+
+      await pageReload(page);
 
       await pasteFromClipboardAndAddToMacromoleculesCanvas(
         'IDT',

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
@@ -30,6 +30,7 @@ import {
 } from '@utils/files/receiveFileComparisonData';
 import {
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
   zoomWithMouseWheel,
 } from '@utils/macromolecules';
 import {
@@ -138,6 +139,7 @@ test.describe('Import-Saving .ket Files', () => {
     await selectClearCanvasTool(page);
     await openFileAndAddToCanvasMacro('KET/monomer-expected.ket', page);
     await page.getByText('Bal').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -360,6 +362,7 @@ test.describe('Base monomers on the canvas, their connection points and preview 
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('R1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       await verifyFileExport(
@@ -407,6 +410,7 @@ test.describe('CHEM monomers on the canvas, their connection points and preview 
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       await verifyFileExport(
@@ -454,6 +458,7 @@ test.describe('Peptide monomers on the canvas, their connection points and previ
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       await verifyFileExport(
@@ -501,6 +506,7 @@ test.describe('Phosphate monomers on the canvas, their connection points and pre
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       await verifyFileExport(
@@ -548,6 +554,7 @@ test.describe('Sugar monomers on the canvas, their connection points and preview
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       await verifyFileExport(

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
@@ -827,6 +827,7 @@ test(`Verify that the structure in macro mode can be saved as a .ket file, and a
    *       6. Take screenshot to witness saved state
    *        (screenshots have to be equal)
    */
+  await pageReload(page);
 
   const KETFile =
     'KET/Micro-Macro-Switcher/Complicated structures on the canvas.ket';

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-mol.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-mol.spec.ts
@@ -31,6 +31,7 @@ import { pageReload } from '@utils/common/helpers';
 import {
   chooseFileFormat,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 
 function removeNotComparableData(file: string) {
@@ -162,6 +163,7 @@ test.describe('Import-Saving .mol Files', () => {
     */
     await openFileAndAddToCanvasMacro('Molfiles-V3000/peptide-bzl.mol', page);
     await page.getByText('K').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
 
     // Closing page since test expects it to have closed at the end
@@ -184,6 +186,7 @@ test.describe('Import-Saving .mol Files', () => {
     );
     await page.getByTestId('select-rectangle').click();
     await page.getByText('cdaC').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -758,6 +761,7 @@ test.describe('Base monomers on the canvas, their connection points and preview 
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('R1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       const expectedFile = await getMolfile(page);
@@ -817,6 +821,7 @@ test.describe('CHEM monomers on the canvas, their connection points and preview 
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       const expectedFile = await getMolfile(page);
@@ -876,6 +881,7 @@ test.describe('Peptide monomers on the canvas, their connection points and previ
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       const expectedFile = await getMolfile(page);
@@ -936,6 +942,7 @@ test.describe('Phosphate monomers on the canvas, their connection points and pre
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       const expectedFile = await getMolfile(page);
@@ -995,6 +1002,7 @@ test.describe('Sugar monomers on the canvas, their connection points and preview
       );
       await page.getByTestId('single-bond').click();
       await page.getByText('(R').locator('..').first().hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
 
       const expectedFile = await getMolfile(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/saving-svg.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/saving-svg.spec.ts
@@ -262,9 +262,11 @@ test.describe('Saving in .svg files', () => {
     {
       filename: 'KET/all-kind-of-monomers.ket',
       description: 'all kind of monomers',
-      pageReloadNeeded: true,
     },
-    { filename: 'KET/all-chems.ket', description: 'all chems' },
+    {
+      filename: 'KET/all-chems.ket',
+      description: 'all chems',
+    },
     {
       filename: 'KET/all-types-of-connection-between-Base-and-RNA.ket',
       description: 'all types of connection between Base and RNA',
@@ -287,9 +289,10 @@ test.describe('Saving in .svg files', () => {
     },
   ];
 
-  for (const { filename, description, pageReloadNeeded } of testData3) {
+  for (const { filename, description } of testData3) {
     test(`Export to SVG: Verify it is possible to export Sequence-DNA mode canvas with ${description} to SVG`, async () => {
-      if (pageReloadNeeded) await pageReload(page);
+      await pageReload(page);
+
       await openFileAndAddToCanvasMacro(filename, page);
       await selectSequenceLayoutModeTool(page);
       await switchSequenceEnteringButtonType(page, SequenceType.DNA);

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -478,7 +478,7 @@ test.describe('Macro-Micro-Switcher', () => {
     Test case: Macro-Micro-Switcher
     Description: Ket-structure pasted from the clipboard in Macro mode is visible in Micro mode
     */
-    await turnOnMacromoleculesEditor(page);
+    await pageReload(page);
     await pasteFromClipboard(
       page,
       FILE_TEST_DATA.oneFunctionalGroupExpandedKet,
@@ -534,7 +534,7 @@ test.describe('Macro-Micro-Switcher', () => {
     Test case: Macro-Micro-Switcher
     Description: Remove abbreviation restricted for CHEMs in micro mode.
     */
-    await turnOnMacromoleculesEditor(page);
+    await pageReload(page);
     await selectMonomer(page, Chem.Test_6_Ch);
     await clickInTheMiddleOfTheScreen(page);
     await turnOnMicromoleculesEditor(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -516,7 +516,8 @@ test.describe('Macro-Micro-Switcher', () => {
       Test case: Macro-Micro-Switcher/3712
       Description: Pressing Layout or Clean Up button not erase all macromolecules from canvas
       */
-      await turnOnMacromoleculesEditor(page);
+      await pageReload(page);
+
       await selectMonomer(page, Peptides.A);
       await clickInTheMiddleOfTheScreen(page);
       await turnOnMicromoleculesEditor(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -86,6 +86,7 @@ import {
   enterSequence,
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { goToRNATab, goToTab } from '@utils/macromolecules/library';
 import { moveMonomerOnMicro } from '@utils/macromolecules/monomer';
@@ -628,6 +629,7 @@ test.describe('Macro-Micro-Switcher', () => {
       );
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     },
   );
@@ -648,6 +650,7 @@ test.describe('Macro-Micro-Switcher', () => {
       );
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     },
   );
@@ -668,6 +671,7 @@ test.describe('Macro-Micro-Switcher', () => {
       );
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F2').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     },
   );
@@ -688,6 +692,7 @@ test.describe('Macro-Micro-Switcher', () => {
       );
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     },
   );
@@ -750,6 +755,7 @@ test.describe('Macro-Micro-Switcher', () => {
       await waitForRender(page, async () => {
         await page.getByText('F1').locator('..').hover();
       });
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     },
   );
@@ -816,6 +822,7 @@ test.describe('Macro-Micro-Switcher', () => {
       await clickOnCanvas(page, coordsToClick.x, coordsToClick.y);
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     },
   );
@@ -904,6 +911,7 @@ test.describe('Macro-Micro-Switcher', () => {
     await turnOnMacromoleculesEditor(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('F1').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -941,6 +949,7 @@ test.describe('Macro-Micro-Switcher', () => {
     await turnOnMacromoleculesEditor(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('F1').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -959,6 +968,7 @@ test.describe('Macro-Micro-Switcher', () => {
     await turnOnMacromoleculesEditor(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('F1').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -1040,6 +1050,7 @@ test.describe('Macro-Micro-Switcher', () => {
       await takeEditorScreenshot(page);
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await dragMouseTo(x1, y1, page);
       await moveMouseAway(page);
       await takeEditorScreenshot(page);
@@ -1065,6 +1076,7 @@ test.describe('Macro-Micro-Switcher', () => {
       await takeEditorScreenshot(page);
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await dragMouseTo(x1, y1, page);
       await moveMouseAway(page);
       await takeEditorScreenshot(page);
@@ -1090,6 +1102,7 @@ test.describe('Macro-Micro-Switcher', () => {
       await takeEditorScreenshot(page);
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await dragMouseTo(x1, y1, page);
       await moveMouseAway(page);
       await takeEditorScreenshot(page);
@@ -1115,6 +1128,7 @@ test.describe('Macro-Micro-Switcher', () => {
       await takeEditorScreenshot(page);
       await turnOnMacromoleculesEditor(page);
       await page.getByText('F1').locator('..').hover();
+      await waitForMonomerPreview(page);
       await dragMouseTo(x1, y1, page);
       await moveMouseAway(page);
       await takeEditorScreenshot(page);
@@ -1921,6 +1935,7 @@ test.describe('Macro-Micro-Switcher', () => {
         await selectSnakeLayoutModeTool(page);
         await selectMacroBond(page, MacroBondTool.SINGLE);
         await page.getByText('F1').locator('..').hover();
+        await waitForMonomerPreview(page);
         await takeEditorScreenshot(page);
       },
     );

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -75,6 +75,7 @@ import {
 } from '@utils/canvas/atoms/superatomAttachmentPoints';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
 import { pageReload } from '@utils/common/helpers';
+import { waitForMonomerTooltip } from '@utils/common/loaders/previewWaiters';
 import { miewApplyButtonIsEnabled } from '@utils/common/loaders/waitForMiewApplyButtonIsEnabled';
 import {
   FileType,
@@ -358,6 +359,7 @@ test.describe('Macro-Micro-Switcher', () => {
     );
     await turnOnMicromoleculesEditor(page);
     await page.getByText('A6OH').click({ button: 'right' });
+    await waitForMonomerTooltip(page);
     await takeEditorScreenshot(page);
   });
 
@@ -536,6 +538,7 @@ test.describe('Macro-Micro-Switcher', () => {
     await clickInTheMiddleOfTheScreen(page);
     await turnOnMicromoleculesEditor(page);
     await page.getByText('Test-6-Ch').click({ button: 'right' });
+    await waitForMonomerTooltip(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -75,7 +75,7 @@ import {
 } from '@utils/canvas/atoms/superatomAttachmentPoints';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
 import { pageReload } from '@utils/common/helpers';
-import { waitForMonomerTooltip } from '@utils/common/loaders/previewWaiters';
+import { waitForMonomerPreviewMicro } from '@utils/common/loaders/previewWaiters';
 import { miewApplyButtonIsEnabled } from '@utils/common/loaders/waitForMiewApplyButtonIsEnabled';
 import {
   FileType,
@@ -359,7 +359,7 @@ test.describe('Macro-Micro-Switcher', () => {
     );
     await turnOnMicromoleculesEditor(page);
     await page.getByText('A6OH').click({ button: 'right' });
-    await waitForMonomerTooltip(page);
+    await waitForMonomerPreviewMicro(page);
     await takeEditorScreenshot(page);
   });
 
@@ -539,7 +539,7 @@ test.describe('Macro-Micro-Switcher', () => {
     await clickInTheMiddleOfTheScreen(page);
     await turnOnMicromoleculesEditor(page);
     await page.getByText('Test-6-Ch').click({ button: 'right' });
-    await waitForMonomerTooltip(page);
+    await waitForMonomerPreviewMicro(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -1215,6 +1215,7 @@ test.describe('Macro-Micro-Switcher', () => {
     );
     const bondLine = page.locator('g[pointer-events="stroke"]').first();
     await bondLine.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
@@ -8,6 +8,7 @@ import {
   chooseFileFormat,
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { test, Page } from '@playwright/test';
 import {
@@ -257,6 +258,7 @@ test.describe('Macro-Micro-Switcher2', () => {
     await turnOnMacromoleculesEditor(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('F1').locator('..').hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Peptides/peptide-monomer-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Peptides/peptide-monomer-library.spec.ts
@@ -20,7 +20,10 @@ import {
   waitForPageInit,
 } from '@utils';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import { goToPeptidesTab, goToTab } from '@utils/macromolecules/library';
 
 test.describe('Peptide library testing', () => {
@@ -37,7 +40,7 @@ test.describe('Peptide library testing', () => {
   test('Structure displaying in library', async ({ page }) => {
     // structure preview, molecule hovered state check
     await page.getByTestId(Peptides.A).hover();
-    await page.waitForSelector('[data-testid="polymer-library-preview"]');
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
   });
 
@@ -51,6 +54,7 @@ test.describe('Peptide library testing', () => {
     // favourites check. there is a bug - favourite sign (star) is golden when hovered(should be dark grey)
     // https://github.com/epam/ketcher/issues/3477
     await addMonomerToFavorites(page, Peptides.A);
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
   });
 
@@ -89,6 +93,7 @@ test.describe('Peptide library testing', () => {
     ]);
 
     await removeMonomerFromFavorites(page, Presets.A);
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Peptides/peptide-monomer-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Peptides/peptide-monomer-library.spec.ts
@@ -139,6 +139,7 @@ test.describe('Peptide library testing', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectEraseTool(page);
     await page.getByText('dA').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -153,6 +154,7 @@ test.describe('Peptide library testing', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('Edc').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -167,6 +169,7 @@ test.describe('Peptide library testing', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectRectangleSelectionTool(page);
     await page.getByText('Edc').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -195,6 +198,7 @@ test.describe('Peptide library testing', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectEraseTool(page);
     await page.getByText('Test-6-Ch').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -209,6 +213,7 @@ test.describe('Peptide library testing', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('MCC').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -223,6 +228,7 @@ test.describe('Peptide library testing', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectRectangleSelectionTool(page);
     await page.getByText('SMPEG2').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Peptides/peptides-add-to-canvas.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Peptides/peptides-add-to-canvas.spec.ts
@@ -10,6 +10,7 @@ import {
 import {
   hideMonomerPreview,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
 import { Peptides } from '@constants/monomers';
@@ -40,6 +41,7 @@ test.describe('Peptide', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await moveMouseToTheMiddleOfTheScreen(page);
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 });

--- a/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/attachment-point-rotation.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/attachment-point-rotation.spec.ts
@@ -10,7 +10,10 @@ import {
   selectMacroBond,
 } from '@utils';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import { bondTwoMonomers } from '@utils/macromolecules/polymerBond';
 /* eslint-disable no-magic-numbers */
 
@@ -77,7 +80,7 @@ test.describe('Check attachment point rotation', () => {
     await peptide1.hover();
 
     // Get rid of flakiness because of preview
-    await page.waitForSelector('[data-testid="polymer-library-preview"]');
+    await waitForMonomerPreview(page);
 
     await takeEditorScreenshot(page, {
       hideMonomerPreview: true,
@@ -88,7 +91,7 @@ test.describe('Check attachment point rotation', () => {
     await peptide2.hover();
 
     // Get rid of flakiness because of preview
-    await page.waitForSelector('[data-testid="polymer-library-preview"]');
+    await waitForMonomerPreview(page);
 
     await takeEditorScreenshot(page, {
       hideMonomerPreview: true,
@@ -147,7 +150,7 @@ test.describe('Check attachment point rotation', () => {
     await selectMacroBond(page, MacroBondTool.SINGLE);
     // Hover 1th peptide
     await peptide1.hover();
-    await page.getByTestId('polymer-library-preview');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page, {
       hideMonomerPreview: true,
     });

--- a/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/attachment-point-rotation.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/attachment-point-rotation.spec.ts
@@ -10,10 +10,7 @@ import {
   selectMacroBond,
 } from '@utils';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
-import {
-  turnOnMacromoleculesEditor,
-  waitForMonomerPreview,
-} from '@utils/macromolecules';
+import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
 import { bondTwoMonomers } from '@utils/macromolecules/polymerBond';
 /* eslint-disable no-magic-numbers */
 
@@ -79,9 +76,6 @@ test.describe('Check attachment point rotation', () => {
     await moveMouseAway(page);
     await peptide1.hover();
 
-    // Get rid of flakiness because of preview
-    await waitForMonomerPreview(page);
-
     await takeEditorScreenshot(page, {
       hideMonomerPreview: true,
     });
@@ -89,9 +83,6 @@ test.describe('Check attachment point rotation', () => {
     // Hover 2nd peptide
     await moveMouseAway(page);
     await peptide2.hover();
-
-    // Get rid of flakiness because of preview
-    await waitForMonomerPreview(page);
 
     await takeEditorScreenshot(page, {
       hideMonomerPreview: true,
@@ -150,7 +141,6 @@ test.describe('Check attachment point rotation', () => {
     await selectMacroBond(page, MacroBondTool.SINGLE);
     // Hover 1th peptide
     await peptide1.hover();
-    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page, {
       hideMonomerPreview: true,
     });

--- a/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/connection-rules-common.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/connection-rules-common.spec.ts
@@ -24,6 +24,7 @@ import {
   ZoomInByKeyboard,
 } from '@utils';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
+import { waitForMonomerPreviewMicro } from '@utils/common/loaders/previewWaiters';
 import {
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
@@ -529,7 +530,8 @@ test.describe('Common connection rules: ', () => {
     );
     await turnOnMicromoleculesEditor(page);
     await page.getByText('C', { exact: true }).locator('..').first().hover();
-    await takeEditorScreenshot(page, { hideMonomerPreview: true });
+    await waitForMonomerPreviewMicro(page);
+    await takeEditorScreenshot(page);
     await turnOnMacromoleculesEditor(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/connection-rules-common.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/connection-rules-common.spec.ts
@@ -529,11 +529,7 @@ test.describe('Common connection rules: ', () => {
     );
     await turnOnMicromoleculesEditor(page);
     await page.getByText('C', { exact: true }).locator('..').first().hover();
-    await delay(1);
-    await takeEditorScreenshot(page, {
-      hideMonomerPreview: true,
-    });
-
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await turnOnMacromoleculesEditor(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/polymer-bond-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/polymer-bond-tool.spec.ts
@@ -40,10 +40,7 @@ import {
   FileType,
   verifyFileExport,
 } from '@utils/files/receiveFileComparisonData';
-import {
-  hideMonomerPreview,
-  turnOnMacromoleculesEditor,
-} from '@utils/macromolecules';
+import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
 import { connectMonomersWithBonds } from '@utils/macromolecules/monomer';
 import { bondTwoMonomers } from '@utils/macromolecules/polymerBond';
 import {
@@ -208,14 +205,11 @@ test('Create bond between two chems', async () => {
   // Create bonds between chems, taking screenshots in middle states
   await chem1.hover();
   await page.mouse.down();
-  await hideMonomerPreview(page);
-
   await takeEditorScreenshot(page, {
     hideMonomerPreview: true,
   });
   await chem2.hover();
   await page.mouse.up();
-  await hideMonomerPreview(page);
   await takeEditorScreenshot(page, {
     hideMonomerPreview: true,
   });

--- a/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/preview-for-hovering-over-bond.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Polymer-Bond-Tool/preview-for-hovering-over-bond.spec.ts
@@ -8,7 +8,10 @@ import {
   takeEditorScreenshot,
   waitForPageInit,
 } from '@utils';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 
 test.beforeEach(async ({ page }) => {
   await waitForPageInit(page);
@@ -92,6 +95,7 @@ test(
       let bondNumber = 0;
       for (bondNumber; bondNumber < numberOfBonds; bondNumber++) {
         await hoverOverBond(page, bondNumber);
+        await waitForMonomerPreview(page);
         await takeEditorScreenshot(page);
       }
       await selectClearCanvasTool(page);
@@ -135,6 +139,7 @@ test(
     let bondNumber = 0;
     for (bondNumber; bondNumber < numberOfBonds; bondNumber++) {
       await hoverOverBond(page, bondNumber);
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     }
   },

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/add-custom-preset.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/add-custom-preset.spec.ts
@@ -9,7 +9,10 @@ import {
   takeMonomerLibraryScreenshot,
 } from '@utils';
 import { waitForPageInit } from '@utils/common';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import { goToRNATab } from '@utils/macromolecules/library';
 import {
   pressAddToPresetsButton,
@@ -86,8 +89,9 @@ test.describe('Macromolecules custom presets', () => {
     await takeMonomerLibraryScreenshot(page);
 
     await selectCustomPreset(page, 'MyRNA_baA_25R_.');
-
     await page.click('#polymer-editor-canvas');
+
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 });

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/add-default-presets.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/add-default-presets.spec.ts
@@ -1,4 +1,7 @@
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import { test } from '@playwright/test';
 import {
   selectMonomer,
@@ -24,6 +27,7 @@ test.describe('Macromolecules default presets', () => {
     Description: Switch to Polymer Editor
     */
     await selectMonomer(page, Presets.G);
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/add-preset-to-favorites.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/add-preset-to-favorites.spec.ts
@@ -1,6 +1,10 @@
 import { Presets } from '@constants/monomers';
 import { test, expect } from '@playwright/test';
-import { takeMonomerLibraryScreenshot, waitForPageInit } from '@utils';
+import {
+  takeMonomerLibraryScreenshot,
+  waitForMonomerPreview,
+  waitForPageInit,
+} from '@utils';
 import { goToFavoritesTab, goToRNATab } from '@utils/macromolecules/library';
 import { gotoRNA } from '@utils/macromolecules/rnaBuilder';
 
@@ -12,6 +16,7 @@ test.describe('Macromolecules add RNA presets to Favorites', () => {
 
   test('Should have star when hover over RNA presets', async ({ page }) => {
     await page.getByTestId(Presets.A).hover();
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/connect-phosphate-and-sugar.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/connect-phosphate-and-sugar.spec.ts
@@ -5,7 +5,10 @@ import {
   selectMacroBond,
   takeEditorScreenshot,
 } from '@utils';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import { bondTwoMonomers } from '@utils/macromolecules/polymerBond';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
 
@@ -31,7 +34,7 @@ test.describe('Macromolecules connect phosphate and sugar', () => {
     const bondLine = page.locator('g[pointer-events="stroke"]').nth(1);
 
     bondLine.hover();
-
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 });

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -793,6 +793,7 @@ test.describe('RNA Library', () => {
     const bondLine = page.locator('g[pointer-events="stroke"]');
     await drawBasePhosphate(page);
     await bondLine.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -804,6 +805,7 @@ test.describe('RNA Library', () => {
     const bondLine = page.locator('g[pointer-events="stroke"]').nth(1);
     await drawThreeMonomersConnectedWithBonds(page);
     await bondLine.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -23,7 +23,6 @@ import {
   waitForPageInit,
   waitForRender,
   moveMouseAway,
-  delay,
   takeElementScreenshot,
   takeTopToolbarScreenshot,
   selectSnakeLayoutModeTool,
@@ -328,6 +327,7 @@ test.describe('RNA Library', () => {
     */
     await addMonomerToCenterOfCanvas(page, Sugars._12ddR);
     await page.getByText('12ddR').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -340,6 +340,7 @@ test.describe('RNA Library', () => {
     */
     await addMonomerToCenterOfCanvas(page, Bases.clA);
     await page.getByText('clA').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -352,6 +353,7 @@ test.describe('RNA Library', () => {
     */
     await addMonomerToCenterOfCanvas(page, Phosphates.Test_6_Ph);
     await page.getByText('Test-6-Ph').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -770,6 +770,7 @@ test.describe('RNA Library', () => {
     const bondLine = page.locator('g[pointer-events="stroke"]');
     await drawSugarBase(page);
     await bondLine.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -3,6 +3,7 @@ import {
   Tabs,
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { Page, test, expect } from '@playwright/test';
 import {
@@ -45,16 +46,13 @@ import {
   selectSugarSlot,
   toggleBasesAccordion,
   toggleNucleotidesAccordion,
-  togglePhosphatesAccordion,
   toggleSugarsAccordion,
   RnaAccordionType,
   toggleRnaAccordionItem,
   toggleRnaBuilder,
 } from '@utils/macromolecules/rnaBuilder';
 import {
-  goToCHEMTab,
-  goToPeptidesTab,
-  goToRNATab,
+  goToMonomerLocationTab,
   MonomerLocationTabs,
 } from '@utils/macromolecules/library';
 import { clearLocalStorage, pageReload } from '@utils/common/helpers';
@@ -645,8 +643,7 @@ test.describe('RNA Library', () => {
     await moveMouseAway(page);
     await selectPhosphateSlot(page);
     await selectMonomer(page, Phosphates.bP);
-    await moveMouseAway(page);
-    await takeRNABuilderScreenshot(page);
+    await takeRNABuilderScreenshot(page, { hideMonomerPreview: true });
 
     // Reset to default state
     await toggleRnaBuilder(page, 'collapse');
@@ -670,7 +667,6 @@ test.describe('RNA Library', () => {
     await page.getByPlaceholder('Name your structure').click();
     await page.getByPlaceholder('Name your structure').fill('cTest');
     await pressAddToPresetsButton(page);
-    await clickInTheMiddleOfTheScreen(page);
     await takeRNABuilderScreenshot(page);
   });
 
@@ -1217,6 +1213,7 @@ test.describe('RNA Library', () => {
     await takeMonomerLibraryScreenshot(page);
 
     await removeMonomerFromFavorites(page, Presets.A);
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
   });
 
@@ -1351,21 +1348,17 @@ test.describe('RNA Library', () => {
      *    Check that preview window disappears when a cursor moves off from RNA in library
      *    (phosphates, sugars, bases)
      */
-    const toolTipPreviewWindow = page.getByTestId('polymer-library-preview');
-
     await toggleSugarsAccordion(page);
     await scrollAccordionContentToTheTop(page, 'rna-accordion-details-Sugars');
     await page.getByTestId(Sugars._12ddR).hover();
-    await expect(toolTipPreviewWindow).toBeVisible();
-    await moveMouseAway(page);
-    await takeMonomerLibraryScreenshot(page);
+    await waitForMonomerPreview(page);
+    await takeMonomerLibraryScreenshot(page, { hideMonomerPreview: true });
 
     await toggleBasesAccordion(page);
     await scrollAccordionContentToTheTop(page, 'rna-accordion-details-Bases');
     await page.getByTestId(Bases._2imen2).hover();
-    await expect(toolTipPreviewWindow).toBeVisible();
-    await moveMouseAway(page);
-    await takeMonomerLibraryScreenshot(page);
+    await waitForMonomerPreview(page);
+    await takeMonomerLibraryScreenshot(page, { hideMonomerPreview: true });
 
     // await togglePhosphatesAccordion(page);
     // await scrollAccordionContentToTheTop(
@@ -1373,9 +1366,8 @@ test.describe('RNA Library', () => {
     //   'rna-accordion-details-Phosphates',
     // );
     // await page.getByTestId('P___Phosphate').hover();
-    // await expect(toolTipPreviewWindow).toBeVisible();
-    // await moveMouseAway(page);
-    // await takeMonomerLibraryScreenshot(page);
+    // await waitForMonomerPreview(page);
+    // await takeMonomerLibraryScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('CHEM tab check at Library', async () => {
@@ -1399,16 +1391,15 @@ test.describe('RNA Library', () => {
 
     // Case 23
     await selectMonomer(page, Chem.Test_6_Ch);
-    await moveMouseAway(page);
     await takeElementScreenshot(page, Chem.Test_6_Ch, {
       maxDiffPixelRatio: 0.03,
+      hideMonomerPreview: true,
     });
-    // await takeMonomerLibraryScreenshot(page);
     await moveMouseAway(page);
 
     // Case 24
     await page.getByTestId(Chem.SMPEG2).hover();
-    await delay(1);
+    await waitForMonomerPreview(page);
     await takeMonomerLibraryScreenshot(page);
     await moveMouseAway(page);
 
@@ -1446,46 +1437,14 @@ test.describe('RNA Library', () => {
     pageReloadNeeded?: boolean;
   }
 
-  async function goToMonomerLocationTab(
-    page: Page,
-    monomerLocation: MonomerLocationTabs,
-  ) {
-    switch (monomerLocation) {
-      case 'Peptides':
-        await goToPeptidesTab(page);
-        break;
-      case 'Presets':
-        await goToRNATab(page);
-        // Presets tab openned by default
-        break;
-      case 'Sugars':
-        await goToRNATab(page);
-        await toggleSugarsAccordion(page);
-        break;
-      case 'Bases':
-        await goToRNATab(page);
-        await toggleBasesAccordion(page);
-        break;
-      case 'Phosphates':
-        await goToRNATab(page);
-        await togglePhosphatesAccordion(page);
-        break;
-      case 'Nucleotides':
-        await goToRNATab(page);
-        await toggleNucleotidesAccordion(page);
-        break;
-      case 'CHEM':
-        await goToCHEMTab(page);
-        break;
-      default:
-        await goToRNATab(page);
-        break;
-    }
-  }
-
   async function searchMonomerByName(page: Page, monomerName: string) {
     const rnaLibrarySearch = page.getByTestId('monomer-library-input');
     await rnaLibrarySearch.fill(monomerName);
+  }
+
+  async function blurMonomerSearchInput(page: Page) {
+    const rnaLibrarySearch = page.getByTestId('monomer-library-input');
+    rnaLibrarySearch.blur();
   }
 
   const IDTSearchStrings: ISearchString[] = [
@@ -1574,6 +1533,8 @@ test.describe('RNA Library', () => {
           page,
           IDTSearchString.ResultMonomerLocationTab,
         );
+
+        await blurMonomerSearchInput(page);
         await takeMonomerLibraryScreenshot(page);
 
         // Test should be skipped if related bug exists
@@ -1610,7 +1571,7 @@ test.describe('RNA Library', () => {
       // 2. Verify the correct addition of ambiguous monomers in the "Ambiguous Amino Acids" subsection (The first monomer is X, and the others are arranged alphabetically)
       // 3. Verify the class designation of ambiguous monomers as "AminoAcid" and classified as "Alternatives"
       await selectMonomer(page, Peptides.X);
-      await delay(1);
+      await waitForMonomerPreview(page);
       await takeMonomerLibraryScreenshot(page);
 
       // Test should be skipped if related bug exists
@@ -1656,17 +1617,17 @@ test.describe('RNA Library', () => {
       // 6. Verify the class designation of ambiguous monomers as "Base" and ambiguous monomers in the "Ambiguous Bases", "Ambiguous DNA Bases" and
       //    "Ambiguous RNA Bases" subsection are classified as "Alternatives"
       await selectMonomer(page, Bases.DNA_N);
-      await delay(1);
+      await waitForMonomerPreview(page);
       await takeMonomerLibraryScreenshot(page);
       await toggleBasesAccordion(page);
 
       await selectMonomer(page, Bases.RNA_N);
-      await delay(1);
+      await waitForMonomerPreview(page);
       await takeMonomerLibraryScreenshot(page);
       await toggleBasesAccordion(page);
 
       await selectMonomer(page, Bases.M);
-      await delay(1);
+      await waitForMonomerPreview(page);
       await takeMonomerLibraryScreenshot(page);
 
       // Test should be skipped if related bug exists

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -782,6 +782,7 @@ test.describe('RNA Library', () => {
     const bondLine = page.locator('g[pointer-events="stroke"]');
     await drawSugarPhosphate(page);
     await bondLine.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -1687,6 +1688,7 @@ test.describe('RNA Library', () => {
           page,
           AmbiguousMonomersSearchString.ResultMonomerLocationTab,
         );
+        await blurMonomerSearchInput(page);
         await takeMonomerLibraryScreenshot(page);
 
         // Test should be skipped if related bug exists

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
@@ -159,6 +159,7 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     await clickOnSequenceSymbol(page, 'T');
     await page.keyboard.up('Control');
     // should see the whole chain selected
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
     await clickOnSequenceSymbol(page, 'T', { button: 'right' });
     // should see correct context menu title and enabled 'modify_in_rna_builder' button

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
@@ -19,6 +19,7 @@ import {
 import {
   enterSequence,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { SUGAR } from '@constants/testIdConstants';
 import { clickOnSequenceSymbol } from '@utils/macromolecules/sequence';
@@ -37,6 +38,8 @@ test.describe('Sequence mode edit in RNA Builder', () => {
   test('Select one nucleotide and modify sugar', async ({ page }) => {
     await clickOnSequenceSymbol(page, 'T');
     await clickOnSequenceSymbol(page, 'T', { button: 'right' });
+    await waitForMonomerPreview(page);
+
     // should see correct context menu title and available 'modify_in_rna_builder' button
     await takeEditorScreenshot(page);
     await page.getByTestId('modify_in_rna_builder').click();
@@ -48,7 +51,6 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     // should see disabled and nondisabled sugars
     await takeMonomerLibraryScreenshot(page);
     await selectMonomer(page, Sugars._25R);
-    await moveMouseAway(page);
     // should see updated sugar, updated title of preset and nondisabled "Update" button
     await takeRNABuilderScreenshot(page);
     await pressSaveButton(page);
@@ -68,19 +70,17 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     const endY = 200;
     await selectRectangleArea(page, startX, startY, endX, endY);
     await clickOnSequenceSymbol(page, 'T', { button: 'right', nthNumber: 2 });
+    await waitForMonomerPreview(page);
+
     // should see correct context menu title and available 'modify_in_rna_builder' button
     await takeEditorScreenshot(page);
     await page.getByTestId('modify_in_rna_builder').click();
     // should see uploaded nucleotide (nucleoside + phosphate) data to RNA Builder and disabled "Update" button
     await takeRNABuilderScreenshot(page);
-    // Update Sugar
-    await selectMonomer(page, Sugars._25R);
-    await moveMouseAway(page);
-    // Update Phosphate
-    await selectMonomer(page, Phosphates.bP);
-    await moveMouseAway(page);
+    // Update Sugar and Phosphate
+    await selectMonomers(page, [Sugars._25R, Phosphates.bP]);
     // should see updated sugar and phosphate, updated title of preset and nondisabled "Update" button
-    await takeRNABuilderScreenshot(page);
+    await takeRNABuilderScreenshot(page, { hideMonomerPreview: true });
     await pressSaveButton(page);
     await takePageScreenshot(page);
   });
@@ -95,19 +95,17 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     const endY = 200;
     await selectRectangleArea(page, startX, startY, endX, endY);
     await clickOnSequenceSymbol(page, 'T', { button: 'right', nthNumber: 2 });
+    await waitForMonomerPreview(page);
+
     // should see correct context menu title and available 'modify_in_rna_builder' button
     await takeEditorScreenshot(page);
     await page.getByTestId('modify_in_rna_builder').click();
     // should see uploaded data to RNA Builder and disabled "Update" button
     await takeRNABuilderScreenshot(page);
-    // Update Sugar
-    await selectMonomer(page, Sugars._25R);
-    await moveMouseAway(page);
-    // Update Phosphate
-    await selectMonomer(page, Phosphates.bP);
-    await moveMouseAway(page);
+    // Update Sugar and Phosphate
+    await selectMonomers(page, [Sugars._25R, Phosphates.bP]);
     // should see updated sugar and phosphate of preset and nondisabled "Update" button
-    await takeRNABuilderScreenshot(page);
+    await takeRNABuilderScreenshot(page, { hideMonomerPreview: true });
     await pressSaveButton(page);
     // Click 'Yes' in modal
     await page.getByText('Yes').click();
@@ -119,9 +117,8 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     await clickOnSequenceSymbol(page, 'T', { button: 'right' });
     await page.getByTestId('modify_in_rna_builder').click();
     await selectMonomer(page, Sugars._25R);
-    await moveMouseAway(page);
     // should see updated sugar, updated title of preset and nondisabled "Update" button
-    await takeRNABuilderScreenshot(page);
+    await takeRNABuilderScreenshot(page, { hideMonomerPreview: true });
     await page.getByTestId('cancel-btn').click();
     // should see not updated nucleotide in chain
     await takeEditorScreenshot(page);
@@ -138,17 +135,15 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     await selectRectangleArea(page, startX, startY, endX, endY);
     await takeEditorScreenshot(page);
     await clickOnSequenceSymbol(page, 'T', { button: 'right' });
+    await waitForMonomerPreview(page);
     // should see correct context menu title and available 'modify_in_rna_builder' button
     await takeEditorScreenshot(page);
     await page.getByTestId('modify_in_rna_builder').click();
     // should see uploaded nucleotides data to RNA Builder and disabled "Update" button
     await takeRNABuilderScreenshot(page);
-    await selectMonomer(page, Sugars._25R);
-    await moveMouseAway(page);
-    await selectMonomer(page, Phosphates.bP);
-    await moveMouseAway(page);
+    await selectMonomers(page, [Sugars._25R, Phosphates.bP]);
     // should see updated sugar and phosphate, and nondisabled "Update" button
-    await takeRNABuilderScreenshot(page);
+    await takeRNABuilderScreenshot(page, { hideMonomerPreview: true });
     await pressSaveButton(page);
     // should see modal to apply or cancel modification
     await takeEditorScreenshot(page);
@@ -245,8 +240,7 @@ test.describe('Modify nucleotides from sequence in RNA builder', () => {
     await clickOnSequenceSymbol(page, 'G', { button: 'right' });
     await page.getByTestId('modify_in_rna_builder').click();
     await selectMonomers(page, [Sugars._3A6, Bases.dabA, Phosphates.sP_]);
-    await moveMouseAway(page);
-    await takeRNABuilderScreenshot(page);
+    await takeRNABuilderScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that Nucleoside editable in RNA builder', async ({ page }) => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -33,6 +33,7 @@ import {
 import {
   enterSequence,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { goToRNATab } from '@utils/macromolecules/library';
 import { expandCollapseRnaBuilder } from '@utils/macromolecules/rnaBuilder';
@@ -309,8 +310,10 @@ test.describe('Sequence edit mode', () => {
     */
     await openFileAndAddToCanvasMacro('KET/sequence-with-monomers.ket', page);
     await hoverOnSequenceSymbol(page, 'A');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
     await hoverOnSequenceSymbol(page, 'K');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -324,8 +327,10 @@ test.describe('Sequence edit mode', () => {
     await selectFlexLayoutModeTool(page);
     await openFileAndAddToCanvasMacro('KET/sequence-with-monomers.ket', page);
     await hoverOnSequenceSymbol(page, 'A');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
     await hoverOnSequenceSymbol(page, 'Aad');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -343,10 +348,12 @@ test.describe('Sequence edit mode', () => {
 
     for (const symbol of sequenceSymbols) {
       await hoverOnSequenceSymbol(page, symbol);
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
       await moveMouseAway(page);
     }
     await page.getByText('5HydMe').locator('..').locator('..').first().click();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -430,6 +437,7 @@ test.describe('Sequence edit mode', () => {
 
     for (const symbol of sequenceSymbols) {
       await hoverOnSequenceSymbol(page, symbol);
+      await waitForMonomerPreview(page);
       await takePageScreenshot(page);
       await moveMouseAway(page);
     }
@@ -445,6 +453,7 @@ test.describe('Sequence edit mode', () => {
     await goToRNATab(page);
     await expandCollapseRnaBuilder(page);
     await page.getByTestId(Presets.dR_U_P).hover();
+    await waitForMonomerPreview(page);
     await takePageScreenshot(page);
   });
 
@@ -469,6 +478,7 @@ test.describe('Sequence edit mode', () => {
     */
     await enterSequence(page, 'aaaaaaaaaa');
     await hoverOnSequenceSymbol(page, 'A', 0);
+    await waitForMonomerPreview(page);
     await takePageScreenshot(page);
   });
 
@@ -481,6 +491,7 @@ test.describe('Sequence edit mode', () => {
     */
     await enterSequence(page, 'aaaagaaaaaa');
     await clickOnSequenceSymbol(page, 'G');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -507,6 +507,7 @@ test.describe('Sequence edit mode', () => {
     */
     await openFileAndAddToCanvasMacro('KET/sequence-with-monomers.ket', page);
     await doubleClickOnSequenceSymbol(page, 'G');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -81,6 +81,8 @@ test.describe('Sequence edit mode', () => {
       .locator('g', { has: page.locator('text="G"') })
       .first()
       .click({ button: 'right' });
+
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
@@ -2014,6 +2014,8 @@ test(`23. Verify functionality of 'Cancel' option in warning modal window`, asyn
     MonomerDescription: 'peptide (Cys_Bn)',
   };
 
+  await pageReload(page);
+
   await openFileAndAddToCanvasMacro(sequence.FileName, page);
   await selectSequenceLayoutModeTool(page);
   await clickOnSequenceSymbolByIndex(
@@ -2067,6 +2069,8 @@ test(`24. Verify functionality of 'Cancel' option for multiple selected monomers
     MonomerTestId: Peptides.Cys_Bn,
     MonomerDescription: 'peptide (Cys_Bn)',
   };
+
+  await pageReload(page);
 
   await openFileAndAddToCanvasMacro(sequence.FileName, page);
   await selectSequenceLayoutModeTool(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-selection.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-selection.spec.ts
@@ -19,7 +19,10 @@ import {
   selectZoomOutTool,
   moveMouseAway,
 } from '@utils';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import {
   getSequenceSymbolLocator,
   selectSequenceRangeInEditMode,
@@ -54,6 +57,7 @@ test.describe('Sequence mode selection for view mode', () => {
     await getSequenceSymbolLocator(page, 'G').click();
     await getSequenceSymbolLocator(page, 'G', 1).click();
     await page.keyboard.up('Shift');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -61,6 +65,7 @@ test.describe('Sequence mode selection for view mode', () => {
     await page.keyboard.down('Control');
     await getSequenceSymbolLocator(page, 'G').click();
     await page.keyboard.up('Control');
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 });
@@ -167,6 +172,7 @@ test.describe('Sequence mode selection for view mode', () => {
         .locator('g', { has: page.locator('text="G"') })
         .first()
         .click();
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     });
   }

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode.spec.ts
@@ -24,6 +24,7 @@ import {
 import {
   enterSequence,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 
 test.describe('Sequence Mode', () => {
@@ -293,6 +294,8 @@ test.describe('Sequence Mode', () => {
         .locator('g', { has: page.locator('text="G"') })
         .first()
         .hover();
+
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     });
   }
@@ -619,6 +622,8 @@ test.describe('Sequence Mode', () => {
         .locator('g', { has: page.locator(`text="${testCase.hoverText}"`) })
         .first()
         .hover();
+
+      await waitForMonomerPreview(page);
       await takeEditorScreenshot(page);
     });
   }

--- a/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/side-chain-connections.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/side-chain-connections.spec.ts
@@ -31,6 +31,7 @@ import { pageReload } from '@utils/common/helpers';
 import {
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 
 let page: Page;
@@ -1009,6 +1010,7 @@ test.describe('Side chain connections', () => {
 
     const randomSideBondToSelect = 12;
     await clickNthConnectionLine(page, randomSideBondToSelect);
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/snake-bond-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/snake-bond-tool.spec.ts
@@ -31,6 +31,7 @@ import { pageReload } from '@utils/common/helpers';
 import {
   turnOnMacromoleculesEditor,
   turnOnMicromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 import { goToPeptidesTab, goToRNATab } from '@utils/macromolecules/library';
 import { bondTwoMonomers } from '@utils/macromolecules/polymerBond';
@@ -771,6 +772,7 @@ test.describe('Snake Bond Tool', () => {
       filename: 'KET/rna-chain-connected-to-peptide-chain.ket',
       description:
         'Bonds connecting RNA monomers to monomers of different types (peptide monomers) remain straight.',
+      waitForMonomerPreview: true,
     },
     {
       filename: 'KET/rna-chain-connected-to-chem.ket',
@@ -788,6 +790,9 @@ test.describe('Snake Bond Tool', () => {
       await page.mouse.wheel(400, 0);
       await page.mouse.wheel(-400, 0);
 
+      if (testCase.waitForMonomerPreview) {
+        await waitForMonomerPreview(page);
+      }
       await takeEditorScreenshot(page);
       await selectSnakeLayoutModeTool(page);
       await takeEditorScreenshot(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom-tool.spec.ts
@@ -23,6 +23,7 @@ import {
   selectZoomOutTool,
 } from '@utils';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
+import { pageReload } from '@utils/common/helpers';
 import {
   zoomWithMouseWheel,
   turnOnMacromoleculesEditor,
@@ -411,6 +412,8 @@ test.describe('Zoom Tool', () => {
      *        6. Zoom Out using button 5 times
      *        7. Take screenshot to witness the result
      */
+    await pageReload(page);
+
     await selectClearCanvasTool(page);
     await pasteFromClipboardAndAddToMacromoleculesCanvas(
       page,

--- a/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom-tool.spec.ts
@@ -26,6 +26,7 @@ import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
 import {
   zoomWithMouseWheel,
   turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
 } from '@utils/macromolecules';
 
 let page: Page;
@@ -122,18 +123,20 @@ test.describe('Zoom Tool', () => {
     await clickInTheMiddleOfTheScreen(page);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await peptide.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
 
     await selectZoomReset(page);
     await clickInTheMiddleOfTheScreen(page);
     await peptide.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
 
     const zoomOutCount = 2;
     await selectZoomOutTool(page, zoomOutCount);
     await clickInTheMiddleOfTheScreen(page);
     await peptide.hover();
-
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -142,15 +145,17 @@ test.describe('Zoom Tool', () => {
     await page.mouse.wheel(deltas.x, deltas.y);
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await peptide.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
 
     await page.mouse.wheel(deltas.x, -deltas.y);
     await peptide.hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
 
     await page.mouse.wheel(deltas.x, -deltas.y);
     await peptide.hover();
-
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom.spec.ts
@@ -27,7 +27,10 @@ import {
   selectMonomer,
 } from '@utils';
 import { MacroBondTool } from '@utils/canvas/tools/selectNestedTool/types';
-import { turnOnMacromoleculesEditor } from '@utils/macromolecules';
+import {
+  turnOnMacromoleculesEditor,
+  waitForMonomerPreview,
+} from '@utils/macromolecules';
 import { connectMonomersWithBonds } from '@utils/macromolecules/monomer';
 
 async function zoomWithMouseScrollAndTakeScreenshot(page: Page) {
@@ -136,6 +139,7 @@ test.describe('Zoom Tool', () => {
       page,
     );
     await page.getByText('DTrp2M').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await zoomWithMouseScrollAndTakeScreenshot(page);
   });
 
@@ -223,6 +227,7 @@ test.describe('Zoom Tool', () => {
     await page.mouse.wheel(wheelXDelta, 0);
     await page.keyboard.up('Shift');
     await page.mouse.wheel(0, wheelYDelta);
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 
@@ -365,6 +370,7 @@ test.describe('Zoom Tool', () => {
     }
     await selectMacroBond(page, MacroBondTool.SINGLE);
     await page.getByText('(R').locator('..').first().hover();
+    await waitForMonomerPreview(page);
     await takeEditorScreenshot(page);
   });
 

--- a/ketcher-autotests/tests/Reactions/Reaction-tools/Plus-and-Arrow-tools/plus-and-arrows-tools.spec.ts
+++ b/ketcher-autotests/tests/Reactions/Reaction-tools/Plus-and-Arrow-tools/plus-and-arrows-tools.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import {
   ArrowTool,
   copyAndPaste,
@@ -33,6 +33,7 @@ import {
   selectCleanTool,
   selectLayoutTool,
 } from '@utils';
+import { pageReloadMicro } from '@utils/common/helpers';
 import {
   pressRedoButton,
   pressUndoButton,
@@ -363,6 +364,10 @@ test.describe('Plus and Arrows tools ', () => {
      */
     let point: Point;
     test.beforeEach(async ({ page }) => {
+      await configureInitialState(page);
+    });
+
+    async function configureInitialState(page: Page) {
       await openFileAndAddToCanvas(
         'Molfiles-V2000/benzene-and-cyclopentadiene.mol',
         page,
@@ -371,7 +376,7 @@ test.describe('Plus and Arrows tools ', () => {
       await clickOnTheCanvas(page, -40, 0);
       point = await getCoordinatesOfTheMiddleOfTheScreen(page);
       await selectLeftPanelButton(LeftPanelButton.RectangleSelection, page);
-    });
+    }
 
     test('Select the reaction arrow and move it', async ({ page }) => {
       await page.mouse.move(point.x + OFFSET_FROM_ARROW, point.y);
@@ -417,6 +422,9 @@ test.describe('Plus and Arrows tools ', () => {
     test('Select reaction arrow, copy and paste it onto the canvas', async ({
       page,
     }) => {
+      await pageReloadMicro(page);
+      await configureInitialState(page);
+
       await clickOnCanvas(page, point.x + OFFSET_FROM_ARROW, point.y);
 
       await copyToClipboardByKeyboard(page);

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Bond-Tool/all-bonds.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Bond-Tool/all-bonds.spec.ts
@@ -45,6 +45,7 @@ import {
   clickOnCanvas,
   selectAromatizeTool,
   selectDearomatizeTool,
+  delay,
 } from '@utils';
 import { getAtomByIndex } from '@utils/canvas/atoms';
 import {
@@ -475,7 +476,13 @@ test.describe('Bond Tool', () => {
      *Description: Bond Tool - Hot keys
      */
     const hotKeys = ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit0'];
-    for (const hotKey of hotKeys) {
+    for (const [index, hotKey] of hotKeys.entries()) {
+      // Delay prevents the search field from opening after the hotkey press
+      // (otherwise the main window is blocked and the panel tools can't be selected)
+      if (index > 0) {
+        await delay(1);
+      }
+
       await page.keyboard.press(hotKey);
       await takeLeftToolbarScreenshot(page);
     }

--- a/ketcher-autotests/tests/Templates/Template-Manipulations/Template-manipulations.spec.ts
+++ b/ketcher-autotests/tests/Templates/Template-Manipulations/Template-manipulations.spec.ts
@@ -52,6 +52,7 @@ import {
   clickOnCanvas,
   selectUndoByKeyboard,
   selectZoomOutTool,
+  waitForElementInCanvas,
 } from '@utils';
 import { getRotationHandleCoordinates } from '@utils/clicks/selectButtonByTitle';
 import { getMolfile, getRxn } from '@utils/formats';
@@ -564,6 +565,8 @@ test.describe('Open Ketcher', () => {
     );
     await moveOnBond(page, BondType.DOUBLE, 1);
     await moveOnBond(page, BondType.DOUBLE, 0);
+    await waitForElementInCanvas(page, 'A=Test');
+
     await takePageScreenshot(page);
     await selectAction(TopPanelButton.Clear, page);
   });

--- a/ketcher-autotests/tests/User-Interface/Toolbar/toolbar-ui.spec.ts
+++ b/ketcher-autotests/tests/User-Interface/Toolbar/toolbar-ui.spec.ts
@@ -21,6 +21,7 @@ import {
   selectDearomatizeTool,
   selectAddRemoveExplicitHydrogens,
 } from '@utils';
+import { waitForElementEnabled } from '@utils/common/loaders/waitForElementState';
 
 test.describe('Open Ketcher', () => {
   test.beforeEach(async ({ page }) => {
@@ -85,6 +86,11 @@ test.describe('Open Ketcher', () => {
         */
 
       await page.goto('/?hiddenControls=clear');
+
+      // Wait for the page to load
+      const aromatizeButton = page.getByTitle('Aromatize (Alt+A)');
+      await waitForElementEnabled(aromatizeButton);
+
       await takeTopToolbarScreenshot(page);
     },
   );

--- a/ketcher-autotests/tests/utils/canvas/helpers.ts
+++ b/ketcher-autotests/tests/utils/canvas/helpers.ts
@@ -167,12 +167,11 @@ export async function takeElementScreenshot(
     hideMonomerPreview?: boolean;
   },
 ) {
-  const maxTimeout = 1500;
-  const element = page.getByTestId(elementId).first();
-  await waitForRender(page, emptyFunction, maxTimeout);
   if (options?.hideMonomerPreview) {
     await page.keyboard.press('Shift');
   }
+
+  const element = page.getByTestId(elementId).first();
   await expect(element).toHaveScreenshot({
     mask: options?.masks,
     maxDiffPixelRatio: options?.maxDiffPixelRatio,
@@ -209,8 +208,6 @@ export async function takePageScreenshot(
   page: Page,
   options?: { masks?: Locator[]; maxDiffPixelRatio?: number },
 ) {
-  const maxTimeout = 1500;
-  await waitForRender(page, emptyFunction, maxTimeout);
   await expect(page).toHaveScreenshot({
     mask: options?.masks,
     maxDiffPixelRatio: options?.maxDiffPixelRatio,
@@ -226,14 +223,23 @@ export async function takePresetsScreenshot(
 
 export async function takeRNABuilderScreenshot(
   page: Page,
-  options?: { masks?: Locator[]; maxDiffPixelRatio?: number },
+  options?: {
+    masks?: Locator[];
+    maxDiffPixelRatio?: number;
+    hideMonomerPreview?: boolean;
+    timeout?: number;
+  },
 ) {
   await takeElementScreenshot(page, 'rna-editor-expanded', options);
 }
 
 export async function takeMonomerLibraryScreenshot(
   page: Page,
-  options?: { masks?: Locator[]; maxDiffPixelRatio?: number },
+  options?: {
+    masks?: Locator[];
+    maxDiffPixelRatio?: number;
+    hideMonomerPreview?: boolean;
+  },
 ) {
   await takeElementScreenshot(page, 'monomer-library', options);
 }
@@ -266,9 +272,7 @@ export async function takeTopToolbarScreenshot(page: Page) {
 }
 
 export async function takePolymerEditorScreenshot(page: Page) {
-  const maxTimeout = 3000;
   const editor = page.locator('.Ketcher-polymer-editor-root');
-  await waitForRender(page, emptyFunction, maxTimeout);
   await expect(editor).toHaveScreenshot();
 }
 
@@ -537,4 +541,13 @@ export async function copyStructureByCtrlMove(
   await page.keyboard.down('Control');
   await dragMouseTo(targetCoordinates.x, targetCoordinates.y, page);
   await page.keyboard.up('Control');
+}
+
+export async function waitForElementInCanvas(
+  page: Page,
+  text: string,
+): Promise<void> {
+  const canvas = page.getByTestId('ketcher-canvas');
+  const targetElement = canvas.locator(`div:has-text("${text}")`);
+  await expect(targetElement).toBeVisible();
 }

--- a/ketcher-autotests/tests/utils/canvas/selectSelection.ts
+++ b/ketcher-autotests/tests/utils/canvas/selectSelection.ts
@@ -4,6 +4,7 @@ import { getControlModifier } from '@utils/keyboard';
 import { clickInTheMiddleOfTheScreen } from '@utils/clicks';
 import { INPUT_DELAY } from '@utils/globals';
 import { moveMouseAway, waitForRender } from '..';
+import { waitForElementEnabled } from '@utils/common/loaders/waitForElementState';
 
 export enum SelectionType {
   Rectangle = 'Rectangle',
@@ -121,4 +122,11 @@ export async function selectAllStructuresOnCanvas(
     page,
     async () => await page.keyboard.press(`${modifier}+KeyA`, options),
   );
+}
+
+export async function waitForAllStructuresSelected(page: Page) {
+  // Waiting for all selected elements to lose `display: none` is insufficient
+  // because the "Copy" button becomes enabled last as an indicator of completion.
+  const copyButton = page.getByTitle('Copy (Ctrl+C)');
+  await waitForElementEnabled(copyButton);
 }

--- a/ketcher-autotests/tests/utils/canvas/selectSelection.ts
+++ b/ketcher-autotests/tests/utils/canvas/selectSelection.ts
@@ -4,7 +4,6 @@ import { getControlModifier } from '@utils/keyboard';
 import { clickInTheMiddleOfTheScreen } from '@utils/clicks';
 import { INPUT_DELAY } from '@utils/globals';
 import { moveMouseAway, waitForRender } from '..';
-import { waitForElementEnabled } from '@utils/common/loaders/waitForElementState';
 
 export enum SelectionType {
   Rectangle = 'Rectangle',
@@ -122,11 +121,4 @@ export async function selectAllStructuresOnCanvas(
     page,
     async () => await page.keyboard.press(`${modifier}+KeyA`, options),
   );
-}
-
-export async function waitForAllStructuresSelected(page: Page) {
-  // Waiting for all selected elements to lose `display: none` is insufficient
-  // because the "Copy" button becomes enabled last as an indicator of completion.
-  const copyButton = page.getByTitle('Copy (Ctrl+C)');
-  await waitForElementEnabled(copyButton);
 }

--- a/ketcher-autotests/tests/utils/common/loaders/previewWaiters.ts
+++ b/ketcher-autotests/tests/utils/common/loaders/previewWaiters.ts
@@ -1,5 +1,5 @@
 import { Page } from '@playwright/test';
 
-export async function waitForMonomerTooltip(page: Page) {
-  await page.getByTestId('monomer-tooltip').waitFor({ state: 'visible' });
+export async function waitForMonomerPreviewMicro(page: Page) {
+  await page.getByTestId('monomer-preview-micro').waitFor({ state: 'visible' });
 }

--- a/ketcher-autotests/tests/utils/common/loaders/previewWaiters.ts
+++ b/ketcher-autotests/tests/utils/common/loaders/previewWaiters.ts
@@ -1,0 +1,5 @@
+import { Page } from '@playwright/test';
+
+export async function waitForMonomerTooltip(page: Page) {
+  await page.getByTestId('monomer-tooltip').waitFor({ state: 'visible' });
+}

--- a/ketcher-autotests/tests/utils/common/loaders/waitForElementState.ts
+++ b/ketcher-autotests/tests/utils/common/loaders/waitForElementState.ts
@@ -1,0 +1,27 @@
+import { Locator } from '@playwright/test';
+
+export async function waitForElementEnabled(
+  locator: Locator,
+  timeout = 10000,
+): Promise<void> {
+  await locator
+    .page()
+    .waitForFunction(
+      (element) => !element?.hasAttribute('disabled'),
+      await locator.elementHandle(),
+      { timeout },
+    );
+}
+
+export async function waitForElementDisabled(
+  locator: Locator,
+  timeout = 10000,
+): Promise<void> {
+  await locator
+    .page()
+    .waitForFunction(
+      (element) => element?.hasAttribute('disabled'),
+      await locator.elementHandle(),
+      { timeout },
+    );
+}

--- a/ketcher-autotests/tests/utils/common/loaders/waitForElementState.ts
+++ b/ketcher-autotests/tests/utils/common/loaders/waitForElementState.ts
@@ -1,4 +1,4 @@
-import { Locator } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 export async function waitForElementEnabled(
   locator: Locator,
@@ -24,4 +24,9 @@ export async function waitForElementDisabled(
       await locator.elementHandle(),
       { timeout },
     );
+}
+
+export async function waitForOpenButtonEnabled(page: Page) {
+  const copyButton = page.getByTitle('Copy (Ctrl+C)');
+  await waitForElementEnabled(copyButton);
 }

--- a/ketcher-autotests/tests/utils/formats/formats.ts
+++ b/ketcher-autotests/tests/utils/formats/formats.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { TopPanelButton } from '@utils/selectors';
 import { MolfileFormat, Struct, SupportedModes } from 'ketcher-core';
 import { clickOnFileFormatDropdown } from './clicks';
@@ -145,31 +145,56 @@ export async function enableDearomatizeOnLoad(page: Page): Promise<void> {
 }
 
 export async function enableViewOnlyMode(page: Page): Promise<void> {
-  return await page.evaluate(() =>
+  await page.evaluate(() =>
     window.ketcher.editor.options({ viewOnlyMode: true }),
   );
+
+  await waitForViewOnlyModeState(page, true);
 }
 
 export async function disableViewOnlyMode(page: Page): Promise<void> {
-  return await page.evaluate(() =>
+  await page.evaluate(() =>
     window.ketcher.editor.options({ viewOnlyMode: false }),
   );
+
+  await waitForViewOnlyModeState(page, false);
 }
 
 export async function enableViewOnlyModeBySetOptions(
   page: Page,
 ): Promise<void> {
-  return await page.evaluate(() =>
+  await page.evaluate(() =>
     window.ketcher.editor.setOptions(JSON.stringify({ viewOnlyMode: true })),
   );
+
+  await waitForViewOnlyModeState(page, true);
 }
 
 export async function disableViewOnlyModeBySetOptions(
   page: Page,
 ): Promise<void> {
-  return await page.evaluate(() =>
+  await page.evaluate(() =>
     window.ketcher.editor.setOptions(JSON.stringify({ viewOnlyMode: false })),
   );
+
+  await waitForViewOnlyModeState(page, false);
+}
+
+/*
+ * Waits until View Only Mode is in the specified state by checking the state of the "Erase" button.
+ */
+export async function waitForViewOnlyModeState(
+  page: Page,
+  isEnabled: boolean,
+  timeout = 100000,
+): Promise<void> {
+  const eraseButton = page.getByTestId('erase');
+
+  if (isEnabled) {
+    await expect(eraseButton).toBeDisabled({ timeout });
+  } else {
+    await expect(eraseButton).toBeEnabled({ timeout });
+  }
 }
 
 export async function disableQueryElements(page: Page): Promise<void> {

--- a/ketcher-autotests/tests/utils/macromolecules/index.ts
+++ b/ketcher-autotests/tests/utils/macromolecules/index.ts
@@ -51,6 +51,12 @@ export async function turnOnMicromoleculesEditor(page: Page) {
   await page.getByTestId(MOLECULES_MODE).click();
 }
 
+export async function waitForMonomerPreview(page: Page) {
+  await page
+    .getByTestId('polymer-library-preview')
+    .waitFor({ state: 'visible' });
+}
+
 export async function hideMonomerPreview(page: Page) {
   await page.mouse.move(9999, 9999);
   await page

--- a/packages/ketcher-react/src/components/StructRender/StructRender.tsx
+++ b/packages/ketcher-react/src/components/StructRender/StructRender.tsx
@@ -57,6 +57,7 @@ const StructRender = ({
 
   return (
     <Container
+      data-testid="monomer-tooltip"
       ref={renderRef}
       className={className}
       fullsize={fullsize}

--- a/packages/ketcher-react/src/components/StructRender/StructRender.tsx
+++ b/packages/ketcher-react/src/components/StructRender/StructRender.tsx
@@ -57,7 +57,7 @@ const StructRender = ({
 
   return (
     <Container
-      data-testid="monomer-tooltip"
+      data-testid="monomer-preview-micro"
       ref={renderRef}
       className={className}
       fullsize={fullsize}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
This pull request optimizes screenshot-taking logic by removing unnecessary delays and adding precise element readiness checks.
Requirements can be found in [this task](https://github.com/epam/ketcher/issues/6306).

## Key Changes
1.  Screenshot Optimization
- Removed implicit delays acting as artificial wait times:
  - 1.5-second delay in `takeElementScreenshot` and `takePageScreenshot`.
  - 3-second delay in `takePolymerEditorScreenshot`.
- Added explicit element readiness waits before capturing screenshots:
  - Added `data-testid="monomer-tooltip"` to improve monomer tooltip detection (`waitForMonomerTooltip`).
  - Implemented waits:
`waitForMonomerPreview`, `waitForMonomerTooltip`, `waitForViewOnlyModeState`, `waitForElementEnabled`, `waitForElementDisabled`, `waitForAllStructuresSelected`, `waitForElementInCanvas`.
2. Flaky Test Stabilization
- Added `pageReload` to mitigate flakiness in tests affected by inconsistent element positioning, zoom levels, etc.
- Added `blurMonomerSearchInput` to hide the clear button (×) in the search field before taking screenshots.
3. Code Cleanup & Refactoring
- Removed redundant waits for monomer preview visibility/toggling; now, screenshots are captured while attempting to close the preview.
- Eliminated unnecessary delay calls.
- Removed the redundant implementation of `goToMonomerLocationTab`, replacing it with the existing function.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request