### PR TITLE
Backmerge:#6196-Ambiguous DNA bases (N, D, H, W) wrongly converted to DNA bases on antisense creation

### DIFF
--- a/packages/ketcher-core/src/domain/constants/monomers.ts
+++ b/packages/ketcher-core/src/domain/constants/monomers.ts
@@ -22,6 +22,11 @@ export enum RnaDnaNaturalAnaloguesEnum {
   URACIL = 'U',
 }
 
+export enum RnaDnaBaseNames {
+  URACIL = 'Uracil',
+  THYMINE = 'Thymine',
+}
+
 export enum StandardAmbiguousRnaBase {
   N = 'N',
   B = 'B',

--- a/packages/ketcher-core/src/domain/helpers/rna.ts
+++ b/packages/ketcher-core/src/domain/helpers/rna.ts
@@ -1,6 +1,9 @@
 import { CoreEditor } from 'application/editor/internal';
 import { AmbiguousMonomer, SequenceType } from 'domain/entities';
-import { RNA_DNA_NON_MODIFIED_PART } from 'domain/constants/monomers';
+import {
+  RNA_DNA_NON_MODIFIED_PART,
+  RnaDnaBaseNames,
+} from 'domain/constants/monomers';
 import { MONOMER_CONST } from 'application/editor';
 import { isAmbiguousMonomerLibraryItem } from 'domain/helpers/monomers';
 import { KetMonomerClass } from 'application/formatters';
@@ -10,15 +13,31 @@ export function getRnaPartLibraryItem(
   rnaBaseName: string,
   monomerClass?: KetMonomerClass,
 ) {
-  return editor.monomersLibrary.find((libraryItem) =>
-    isAmbiguousMonomerLibraryItem(libraryItem)
-      ? (!monomerClass ||
-          AmbiguousMonomer.getMonomerClass(libraryItem.monomers) ===
-            monomerClass) &&
-        libraryItem.label === rnaBaseName
-      : (!monomerClass || libraryItem.props.MonomerClass === monomerClass) &&
-        libraryItem.props.MonomerName === rnaBaseName,
-  );
+  return editor.monomersLibrary.find((libraryItem) => {
+    if (isAmbiguousMonomerLibraryItem(libraryItem)) {
+      if (
+        monomerClass &&
+        AmbiguousMonomer.getMonomerClass(libraryItem.monomers) !== monomerClass
+      ) {
+        return false;
+      }
+
+      if (libraryItem.label !== rnaBaseName) {
+        return false;
+      }
+
+      return libraryItem.options.every(
+        (option) =>
+          option.templateId.includes(RnaDnaBaseNames.URACIL) ||
+          !option.templateId.includes(RnaDnaBaseNames.THYMINE),
+      );
+    }
+
+    return (
+      (!monomerClass || libraryItem.props.MonomerClass === monomerClass) &&
+      libraryItem.props.MonomerName === rnaBaseName
+    );
+  });
 }
 
 export function getPeptideLibraryItem(editor: CoreEditor, peptideName: string) {


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/6196

https://github.com/user-attachments/assets/49abd871-aec0-4e37-bf5b-00e0b3456364




## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request