### PR TITLE
#6219-unable-to-save-to-helm-hydrogen-connection-between-micromolecule-with-ap-and-monomer

### DIFF
--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -70,6 +70,9 @@ export class MacromoleculesConverter {
   public static convertAttachmentPointNameToNumber(
     attachmentPointName: AttachmentPointName,
   ) {
+    if (attachmentPointName === 'hydrogen') {
+      return 0;
+    }
     return Number(attachmentPointName?.replace('R', ''));
   }
 
@@ -92,7 +95,9 @@ export class MacromoleculesConverter {
         attachmentPointName,
       );
     const attachmentPointIndex =
-      monomer.listOfAttachmentPoints.indexOf(attachmentPointName);
+      attachmentPointName === 'hydrogen'
+        ? 0
+        : monomer.listOfAttachmentPoints.indexOf(attachmentPointName);
     const attachmentPoint =
       monomer.monomerItem.attachmentPoints?.[attachmentPointIndex];
     const atomIdMap = monomerToAtomIdMap.get(monomer);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Add handling for hydrogen attachment point in MacromoleculesConverter

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request