### PR TITLE
Backmerge: #6084 - Backmerge system doesnt allow select ambiguous monomers from the library (#6451)

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -46,6 +46,7 @@ import {
   ITwoStrandedChainItem,
 } from 'domain/entities/monomer-chains/ChainsCollection';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
+import { replaceMonomer } from 'domain/entities/DrawingEntitiesManager.replaceMonomer';
 import { Chain } from 'domain/entities/monomer-chains/Chain';
 import { MonomerSequenceNode } from 'domain/entities/MonomerSequenceNode';
 import {
@@ -59,6 +60,7 @@ import { BackBoneSequenceNode } from 'domain/entities/BackBoneSequenceNode';
 import { STRAND_TYPE } from 'domain/constants';
 import { getNodeFromTwoStrandedNode } from 'domain/helpers/chains';
 import { MACROMOLECULES_BOND_TYPES } from 'application/editor';
+import { KetMonomerClass } from 'application/formatters';
 
 const naturalAnalogues = uniq([
   ...rnaDnaNaturalAnalogues,
@@ -244,18 +246,21 @@ export class SequenceMode extends BaseMode {
         sugarMonomerItem = getRnaPartLibraryItem(
           editor,
           labeledNucleoelement.sugarLabel,
+          KetMonomerClass.Sugar,
         );
       }
       if (labeledNucleoelement.baseLabel) {
         baseMonomerItem = getRnaPartLibraryItem(
           editor,
           labeledNucleoelement.baseLabel,
+          KetMonomerClass.Base,
         );
       }
       if (labeledNucleoelement.phosphateLabel) {
         phosphateMonomerItem = getRnaPartLibraryItem(
           editor,
           labeledNucleoelement.phosphateLabel,
+          KetMonomerClass.Phosphate,
         );
       }
 
@@ -275,13 +280,26 @@ export class SequenceMode extends BaseMode {
           );
         }
         // Update Base monomerItem object
-        if (nodeToModify.senseNode.rnaBase && baseMonomerItem) {
-          modelChanges.merge(
-            editor.drawingEntitiesManager.modifyMonomerItem(
-              nodeToModify.senseNode.rnaBase,
-              baseMonomerItem,
-            ),
-          );
+        if (nodeToModify?.senseNode.rnaBase && baseMonomerItem) {
+          if (
+            nodeToModify?.senseNode.rnaBase.monomerItem.isAmbiguous ===
+            baseMonomerItem.isAmbiguous
+          ) {
+            modelChanges.merge(
+              editor.drawingEntitiesManager.modifyMonomerItem(
+                nodeToModify?.senseNode.rnaBase,
+                baseMonomerItem,
+              ),
+            );
+          } else {
+            modelChanges.merge(
+              replaceMonomer(
+                editor.drawingEntitiesManager,
+                nodeToModify?.senseNode.rnaBase,
+                baseMonomerItem,
+              ),
+            );
+          }
         }
       }
 

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -9,6 +9,7 @@ import {
   MonomerToAtomBond,
   Nucleotide,
   Phosphate,
+  Pool,
   Sugar,
   Vec2,
 } from 'domain/entities';
@@ -70,6 +71,7 @@ export class SequenceRenderer {
   public static lastChainStartPosition: Vec2;
   private static newSequenceButtons: NewSequenceButton[] = [];
   public static sequenceViewModel: SequenceViewModel;
+
   public static show(
     chainsCollection: ChainsCollection,
     chainBeforeNewEmptyChainIndex?: number,
@@ -1190,4 +1192,31 @@ export class SequenceRenderer {
     });
     this.removeNewSequenceButtons();
   }
+}
+
+export function sequenceReplacer(key: string, value: unknown): unknown {
+  if (key === 'renderer') {
+    return `<${typeof value}>`;
+  } else if (key === 'baseRenderer') {
+    return `<${typeof value}>`;
+  } else if (['R1', 'R2', 'R3'].includes(key)) {
+    return `<${typeof value}>`;
+  } else if (value instanceof Pool) {
+    return {
+      // eslint-disable-next-line dot-notation
+      nextId: value['nextId'],
+      items: Array.from(value),
+    };
+  } else if (
+    value instanceof Object &&
+    !['Object', 'Array'].includes(value.constructor.name)
+  ) {
+    const valueObj = value as object;
+    return {
+      ctor: value.constructor.name,
+      repr: valueObj.toString(),
+      ...value,
+    };
+  }
+  return value;
 }

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
@@ -1,0 +1,153 @@
+import { BaseMonomer } from 'domain/entities/BaseMonomer';
+import {
+  AttachmentPointName,
+  MonomerItemType,
+  MonomerOrAmbiguousType,
+} from 'domain/types';
+import { Command } from 'domain/entities/Command';
+import { PolymerBond } from 'domain/entities/PolymerBond';
+import { Atom } from 'domain/entities/CoreAtom';
+import { MonomerToAtomBond } from 'domain/entities/MonomerToAtomBond';
+import assert from 'assert';
+
+import { DrawingEntitiesManager } from './DrawingEntitiesManager';
+
+export function replaceMonomer(
+  drawingEntitiesManager: DrawingEntitiesManager,
+  monomer: BaseMonomer,
+  newMonomerItem: MonomerOrAmbiguousType,
+): Command {
+  const command = new Command();
+  // TODO: monomer.hydrogenBonds
+  const monomerId = monomer.id;
+
+  const polymerBondInfoList: {
+    id: number;
+    firstMonomer: BaseMonomer;
+    firstMonomerAttachmentPoint?: AttachmentPointName;
+    secondMonomer?: BaseMonomer;
+    secondMonomerAttachmentPoint?: AttachmentPointName;
+    bond?: PolymerBond;
+  }[] = Array.from(drawingEntitiesManager.polymerBonds)
+    .filter(([_id, bond]) => {
+      return bond.firstMonomer === monomer || bond.secondMonomer === monomer;
+    })
+    .map(([id, bond]) => {
+      return {
+        id,
+        firstMonomer: bond.firstMonomer,
+        firstMonomerAttachmentPoint: bond.firstMonomerAttachmentPoint,
+        secondMonomer: bond.secondMonomer,
+        secondMonomerAttachmentPoint: bond.secondMonomerAttachmentPoint,
+        bond,
+      };
+    });
+  const monomerToAtomBondInfoList: {
+    id: number;
+    monomer: BaseMonomer;
+    attachmentPoint: AttachmentPointName;
+    atom: Atom;
+    bond?: MonomerToAtomBond;
+  }[] = Array.from(drawingEntitiesManager.monomerToAtomBonds)
+    .filter(([_id, bond]) => {
+      return bond.monomer === monomer;
+    })
+    .map(([id, bond]) => {
+      const attachmentPoint = Object.entries(
+        monomer.attachmentPointsToBonds,
+      ).find(([_ap, apBond]) => apBond === bond)?.[0] as AttachmentPointName;
+      return {
+        id,
+        monomer: bond.monomer,
+        attachmentPoint,
+        atom: bond.atom,
+        bond,
+      };
+    });
+
+  for (const polymerBondInfo of polymerBondInfoList) {
+    assert(polymerBondInfo.bond);
+    // TODO: bond.selected ? see deleteMonomer method
+    polymerBondInfo.bond.turnOnSelection();
+    command.merge(
+      drawingEntitiesManager.deletePolymerBond(polymerBondInfo.bond),
+    );
+    delete polymerBondInfo.bond;
+  }
+
+  for (const monomerToAtomBondInfo of monomerToAtomBondInfoList) {
+    assert(monomerToAtomBondInfo.bond);
+    command.merge(
+      drawingEntitiesManager.deleteMonomerToAtomBond(
+        monomerToAtomBondInfo.bond,
+      ),
+    );
+    delete monomerToAtomBondInfo.bond;
+  }
+
+  command.merge(drawingEntitiesManager.deleteMonomer(monomer, true));
+  const newMonomer: BaseMonomer = drawingEntitiesManager.createMonomer(
+    newMonomerItem,
+    monomer.position,
+  );
+  newMonomer.id = monomerId;
+  command.merge(
+    drawingEntitiesManager.addMonomer(
+      new Proxy(newMonomerItem, {}) as MonomerItemType,
+      monomer.position,
+      newMonomer,
+    ),
+  );
+
+  for (const polymerBondInfo of polymerBondInfoList) {
+    if (
+      !polymerBondInfo.firstMonomerAttachmentPoint ||
+      !polymerBondInfo.secondMonomerAttachmentPoint ||
+      !polymerBondInfo.secondMonomer
+    )
+      throw new Error(
+        'Polymer bond requires both monomers and attachment points defined',
+      );
+
+    command.merge(
+      drawingEntitiesManager.createPolymerBond(
+        polymerBondInfo.firstMonomer === monomer
+          ? newMonomer
+          : polymerBondInfo.firstMonomer,
+        polymerBondInfo.secondMonomer === monomer
+          ? newMonomer
+          : polymerBondInfo.secondMonomer,
+        polymerBondInfo.firstMonomerAttachmentPoint,
+        polymerBondInfo.secondMonomerAttachmentPoint,
+      ),
+    );
+  }
+
+  for (const monomerToAtomBondInfo of monomerToAtomBondInfoList) {
+    command.merge(
+      drawingEntitiesManager.addMonomerToAtomBond(
+        monomerToAtomBondInfo.monomer,
+        monomerToAtomBondInfo.atom,
+        monomerToAtomBondInfo.attachmentPoint as AttachmentPointName,
+      ),
+    );
+  }
+
+  return command;
+}
+
+// declare module './DrawingEntitiesManager' {
+//   interface DrawingEntitiesManager {
+//     replaceMonomer(
+//       monomer: BaseMonomer,
+//       newMonomerItem: MonomerOrAmbiguousType,
+//     ): Command;
+//   }
+// }
+//
+// DrawingEntitiesManager.prototype.replaceMonomer = function (
+//   monomer: BaseMonomer,
+//   newMonomerItem: MonomerOrAmbiguousType,
+// ): Command {
+//   return replaceMonomer(this, monomer, newMonomerItem);
+// };

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -127,6 +127,7 @@ export class DrawingEntitiesManager {
   public micromoleculesHiddenEntities: Struct = new Struct();
   public canvasMatrix?: CanvasMatrix;
   public snakeLayoutMatrix?: Matrix<Cell>;
+
   public get bottomRightMonomerPosition(): Vec2 {
     let position: Vec2 | null = null;
 
@@ -217,21 +218,25 @@ export class DrawingEntitiesManager {
       return _monomer;
     }
 
-    const monomer = this.createMonomer(monomerItem, position);
+    const newMonomer = this.createMonomer(monomerItem, position);
 
-    monomer.moveAbsolute(position);
-    this.monomers.set(monomer.id, monomer);
+    newMonomer.moveAbsolute(position);
+    this.monomers.set(newMonomer.id, newMonomer);
 
-    return monomer;
+    return newMonomer;
   }
 
-  public createMonomer(monomerItem: MonomerOrAmbiguousType, position: Vec2) {
+  public createMonomer(
+    monomerItem: MonomerOrAmbiguousType,
+    position: Vec2,
+    generateId = true,
+  ) {
     if (isAmbiguousMonomerLibraryItem(monomerItem)) {
-      return new AmbiguousMonomer(monomerItem, position);
+      return new AmbiguousMonomer(monomerItem, position, generateId);
     } else {
       const [Monomer] = monomerFactory(monomerItem);
 
-      return new Monomer(monomerItem, position);
+      return new Monomer(monomerItem, position, { generateId });
     }
   }
 
@@ -2656,7 +2661,7 @@ export class DrawingEntitiesManager {
     return monomerAtomBond;
   }
 
-  private deleteMonomerToAtomBond(monomerAtomBond: MonomerToAtomBond) {
+  public deleteMonomerToAtomBond(monomerAtomBond: MonomerToAtomBond) {
     const command = new Command();
 
     command.addOperation(

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -26,6 +26,14 @@ export class Nucleotide {
     public phosphate: Phosphate,
   ) {}
 
+  toString() {
+    return (
+      `sugar: ${this.sugar.constructor.name}, ` +
+      `rnaBase: ${this.rnaBase.constructor.name}, ` +
+      `phosphate: ${this.phosphate.constructor.name}`
+    );
+  }
+
   static fromSugar(sugar: Sugar, needValidation = true) {
     if (needValidation) {
       assert(

--- a/packages/ketcher-core/src/domain/types/monomers.ts
+++ b/packages/ketcher-core/src/domain/types/monomers.ts
@@ -36,10 +36,14 @@ export enum AttachmentPointName {
   HYDROGEN = 'hydrogen',
 }
 
-export type MonomerItemType = {
+export type MonomerItemBase = {
   label: string;
-  colorScheme?: MonomerColorScheme;
+  isAmbiguous?: boolean;
   favorite?: boolean;
+};
+
+export type MonomerItemType = MonomerItemBase & {
+  colorScheme?: MonomerColorScheme;
   struct: Struct;
   props: {
     id?: string;
@@ -59,20 +63,17 @@ export type MonomerItemType = {
   };
   attachmentPoints?: IKetAttachmentPoint[];
   seqId?: number;
-  isAmbiguous?: boolean;
   isAntisense?: boolean;
   isSense?: boolean;
 };
 
-export type AmbiguousMonomerType = {
+export type AmbiguousMonomerType = MonomerItemBase & {
   id: string;
   monomers: BaseMonomer[];
   subtype: KetAmbiguousMonomerTemplateSubType;
-  label: string;
   options: KetAmbiguousMonomerTemplateOption[];
   idtAliases?: IKetIdtAliases;
   isAmbiguous: true;
-  favorite?: boolean;
 };
 
 export type MonomerOrAmbiguousType = MonomerItemType | AmbiguousMonomerType;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Fix SequenceMode.modifySequenceInRnaBuilder replacing a monomer for other isAmbiguous value.

Fix #6084
Fix #6085

Fix SequenceMode.modifySequenceInRnaBuilder replacing a monomer for other isAmbiguous.
Fix RnaEditorExpanded adding keyDown handle for Escape, Enter.
Fix resetRnaBuilderAfterSequenceUpdate adding turnOffEditMode;
Fix SequenceItemContextMenu consts with enum.
Fix Editor.events.selectTool, .rightClickSequence using single arguments only.
Fix npm scripts adding test:types, use in prepush.
Fix editorEvent adding typing, adding keydown event.
Fix OpenOptions interactivity visuals.
Fix snapshots for OpenOptions interactivity visuals.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request