### PR TITLE
Backmerge: #6132 - System should not re-layout canvas in case of antisense creation

### DIFF
--- a/ketcher-autotests/tests/Macromolecule-editor/Antisense-Chains/antisense-chains.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Antisense-Chains/antisense-chains.spec.ts
@@ -3012,47 +3012,51 @@ test(`16. Ensure that switching between macro and micro modes does not break the
   await takeEditorScreenshot(page, { hideMonomerPreview: true });
 });
 
-test(`17. Verify that copying the sense and antisense strand and pasting it within the same canvas retains the correct orientation and complementary base pairing`, async () => {
-  /*
-   * Test task: https://github.com/epam/ketcher/issues/6134
-   * Description: Verify that copying the sense and antisense strand and pasting it within the same canvas retains the correct orientation and complementary base pairing
-   * Case:
-   *       1. Load chain with antisense base
-   *       2. Select it (using Control+A)
-   *       3. Call context menu for monomer and click "Create Antisense Strand" option
-   *       4. Select all structures on the canvas
-   *       6. Copy structures to clipboard
-   *       7. Paste clipboard content to the canvas
-   *       8. Take screenshot to validate layout
-   */
-  test.setTimeout(30000);
-  await pageReload(page);
+test.fail(
+  `17. Verify that copying the sense and antisense strand and pasting it within the same canvas retains the correct orientation and complementary base pairing`,
+  async () => {
+    /*
+     * IMPORTANT: Test fails because we have a bug: https://github.com/epam/ketcher/issues/6441
+     * Test task: https://github.com/epam/ketcher/issues/6134
+     * Description: Verify that copying the sense and antisense strand and pasting it within the same canvas retains the correct orientation and complementary base pairing
+     * Case:
+     *       1. Load chain with antisense base
+     *       2. Select it (using Control+A)
+     *       3. Call context menu for monomer and click "Create Antisense Strand" option
+     *       4. Select all structures on the canvas
+     *       6. Copy structures to clipboard
+     *       7. Paste clipboard content to the canvas
+     *       8. Take screenshot to validate layout
+     */
+    test.setTimeout(30000);
+    await pageReload(page);
 
-  const chain = chainOfNucleotidesAndPeptides[0];
+    const chain = chainOfNucleotidesAndPeptides[0];
 
-  await loadMonomerOnCanvas(page, chain, chain.pageReloadNeeded);
+    await loadMonomerOnCanvas(page, chain, chain.pageReloadNeeded);
 
-  await selectAllStructuresOnCanvas(page);
-  await callContextMenuForMonomer(page, chain.monomerLocatorIndex);
+    await selectAllStructuresOnCanvas(page);
+    await callContextMenuForMonomer(page, chain.monomerLocatorIndex);
 
-  const createAntisenseStrandOption = page
-    .getByTestId('create_antisense_chain')
-    .first();
+    const createAntisenseStrandOption = page
+      .getByTestId('create_antisense_chain')
+      .first();
 
-  // Checking presence of Create Antisense Strand option on the context menu and enabled
-  await expect(createAntisenseStrandOption).toHaveCount(1);
-  await expect(createAntisenseStrandOption).toHaveAttribute(
-    'aria-disabled',
-    'false',
-  );
+    // Checking presence of Create Antisense Strand option on the context menu and enabled
+    await expect(createAntisenseStrandOption).toHaveCount(1);
+    await expect(createAntisenseStrandOption).toHaveAttribute(
+      'aria-disabled',
+      'false',
+    );
 
-  await createAntisenseStrandOption.click();
+    await createAntisenseStrandOption.click();
 
-  await selectAllStructuresOnCanvas(page);
-  await copyToClipboardByKeyboard(page);
-  await pasteFromClipboardByKeyboard(page);
-  await takeEditorScreenshot(page, { hideMonomerPreview: true });
-});
+    await selectAllStructuresOnCanvas(page);
+    await copyToClipboardByKeyboard(page);
+    await pasteFromClipboardByKeyboard(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
+  },
+);
 
 test(`18. Flipping checks`, async () => {
   /*

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -62,6 +62,7 @@ import { Nucleoside } from './Nucleoside';
 import { Nucleotide } from './Nucleotide';
 import {
   MACROMOLECULES_BOND_TYPES,
+  FlexMode,
   SequenceMode,
   SnakeMode,
 } from 'application/editor';
@@ -3145,8 +3146,10 @@ function getFirstPosition(
   lastPosition: Vec2,
   restOfRowsWithAntisense = 0,
 ) {
+  const editor = CoreEditor.provideEditorInstance();
+
   return new Vec2(
-    MONOMER_START_X_POSITION,
+    editor.mode instanceof FlexMode ? lastPosition.x : MONOMER_START_X_POSITION,
     lastPosition.y +
       height +
       (restOfRowsWithAntisense > 0 ? SNAKE_LAYOUT_Y_OFFSET_BETWEEN_CHAINS : 0),


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Changed starting position for flex mode.
![image](https://github.com/user-attachments/assets/e20c9226-23db-42ae-8391-14b1a04b5e87)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request