### PR TITLE
#4145 - fix implement popup versions of ketcher and routing for vite from master

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -42,7 +42,8 @@
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-app-polyfill": "^2.0.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.29.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.2",

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -6,16 +6,16 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import App from './App';
-import DuoApp from './DuoApp';
 import PopupApp from './PopupApp';
+import DuoApp from './DuoApp';
 
 const container = document.getElementById('root');
 const root = createRoot(container as HTMLElement);
 root.render(
   <BrowserRouter>
     <Routes>
-      <Route path="/duo" element={<DuoApp />} />
       <Route path="/popup" element={<PopupApp />} />
+      <Route path="/duo" element={<DuoApp />} />
       <Route path="*" element={<App />} />
     </Routes>
   </BrowserRouter>,

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -3,8 +3,20 @@ import 'react-app-polyfill/stable';
 import 'url-search-params-polyfill';
 import './index.css';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
 import App from './App';
+import DuoApp from './DuoApp';
+import PopupApp from './PopupApp';
 
 const container = document.getElementById('root');
 const root = createRoot(container as HTMLElement);
-root.render(<App />);
+root.render(
+  <BrowserRouter>
+    <Routes>
+      <Route path="/duo" element={<DuoApp />} />
+      <Route path="/popup" element={<PopupApp />} />
+      <Route path="*" element={<App />} />
+    </Routes>
+  </BrowserRouter>,
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,7 +567,8 @@
         "normalize.css": "^8.0.1",
         "react": "^18.2.0",
         "react-app-polyfill": "^2.0.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.29.0"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "^5.0.2",
@@ -6123,6 +6124,15 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
+      "integrity": "sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -23839,6 +23849,38 @@
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.29.0.tgz",
+      "integrity": "sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
+      "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.22.0",
+        "react-router": "6.29.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Fix example enabling routes for popup and duo for vite.

Fix #4145 

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request