### PR TITLE
Backmerge: 6493 - Undo of deleted bond on sequence mode causes "ghost" monomer appearence on the canvas

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -980,7 +980,8 @@ export class SequenceMode extends BaseMode {
 
         if (
           nodeToDelete.antisenseNode &&
-          !(nodeToDelete.antisenseNode instanceof BackBoneSequenceNode)
+          !(nodeToDelete.antisenseNode instanceof BackBoneSequenceNode) &&
+          !(nodeToDelete.antisenseNode instanceof EmptySequenceNode)
         ) {
           nodeToDelete.antisenseNode?.monomers.forEach((monomer) => {
             modelChanges.merge(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request