### PR TITLE
Autotests: #6511 - Removed unnecessary metaDataIndexes from verifyFileExport calls

### DIFF
--- a/ketcher-autotests/tests/API/api-set-get-molecule.spec.ts
+++ b/ketcher-autotests/tests/API/api-set-get-molecule.spec.ts
@@ -207,7 +207,6 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'Molfiles-V3000/test-data-for-enatiomer.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
 
     await takeEditorScreenshot(page);

--- a/ketcher-autotests/tests/API/view-only-mode.spec.ts
+++ b/ketcher-autotests/tests/API/view-only-mode.spec.ts
@@ -517,7 +517,6 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'Molfiles-V2000/benzene-ring-saved-in-view-only-mode-molv2000-expected.mol',
       FileType.MOL,
       'v2000',
-      [1],
     );
 
     await openFileAndAddToCanvasAsNewProject(
@@ -542,7 +541,6 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
       'Molfiles-V3000/benzene-ring-saved-in-view-only-mode-molv3000-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
 
     await openFileAndAddToCanvasAsNewProject(

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files-export-import-query-features.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files-export-import-query-features.spec.ts
@@ -77,7 +77,6 @@ test.describe('Open Ketcher', () => {
       'SDF/Query-Feature/Aromaticity-expected.sdf',
       FileType.SDF,
       'v2000',
-      [1, 25],
     );
 
     await openFileAndAddToCanvasAsNewProject(
@@ -114,7 +113,6 @@ test.describe('Open Ketcher', () => {
       'Rxn-V2000/Query-Feature/Aromaticity2-expected.rxn',
       FileType.RXN,
       'v2000',
-      [2, 7, 31, 49, 67],
     );
 
     await openFileAndAddToCanvasAsNewProject(
@@ -151,7 +149,6 @@ test.describe('Open Ketcher', () => {
       'Molfiles-V2000/Query-Feature/Chirality-expected.mol',
       FileType.MOL,
       'v2000',
-      [1],
     );
 
     await openFileAndAddToCanvasAsNewProject(
@@ -189,7 +186,6 @@ test.describe('Open Ketcher', () => {
       'SDF/Query-Feature/Chirality-expected.sdf',
       FileType.SDF,
       'v2000',
-      [1, 19],
     );
 
     await openFileAndAddToCanvasAsNewProject(

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/MOL-Files/mol-files.spec.ts
@@ -87,7 +87,6 @@ test('Open and Save file - Open/Save V3000 file with atom and bond properties 2/
     'Molfiles-V3000/atom-properties-V3000-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 });
 
@@ -120,7 +119,6 @@ test('Open and Save file - Open/Save Markush files 2/2 - save', async ({
     'Molfiles-V2000/markush-expected.mol',
     FileType.MOL,
     'v2000',
-    [0, 4],
   );
 });
 
@@ -185,7 +183,6 @@ test('Open and Save file - Open/Save V3000 *.mol file contains abbreviation 2/2 
     'Molfiles-V3000/sec_butyl_abr_V3000-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 });
 
@@ -218,7 +215,6 @@ test('Open and Save file - Open/Save file with R-Groups 2/2 - save', async ({
     'Molfiles-V2000/r-group-expected.mol',
     FileType.MOL,
     'v2000',
-    [0, 4],
   );
 });
 
@@ -289,7 +285,6 @@ test('Open and Save file - Open/Save V3000 mol file contains attached data 2/2 -
     'Molfiles-V3000/attached-data-V3000-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 });
 
@@ -322,7 +317,6 @@ test('Open and Save file - V3000 *.mol file contains Heteroatoms 2/2 - save', as
     'Molfiles-V3000/heteroatoms-V3000-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 });
 
@@ -419,7 +413,6 @@ test('Open and Save file - Open/Save V3000 mol file contains abs stereochemistry
     'Molfiles-V3000/V3000-abs-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 });
 
@@ -438,7 +431,6 @@ test('Open and Save file - Save V2000 molfile as V3000 molfile', async ({
     'Molfiles-V3000/spiro-expected.mol',
     FileType.MOL,
     'v3000',
-    [1, 3],
   );
 });
 
@@ -637,7 +629,6 @@ test.describe('Open and Save file', () => {
         'Molfiles-V3000/more-900-atoms-expected.mol',
         FileType.MOL,
         'v3000',
-        [1],
       );
     },
   );
@@ -765,7 +756,6 @@ test.describe('Open and Save file', () => {
       'Molfiles-V3000/adenosine-triphosphate-cm-bond-lengh.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/adenosine-triphosphate-cm-bond-lengh.mol',
@@ -822,7 +812,6 @@ test.describe('Open and Save file', () => {
       'Molfiles-V3000/adenosine-triphosphate-acs-style.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/adenosine-triphosphate-acs-style.mol',

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/SDF-Files/sdf-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/SDF-Files/sdf-files.spec.ts
@@ -740,7 +740,6 @@ test('The Hash spacing setting with px option is applied and it should be save t
     'SDF/adenosine-triphosphate-px-hash-spacing-v2000-expected.sdf',
     FileType.SDF,
     'v2000',
-    [1],
   );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-px-hash-spacing-v2000-expected.sdf',
@@ -770,7 +769,6 @@ test('The Hash spacing setting with px option is applied and it should be save t
     'SDF/adenosine-triphosphate-px-hash-spacing-v3000-expected.sdf',
     FileType.SDF,
     'v3000',
-    [1],
   );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-px-hash-spacing-v3000-expected.sdf',
@@ -800,7 +798,6 @@ test('The Hash spacing setting with cm option is applied and it should be save t
     'SDF/adenosine-triphosphate-cm-hash-spacing-v2000-expected.sdf',
     FileType.SDF,
     'v2000',
-    [1],
   );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-cm-hash-spacing-v2000-expected.sdf',
@@ -830,7 +827,6 @@ test('The Hash spacing setting with cm option is applied and it should be save t
     'SDF/adenosine-triphosphate-cm-hash-spacing-v3000-expected.sdf',
     FileType.SDF,
     'v3000',
-    [1],
   );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-cm-hash-spacing-v3000-expected.sdf',
@@ -860,7 +856,6 @@ test('The Hash spacing setting with inch option is applied and it should be save
     'SDF/adenosine-triphosphate-inch-hash-spacing-v2000-expected.sdf',
     FileType.SDF,
     'v2000',
-    [1],
   );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-inch-hash-spacing-v2000-expected.sdf',
@@ -890,7 +885,6 @@ test('The Hash spacing setting with inch option is applied and it should be save
     'SDF/adenosine-triphosphate-inch-hash-spacing-v3000-expected.sdf',
     FileType.SDF,
     'v3000',
-    [1],
   );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-inch-hash-spacing-v3000-expected.sdf',

--- a/ketcher-autotests/tests/Indigo-Tools/Aromatize-Dearomatize/aromatize-dearomatize.spec.ts
+++ b/ketcher-autotests/tests/Indigo-Tools/Aromatize-Dearomatize/aromatize-dearomatize.spec.ts
@@ -227,7 +227,6 @@ test.describe('Aromatize/Dearomatize Tool', () => {
       'Molfiles-V3000/aromatic-benzene-v3000-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await takeEditorScreenshot(page);
   });

--- a/ketcher-autotests/tests/Indigo-Tools/Calculate-CIP-Tool/calculate-cip-tool.spec.ts
+++ b/ketcher-autotests/tests/Indigo-Tools/Calculate-CIP-Tool/calculate-cip-tool.spec.ts
@@ -550,7 +550,6 @@ test.describe('Indigo Tools - Calculate CIP Tool', () => {
       'Molfiles-V3000/structure-with-stereo-bonds-expectedV3000.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Antisense-Chains/antisense-chains.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Antisense-Chains/antisense-chains.spec.ts
@@ -2912,7 +2912,6 @@ test(`14. Validate that both sense and antisense strands can be exported correct
     'KET/Antisense-Chains/Antisense-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 
   await verifyHELMExport(

--- a/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
@@ -401,7 +401,6 @@ test.describe('Erase Tool', () => {
       'Molfiles-V3000/peptides-flex-chain-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
 
     await selectClearCanvasTool(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher2.spec.ts
@@ -219,7 +219,6 @@ test.describe('Macro-Micro-Switcher2', () => {
       'Molfiles-V3000/chem-connected-to-micro-structure-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
   });
 
@@ -239,7 +238,6 @@ test.describe('Macro-Micro-Switcher2', () => {
       'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/one-attachment-point-added-in-micro-mode-expected.mol',
@@ -283,7 +281,6 @@ test.describe('Macro-Micro-Switcher2', () => {
       'Molfiles-V3000/micro-macro-structure-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/micro-macro-structure-expected.mol',
@@ -501,7 +498,6 @@ test.describe('Macro-Micro-Switcher2', () => {
       'Molfiles-V3000/single-atom-properties-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await openFileAndAddToCanvasAsNewProject(
       'Molfiles-V3000/single-atom-properties-expected.mol',
@@ -699,7 +695,6 @@ test.describe('Macro-Micro-Switcher2', () => {
       'Molfiles-V3000/single-atom-properties-saved-in-macro-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await turnOnMicromoleculesEditor(page);
     await openFileAndAddToCanvasAsNewProject(

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher4.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher4.spec.ts
@@ -264,7 +264,6 @@ test(`Verify that all 16 bond types are saved/loaded correctly in macromolecules
     'KET/Micro-Macro-Switcher/All 16 types of bonds-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 
   await openFileAndAddToCanvasAsNewProject(
@@ -384,7 +383,6 @@ test(`Verify that all 16 types of bonds saved in macro mode can be opened in mic
     'KET/Micro-Macro-Switcher/All 16 types of bonds-expected.mol',
     FileType.MOL,
     'v3000',
-    [1],
   );
 
   await turnOnMicromoleculesEditor(page);

--- a/ketcher-autotests/tests/Reactions/Cascade-Reactions/cascade-reactions.spec.ts
+++ b/ketcher-autotests/tests/Reactions/Cascade-Reactions/cascade-reactions.spec.ts
@@ -1008,7 +1008,6 @@ test.describe('Cascade Reactions', () => {
       'RDF-V2000/single-arrow-expected.rdf',
       FileType.RDF,
       'v2000',
-      [1, 5],
     );
     await openFileAndAddToCanvasAsNewProject(
       'RDF-V2000/single-arrow-expected.rdf',
@@ -1029,7 +1028,6 @@ test.describe('Cascade Reactions', () => {
       'RDF-V3000/single-arrow-expected.rdf',
       FileType.RDF,
       'v3000',
-      [1, 5],
     );
     await openFileAndAddToCanvasAsNewProject(
       'RDF-V3000/single-arrow-expected.rdf',
@@ -1053,7 +1051,6 @@ test.describe('Cascade Reactions', () => {
       'RDF-V2000/multi-tailed-arrow-default-expected.rdf',
       FileType.RDF,
       'v2000',
-      [1, 5],
     );
     await openFileAndAddToCanvasAsNewProject(
       'RDF-V2000/multi-tailed-arrow-default-expected.rdf',
@@ -1077,7 +1074,6 @@ test.describe('Cascade Reactions', () => {
       'RDF-V3000/multi-tailed-arrow-default-expected.rdf',
       FileType.RDF,
       'v3000',
-      [1, 5],
     );
     await openFileAndAddToCanvasAsNewProject(
       'RDF-V3000/multi-tailed-arrow-default-expected.rdf',

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Attachment-Point-Tool/attachment-point-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/Attachment-Point-Tool/attachment-point-tool.spec.ts
@@ -452,7 +452,6 @@ test.describe('Attachment Point Tool', () => {
       'Molfiles-V3000/chain-with-attachment-points-expectedV3000.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await takeEditorScreenshot(page);
   });

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-fragment-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-fragment-tool.spec.ts
@@ -359,7 +359,6 @@ test.describe('R-Group Fragment Tool', () => {
       'Molfiles-V3000/r1-several-structures-V3000-expected.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
   });
 

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-tool.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Actions-With-Structures/R-group-tool/r-group-tool.spec.ts
@@ -104,7 +104,6 @@ test.describe('R-Group', () => {
       'Molfiles-V3000/r-group-with-allkind-attachment-points-expectedV3000.mol',
       FileType.MOL,
       'v3000',
-      [1],
     );
     await takeEditorScreenshot(page);
   });


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request