### PR TITLE
Backmerge: #6546 - Macro structure duplicated on canvas when using ketcher.getMolfile() and pasting

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -772,6 +772,7 @@ export class CoreEditor {
     }
     this._monomersLibraryParsedJson = null;
     this._type = EditorType.Micromolecules;
+    this.drawingEntitiesManager = new DrawingEntitiesManager();
   }
 
   private switchToMacromolecules() {

--- a/packages/ketcher-core/src/application/utils.ts
+++ b/packages/ketcher-core/src/application/utils.ts
@@ -38,10 +38,13 @@ export function getStructure(
 ): Promise<string> {
   const serverSettings = ketcherProvider.getKetcher().editor.serverSettings;
   const formatter = formatterFactory.create(structureFormat, serverSettings);
+  const drawingEntitiesManagerCloningResult = drawingEntitiesManager?.mergeInto(
+    new DrawingEntitiesManager(),
+  );
 
   return formatter.getStructureFromStructAsync(
     struct,
-    drawingEntitiesManager,
+    drawingEntitiesManagerCloningResult?.mergedDrawingEntities,
     selection,
   );
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request