### PR TITLE
#6364 - Autotests: Replace File comparison (for SDF files ONLY!) operations with valid helper functions (verifyFileExport)

### DIFF
--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/SDF-Files/sdf-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/SDF-Files/sdf-files.spec.ts
@@ -32,45 +32,23 @@ test.describe('CDF files', () => {
     await waitForPageInit(page);
 
     await openFileAndAddToCanvas('SDF/sdf-v2000-to-open.sdf', page);
-    try {
-      const expectedFile = await getSdf(page, 'v2000');
-      await saveToFile('SDF/sdf-v2000-to-open-expected.sdf', expectedFile);
-    } catch (error) {
-      console.log(error);
-    }
-
-    const METADATA_STRING_INDEX = [1, 19];
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName: 'tests/test-data/SDF/sdf-v2000-to-open-expected.sdf',
-        metaDataIndexes: METADATA_STRING_INDEX,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/sdf-v2000-to-open-expected.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await takeEditorScreenshot(page);
   });
 
   test('Open SDF v3000 file and save it', async ({ page }) => {
     await openFileAndAddToCanvas('SDF/sdf-v3000-to-open.sdf', page);
-    try {
-      const expectedFile = await getSdf(page, 'v3000');
-      await saveToFile('SDF/sdf-v3000-to-open-expected.sdf', expectedFile);
-    } catch (error) {
-      console.log(error);
-    }
-
-    const METADATA_STRING_INDEX = [1, 26];
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName: 'tests/test-data/SDF/sdf-v3000-to-open-expected.sdf',
-        metaDataIndexes: METADATA_STRING_INDEX,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/sdf-v3000-to-open-expected.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await takeEditorScreenshot(page);
   });
 
@@ -100,25 +78,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-nucleotides.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-nucleotides-v3000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [1, 107, 213, 319, 425, 531];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-nucleotides-v3000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-nucleotides-v3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-nucleotides-v3000.sdf',
       page,
@@ -138,27 +103,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-chems.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-chems-v3000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 182, 363, 544, 725, 906, 1087, 1267, 1448,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-chems-v3000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-chems-v3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-chems-v3000.sdf',
       page,
@@ -178,27 +128,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-sugars.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-sugars-v3000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 178, 355, 532, 709, 886, 1063, 1240, 1417,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-sugars-v3000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-sugars-v3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-sugars-v3000.sdf',
       page,
@@ -218,27 +153,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-bases.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-bases-v3000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 186, 371, 556, 741, 926, 1111, 1296, 1481,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-bases-v3000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-bases-v3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-bases-v3000.sdf',
       page,
@@ -258,27 +178,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-phosphates.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-phosphates-v3000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 165, 329, 493, 657, 821, 985, 1149, 1313,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-phosphates-v3000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-phosphates-v3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-phosphates-v3000.sdf',
       page,
@@ -298,27 +203,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-peptides.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-peptides-v3000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 188, 375, 562, 749, 936, 1123, 1310, 1497,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-peptides-v3000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-peptides-v3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-peptides-v3000.sdf',
       page,
@@ -340,25 +230,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-nucleotides.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-nucleotides-v2000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [1, 107, 213, 319, 425, 531];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-nucleotides-v2000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-nucleotides-v2000.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-nucleotides-v2000.sdf',
       page,
@@ -380,27 +257,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-chems.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-chems-v2000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 182, 363, 544, 725, 906, 1087, 1267, 1448,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-chems-v2000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-chems-v2000.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-chems-v2000.sdf',
       page,
@@ -422,27 +284,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-sugars.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-sugars-v2000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 178, 355, 532, 709, 886, 1063, 1240, 1417,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-sugars-v2000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-sugars-v2000.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-sugars-v2000.sdf',
       page,
@@ -464,27 +311,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-bases.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-bases-v2000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 186, 371, 556, 741, 926, 1111, 1296, 1481,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-bases-v2000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-bases-v2000.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-bases-v2000.sdf',
       page,
@@ -506,27 +338,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-phosphates.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-phosphates-v2000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 165, 329, 493, 657, 821, 985, 1149, 1313,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-phosphates-v2000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-phosphates-v2000.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-phosphates-v2000.sdf',
       page,
@@ -548,27 +365,12 @@ test.describe('CDF files', () => {
       'KET/unsplit-nucleotides-connected-with-peptides.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/unsplit-nucleotides-connected-with-peptides-v2000.sdf',
-      expectedFile,
-    );
-
-    // eslint-disable-next-line no-magic-numbers
-    const METADATA_STRINGS_INDEXES = [
-      1, 188, 375, 562, 749, 936, 1123, 1310, 1497,
-    ];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/unsplit-nucleotides-connected-with-peptides-v2000.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/unsplit-nucleotides-connected-with-peptides-v2000.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/unsplit-nucleotides-connected-with-peptides-v2000.sdf',
       page,
@@ -693,25 +495,12 @@ test('The Bond length setting with px option is applied and it should be save to
   await pressButton(page, 'Apply');
   await takeEditorScreenshot(page);
 
-  const expectedFile = await getSdf(page, 'v2000');
-  await saveToFile(
-    'SDF/adenosine-triphosphate-px-bond-lengh-v2000.sdf',
-    expectedFile,
-  );
-
-  const METADATA_STRINGS_INDEXES = [1];
-
-  const { fileExpected: sdfFileExpected, file: sdfFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/SDF/adenosine-triphosphate-px-bond-lengh-v2000.sdf',
-      metaDataIndexes: METADATA_STRINGS_INDEXES,
-      fileFormat: 'v2000',
-    });
-
-  expect(sdfFile).toEqual(sdfFileExpected);
-
+  await verifyFileExport(
+            page,
+            'SDF/adenosine-triphosphate-px-bond-lengh-v2000.sdf',
+            FileType.SDF,
+            'v2000',
+          );
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-px-bond-lengh-v2000.sdf',
     page,
@@ -911,24 +700,12 @@ test('The Bond length setting with pt option is applied and it should be save to
   await pressButton(page, 'Apply');
   await takeEditorScreenshot(page);
 
-  const expectedFile = await getSdf(page, 'v2000');
-  await saveToFile(
-    'SDF/adenosine-triphosphate-pt-bond-lengh-v2000.sdf',
-    expectedFile,
-  );
-
-  const METADATA_STRINGS_INDEXES = [1];
-
-  const { fileExpected: sdfFileExpected, file: sdfFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/SDF/adenosine-triphosphate-pt-bond-lengh-v2000.sdf',
-      metaDataIndexes: METADATA_STRINGS_INDEXES,
-      fileFormat: 'v2000',
-    });
-
-  expect(sdfFile).toEqual(sdfFileExpected);
+  await verifyFileExport(
+            page,
+            'SDF/adenosine-triphosphate-pt-bond-lengh-v2000.sdf',
+            FileType.SDF,
+            'v2000',
+          );
 
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-pt-bond-lengh-v2000.sdf',
@@ -955,24 +732,12 @@ test('The ACS setting is applied, click on layout and it should be save to sdf 3
   await selectLayoutTool(page);
   await takeEditorScreenshot(page);
 
-  const expectedFile = await getSdf(page, 'v3000');
-  await saveToFile(
-    'SDF/adenosine-triphosphate-acs-style-v3000.sdf',
-    expectedFile,
-  );
-
-  const METADATA_STRINGS_INDEXES = [1];
-
-  const { fileExpected: sdfFileExpected, file: sdfFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/SDF/adenosine-triphosphate-acs-style-v3000.sdf',
-      metaDataIndexes: METADATA_STRINGS_INDEXES,
-      fileFormat: 'v3000',
-    });
-
-  expect(sdfFile).toEqual(sdfFileExpected);
+  await verifyFileExport(
+            page,
+            'SDF/adenosine-triphosphate-acs-style-v3000.sdf',
+            FileType.SDF,
+            'v3000',
+          );
 
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-acs-style-v3000.sdf',
@@ -998,24 +763,12 @@ test('The ACS setting is applied, click on layout and it should be save to sdf 2
   await selectLayoutTool(page);
   await takeEditorScreenshot(page);
 
-  const expectedFile = await getSdf(page, 'v2000');
-  await saveToFile(
-    'SDF/adenosine-triphosphate-acs-style-v2000.sdf',
-    expectedFile,
-  );
-
-  const METADATA_STRINGS_INDEXES = [1];
-
-  const { fileExpected: sdfFileExpected, file: sdfFile } =
-    await receiveFileComparisonData({
-      page,
-      expectedFileName:
-        'tests/test-data/SDF/adenosine-triphosphate-acs-style-v2000.sdf',
-      metaDataIndexes: METADATA_STRINGS_INDEXES,
-      fileFormat: 'v2000',
-    });
-
-  expect(sdfFile).toEqual(sdfFileExpected);
+  await verifyFileExport(
+            page,
+            'SDF/adenosine-triphosphate-acs-style-v2000.sdf',
+            FileType.SDF,
+            'v2000',
+          );
 
   await openFileAndAddToCanvasAsNewProject(
     'SDF/adenosine-triphosphate-acs-style-v2000.sdf',

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Save-File/save-file.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Save-File/save-file.spec.ts
@@ -241,20 +241,12 @@ test.describe('Save files', () => {
     */
     await openFileAndAddToCanvas('KET/chain.ket', page);
 
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile('SDF/chain-expected.sdf', expectedFile);
-
-    const METADATA_STRING_INDEX = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName: 'tests/test-data/SDF/chain-expected.sdf',
-        fileFormat: 'v2000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
+    await verifyFileExport(
+          page,
+          'SDF/chain-expected.sdf',
+          FileType.SDF,
+          'v2000',
+        );
   });
 
   test('Support for exporting to "SDF V3000" file format', async ({ page }) => {
@@ -264,20 +256,12 @@ test.describe('Save files', () => {
     */
     await openFileAndAddToCanvas('KET/chain.ket', page);
 
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile('SDF/chain-expectedV3000.sdf', expectedFile);
-
-    const METADATA_STRING_INDEX = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName: 'tests/test-data/SDF/chain-expectedV3000.sdf',
-        fileFormat: 'v3000',
-        metaDataIndexes: METADATA_STRING_INDEX,
-      });
-
-    expect(molFile).toEqual(molFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/chain-expectedV3000.sdf',
+              FileType.SDF,
+              'v3000',
+            );
   });
 });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -1592,24 +1592,12 @@ test.describe('Macro-Micro-Switcher', () => {
       'KET/one-attachment-point-added-in-micro-mode.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v2000');
-    await saveToFile(
-      'SDF/one-attachment-point-added-in-micro-modesdfv2000-expected.sdf',
-      expectedFile,
-    );
-
-    const METADATA_STRINGS_INDEXES = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/one-attachment-point-added-in-micro-modesdfv2000-expected.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v2000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/one-attachment-point-added-in-micro-modesdfv2000-expected.sdf',
+              FileType.SDF,
+              'v2000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/one-attachment-point-added-in-micro-modesdfv2000-expected.sdf',
       page,
@@ -1626,24 +1614,12 @@ test.describe('Macro-Micro-Switcher', () => {
       'KET/one-attachment-point-added-in-micro-mode.ket',
       page,
     );
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
-      expectedFile,
-    );
-
-    const METADATA_STRINGS_INDEXES = [1];
-
-    const { fileExpected: molFileExpected, file: molFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(molFile).toEqual(molFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/one-attachment-point-added-in-micro-modesdfv3000-expected.sdf',
       page,
@@ -2218,24 +2194,12 @@ test.describe('Macro-Micro-Switcher', () => {
     After fix we need update expected file micro-macro-structure-v2000-expected.sdf
     */
       await openFileAndAddToCanvas('KET/micro-macro-structure.ket', page);
-      const expectedFile = await getSdf(page, 'v2000');
-      await saveToFile(
-        'SDF/micro-macro-structure-v2000-expected.sdf',
-        expectedFile,
-      );
-
-      const METADATA_STRINGS_INDEXES = [1];
-
-      const { fileExpected: sdfFileExpected, file: sdfFile } =
-        await receiveFileComparisonData({
-          page,
-          expectedFileName:
-            'tests/test-data/SDF/micro-macro-structure-v2000-expected.sdf',
-          metaDataIndexes: METADATA_STRINGS_INDEXES,
-          fileFormat: 'v2000',
-        });
-
-      expect(sdfFile).toEqual(sdfFileExpected);
+      await verifyFileExport(
+                page,
+                'SDF/micro-macro-structure-v2000-expected.sdf',
+                FileType.SDF,
+                'v2000',
+              );
       await openFileAndAddToCanvasAsNewProject(
         'SDF/micro-macro-structure-v2000-expected.sdf',
         page,
@@ -2250,24 +2214,12 @@ test.describe('Macro-Micro-Switcher', () => {
     Description: It is possible to save micro-macro connection to sdf v3000 file.
     */
     await openFileAndAddToCanvas('KET/micro-macro-structure.ket', page);
-    const expectedFile = await getSdf(page, 'v3000');
-    await saveToFile(
-      'SDF/micro-macro-structure-v3000-expected.sdf',
-      expectedFile,
-    );
-
-    const METADATA_STRINGS_INDEXES = [1];
-
-    const { fileExpected: sdfFileExpected, file: sdfFile } =
-      await receiveFileComparisonData({
-        page,
-        expectedFileName:
-          'tests/test-data/SDF/micro-macro-structure-v3000-expected.sdf',
-        metaDataIndexes: METADATA_STRINGS_INDEXES,
-        fileFormat: 'v3000',
-      });
-
-    expect(sdfFile).toEqual(sdfFileExpected);
+    await verifyFileExport(
+              page,
+              'SDF/micro-macro-structure-v3000-expected.sdf',
+              FileType.SDF,
+              'v3000',
+            );
     await openFileAndAddToCanvasAsNewProject(
       'SDF/micro-macro-structure-v3000-expected.sdf',
       page,


### PR DESCRIPTION
… valid helper functions (verifyFileExport)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request