### PR TITLE
6341 autotests remove all movemouseaway operatations made for suppressiong tooltip apperance by adding hidemonomerpreview flag to takeeditorscreenshot function call

### DIFF
--- a/ketcher-autotests/tests/Macromolecule-editor/API-Macro/set-mode.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/API-Macro/set-mode.spec.ts
@@ -32,10 +32,10 @@ test.describe('setMode', () => {
     await openFileAndAddToCanvasMacro('KET/snake-mode-peptides.ket', page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await setMode(page, 'flex');
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Validate ketcher.setMode for Snake Mode', async ({ page }) => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/flex-mode-copy-paste.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/flex-mode-copy-paste.spec.ts
@@ -56,10 +56,10 @@ test.describe('Flex mode copy&paste', () => {
     await page.mouse.move(startX, startY);
     await pasteFromClipboardByKeyboard(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await clickUndo(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 });

--- a/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/sequence-mode-copy-paste.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/sequence-mode-copy-paste.spec.ts
@@ -205,8 +205,10 @@ test.describe('Sequence-edit mode', () => {
     await copyToClipboardByKeyboard(page);
     await page.keyboard.press('Enter');
     await pasteFromClipboardByKeyboard(page);
+    await moveMouseAway(page);
     await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
+    await moveMouseAway(page);
     await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/sequence-mode-copy-paste.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Copy-And-Paste/sequence-mode-copy-paste.spec.ts
@@ -205,11 +205,9 @@ test.describe('Sequence-edit mode', () => {
     await copyToClipboardByKeyboard(page);
     await page.keyboard.press('Enter');
     await pasteFromClipboardByKeyboard(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   // Fail while performance issue on Indigo side
@@ -270,10 +268,10 @@ test.describe('Sequence-edit mode', () => {
     await copyToClipboardByKeyboard(page);
     await pasteFromClipboardByKeyboard(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Pasting several separate monomers are prohibited in text-editing mode', async ({
@@ -297,8 +295,7 @@ test.describe('Sequence-edit mode', () => {
     await page.getByTestId('edit_sequence').click();
     await page.keyboard.press('ArrowLeft');
     await pasteFromClipboardByKeyboard(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('After pasting between two nucleotides in text-editing mode,bond R2-R1 between them is broken,and pasted fragment is merged with existing chain', async ({
@@ -326,6 +323,6 @@ test.describe('Sequence-edit mode', () => {
     });
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 });

--- a/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Erase-Tool/erase-tool.spec.ts
@@ -141,7 +141,7 @@ test.describe('Erase Tool', () => {
     await selectMonomer(page, Chem.Test_6_Ch);
     await clickInTheMiddleOfTheScreen(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectEraseTool(page);
     await getMonomerLocator(page, Chem.Test_6_Ch).click();
     await takeEditorScreenshot(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
@@ -486,6 +486,7 @@ test.describe('Import-Saving .fasta Files', () => {
     );
 
     await zoomWithMouseWheel(page, -200);
+    await moveMouseAway(page);
     await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-fasta.spec.ts
@@ -119,8 +119,7 @@ test.describe('Import-Saving .fasta Files', () => {
   }) => {
     await openFileAndAddToCanvasMacro('FASTA/fasta-snake-mode-rna.fasta', page);
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that you can save snake viewed chain of peptides in a .fasta file', async ({
@@ -422,8 +421,7 @@ test.describe('Import-Saving .fasta Files', () => {
     );
 
     await zoomWithMouseWheel(page, -600);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'FASTA');
@@ -488,8 +486,7 @@ test.describe('Import-Saving .fasta Files', () => {
     );
 
     await zoomWithMouseWheel(page, -200);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'FASTA');
@@ -562,7 +559,7 @@ test.describe('Import-Saving .fasta Files', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'FASTA');
@@ -627,7 +624,7 @@ test.describe('Import-Saving .fasta Files', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'FASTA');
@@ -691,8 +688,7 @@ test.describe('Import-Saving .fasta Files', () => {
     );
 
     await zoomWithMouseWheel(page, -200);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'FASTA');

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-idt.spec.ts
@@ -135,8 +135,7 @@ test.afterAll(async ({ browser }) => {
 test.describe('Import-Saving .idt Files', () => {
   test(`Import .idt file`, async () => {
     await openFileAndAddToCanvasMacro('IDT/idt-a.idt', page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check option "IDT" to the format dropdown menu of modal window Paste from the clipboard is exist', async () => {
@@ -744,7 +743,7 @@ test.describe('Import-Saving .idt Files', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSequenceLayoutModeTool(page);
     await takeEditorScreenshot(page);
   });
@@ -1597,8 +1596,7 @@ test.describe('Ambiguous monomers: ', () => {
     );
 
     await zoomWithMouseWheel(page, -600);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1626,8 +1624,7 @@ test.describe('Ambiguous monomers: ', () => {
     );
 
     await zoomWithMouseWheel(page, -600);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1655,7 +1652,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -200);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1684,7 +1681,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -200);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1712,7 +1709,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1739,7 +1736,7 @@ test.describe('Ambiguous monomers: ', () => {
     );
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await verifyFileExport(
       page,
       'IDT/Ambiguous DNA Bases (mixed)-expected.idt',
@@ -1771,7 +1768,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1798,7 +1795,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await verifyFileExport(
       page,
       'IDT/Ambiguous RNA Bases (mixed)-expected.idt',
@@ -1828,8 +1825,7 @@ test.describe('Ambiguous monomers: ', () => {
       page,
     );
     await zoomWithMouseWheel(page, -200);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
     await takeEditorScreenshot(page);
@@ -1852,8 +1848,7 @@ test.describe('Ambiguous monomers: ', () => {
       page,
     );
     await zoomWithMouseWheel(page, -200);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await verifyFileExport(
       page,
       'IDT/Ambiguous (common) Bases (mixed)-expected.idt',
@@ -1886,7 +1881,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');
@@ -1917,7 +1912,7 @@ test.describe('Ambiguous monomers: ', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'IDT');

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-ket.spec.ts
@@ -185,7 +185,7 @@ test.describe('Import-Saving .ket Files', () => {
     await getMonomerLocator(page, { monomerAlias: 'Ph' }).first().hover();
     await dragMouseTo(400, 400, page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that fields "class" and "classHELM" are presents into .ket file', async () => {
@@ -246,7 +246,7 @@ test.describe('Import-Saving .ket Files', () => {
     await openFileAndAddToCanvasMacro('KET/snake-mode-peptides.ket', page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that .ket file with macro structures is imported correctly in macro mode when saving it in micro mode', async () => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-mol.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-mol.spec.ts
@@ -370,7 +370,7 @@ test.describe('Import-Saving .mol Files', () => {
     );
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     // Closing page since test expects it to have closed at the end
     const context = page.context();

--- a/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-sequence.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Import-Saving-Files/import-saving-sequence.spec.ts
@@ -153,8 +153,7 @@ test.describe('Import-Saving .seq Files', () => {
       page,
     );
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that you can save snake viewed chain of peptides in a .seq file', async ({
@@ -284,8 +283,7 @@ test.describe('Import-Saving .seq Files', () => {
     );
 
     await zoomWithMouseWheel(page, -600);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'Sequence (1-letter code)');
@@ -351,7 +349,7 @@ test.describe('Import-Saving .seq Files', () => {
 
     await zoomWithMouseWheel(page, -200);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'Sequence (1-letter code)');
@@ -424,7 +422,7 @@ test.describe('Import-Saving .seq Files', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'Sequence (1-letter code)');
@@ -489,7 +487,7 @@ test.describe('Import-Saving .seq Files', () => {
 
     await zoomWithMouseWheel(page, -100);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'Sequence (1-letter code)');
@@ -553,8 +551,7 @@ test.describe('Import-Saving .seq Files', () => {
     );
 
     await zoomWithMouseWheel(page, -200);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectTopPanelButton(TopPanelButton.Save, page);
     await chooseFileFormat(page, 'Sequence (1-letter code)');

--- a/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher4.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher4.spec.ts
@@ -625,7 +625,7 @@ test(`Verify the behavior when bonds are dragged and moved in macromolecules mod
     await bondLocator.first().hover({ force: true });
     await dragMouseTo(400, 400, page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   }
 });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -845,8 +845,7 @@ test.describe('RNA Library', () => {
     await drawThreeMonomersConnectedWithBonds(page);
     await selectEraseTool(page);
     await bondLine.click();
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Draw Sugar-Base-Phosphate and try to attach bond to occupied attachment point', async () => {
@@ -1067,7 +1066,7 @@ test.describe('RNA Library', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSequenceLayoutModeTool(page);
     await takeEditorScreenshot(page);
     await turnOnMicromoleculesEditor(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Rectangle-Selection-Tool/rectangle-selection-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Rectangle-Selection-Tool/rectangle-selection-tool.spec.ts
@@ -182,8 +182,7 @@ test.describe('Rectangle Selection Tool', () => {
 
     // Now Beta Alanine must be above Ethylthiocysteine
     await clickOnCanvas(page, betaAlaninePosition.x, betaAlaninePosition.y);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Group selection using `Shift+LClick`', async ({ page }) => {
@@ -245,7 +244,7 @@ test.describe('Rectangle Selection Tool', () => {
     await page.keyboard.up('Shift');
 
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Move selected by selection tool peptide to new position on canvas', async ({
@@ -370,8 +369,7 @@ test.describe('Rectangle Selection Tool', () => {
     const y = 100;
     await openFileAndAddToCanvasMacro('KET/all-kind-of-monomers.ket', page);
     await selectAllStructuresOnCanvas(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await clickOnCanvas(page, x, y);
     await takeEditorScreenshot(page);
   });

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
@@ -331,7 +331,7 @@ test.describe('Modify nucleotides from sequence in RNA builder', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check If among selected elements on canvas there is a single phosphate (selected without an adjacent nucleoside to left)', async ({

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -97,7 +97,7 @@ test.describe('Sequence edit mode', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Exiting text-editing mode occurs with a click outside the sequence', async ({
@@ -201,7 +201,7 @@ test.describe('Sequence edit mode', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Users can add new nucleotides in the middle of a sequence fragment as text', async ({
@@ -223,7 +223,7 @@ test.describe('Sequence edit mode', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that when adding new nucleotides to beginning of a row, order of chains not changes in Sequence mode', async ({

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-import-export.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-import-export.spec.ts
@@ -160,7 +160,7 @@ test.describe('Import/export sequence:', () => {
 
     await zoomWithMouseWheel(page, 300);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('It is possible to paste from clipboard A, T, C, G, U for DNA open structure', async () => {
@@ -181,7 +181,7 @@ test.describe('Import/export sequence:', () => {
 
     await zoomWithMouseWheel(page, 300);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('It is possible to paste from clipboard A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y for Peptide open structure', async () => {
@@ -205,7 +205,7 @@ test.describe('Import/export sequence:', () => {
 
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectFlexLayoutModeTool(page);
   });
 

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-selection.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-selection.spec.ts
@@ -17,7 +17,6 @@ import {
   clickOnCanvas,
   selectZoomInTool,
   selectZoomOutTool,
-  moveMouseAway,
 } from '@utils';
 import {
   turnOnMacromoleculesEditor,

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-selection.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode-selection.spec.ts
@@ -106,8 +106,7 @@ test.describe('Sequence mode selection for edit mode', () => {
       await page.keyboard.press('ArrowRight');
     }
     await page.keyboard.up('Shift');
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectFlexLayoutModeTool(page);
     await selectSequenceLayoutModeTool(page);
@@ -124,8 +123,7 @@ test.describe('Sequence mode selection for edit mode', () => {
       await page.keyboard.press('ArrowLeft');
     }
     await page.keyboard.up('Shift');
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await page.keyboard.press('Backspace');
     await takeEditorScreenshot(page);
@@ -266,7 +264,6 @@ test.describe('Sequence mode selection for view mode', () => {
     await takeEditorScreenshot(page);
     await page.getByText('G').first().click({ button: 'right' });
     await page.getByTestId('edit_sequence').click();
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 });

--- a/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Sequence-Mode/sequence-mode.spec.ts
@@ -64,12 +64,10 @@ test.describe('Sequence Mode', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await scrollDown(page, SCROLL_DOWN_VALUE);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectFlexLayoutModeTool(page);
     await scrollDown(page, SCROLL_DOWN_VALUE);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Nucleotides are connected through R2-R1 bonds and switch to sequence mode.', async ({
@@ -115,8 +113,7 @@ test.describe('Sequence Mode', () => {
     */
     await openFileAndAddToCanvasMacro('Molfiles-V3000/dna-long.mol', page);
     await selectSequenceLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Test sequence display for long Peptides chains', async ({ page }) => {
@@ -175,8 +172,7 @@ test.describe('Sequence Mode', () => {
     await openFileAndAddToCanvasMacro('Molfiles-V3000/rna.mol', page);
     await takeEditorScreenshot(page);
     await selectFlexLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Press Undo button and verify that layout returns to unarranged state', async ({
@@ -214,8 +210,7 @@ test.describe('Sequence Mode', () => {
     */
     await openFileAndAddToCanvasMacro('Molfiles-V3000/dna-long.mol', page);
     await selectSequenceLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Open RNA in sequence mode, switch to snake mode and confirm that RNA chain layout is left-to-right', async ({
@@ -230,7 +225,7 @@ test.describe('Sequence Mode', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Open modified RNA in sequence mode', async ({ page }) => {
@@ -264,7 +259,7 @@ test.describe('Sequence Mode', () => {
     await zoomWithMouseWheel(page, ZOOM_OUT_VALUE);
     await scrollDown(page, SCROLL_DOWN_VALUE);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   const testData = [
@@ -472,8 +467,7 @@ test.describe('Sequence Mode', () => {
     await enterSequence(page, 'cgatu');
     await page.keyboard.press('Escape');
     await selectFlexLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Create a multiple chains in sequence mode. Switch to flex mode and confirm that position of first monomer defines "top left" corner on canvas', async ({
@@ -496,8 +490,7 @@ test.describe('Sequence Mode', () => {
     await page.keyboard.press('Escape');
     await takeEditorScreenshot(page);
     await selectFlexLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('If nucleotide is being added to the end of sequence, then phosphate P should be added automatically between last two nucleosides', async ({
@@ -511,8 +504,7 @@ test.describe('Sequence Mode', () => {
     await startNewSequence(page);
     await enterSequence(page, 'cactt');
     await selectFlexLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Delete any nucleotide within RNA fragment using keyboard keys (Del, Backspace)', async ({
@@ -557,8 +549,7 @@ test.describe('Sequence Mode', () => {
     await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('Backspace');
     await selectFlexLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Verify that selecting RNA/DNA option defines sugar in newly added nucleotides from keyboard (ribose for RNA, deoxyribose for DNA)', async ({
@@ -575,8 +566,7 @@ test.describe('Sequence Mode', () => {
     await enterSequence(page, 'acgtu');
     await takeEditorScreenshot(page);
     await selectFlexLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   const testCases = [

--- a/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/side-chain-connections.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/side-chain-connections.spec.ts
@@ -135,8 +135,7 @@ test.describe('Side chain connections', () => {
 
     await selectSnakeLayoutModeTool(page);
     await openFileAndAddToCanvasMacro(`KET/side-connections-rna.ket`, page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Open file with peptide side chain connection', async () => {
@@ -147,8 +146,7 @@ test.describe('Side chain connections', () => {
 
     await selectSnakeLayoutModeTool(page);
     await openFileAndAddToCanvasMacro(`KET/side-connections-peptide.ket`, page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Open file with cycled side chain connection', async () => {
@@ -162,8 +160,7 @@ test.describe('Side chain connections', () => {
       `KET/side-connection-in-cycle-chain.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('1.1 Verify correct display of side-chain connections when two monomers are in the same row', async () => {
@@ -181,8 +178,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/1.1.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('1.2 Verify correct display of side-chain connections when two monomers are in the same row', async () => {
@@ -200,8 +196,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/1.2.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('1.3 Verify correct display of side-chain connections when two monomers are in the same row', async () => {
@@ -220,8 +215,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/1.3.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('1.4 Verify correct display of side-chain connections when two monomers are in the same row', async () => {
@@ -241,7 +235,7 @@ test.describe('Side chain connections', () => {
       page,
     );
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('2.1 Verify correct display of side-chain connections when two monomers are in different rows', async () => {
@@ -280,8 +274,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/2.2.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('2.3 Verify correct display of side-chain connections when two monomers are in different rows', async () => {
@@ -299,8 +292,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/2.3.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('2.4 Verify correct display of side-chain connections when two monomers are in different rows', async () => {
@@ -318,8 +310,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/2.4.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('2.5 Verify correct display of side-chain connections when two monomers are in different rows', async () => {
@@ -337,8 +328,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/2.5.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('2.6 Verify correct display of side-chain connections when two monomers are in different rows', async () => {
@@ -356,8 +346,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/2.5.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('2.7 Verify correct display of side-chain connections when two monomers are in different rows', async () => {
@@ -375,8 +364,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/2.5.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test(
@@ -788,8 +776,7 @@ test.describe('Side chain connections', () => {
     // Closing Library to enlarge canvas
     await hideLibrary(page);
     await openFileAndAddToCanvasMacro(`KET/Side-Chain-Connections/5.ket`, page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('6. Verify side-chain connections alignment and avoidance of overlap (vertical)', async () => {
@@ -806,7 +793,7 @@ test.describe('Side chain connections', () => {
     await hideLibrary(page);
     await openFileAndAddToCanvasMacro(`KET/Side-Chain-Connections/6.ket`, page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('6.1 Verify side-chain connections alignment and avoidance of overlap (vertical)', async () => {
@@ -826,7 +813,7 @@ test.describe('Side chain connections', () => {
       page,
     );
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('6.2 Verify side-chain connections alignment and avoidance of overlap (vertical)', async () => {
@@ -846,7 +833,7 @@ test.describe('Side chain connections', () => {
       page,
     );
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('7.1 Verify handling of RNA monomer connections between R1 of base and R3 of sugar (should be displayed as a straight line (usual way))', async () => {
@@ -865,8 +852,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/7.1.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('7.2 Verify handling of RNA monomer connections between R1 of base and R3 of sugar (should be displayed as a straight line (usual way))', async () => {
@@ -885,8 +871,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/7.2.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('7.3 Verify handling of RNA monomer connections between R1 of base and R3 of sugar (should be displayed as a straight line (usual way))', async () => {
@@ -905,8 +890,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/7.3.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('7.4 Verify handling of RNA monomer connections between R1 of base and R3 of sugar (should be displayed as a straight line (usual way))', async () => {
@@ -925,8 +909,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/7.4.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('7.5 Verify handling of RNA monomer connections between R1 of base and R3 of sugar (should be displayed as a straight line (usual way))', async () => {
@@ -945,8 +928,7 @@ test.describe('Side chain connections', () => {
       `KET/Side-Chain-Connections/7.5.ket`,
       page,
     );
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('8. Verify display of side-chain connections when switching from snake mode to flex mode', async () => {
@@ -961,7 +943,7 @@ test.describe('Side chain connections', () => {
     await openFileAndAddToCanvasMacro(`KET/Side-Chain-Connections/8.ket`, page);
     await selectFlexLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('9. Verify display of side-chain connections when switching from snake mode to sequence mode', async () => {
@@ -974,8 +956,7 @@ test.describe('Side chain connections', () => {
     await hideLibrary(page);
     await openFileAndAddToCanvasMacro(`KET/Side-Chain-Connections/9.ket`, page);
     await selectSequenceLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('10. Verify display of side-chain connections when switching from sequence mode to flex mode', async () => {
@@ -992,7 +973,7 @@ test.describe('Side chain connections', () => {
     );
     await selectFlexLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('11. Verify selection of a single side-chain connection', async () => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/snake-bond-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Snake-Mode/snake-bond-tool.spec.ts
@@ -332,8 +332,7 @@ test.describe('Snake Bond Tool', () => {
     await bondTwoMonomers(page, phosphate8, sugar9);
 
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Create snake bond for mix chains with nucleotides and peptides', async () => {
@@ -540,8 +539,7 @@ test.describe('Snake Bond Tool', () => {
     await takeEditorScreenshot(page);
 
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Create snake mode for single monomer and nucleoside', async () => {
@@ -606,8 +604,7 @@ test.describe('Snake Bond Tool', () => {
     await getMonomerLocator(page, Peptides.meE).hover();
     await dragMouseTo(x, y, page);
     await clickOnCanvas(page, x1, y1);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Pressing "snake" layout button arrange nucleotides forming chain on screen in a snake-like pattern', async () => {
@@ -622,7 +619,7 @@ test.describe('Snake Bond Tool', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check if even very long chain fit into canvas (algorithm calculate the length of rows)', async () => {
@@ -638,7 +635,7 @@ test.describe('Snake Bond Tool', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that switch to Flex mode on a snake chain change it into a chain with straight lines', async () => {
@@ -653,13 +650,13 @@ test.describe('Snake Bond Tool', () => {
     );
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectFlexLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check move any peptide from middle of chain above main snake chain', async () => {
@@ -678,12 +675,12 @@ test.describe('Snake Bond Tool', () => {
     );
     await scrollUp(page, 200);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await getMonomerLocator(page, Peptides.meS).hover();
     await dragMouseTo(x, y, page);
     await clickOnCanvas(page, x2, y2);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check move any peptide from middle of chain above main flex chain', async () => {
@@ -724,7 +721,7 @@ test.describe('Snake Bond Tool', () => {
     await takeEditorScreenshot(page);
     await selectSnakeLayoutModeTool(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   const testCases = [
@@ -937,11 +934,9 @@ test.describe('Snake Bond Tool', () => {
       }
     });
     await openFileAndAddToCanvasMacro(`KET/sequence-rna-2000.ket`, page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Maximum call stack size exceeded error not appears during snake layout for 4000 RNA', async () => {
@@ -971,11 +966,9 @@ test.describe('Snake Bond Tool', () => {
     // Workaround against fake scroll bars that sometimes shown even if they are not intended to
     await page.mouse.wheel(0, 400);
     await page.mouse.wheel(0, -400);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Maximum call stack size exceeded error not appears during snake layout for 4000 Peptides', async () => {
@@ -993,11 +986,9 @@ test.describe('Snake Bond Tool', () => {
       }
     });
     await openFileAndAddToCanvasMacro(`KET/sequence-peptides-4000.ket`, page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Maximum call stack size exceeded error not appears during snake layout for 8000 Peptides', async () => {
@@ -1021,11 +1012,9 @@ test.describe('Snake Bond Tool', () => {
       }
     });
     await openFileAndAddToCanvasMacro(`KET/sequence-peptides-8000.ket`, page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectSnakeLayoutModeTool(page);
-    await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Activate Snake mode and open external rna-modified file', async () => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Undo-Redo/undo-redo.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Undo-Redo/undo-redo.spec.ts
@@ -436,7 +436,7 @@ test.describe('Undo-Redo tests', () => {
     await page.mouse.move(x, y);
     await pasteFromClipboardByKeyboard(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await pressUndoButton(page);
     await takeEditorScreenshot(page);
     await pressRedoButton(page);

--- a/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom-tool.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom-tool.spec.ts
@@ -89,18 +89,18 @@ test.describe('Zoom Tool', () => {
     await selectZoomInTool(page, zoomInCount);
     await clickInTheMiddleOfTheScreen(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     await selectZoomReset(page);
     await clickInTheMiddleOfTheScreen(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
 
     const zoomOutCount = 2;
     await selectZoomOutTool(page, zoomOutCount);
     await clickInTheMiddleOfTheScreen(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Zoom In & Out monomer with mouse wheel and CTRL', async () => {

--- a/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom.spec.ts
+++ b/ketcher-autotests/tests/Macromolecule-editor/Zoom-Tool/zoom.spec.ts
@@ -164,11 +164,11 @@ test.describe('Zoom Tool', () => {
       await ZoomOutByKeyboard(page);
     }
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
     await selectZoomReset(page);
     await clickInTheMiddleOfTheScreen(page);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that hotkey "Ctrl + 0" is reset zoom settings to 100%', async ({
@@ -254,7 +254,7 @@ test.describe('Zoom Tool', () => {
     await clickOnMiddleOfCanvas(page);
     await zoomWithMouseWheel(page, MOUSE_WHEEL_VALUE_FOR_MAX_ZOOM);
     await moveMouseAway(page);
-    await takeEditorScreenshot(page);
+    await takeEditorScreenshot(page, { hideMonomerPreview: true });
   });
 
   test('Check that is possible to zoom in and out on empty canvas and it wont cause any errors', async ({


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request