### PR TITLE
#6159 - Aromatizing doesn't work for Pyridone and Pyrone (molecules from Template library)

### DIFF
--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -137,6 +137,7 @@ export function pickStandardServerOptions(options?: StructServiceOptions) {
 
   return {
     'dearomatize-on-load': options?.['dearomatize-on-load'],
+    'aromaticity-model': 'generic',
     'smart-layout': options?.['smart-layout'],
     'ignore-stereochemistry-errors': options?.['ignore-stereochemistry-errors'],
     'mass-skip-error-on-pseudoatoms':


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request