### PR TITLE
Backmerge: #6608 - API setMolecule moves molecule off-canvas on second call

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,18 @@ Parameters: `withAuxInfo: boolean`. Optional, by default, `false`.
 
 `isQueryStructureSelected(): boolean` – returns `true`, in case selected structure has query.
 
-`setMolecule(structure: string, options?: Object): Promise<void>` – draws passed structure on the canvas. Before drawing passed structure, current structure is removed.
-Parameters: `structure: string`. Structure is a string in any supported format. `options?: { position?: { x: number, y: number } }`. – (Optional) "position" specifies the X and Y coordinates on the canvas where the structure should be placed.
+`setMolecule(structure: string, options?: Object): Promise<void>` – draws passed structure on the canvas. Before drawing passed structure, current structure will be removed. The editor viewport will automatically adjust to fit all structures after insertion.
 
-`addFragment(structure: string, options?: Object): Promise<void>` – adds passed structure on the canvas. Current structure is not changed.
-Parameters: `structure: string`. Structure is a string in any supported format. `options?: { position?: { x: number, y: number } }`. – (Optional) "position" specifies the X and Y coordinates on the canvas where the structure should be placed.
+Parameters:
+
+- `structure: string`. Structure is a string in any supported format.
+- `options?: { position?: { x: number, y: number } }`. – (Optional) "position" - coordinates of top left corner of inserted structure in angstroms. Y coordinate value increases from bottom to top.
+
+`addFragment(structure: string, options?: Object): Promise<void>` – adds the given structure to the canvas without altering the current structure. The editor viewport will automatically adjust to fit all structures after insertion.
+
+Parameters: 
+- `structure: string`. Structure is a string in any supported format. 
+- `options?: { position?: { x: number, y: number } }`. – (Optional) "position" - coordinates of top left corner of inserted structure in angstroms. Y coordinate value increases from bottom to top.
 
 `layout(): Promise<void>` – performs layout algorithm for drawn structure.
 

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -57,8 +57,11 @@ export function fromPaste(
   point,
   angle = 0,
   isPreview = false,
+  needMoveFromTopLeftPoint = false,
 ): [Action, { atoms: number[]; bonds: number[] }, CreatedItems] {
-  const xy0 = getStructCenter(pstruct);
+  const xy0 = needMoveFromTopLeftPoint
+    ? pstruct.getCoordBoundingBox().min
+    : getStructCenter(pstruct);
   const offset = Vec2.diff(point, xy0);
 
   const action = new Action();

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -52,6 +52,7 @@ import {
   SupportedImageFormats,
   SupportedModes,
 } from 'application/ketcher.types';
+import { isNumber } from 'lodash';
 
 type SetMoleculeOptions = {
   position?: { x: number; y: number };
@@ -397,8 +398,12 @@ export class Ketcher {
         );
 
         struct.rescale();
+
         const { x, y } = options?.position ?? {};
-        this.#editor.struct(struct, false, x, y);
+
+        // System coordinates for browser and for chemistry files format (mol, ket, etc.) area are different.
+        // It needs to rotate them by 180 degrees in y-axis.
+        this.#editor.struct(struct, false, x, isNumber(y) ? -y : y);
         this.#editor.zoomAccordingContent(struct);
         if (x == null && y == null) {
           this.#editor.centerStruct();
@@ -451,7 +456,10 @@ export class Ketcher {
 
         struct.rescale();
         const { x, y } = options?.position ?? {};
-        this.#editor.structToAddFragment(struct, x, y);
+
+        // System coordinates for browser and for chemistry files format (mol, ket, etc.) area are different.
+        // It needs to rotate them by 180 degrees in y-axis.
+        this.#editor.structToAddFragment(struct, x, isNumber(y) ? -y : y);
       }
     }, this.eventBus);
   }

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -243,6 +243,7 @@ export default function initEditor(dispatch, getState) {
 
     onZoomIn: updateAction,
     onZoomOut: updateAction,
+    onZoomChanged: updateAction,
 
     onShowMacromoleculesErrorMessage: (payload) =>
       dispatch(openInfoModalWithCustomMessage(payload)),

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -280,6 +280,7 @@ class StructEditor extends Component {
       onBondEdit,
       onZoomIn,
       onZoomOut,
+      onZoomChanged,
       onRgroupEdit,
       onSgroupEdit,
       onRemoveFG,


### PR DESCRIPTION
Closes: 

#6608 - API setMolecule moves molecule off-canvas on second call
#6607 - README missing coordinate units for setMolecule and addFragment API methods

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request