### PR TITLE
#6588 - Peptide sequence not pasting directly on canvas

### DIFF
--- a/packages/ketcher-core/src/application/indigo.ts
+++ b/packages/ketcher-core/src/application/indigo.ts
@@ -28,7 +28,7 @@ import {
 } from 'domain/services';
 import { StructOrString } from 'application/indigo.types';
 import { KetSerializer } from 'domain/serializers';
-import { Struct } from 'domain/entities';
+import { SequenceType, Struct } from 'domain/entities';
 import { defaultBondThickness } from './editor';
 
 const defaultTypes: Array<CheckTypes> = [
@@ -53,6 +53,7 @@ const defaultCalcProps: Array<CalculateProps> = [
 type ConvertOptions = {
   outputFormat?: ChemicalMimeType;
   inputFormat?: ChemicalMimeType;
+  sequenceType?: SequenceType;
 };
 type AutomapOptions = {
   mode?: AutomapMode;
@@ -106,11 +107,16 @@ export class Indigo {
     const outputFormat = options?.outputFormat || ChemicalMimeType.KET;
     const inputFormat = options?.inputFormat;
 
-    return this.#structService.convert({
-      struct: convertStructToString(struct, this.#ketSerializer),
-      output_format: outputFormat,
-      input_format: inputFormat,
-    });
+    return this.#structService.convert(
+      {
+        struct: convertStructToString(struct, this.#ketSerializer),
+        output_format: outputFormat,
+        input_format: inputFormat,
+      },
+      {
+        'sequence-type': options?.sequenceType,
+      },
+    );
   }
 
   layout(struct: StructOrString, options): Promise<Struct> {

--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -232,6 +232,7 @@ export class RemoteStructService implements StructService {
         options?.['reaction-component-margin-size'],
       'image-resolution': options?.['image-resolution'],
       'molfile-saving-mode': options?.['molfile-saving-mode'],
+      'sequence-type': options?.['sequence-type'],
     };
 
     return indigoCall(

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -344,6 +344,7 @@ class IndigoService implements StructService {
         'image-resolution': options?.['image-resolution'],
         'input-format': inputFormat,
         'molfile-saving-mode': options?.['molfile-saving-mode'],
+        'sequence-type': options?.['sequence-type'],
         monomerLibrary,
       };
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- removed format autodetection during copy/paste from ketcher
- added sequence-type parameter to indigo convert payload

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request