### PR TITLE
#6632 - New sequence appears gray after clearing the canvas in non-sync mode (#6656)

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -398,6 +398,9 @@ export class CoreEditor {
       (isSequenceSyncEditMode: boolean) =>
         this.onChangeToggleIsSequenceSyncEditMode(isSequenceSyncEditMode),
     );
+    this.events.resetSequenceEditMode.add(() =>
+      this.onResetSequenceSyncEditMode(),
+    );
     this.events.createAntisenseChain.add((isDnaAntisense: boolean) => {
       this.onCreateAntisenseChain(isDnaAntisense);
     });
@@ -474,6 +477,14 @@ export class CoreEditor {
     } else {
       this.mode.turnOffSyncEditMode();
     }
+  }
+
+  private onResetSequenceSyncEditMode() {
+    if (!(this.mode instanceof SequenceMode)) {
+      return;
+    }
+
+    this.mode.resetEditMode();
   }
 
   private onCreateAntisenseChain(isDnaAntisense: boolean) {

--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -49,6 +49,7 @@ export interface IEditorEvents {
   toggleSequenceEditMode: Subscription;
   toggleSequenceEditInRNABuilderMode: Subscription;
   toggleIsSequenceSyncEditMode: Subscription;
+  resetSequenceEditMode: Subscription;
   clickOnSequenceItem: Subscription;
   mousedownBetweenSequenceItems: Subscription;
   mouseDownOnSequenceItem: Subscription;
@@ -108,6 +109,7 @@ export function resetEditorEvents() {
     toggleSequenceEditMode: new Subscription(),
     toggleSequenceEditInRNABuilderMode: new Subscription(),
     toggleIsSequenceSyncEditMode: new Subscription(),
+    resetSequenceEditMode: new Subscription(),
     clickOnSequenceItem: new Subscription(),
     mousedownBetweenSequenceItems: new Subscription(),
     mouseDownOnSequenceItem: new Subscription(),

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -154,6 +154,11 @@ export class SequenceMode extends BaseMode {
     this.initialize(false, false, false);
   }
 
+  public resetEditMode() {
+    this.turnOffAntisenseEditMode();
+    this.turnOffSyncEditMode();
+  }
+
   public initialize(
     needScroll = true,
     needRemoveSelection = true,

--- a/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
@@ -411,6 +411,7 @@ export abstract class BaseSequenceItemRenderer extends BaseSequenceRenderer {
       (this.isSequenceEditInRnaBuilderModeTurnedOn &&
         !this.node.monomer.selected) ||
       (!this.isSyncEditMode &&
+        this.hasAntisenseInChain &&
         ((this.isAntisenseNode && !this.isAntisenseEditMode) ||
           (!this.isAntisenseNode && this.isAntisenseEditMode)))
     ) {

--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -15,6 +15,7 @@
  ***************************************************************************/
 import { useCallback, useEffect } from 'react';
 import {
+  hasAntisenseChains,
   selectEditor,
   selectEditorActiveTool,
   selectTool,
@@ -57,6 +58,7 @@ export const EditorEvents = () => {
   const activeTool = useAppSelector(selectEditorActiveTool);
   const dispatch = useAppDispatch();
   const presets = useAppSelector(selectAllPresets);
+  const hasAtLeastOneAntisense = useAppSelector(hasAntisenseChains);
 
   const handleMonomersLibraryUpdate = useCallback(() => {
     dispatch(loadMonomerLibrary(editor?.monomersLibrary));
@@ -327,6 +329,12 @@ export const EditorEvents = () => {
       editor?.events.mouseLeavePolymerBond.remove(handleClosePreview);
     };
   }, [editor, activeTool, handleOpenPreview, handleClosePreview]);
+
+  useEffect(() => {
+    if (!hasAtLeastOneAntisense) {
+      editor?.events.resetSequenceEditMode.dispatch();
+    }
+  }, [hasAtLeastOneAntisense]);
 
   return <></>;
 };


### PR DESCRIPTION
Closes:

- #6632 - New sequence appears gray after clearing the canvas in non-sync mode
- #6631 - Sync mode causes incorrect letter input after adding a monomer in non-sync mode

(cherry picked from commit dc7643cca39958e0f4384c8889795912dc3903f8)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request