### PR TITLE
#6606 - Adding nucleotide to the last position having phosphate in antisense works wrong

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -697,12 +697,7 @@ export class SequenceMode extends BaseMode {
       return;
     }
 
-    if (
-      addPhosphateIfNeeded &&
-      firstNodeToConnect instanceof Nucleoside &&
-      (secondNodeToConnect instanceof Nucleotide ||
-        secondNodeToConnect instanceof Nucleoside)
-    ) {
+    if (addPhosphateIfNeeded && firstNodeToConnect instanceof Nucleoside) {
       modelChanges.merge(
         this.bondNodesThroughNewPhosphate(
           newNodePosition,
@@ -2421,13 +2416,6 @@ export class SequenceMode extends BaseMode {
     const newNodePosition = this.getNewNodePosition();
     const previousTwoStrandedNodeInSameChain =
       SequenceRenderer.previousNodeInSameChain;
-
-    if (
-      nextNodeToConnect instanceof MonomerSequenceNode &&
-      nextNodeToConnect.monomer instanceof Phosphate
-    ) {
-      return;
-    }
 
     if (
       nextNodeToConnect instanceof EmptySequenceNode &&


### PR DESCRIPTION
Closes:

#6531 - System can't add nucleotide between phosphate and nucleotide in antisence chain
#6606 - Adding nucleotide to the last position having phosphate in antisense works wrong

## How the feature works? / How did you fix the issue?

- fixed phosphate auto-add rules for sequence mode

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request