### PR TITLE
#6633 - Autotests: Replace selectTopPanelButton(TopPanelButton.Clear, page); function on selectClearCanvasTool(page);

### DIFF
--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Files/cdxml-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/CDXML-Files/cdxml-files.spec.ts
@@ -117,7 +117,7 @@ test.describe('Tests for API setMolecule/getMolecule', () => {
      */
     await openFileAndAddToCanvas('CDXML/cdxml-4716.cdxml', page);
 
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
 
     await pressUndoButton(page);

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Image-files/image-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Image-files/image-files.spec.ts
@@ -683,7 +683,7 @@ test.describe('Image files', () => {
      */
     await openFileAndAddToCanvasAsNewProject('KET/images-png-svg.ket', page);
     await takeEditorScreenshot(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
     await pressUndoButton(page);
     await takeEditorScreenshot(page);
@@ -701,7 +701,7 @@ test.describe('Image files', () => {
       page,
     );
     await takeEditorScreenshot(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
     await pressUndoButton(page);
     await takeEditorScreenshot(page);
@@ -719,7 +719,7 @@ test.describe('Image files', () => {
       page,
     );
     await takeEditorScreenshot(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
     await pressUndoButton(page);
     await takeEditorScreenshot(page);
@@ -735,7 +735,7 @@ test.describe('Image files', () => {
     await openImageAndAddToCanvas('Images/image-svg.svg', page);
     await openImageAndAddToCanvas('Images/image-png.png', page, 200, 200);
     await takeEditorScreenshot(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
     await pressUndoButton(page);
     await takeEditorScreenshot(page);
@@ -946,7 +946,7 @@ test.describe('Image files', () => {
     await selectRing(RingButton.Benzene, page);
     await clickOnCanvas(page, 200, 400);
     await saveToTemplates(page, 'My Custom Template');
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await openStructureLibrary(page);
     await page.getByRole('button', { name: 'User Templates (1)' }).click();
     await page

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/InChi/InChi.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/InChi/InChi.spec.ts
@@ -15,6 +15,7 @@ import {
   copyToClipboardByKeyboard,
   openFileAndAddToCanvasAsNewProject,
   selectOpenFileTool,
+  selectClearCanvasTool,
 } from '@utils';
 import {
   FileType,
@@ -397,7 +398,7 @@ test.describe('Open and Save InChI file', () => {
       .inputValue();
     await copyToClipboardByKeyboard(page);
     await page.getByTestId('close-icon').click();
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await pasteFromClipboardAndAddToCanvas(page, inChistring);
   });
 

--- a/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Rxn-Files/rxn-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Open-And-Save-Files/Rxn-Files/rxn-files.spec.ts
@@ -31,6 +31,7 @@ import {
   setHashSpacingValue,
   setHashSpacingOptionUnit,
   openBondsSettingsSection,
+  selectClearCanvasTool,
 } from '@utils';
 
 import { drawReactionWithTwoBenzeneRings } from '@utils/canvas/drawStructures';
@@ -187,7 +188,7 @@ test.describe('Tests for Open and Save RXN file operations', () => {
     await savedFileInfoStartsWithRxn(page);
 
     await pressButton(page, 'Cancel');
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await selectNestedTool(page, ArrowTool.ARROW_FILLED_BOW);
     await page.mouse.move(xCoordinatesWithShiftHalf, yArrowStart);
     await dragMouseTo(xCoordinatesWithShiftHalf, yArrowEnd, page);

--- a/ketcher-autotests/tests/File-Management/Smile-Files/smile-files.spec.ts
+++ b/ketcher-autotests/tests/File-Management/Smile-Files/smile-files.spec.ts
@@ -17,6 +17,7 @@ import {
   openFileAndAddToCanvasAsNewProject,
   moveMouseAway,
   selectOpenFileTool,
+  selectClearCanvasTool,
 } from '@utils';
 import {
   clickOnFileFormatDropdown,
@@ -41,7 +42,7 @@ async function getAndCompareSmiles(page: Page, smilesFilePath: string) {
 
 async function clearCanvasAndPasteSmiles(page: Page, smiles: string) {
   await pressButton(page, 'Cancel');
-  await selectTopPanelButton(TopPanelButton.Clear, page);
+  await selectClearCanvasTool(page);
   await selectOpenFileTool(page);
   await page.getByText('Paste from clipboard').click();
   await pasteFromClipboard(page, smiles);

--- a/ketcher-autotests/tests/Reactions/Reaction-tools/Multi-Tailed-Arrow-Tool/multi-tailed-arrow-tool.spec.ts
+++ b/ketcher-autotests/tests/Reactions/Reaction-tools/Multi-Tailed-Arrow-Tool/multi-tailed-arrow-tool.spec.ts
@@ -1002,7 +1002,7 @@ test.describe('Multi-Tailed Arrow Tool', () => {
     );
     await selectTopPanelButton(TopPanelButton.Save, page);
     await saveToTemplates(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
 
     await openStructureLibrary(page);
     await selectFromSaveToTemplates(page);

--- a/ketcher-autotests/tests/Reactions/Reaction-tools/Plus-and-Arrow-tools/plus-and-arrows-tools.spec.ts
+++ b/ketcher-autotests/tests/Reactions/Reaction-tools/Plus-and-Arrow-tools/plus-and-arrows-tools.spec.ts
@@ -32,6 +32,7 @@ import {
   clickOnCanvas,
   selectCleanTool,
   selectLayoutTool,
+  selectClearCanvasTool,
 } from '@utils';
 import { pageReloadMicro } from '@utils/common/helpers';
 import {
@@ -642,7 +643,7 @@ test.describe('Plus and Arrows tools ', () => {
         page,
       );
       await takeEditorScreenshot(page);
-      await selectTopPanelButton(TopPanelButton.Clear, page);
+      await selectClearCanvasTool(page);
       await openFileAndAddToCanvas(
         `KET/resizing-reaction-arrow-saving.ket`,
         page,
@@ -673,7 +674,7 @@ test.describe('Plus and Arrows tools ', () => {
     await copyToClipboardByKeyboard(page);
     await pasteFromClipboardByKeyboard(page, { delay: INPUT_DELAY });
 
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
   });
 
   test.describe('Arrow snapping', () => {

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Simple-Objects/action-on-simple-objects.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Simple-Objects/action-on-simple-objects.spec.ts
@@ -21,6 +21,7 @@ import {
   selectAllStructuresOnCanvas,
   clickOnCanvas,
   ZoomInByKeyboard,
+  selectClearCanvasTool,
 } from '@utils';
 import { pressUndoButton } from '@utils/macromolecules/topToolBar';
 import {

--- a/ketcher-autotests/tests/Structure-Creating-&-Editing/Simple-Objects/action-on-simple-objects.spec.ts
+++ b/ketcher-autotests/tests/Structure-Creating-&-Editing/Simple-Objects/action-on-simple-objects.spec.ts
@@ -202,7 +202,7 @@ test.describe('Action on simples objects', () => {
     await clickInTheMiddleOfTheScreen(page);
     await drawBenzeneRing(page);
     await saveToTemplates(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await pressButton(page, STRUCTURE_LIBRARY_BUTTON_NAME);
     await page.getByRole('button', { name: 'User Templates (1)' }).click();
     await takeEditorScreenshot(page);

--- a/ketcher-autotests/tests/Templates/Functional-Groups/Functional-Group-Tools/functional-group-tools.spec.ts
+++ b/ketcher-autotests/tests/Templates/Functional-Groups/Functional-Group-Tools/functional-group-tools.spec.ts
@@ -512,7 +512,7 @@ test.describe('Templates - Functional Group Tools2', () => {
     await resetCurrentTool(page);
     await takeEditorScreenshot(page);
 
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
 
     await openFileAndAddToCanvas(
       'Molfiles-V2000/functional-group-expanded.mol',

--- a/ketcher-autotests/tests/Templates/Functional-Groups/Functional-Group-Tools/functional-group-tools.spec.ts
+++ b/ketcher-autotests/tests/Templates/Functional-Groups/Functional-Group-Tools/functional-group-tools.spec.ts
@@ -35,6 +35,7 @@ import {
   selectDearomatizeTool,
   selectCleanTool,
   selectLayoutTool,
+  selectClearCanvasTool,
 } from '@utils';
 import { getAtomByIndex } from '@utils/canvas/atoms';
 import { getRotationHandleCoordinates } from '@utils/clicks/selectButtonByTitle';

--- a/ketcher-autotests/tests/Templates/Functional-Groups/functional-groups.spec.ts
+++ b/ketcher-autotests/tests/Templates/Functional-Groups/functional-groups.spec.ts
@@ -32,6 +32,7 @@ import {
   moveOnAtom,
   selectAllStructuresOnCanvas,
   clickOnCanvas,
+  selectClearCanvasTool,
 } from '@utils';
 import { getAtomByIndex } from '@utils/canvas/atoms';
 let point: { x: number; y: number };
@@ -197,7 +198,7 @@ test.describe('Functional Groups', () => {
 
     await saveToTemplates(page);
 
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await pressButton(page, STRUCTURE_LIBRARY_BUTTON_NAME);
     await page.getByRole('button', { name: 'User Templates (1)' }).click();
     await page.getByText('0OOCH3CCl3OO').click();

--- a/ketcher-autotests/tests/Templates/Template-Manipulations/Manipulations-rings.spec.ts
+++ b/ketcher-autotests/tests/Templates/Template-Manipulations/Manipulations-rings.spec.ts
@@ -20,6 +20,7 @@ import {
   takeEditorScreenshot,
   TopPanelButton,
   waitForPageInit,
+  selectClearCanvasTool,
 } from '@utils';
 import {
   pressRedoButton,
@@ -92,14 +93,14 @@ async function manipulateRingsByName(type: RingButton, page: Page) {
   await placeTwoRingsMergedByAtom(type, page);
   await moveMouseAway(page);
   await takeEditorScreenshot(page);
-  await selectTopPanelButton(TopPanelButton.Clear, page);
+  await selectClearCanvasTool(page);
 
   await placeTwoRingsMergedByAtom(type, page);
   await mergeRingByBond(type, page);
   await mergeDistantRingByABond(type, page);
   await moveMouseAway(page);
   await takeEditorScreenshot(page);
-  await selectTopPanelButton(TopPanelButton.Clear, page);
+  await selectClearCanvasTool(page);
 
   await selectButtonByTitle(type, page);
   await clickInTheMiddleOfTheScreen(page);

--- a/ketcher-autotests/tests/Templates/User-Templates/user-templates.spec.ts
+++ b/ketcher-autotests/tests/Templates/User-Templates/user-templates.spec.ts
@@ -20,6 +20,7 @@ import {
   getEditorScreenshot,
   clickOnCanvas,
   selectCleanTool,
+  selectClearCanvasTool,
 } from '@utils';
 
 const CANVAS_CLICK_X = 300;
@@ -146,7 +147,7 @@ test.describe('Click User Templates on canvas', () => {
     await page.getByPlaceholder('template').click();
     await page.getByPlaceholder('template').fill('reaction_arrow_template');
     await page.getByRole('button', { name: 'Save', exact: true }).click();
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
 
     await openStructureLibrary(page);
     await page.getByRole('button', { name: 'User Templates (1)' }).click();
@@ -198,7 +199,7 @@ test.describe('Create and Save Templates', () => {
     await clickInTheMiddleOfTheScreen(page);
     await saveToTemplates(page);
 
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await pressButton(page, STRUCTURE_LIBRARY_BUTTON_NAME);
     await page.getByRole('button', { name: 'User Templates (1)' }).click();
     await page.getByText('0NNNNHNHNNHNNHNH').click();
@@ -241,7 +242,7 @@ test.describe('Create and Save Templates', () => {
     await openFileAndAddToCanvas('Molfiles-V2000/long-structure.mol', page);
     await saveToTemplates(page);
 
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await drawBenzeneRing(page);
     await openStructureLibrary(page);
     await page.getByRole('button', { name: 'User Templates (1)' }).click();

--- a/ketcher-autotests/tests/User-Interface/Clear-Canvas/clear-canvas.spec.ts
+++ b/ketcher-autotests/tests/User-Interface/Clear-Canvas/clear-canvas.spec.ts
@@ -25,7 +25,7 @@ test.describe('Clear canvas', () => {
 
   test('Clear Canvas - checking button tooltip', async ({ page }) => {
     // Test case: EPMLSOPKET-1702
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     const button = page.getByTestId('clear-canvas');
     await expect(button).toHaveAttribute('title', 'Clear Canvas (Ctrl+Del)');
     await takeEditorScreenshot(page);
@@ -36,7 +36,7 @@ test.describe('Clear canvas', () => {
     await addTextBoxToCanvas(page);
     await page.getByRole('dialog').getByRole('textbox').fill('one two three');
     await pressButton(page, 'Apply');
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
   });
 
@@ -45,7 +45,7 @@ test.describe('Clear canvas', () => {
     await openFileAndAddToCanvas('Rxn-V2000/reaction-dif-prop.rxn', page);
     await clickInTheMiddleOfTheScreen(page);
     await takeEditorScreenshot(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await clickInTheMiddleOfTheScreen(page);
     await waitForRender(page, async () => {
       await pressUndoButton(page);
@@ -98,7 +98,7 @@ test.describe('Clear canvas', () => {
     // Test case: EPMLSOPKET-1706
     await openFileAndAddToCanvas('SMILES/chain-with-r-group.smi', page);
     await clickInTheMiddleOfTheScreen(page);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await pressUndoButton(page);
     await selectClearCanvasTool(page);
     await pressUndoButton(page);

--- a/ketcher-autotests/tests/User-Interface/Hot-Keys/hotkeys.spec.ts
+++ b/ketcher-autotests/tests/User-Interface/Hot-Keys/hotkeys.spec.ts
@@ -34,6 +34,7 @@ import {
   selectAromatizeTool,
   selectDearomatizeTool,
   selectAddRemoveExplicitHydrogens,
+  selectClearCanvasTool,
 } from '@utils';
 
 test.describe('Hot keys', () => {
@@ -509,7 +510,7 @@ test.describe('Hot key Del', () => {
     });
     await page.keyboard.press('Delete');
     await page.mouse.move(x, y);
-    await selectTopPanelButton(TopPanelButton.Clear, page);
+    await selectClearCanvasTool(page);
     await takeEditorScreenshot(page);
   });
 });


### PR DESCRIPTION
… page); function on selectClearCanvasTool(page);

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [X] e2e-tests written
- [X] documentation updated
- [X] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [X] base branch (master or release/xx) is correct
- [X] task status changed to "Code review"
- [X] reviewers are notified about the pull request