### PR TITLE
Backmerge: #6615 - Missing warning message when deleting all hydrogen bonds between two chains

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceViewModel/SequenceViewModel.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceViewModel/SequenceViewModel.ts
@@ -38,7 +38,7 @@ export class SequenceViewModel {
 
   private chainToHasAntisense: Map<Chain, boolean> = new Map();
 
-  constructor(chainsCollection: ChainsCollection) {
+  constructor(public chainsCollection: ChainsCollection) {
     this.fillNodes(chainsCollection);
     this.fillChains();
     this.postProcessNodes(chainsCollection);

--- a/packages/ketcher-core/src/domain/entities/index.ts
+++ b/packages/ketcher-core/src/domain/entities/index.ts
@@ -50,6 +50,7 @@ export * from './Axis';
 export * from './Nucleoside';
 export * from './Nucleotide';
 export * from './monomer-chains/types';
+export * from './monomer-chains/Chain';
 export * from './MonomerSequenceNode';
 export * from './EmptySequenceNode';
 export * from './LinkerSequenceNode';

--- a/packages/ketcher-macromolecules/src/components/modal/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/ConfirmationDialog/ConfirmationDialog.tsx
@@ -4,6 +4,7 @@ import { ActionButton } from 'components/shared/actionButton';
 import { ConfirmationText } from './ConfirmationDialog.styles';
 
 export const ConfirmationDialog = ({
+  title,
   confirmationText,
   onConfirm,
   isModalOpen,
@@ -15,7 +16,11 @@ export const ConfirmationDialog = ({
   };
 
   return (
-    <Modal isOpen={isModalOpen} title="Confirm your action" onClose={onClose}>
+    <Modal
+      isOpen={isModalOpen}
+      title={title || 'Confirm your action'}
+      onClose={onClose}
+    >
       <Modal.Content>
         <ConfirmationText>{confirmationText}</ConfirmationText>
       </Modal.Content>

--- a/packages/ketcher-macromolecules/src/components/modal/modalContainer/types.ts
+++ b/packages/ketcher-macromolecules/src/components/modal/modalContainer/types.ts
@@ -9,6 +9,7 @@ export interface MonomerConnectionOnlyProps {
 }
 
 export interface ConfirmationDialogOnlyProps {
+  title?: string;
   confirmationText?: string;
   onConfirm?: () => void;
 }


### PR DESCRIPTION
(cherry picked from commit 6ce99a4d8bea8f644374cd7ba3961898dedacd86)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request