### PR TITLE
Backmerge: #6617 - Empty element appears after undoing line deletion in Sequence mode and switching to Flex/Snake mode

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -106,6 +106,7 @@ import { SugarWithBaseSnakeLayoutNode } from 'domain/entities/snake-layout-model
 import { SingleMonomerSnakeLayoutNode } from 'domain/entities/snake-layout-model/SingleMonomerSnakeLayoutNode';
 import { getRnaPartLibraryItem } from 'domain/helpers/rna';
 import { KetcherLogger } from 'utilities';
+import { EmptyMonomer } from 'domain/entities/EmptyMonomer';
 
 export const CELL_WIDTH = 60;
 const VERTICAL_DISTANCE_FROM_ROW_WITHOUT_RNA = CELL_WIDTH;
@@ -559,6 +560,11 @@ export class DrawingEntitiesManager {
     needToDeleteConnectedBonds = true,
   ) {
     const command = new Command();
+
+    if (monomer instanceof EmptyMonomer) {
+      return command;
+    }
+
     const operation = new MonomerDeleteOperation(
       monomer,
       this.addMonomerChangeModel.bind(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request