### PR TITLE
Backmerge: #6443 - System allow to select single antisense symbol that causes an error if it got deleted

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1099,16 +1099,33 @@ export class SequenceMode extends BaseMode {
       let nodesToDelete: TwoStrandedNodesSelection;
 
       if (selections.length) {
-        modelChanges.merge(this.deleteSelectedDrawingEntities());
         nodesToDelete = selections;
+
+        const senseNodesToDelete = nodesToDelete.filter((selectionRange) =>
+          selectionRange.every(
+            (nodeSelection) => nodeSelection.node.senseNode?.monomer.selected,
+          ),
+        );
+        const antisenseNodesToDelete = nodesToDelete.filter((selectionRange) =>
+          selectionRange.every(
+            (nodeSelection) =>
+              nodeSelection.node.antisenseNode?.monomer.selected,
+          ),
+        );
+
+        modelChanges.merge(this.deleteSelectedDrawingEntities());
+
         if (this.needToEditSense) {
           modelChanges.merge(
-            this.handleNodesDeletion(nodesToDelete, STRAND_TYPE.SENSE),
+            this.handleNodesDeletion(senseNodesToDelete, STRAND_TYPE.SENSE),
           );
         }
         if (this.needToEditAntisense) {
           modelChanges.merge(
-            this.handleNodesDeletion(nodesToDelete, STRAND_TYPE.ANTISENSE),
+            this.handleNodesDeletion(
+              antisenseNodesToDelete,
+              STRAND_TYPE.ANTISENSE,
+            ),
           );
         }
       } else if (nodeToDelete) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request