### PR TITLE
Backmerge: #6783 - Incorrect cursor jumps after phosphate insertion in middle or at end of sequence

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1415,6 +1415,8 @@ export class SequenceMode extends BaseMode {
           let senseNodeToConnect = currentTwoStrandedNode?.senseNode;
           const isDnaEnteringMode =
             editor.sequenceTypeEnterMode === SequenceType.DNA;
+          const isRnaEnteringMode =
+            editor.sequenceTypeEnterMode === SequenceType.RNA;
           const isEnteringSymbolP = enteredSymbol.toUpperCase() === 'P';
 
           if (this.needToEditSense) {
@@ -1496,7 +1498,30 @@ export class SequenceMode extends BaseMode {
 
           modelChanges.addOperation(new ReinitializeModeOperation());
           editor.renderersContainer.update(modelChanges);
-          modelChanges.addOperation(SequenceRenderer.moveCaretForward());
+
+          if (
+            // If user type symbol that becomes part of a linker then caret does not move
+            !(isDnaEnteringMode || isRnaEnteringMode) ||
+            !(
+              isEnteringSymbolP &&
+              (this.needToEditSense
+                ? LinkerSequenceNode.isPartOfLinker(
+                    previousTwoStrandedNodeInSameChain?.senseNode?.monomer,
+                  ) ||
+                  LinkerSequenceNode.isPartOfLinker(
+                    currentTwoStrandedNode?.senseNode?.monomer,
+                  )
+                : LinkerSequenceNode.isPartOfLinker(
+                    previousTwoStrandedNodeInSameChain?.antisenseNode?.monomer,
+                  ) ||
+                  LinkerSequenceNode.isPartOfLinker(
+                    currentTwoStrandedNode?.antisenseNode?.monomer,
+                  ))
+            )
+          ) {
+            modelChanges.addOperation(SequenceRenderer.moveCaretForward());
+          }
+
           history.update(modelChanges);
         },
       },


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- prevent caret move if added sequence item becomes part of linker

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request