### PR TITLE
add types to exports in package.json files

### DIFF
--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -138,6 +138,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "require": "./dist/cjs/index.js"
     },
     "./dist/index.css": {

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -81,7 +81,8 @@
   "exports": {
     ".": {
       "import": "./dist/main.js",
-      "require": "./dist/cjs/main.js"
+      "require": "./dist/cjs/main.js",
+      "types": "./dist/index.d.ts"
     },
     "./dist/binaryWasm": {
       "import": "./dist/binaryWasm/main.js",


### PR DESCRIPTION
## How did you fix the issue?
I've added the missing types fields to the exports in `package.json`. When using `"moduleResolution": "bundler"` typescript, currently raises issues like (#5760):
```
Could not find a declaration file for module 'ketcher-standalone'. '/Users/oliver/codetemp/im/squonk-frontend/apps/data-manager-ui/node_modules/.pnpm/ketcher-standalone@3.1.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/ketcher-standalone/dist/main.js' implicitly has an 'any' type.
  There are types at '/Users/oliver/codetemp/im/squonk-frontend/apps/data-manager-ui/node_modules/ketcher-standalone/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'ketcher-standalone' library may need to update its package.json or typings.ts(7016)
```

Now when Typescript uses the exports field, it is able to find the types correctly.