### PR TITLE
#6870 - Enter key adds undeletable preset to preset section

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -336,7 +336,9 @@ export const RnaEditorExpanded = ({
         event.preventDefault();
         event.stopPropagation();
       } else if (event.key === 'Enter') {
-        isSequenceEditInRNABuilderMode ? onUpdateSequence() : onSave();
+        isSequenceEditInRNABuilderMode
+          ? onUpdateSequence()
+          : editor.events.startNewSequence.dispatch({});
         event.preventDefault();
         event.stopPropagation();
       }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

##What was the issue?
On Macromolecules mode RNA Editor tab if any presets selected in presets section on sequence mode. If I press the `Enter` key the a new preset was duplication happens (because of triggering the onSave func on the case). That was blocking the present selection and the Enter key behaviour.

##What was done?
Regarding the case onSave method has been replaced with the Editor New Sequence method. `Enter` key starts new sequence in editor as expected.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request