### PR TITLE
Backmerge: #7008 – Support of expanded monomer options doesn't work if monomer loaded from file/clipboard

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher.spec.ts
@@ -2401,8 +2401,6 @@ const nonExpandableMonomers: IMonomer[] = [
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/1. Peptide X (ambiguouse, alternatives, from library).ket',
     monomerLocatorText: 'X',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription:
@@ -2410,16 +2408,12 @@ const nonExpandableMonomers: IMonomer[] = [
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/2. Peptide A+C+D+E+F+G+H+I+K+L+M+N+O+P+Q+R+S+T+U+V+W+Y (ambiguouse, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '3. Peptide G+H+I+K+L+M+N+O+P (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/3. Peptide G+H+I+K+L+M+N+O+P (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription:
@@ -2427,112 +2421,84 @@ const nonExpandableMonomers: IMonomer[] = [
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/4. Peptide G,H,I,K,L,M,N,O,P (ambiguous, alternatives).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '5. Sugar UNA, SGNA, RGNA (ambiguous, alternatives)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/5. Sugar UNA, SGNA, RGNA (ambiguous, alternatives).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '6. Sugar UNA, SGNA, RGNA (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/6. Sugar UNA, SGNA, RGNA (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '7. DNA base N (ambiguous, alternatives, from library)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/7. DNA base N (ambiguous, alternatives, from library).ket',
     monomerLocatorText: 'N',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '8. RNA base N (ambiguous, alternatives, from library)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/8. RNA base N (ambiguous, alternatives, from library).ket',
     monomerLocatorText: 'N',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '9. Base M (ambiguous, alternatives, from library)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/9. Base M (ambiguous, alternatives, from library).ket',
     monomerLocatorText: 'M',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '10. DNA base A+C+G+T (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/10. DNA base A+C+G+T (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '11. RNA base A+C+G+U (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/11. RNA base A+C+G+U (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '12. Base A+C (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/12. Base A+C (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '13. Phosphate bnn,cmp,nen (ambiguous, alternatives)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/13. Phosphate bnn,cmp,nen (ambiguous, alternatives).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '14. Phosphate bnn+cmp+nen (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/14. Phosphate bnn+cmp+nen (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '15. CHEM PEG-2,PEG-4,PEG-6 (ambiguous, alternatives)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/15. CHEM PEG-2,PEG-4,PEG-6 (ambiguous, alternatives).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '16. CHEM PEG-2+PEG-4+PEG-6 (ambiguous, mixed)',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/16. CHEM PEG-2+PEG-4+PEG-6 (ambiguous, mixed).ket',
     monomerLocatorText: '%',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5789',
   },
   {
     monomerDescription: '17. Unknown nucleotide',
     KETFile:
       'KET/Micro-Macro-Switcher/Basic-Monomers/Negative/17. Unknown nucleotide.ket',
     monomerLocatorText: 'Unknown',
-    shouldFail: true,
-    issueNumber: 'https://github.com/epam/ketcher/issues/5791',
   },
 ];
 
@@ -2552,12 +2518,6 @@ test.describe('Impossible to expand on Micro canvas: ', () => {
        *       3. Call context menu for appeared monomer
        *       4. Check if Expand monomer menu option is disabled
        */
-      // Test should be skipped if related bug exists
-      test.fail(
-        nonExpandableMonomer.shouldFail === true,
-        `That test fails because of ${nonExpandableMonomer.issueNumber} issue(s).`,
-      );
-
       await openFileAndAddToCanvasAsNewProject(
         nonExpandableMonomer.KETFile,
         page,

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -34,6 +34,8 @@ import {
   KetcherLogger,
   fromPaste,
   Coordinates,
+  Atom,
+  Pool,
 } from 'ketcher-core';
 import {
   DOMSubscription,
@@ -97,25 +99,32 @@ const highlightTargets = [
 ];
 
 function selectStereoFlagsIfNecessary(
-  atoms: any,
-  expAtoms: number[],
+  atoms: Pool<Atom>,
+  explicitlySelectedAtoms: number[],
 ): number[] {
-  const atomsOfFragments = {};
+  const fragmentToAtoms: Map<number, number[]> = new Map();
   atoms.forEach((atom, atomId) => {
-    atomsOfFragments[atom.fragment]
-      ? atomsOfFragments[atom.fragment].push(atomId)
-      : (atomsOfFragments[atom.fragment] = [atomId]);
+    const atomFragment = atom.fragment;
+    if (atomFragment === -1) {
+      return;
+    }
+
+    const currentAtoms = fragmentToAtoms.get(atomFragment) ?? [];
+    const updatedAtoms = currentAtoms.concat(atomId);
+    fragmentToAtoms.set(atomFragment, updatedAtoms);
   });
 
-  const stereoFlags: number[] = [];
+  let stereoFlags: number[] = [];
+  fragmentToAtoms.forEach((fragmentAtoms, fragmentId) => {
+    const shouldSelectStereoFlag = fragmentAtoms.every((atomId) =>
+      explicitlySelectedAtoms.includes(atomId),
+    );
 
-  Object.keys(atomsOfFragments).forEach((fragId) => {
-    let shouldSelSFlag = true;
-    atomsOfFragments[fragId].forEach((atomId) => {
-      if (!expAtoms.includes(atomId)) shouldSelSFlag = false;
-    });
-    shouldSelSFlag && stereoFlags.push(Number(fragId));
+    if (shouldSelectStereoFlag) {
+      stereoFlags = stereoFlags.concat(fragmentId);
+    }
   });
+
   return stereoFlags;
 }
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMonomerExpansionHandlers.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMonomerExpansionHandlers.ts
@@ -1,4 +1,11 @@
-import { Action, setExpandMonomerSGroup } from 'ketcher-core';
+import {
+  Action,
+  AmbiguousMonomer,
+  FunctionalGroup,
+  MonomerMicromolecule,
+  setExpandMonomerSGroup,
+  UnresolvedMonomer,
+} from 'ketcher-core';
 import { useCallback } from 'react';
 import { useAppContext } from 'src/hooks';
 import Editor from 'src/script/editor';
@@ -8,6 +15,14 @@ import {
 } from '../contextMenu.types';
 
 type Params = ItemEventParams<MacromoleculeContextMenuProps>;
+
+export const canExpandMonomer = (functionalGroup: FunctionalGroup) => {
+  return (
+    functionalGroup.relatedSGroup instanceof MonomerMicromolecule &&
+    !(functionalGroup.relatedSGroup.monomer instanceof AmbiguousMonomer) &&
+    !(functionalGroup.relatedSGroup.monomer instanceof UnresolvedMonomer)
+  );
+};
 
 const useMonomerExpansionHandlers = () => {
   const { getKetcherInstance } = useAppContext();
@@ -21,6 +36,10 @@ const useMonomerExpansionHandlers = () => {
       const action = new Action();
 
       selectedFunctionalGroups?.forEach((fg) => {
+        if (!canExpandMonomer(fg)) {
+          return;
+        }
+
         action.mergeWith(
           setExpandMonomerSGroup(molecule, fg.relatedSGroupId, {
             expanded: toExpand,

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/MacromoleculeMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/MacromoleculeMenuItems.tsx
@@ -3,7 +3,9 @@ import {
   MenuItemsProps,
 } from '../contextMenu.types';
 import { Item } from 'react-contexify';
-import useMonomerExpansionHandlers from '../hooks/useMonomerExpansionHandlers';
+import useMonomerExpansionHandlers, {
+  canExpandMonomer,
+} from '../hooks/useMonomerExpansionHandlers';
 
 const MacromoleculeMenuItems = (
   props: MenuItemsProps<MacromoleculeContextMenuProps>,
@@ -11,8 +13,14 @@ const MacromoleculeMenuItems = (
   const [action, hidden] = useMonomerExpansionHandlers();
 
   const multipleMonomersSelected =
-    props?.propsFromTrigger?.functionalGroups &&
+    props?.propsFromTrigger?.functionalGroups !== undefined &&
     props.propsFromTrigger.functionalGroups.length > 1;
+
+  const expandingDisabled =
+    props.propsFromTrigger?.functionalGroups !== undefined &&
+    props.propsFromTrigger.functionalGroups.every(
+      (fg) => !canExpandMonomer(fg),
+    );
 
   const expandText = multipleMonomersSelected
     ? 'Expand monomers'
@@ -27,6 +35,7 @@ const MacromoleculeMenuItems = (
         {...props}
         hidden={(params) => hidden(params, true)}
         onClick={(params) => action(params, true)}
+        disabled={expandingDisabled}
       >
         {expandText}
       </Item>


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request