### PR TITLE
#7033 – calculateMacroProperties API is called immediately on sequence selection, even when Calculate Properties window is closed

### DIFF
--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/CalculateMacromoleculePropertiesButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/CalculateMacromoleculePropertiesButton.tsx
@@ -17,7 +17,7 @@
 import { useAppDispatch, useAppSelector } from 'hooks';
 import {
   selectIsMacromoleculesPropertiesWindowOpened,
-  setMacromoleculesPropertiesWindowVisibility,
+  toggleMacromoleculesPropertiesWindowVisibility,
 } from 'state/common';
 import styled from '@emotion/styled';
 import { Button } from 'ketcher-react';
@@ -51,22 +51,20 @@ const StyledButton = styled(Button)<{ isActive?: boolean }>(
 
 export const CalculateMacromoleculePropertiesButton = () => {
   const dispatch = useAppDispatch();
+
   const isMacromoleculesPropertiesWindowOpened = useAppSelector(
     selectIsMacromoleculesPropertiesWindowOpened,
   );
+
   const recalculateMacromoleculeProperties =
     useRecalculateMacromoleculeProperties();
 
   const handleClick = async () => {
-    const isMacromoleculesPropertiesWindowOpenedNewState =
-      !isMacromoleculesPropertiesWindowOpened;
+    if (!isMacromoleculesPropertiesWindowOpened) {
+      await recalculateMacromoleculeProperties();
+    }
 
-    await recalculateMacromoleculeProperties();
-    dispatch(
-      setMacromoleculesPropertiesWindowVisibility(
-        isMacromoleculesPropertiesWindowOpenedNewState,
-      ),
-    );
+    dispatch(toggleMacromoleculesPropertiesWindowVisibility({}));
 
     blurActiveElement();
   };

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/CalculateMacromoleculePropertiesButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/CalculateMacromoleculePropertiesButton.tsx
@@ -60,9 +60,8 @@ export const CalculateMacromoleculePropertiesButton = () => {
     useRecalculateMacromoleculeProperties();
 
   const handleClick = async () => {
-    if (!isMacromoleculesPropertiesWindowOpened) {
-      await recalculateMacromoleculeProperties();
-    }
+    const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
+    await recalculateMacromoleculeProperties(skipDataFetch);
 
     dispatch(toggleMacromoleculesPropertiesWindowVisibility({}));
 

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -689,26 +689,6 @@ export const MacromoleculePropertiesWindow = () => {
   const macromoleculesProperties = useAppSelector(
     selectMacromoleculesProperties,
   );
-  const firstMacromoleculesProperties:
-    | SingleChainMacromoleculeProperties
-    | undefined = macromoleculesProperties?.[0];
-  const [selectedTabIndex, setSelectedTabIndex] = useState(
-    PROPERTIES_TABS.PEPTIDES,
-  );
-  const [massMeasurementUnit, setMassMeasurementUnit] = useState(
-    calculateMassMeasurementUnit(firstMacromoleculesProperties?.mass),
-  );
-  const isMacromoleculesPropertiesWindowOpened = useAppSelector(
-    selectIsMacromoleculesPropertiesWindowOpened,
-  );
-  const recalculateMacromoleculeProperties =
-    useRecalculateMacromoleculeProperties();
-  const debouncedRecalculateMacromoleculeProperties = useCallback(
-    debounce(() => {
-      recalculateMacromoleculeProperties();
-    }, 500),
-    [recalculateMacromoleculeProperties],
-  );
   const unipositiveIonsMeasurementUnit = useAppSelector(
     selectUnipositiveIonsMeasurementUnit,
   );
@@ -716,9 +696,34 @@ export const MacromoleculePropertiesWindow = () => {
     selectOligonucleotidesMeasurementUnit,
   );
 
+  const firstMacromoleculesProperties:
+    | SingleChainMacromoleculeProperties
+    | undefined = macromoleculesProperties?.[0];
+
+  const [selectedTabIndex, setSelectedTabIndex] = useState(
+    PROPERTIES_TABS.PEPTIDES,
+  );
+  const [massMeasurementUnit, setMassMeasurementUnit] = useState(
+    calculateMassMeasurementUnit(firstMacromoleculesProperties?.mass),
+  );
+
+  const isMacromoleculesPropertiesWindowOpened = useAppSelector(
+    selectIsMacromoleculesPropertiesWindowOpened,
+  );
+
+  const recalculateMacromoleculeProperties =
+    useRecalculateMacromoleculeProperties();
+  const debouncedRecalculateMacromoleculeProperties = useCallback(
+    debounce((shouldSkip?: boolean) => {
+      recalculateMacromoleculeProperties(shouldSkip);
+    }, 500),
+    [recalculateMacromoleculeProperties],
+  );
+
+  const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
   useEffect(() => {
     const selectEntitiesHandler = () => {
-      debouncedRecalculateMacromoleculeProperties();
+      debouncedRecalculateMacromoleculeProperties(skipDataFetch);
     };
 
     editor?.events.selectEntities.add(selectEntitiesHandler);
@@ -726,10 +731,10 @@ export const MacromoleculePropertiesWindow = () => {
     return () => {
       editor?.events.selectEntities.remove(selectEntitiesHandler);
     };
-  }, [editor]);
+  }, [editor, skipDataFetch]);
 
   useEffect(() => {
-    debouncedRecalculateMacromoleculeProperties();
+    debouncedRecalculateMacromoleculeProperties(skipDataFetch);
   }, [unipositiveIonsMeasurementUnit, oligonucleotidesMeasurementUnit]);
 
   useEffect(() => {

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -735,7 +735,11 @@ export const MacromoleculePropertiesWindow = () => {
 
   useEffect(() => {
     debouncedRecalculateMacromoleculeProperties(skipDataFetch);
-  }, [unipositiveIonsMeasurementUnit, oligonucleotidesMeasurementUnit]);
+  }, [
+    unipositiveIonsMeasurementUnit,
+    oligonucleotidesMeasurementUnit,
+    skipDataFetch,
+  ]);
 
   useEffect(() => {
     setSelectedTabIndex(

--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -33,8 +33,8 @@ export const useRecalculateMacromoleculeProperties = () => {
     selectOligonucleotidesMeasurementUnit,
   );
 
-  return async () => {
-    if (!editor) {
+  return async (shouldSkip?: boolean) => {
+    if (!editor || shouldSkip) {
       return;
     }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request