### PR TITLE
Backmerge: #7033 – calculateMacroProperties API is called immediately…

### DIFF
--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/CalculateMacromoleculePropertiesButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/CalculateMacromoleculePropertiesButton.tsx
@@ -17,7 +17,7 @@
 import { useAppDispatch, useAppSelector } from 'hooks';
 import {
   selectIsMacromoleculesPropertiesWindowOpened,
-  setMacromoleculesPropertiesWindowVisibility,
+  toggleMacromoleculesPropertiesWindowVisibility,
 } from 'state/common';
 import styled from '@emotion/styled';
 import { Button } from 'ketcher-react';
@@ -51,22 +51,19 @@ const StyledButton = styled(Button)<{ isActive?: boolean }>(
 
 export const CalculateMacromoleculePropertiesButton = () => {
   const dispatch = useAppDispatch();
+
   const isMacromoleculesPropertiesWindowOpened = useAppSelector(
     selectIsMacromoleculesPropertiesWindowOpened,
   );
+
   const recalculateMacromoleculeProperties =
     useRecalculateMacromoleculeProperties();
 
   const handleClick = async () => {
-    const isMacromoleculesPropertiesWindowOpenedNewState =
-      !isMacromoleculesPropertiesWindowOpened;
+    const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
+    await recalculateMacromoleculeProperties(skipDataFetch);
 
-    await recalculateMacromoleculeProperties();
-    dispatch(
-      setMacromoleculesPropertiesWindowVisibility(
-        isMacromoleculesPropertiesWindowOpenedNewState,
-      ),
-    );
+    dispatch(toggleMacromoleculesPropertiesWindowVisibility({}));
 
     blurActiveElement();
   };

--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -33,8 +33,8 @@ export const useRecalculateMacromoleculeProperties = () => {
     selectOligonucleotidesMeasurementUnit,
   );
 
-  return async () => {
-    if (!editor) {
+  return async (shouldSkip?: boolean) => {
+    if (!editor || shouldSkip) {
       return;
     }
 


### PR DESCRIPTION
… on sequence selection, even when Calculate Properties window is closed

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request