### PR TITLE
Backmerge: #7017 - “Calculate Properties” shows wrong behavior when sequence is connected to microstructure

### DIFF
--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -43,7 +43,7 @@ export const useRecalculateMacromoleculeProperties = () => {
       editor.drawingEntitiesManager.filterSelection();
     const ketSerializer = new KetSerializer();
     const drawingEntitiesManagerToCalculateProperties =
-      selectionDrawingEntitiesManager.hasMonomers
+      selectionDrawingEntitiesManager.hasDrawingEntities
         ? selectionDrawingEntitiesManager
         : editor.drawingEntitiesManager;
     const chainsCollection = ChainsCollection.fromMonomers([
@@ -51,7 +51,7 @@ export const useRecalculateMacromoleculeProperties = () => {
     ]);
 
     if (
-      !drawingEntitiesManagerToCalculateProperties.hasMonomers ||
+      !drawingEntitiesManagerToCalculateProperties.hasDrawingEntities ||
       chainsCollection.chains.length > 2 ||
       (chainsCollection.chains.length === 2 &&
         !isSenseAntisenseChains(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed recalculate properties to handle only micro structures selected

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request