### PR TITLE
#6340 - Get rid of GENERATE_DATA flag in updating example files process 

### DIFF
--- a/ketcher-autotests/package.json
+++ b/ketcher-autotests/package.json
@@ -20,8 +20,8 @@
     "docker:test-popup": "docker-compose run --rm autotests bash /app/test_run.sh --project=chromium-popup --grep @chromium-popup",
     "docker:trace": "docker-compose run --rm autotests bash /app/test_run.sh --project=chromium --grep-invert @chromium-popup --trace on",
     "docker:trace-popup": "docker-compose run --rm autotests bash /app/test_run.sh --project=chromium-popup --grep @chromium-popup --trace on",
-    "docker:update": "docker-compose run --rm autotests bash /app/test_run.sh --project=chromium --grep-invert @chromium-popup --update-snapshots",
-    "docker:update-popup": "docker-compose run --rm autotests bash /app/test_run.sh --project=chromium-popup --grep @chromium-popup --update-snapshots"
+    "docker:update": "docker-compose run --rm -e GENERATE_DATA=true autotests bash /app/test_run.sh --project=chromium --grep-invert @chromium-popup --update-snapshots",
+    "docker:update-popup": "docker-compose run --rm -e GENERATE_DATA=true autotests bash /app/test_run.sh --project=chromium-popup --grep @chromium-popup --update-snapshots"
   },
   "author": "Nitvex",
   "license": "ISC",


### PR DESCRIPTION
Pass GENERATE_DATA environment variable to Docker container for automatic data generation during test runs without manual .env file editing.


## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request