### PR TITLE
Backmerge: #7074 - Formula in "Calculate Properties" window is not updated when selecting monomers with connected microstructure

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -1949,6 +1949,25 @@ export class DrawingEntitiesManager {
           MACROMOLECULES_BOND_TYPES.HYDROGEN,
           entity,
         );
+      } else if (entity instanceof MonomerToAtomBond) {
+        filteredDrawingEntitiesManager.addMonomerToAtomBondChangeModel(
+          entity.monomer,
+          entity.atom,
+          entity.monomer.getAttachmentPointByBond(
+            entity,
+          ) as AttachmentPointName,
+          entity,
+        );
+      } else if (entity instanceof Bond) {
+        filteredDrawingEntitiesManager.addBondChangeModel(
+          entity.firstAtom,
+          entity.secondAtom,
+          entity.type,
+          entity.stereo,
+          entity.bondIdInMicroMode,
+          entity,
+          entity.cip,
+        );
       }
     });
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added monomer to atom bond to selection

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request