### PR TITLE
Backmerge: #7034 - Unipositive ions default value is shown in nM instead of mM for double-stranded sequence selection

### DIFF
--- a/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
+++ b/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
@@ -32,7 +32,7 @@ import {
   isAntisenseCreationDisabled,
   isAntisenseOptionVisible,
 } from 'components/contextMenu/SelectedMonomersContextMenu/helpers';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IconName } from 'ketcher-react';
 import { CalculateMacromoleculePropertiesButton } from 'components/macromoleculeProperties';
 import { hotkeysShortcuts } from 'components/ZoomControls/helpers';
@@ -51,23 +51,32 @@ export function TopMenuComponent() {
     useState<IconName>();
   const activeMenuItems = [activeTool];
   const isDisabled = isSequenceEditInRNABuilderMode;
-  editor?.events.selectEntities.add((selectedEntities: BaseMonomer[]) => {
-    setSelectedEntities(selectedEntities);
-    if (
-      selectedEntities.length &&
-      !isAntisenseCreationDisabled(selectedEntities)
-    ) {
-      setNeedOpenByMenuItemClick(false);
-      if (hasOnlyDeoxyriboseSugars(selectedEntities)) {
-        setAntisenseActiveOption('antisenseDnaStrand');
-      } else if (hasOnlyRiboseSugars(selectedEntities)) {
-        setAntisenseActiveOption('antisenseRnaStrand');
-      } else {
-        setAntisenseActiveOption('antisenseStrand');
-        setNeedOpenByMenuItemClick(true);
+
+  useEffect(() => {
+    const selectEntitiesHandler = (selectedEntities: BaseMonomer[]) => {
+      setSelectedEntities(selectedEntities);
+      if (
+        selectedEntities.length &&
+        !isAntisenseCreationDisabled(selectedEntities)
+      ) {
+        setNeedOpenByMenuItemClick(false);
+        if (hasOnlyDeoxyriboseSugars(selectedEntities)) {
+          setAntisenseActiveOption('antisenseDnaStrand');
+        } else if (hasOnlyRiboseSugars(selectedEntities)) {
+          setAntisenseActiveOption('antisenseRnaStrand');
+        } else {
+          setAntisenseActiveOption('antisenseStrand');
+          setNeedOpenByMenuItemClick(true);
+        }
       }
-    }
-  });
+    };
+
+    editor?.events.selectEntities.add(selectEntitiesHandler);
+
+    return () => {
+      editor?.events.selectEntities.remove(selectEntitiesHandler);
+    };
+  }, [editor]);
 
   const menuItemChanged = (name) => {
     if (modalComponentList[name]) {

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -30,7 +30,7 @@ import styled from '@emotion/styled';
 import _round from 'lodash/round';
 import _map from 'lodash/map';
 import { Tabs } from 'components/shared/Tabs';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   peptideNaturalAnalogues,
   rnaDnaNaturalAnalogues,
@@ -611,7 +611,7 @@ const RnaProperties = (props: DnaRnaPropertiesProps) => {
       <RnaBasicPropertiesWrapper>
         {isNumber(props.macromoleculesProperties.Tm) ? (
           <BasicProperty
-            name="Melting temperature"
+            name="Melting Temp. (°C)"
             value={_round(props.macromoleculesProperties.Tm, 1)}
             hint="The melting temperature is calculated using the method from Khandelwal G. and Bhyravabhotla J. (2010). Only base natural analogues are used in the calculation."
           />
@@ -706,17 +706,23 @@ export const MacromoleculePropertiesWindow = () => {
 
   const recalculateMacromoleculeProperties =
     useRecalculateMacromoleculeProperties();
-  const debouncedRecalculateMacromoleculeProperties = useCallback(
-    debounce((shouldSkip?: boolean) => {
-      recalculateMacromoleculeProperties(shouldSkip);
-    }, 500),
-    [recalculateMacromoleculeProperties],
-  );
-
   const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
+  const debouncedRecalculateMacromoleculePropertiesRef = useRef<
+    (shouldSkip?: boolean) => void
+  >(recalculateMacromoleculeProperties);
+
+  useEffect(() => {
+    debouncedRecalculateMacromoleculePropertiesRef.current = debounce(
+      (shouldSkip?: boolean) => {
+        recalculateMacromoleculeProperties(shouldSkip);
+      },
+      500,
+    );
+  }, [recalculateMacromoleculeProperties]);
+
   useEffect(() => {
     const selectEntitiesHandler = () => {
-      debouncedRecalculateMacromoleculeProperties(skipDataFetch);
+      debouncedRecalculateMacromoleculePropertiesRef.current(skipDataFetch);
     };
 
     editor?.events.selectEntities.add(selectEntitiesHandler);
@@ -727,7 +733,7 @@ export const MacromoleculePropertiesWindow = () => {
   }, [editor, skipDataFetch]);
 
   useEffect(() => {
-    debouncedRecalculateMacromoleculeProperties(skipDataFetch);
+    debouncedRecalculateMacromoleculePropertiesRef.current(skipDataFetch);
   }, [
     unipositiveIonsMeasurementUnit,
     oligonucleotidesMeasurementUnit,

--- a/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
@@ -68,7 +68,7 @@ const initialState: EditorState = {
   isContextMenuActive: false,
   isMacromoleculesPropertiesWindowOpened: false,
   macromoleculesProperties: undefined,
-  unipositiveIonsMeasurementUnit: MolarMeasurementUnit.nanoMol,
+  unipositiveIonsMeasurementUnit: MolarMeasurementUnit.milliMol,
   oligonucleotidesMeasurementUnit: MolarMeasurementUnit.microMol,
 };
 


### PR DESCRIPTION
Closes:
#7034 - Unipositive ions default value is shown in nM instead of mM for double-stranded sequence selection
#7030 - Missing Celsius symbol (°C) in “Melting temperature” label

## How the feature works? / How did you fix the issue?

- fixed default value for upc
- fixed title for melting temperature
- fixed memory leak for selectEntities event
- fixed sending macro properties calculation request with stale upc and nac measurement units

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request