### PR TITLE
Backmerge: #7085 - Ketcher does not send bond type to Indigo if connection is different from R2–R1, causing missing data in "Calculate Properties"

### DIFF
--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -1,6 +1,7 @@
 import {
   AmbiguousMonomer,
   BaseMonomer,
+  HydrogenBond,
   MONOMER_CLASS_TO_CONSTRUCTOR,
   Peptide,
   Phosphate,
@@ -296,4 +297,34 @@ export function isRnaBaseApplicableForAntisense(monomer?: BaseMonomer) {
     (isRnaBaseOrAmbiguousRnaBase(monomer) &&
       Boolean(getSugarFromRnaBase(monomer)))
   );
+}
+
+export function getAllConnectedMonomersRecursively(
+  monomer: BaseMonomer,
+): BaseMonomer[] {
+  const stack = [monomer];
+  const visited = new Set<BaseMonomer>();
+  const connectedMonomers: BaseMonomer[] = [];
+
+  while (stack.length > 0) {
+    const currentMonomer = stack.pop();
+
+    if (!currentMonomer || visited.has(currentMonomer)) {
+      continue;
+    }
+
+    visited.add(currentMonomer);
+    connectedMonomers.push(currentMonomer);
+
+    currentMonomer.forEachBond((bond) => {
+      if (bond instanceof PolymerBond || bond instanceof HydrogenBond) {
+        const anotherMonomer = bond.getAnotherMonomer(currentMonomer);
+        if (anotherMonomer && !visited.has(anotherMonomer)) {
+          stack.push(anotherMonomer);
+        }
+      }
+    });
+  }
+
+  return connectedMonomers;
 }

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -764,7 +764,7 @@ export const MacromoleculePropertiesWindow = () => {
   };
 
   const hasCommonError =
-    !firstMacromoleculesProperties || macromoleculesProperties.length > 2;
+    !firstMacromoleculesProperties || macromoleculesProperties.length > 1;
   const hasPeptidesTabError =
     hasCommonError ||
     !hasSpecificProperty(firstMacromoleculesProperties, 'peptides');

--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -2,6 +2,7 @@ import { IndigoProvider } from 'ketcher-react';
 import {
   Chain,
   ChainsCollection,
+  getAllConnectedMonomersRecursively,
   KetcherLogger,
   KetSerializer,
   Struct,
@@ -15,13 +16,6 @@ import {
   setMacromoleculesProperties,
 } from 'state/common';
 import { useAppDispatch, useAppSelector } from './stateHooks';
-
-function isSenseAntisenseChains(chain1: Chain, chain2: Chain) {
-  return (
-    (chain1.isAntisense && !chain2.isAntisense) ||
-    (!chain1.isAntisense && chain2.isAntisense)
-  );
-}
 
 export const useRecalculateMacromoleculeProperties = () => {
   const dispatch = useAppDispatch();
@@ -49,15 +43,17 @@ export const useRecalculateMacromoleculeProperties = () => {
     const chainsCollection = ChainsCollection.fromMonomers([
       ...drawingEntitiesManagerToCalculateProperties.monomers.values(),
     ]);
+    const areAllMonomersConnectedByCovalentOrHydrogenBonds =
+      chainsCollection.chains.reduce(
+        (acc: number, chain: Chain) => acc + chain.monomers.length,
+        0,
+      ) <=
+      getAllConnectedMonomersRecursively(chainsCollection.firstNode.monomer)
+        .length;
 
     if (
       !drawingEntitiesManagerToCalculateProperties.hasDrawingEntities ||
-      chainsCollection.chains.length > 2 ||
-      (chainsCollection.chains.length === 2 &&
-        !isSenseAntisenseChains(
-          chainsCollection.chains[0],
-          chainsCollection.chains[1],
-        ))
+      !areAllMonomersConnectedByCovalentOrHydrogenBonds
     ) {
       dispatch(setMacromoleculesProperties(undefined));
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request