### PR TITLE
Backmerge: #7027 - Incorrect highlight (missing fill) for leaving-group atoms

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -89,6 +89,8 @@ class ReAtom extends ReObject {
     rectangle: any;
   };
 
+  private expandedMonomerAttachmentPoints?: any; // Raphael paths
+
   constructor(atom: Atom) {
     super('atom');
     this.a = atom; // TODO rename a to item
@@ -117,11 +119,28 @@ class ReAtom extends ReObject {
 
     render.ctab.addReObjectPath(LayerMap.atom, this.visel, ret);
 
-    if (!this.selected) {
-      this.makeMonomerAttachmentPointHighlightPlate(render);
+    return ret;
+  }
+
+  setHover(hover: boolean, render: Render) {
+    super.setHover(hover, render);
+
+    if (!hover || this.selected) {
+      this.expandedMonomerAttachmentPoints?.hide();
+
+      return;
     }
 
-    return ret;
+    if (this.expandedMonomerAttachmentPoints?.removed) {
+      this.expandedMonomerAttachmentPoints = undefined;
+    }
+
+    if (this.expandedMonomerAttachmentPoints) {
+      this.expandedMonomerAttachmentPoints.show();
+    } else {
+      this.expandedMonomerAttachmentPoints =
+        this.makeMonomerAttachmentPointHighlightPlate(render);
+    }
   }
 
   public makeMonomerAttachmentPointHighlightPlate(render: Render) {

--- a/packages/ketcher-core/src/application/render/restruct/resgroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.ts
@@ -52,6 +52,7 @@ interface SGroupdrawBracketsOptions {
 class ReSGroup extends ReObject {
   public item: SGroup | undefined;
   public render!: Render;
+  private expandedMonomerAttachmentPoints?: any; // Raphael paths
 
   constructor(sgroup: SGroup) {
     super('sgroup');
@@ -237,12 +238,52 @@ class ReSGroup extends ReObject {
         const atom = render?.ctab?.atoms?.get(aid);
 
         set.push(atom?.makeHoverPlate(render));
-        set.push(atom?.makeMonomerAttachmentPointHighlightPlate(render));
       }, this);
       SGroup.getBonds(render.ctab.molecule, sGroupItem).forEach((bid) => {
         set.push(render?.ctab?.bonds?.get(bid)?.makeHoverPlate(render));
       }, this);
       render.ctab.addReObjectPath(LayerMap.hovering, this.visel, set);
+    }
+  }
+
+  setHover(hover: boolean, render: Render) {
+    super.setHover(hover, render);
+
+    if (!hover || this.selected) {
+      this.expandedMonomerAttachmentPoints?.hide();
+
+      return;
+    }
+
+    if (
+      !this.expandedMonomerAttachmentPoints?.length ||
+      this.expandedMonomerAttachmentPoints?.[0]?.removed
+    ) {
+      this.expandedMonomerAttachmentPoints = undefined;
+    }
+
+    if (this.expandedMonomerAttachmentPoints) {
+      this.expandedMonomerAttachmentPoints.show();
+    } else {
+      const paper = render.paper;
+      const sGroupItem = this.item;
+
+      if (!sGroupItem) {
+        return;
+      }
+
+      const set = paper.set();
+
+      render.paper.setStart();
+
+      SGroup.getAtoms(render.ctab.molecule, sGroupItem).forEach((aid) => {
+        const atom = render?.ctab?.atoms?.get(aid);
+
+        set.push(atom?.makeMonomerAttachmentPointHighlightPlate(render));
+      }, this);
+
+      render.ctab.addReObjectPath(LayerMap.atom, this.visel, set);
+      this.expandedMonomerAttachmentPoints = render.paper.setFinish();
     }
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- separated rendering of attachment point atoms and leaving group atoms for expanded monomers from hover rendering

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request