### PR TITLE
Backmerge: #7096 - Clearing canvas while "Calculate Properties" window is open causes console errors

### DIFF
--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -43,13 +43,13 @@ export const useRecalculateMacromoleculeProperties = () => {
     const chainsCollection = ChainsCollection.fromMonomers([
       ...drawingEntitiesManagerToCalculateProperties.monomers.values(),
     ]);
+    const firstMonomer = chainsCollection.firstNode?.monomer;
     const areAllMonomersConnectedByCovalentOrHydrogenBonds =
+      !firstMonomer ||
       chainsCollection.chains.reduce(
         (acc: number, chain: Chain) => acc + chain.monomers.length,
         0,
-      ) <=
-      getAllConnectedMonomersRecursively(chainsCollection.firstNode.monomer)
-        .length;
+      ) <= getAllConnectedMonomersRecursively(firstMonomer).length;
 
     if (
       !drawingEntitiesManagerToCalculateProperties.hasDrawingEntities ||


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added safety check

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request