### PR TITLE
#7142 - Monomer selection without bonds should work the same as with bonds

### DIFF
--- a/packages/ketcher-core/src/application/formatters/types/ket.ts
+++ b/packages/ketcher-core/src/application/formatters/types/ket.ts
@@ -32,6 +32,7 @@ export interface IKetMonomerNode {
   templateId: string;
   expanded?: boolean;
   transformation?: MonomerTransformation;
+  selected?: boolean;
 }
 
 export interface IKetAmbiguousMonomerNode {
@@ -44,6 +45,7 @@ export interface IKetAmbiguousMonomerNode {
   alias: string;
   templateId: string;
   transformation?: AmbiguousMonomerTransformation;
+  selected?: boolean;
 }
 
 export type KetNode = IKetMonomerNode | IKetAmbiguousMonomerNode;
@@ -83,6 +85,7 @@ export interface IKetConnection {
   label?: string;
   endpoint1: IKetConnectionEndPoint;
   endpoint2: IKetConnectionEndPoint;
+  selected?: boolean;
 }
 
 export type monomerClass =

--- a/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/toKet/moleculeToKet.ts
@@ -41,6 +41,11 @@ function fromRlabel(rg) {
   return res;
 }
 
+export interface MoleculesSelection {
+  atoms: Set<number>;
+  bonds: Set<number>;
+}
+
 export function moleculeToKet(struct: Struct, monomer?: BaseMonomer): any {
   const body: any = {
     atoms: Array.from(struct.atoms.values()).map((atom) => {

--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -62,9 +62,10 @@ export const useRecalculateMacromoleculeProperties = () => {
 
     const serializedKet = ketSerializer.serialize(
       new Struct(),
-      drawingEntitiesManagerToCalculateProperties,
+      editor.drawingEntitiesManager,
       undefined,
       false,
+      true,
     );
     const calculateMacromoleculePropertiesResponse =
       await indigo.calculateMacromoleculeProperties(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added selection population to ket during serialization in macro mode

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request