### PR TITLE
Backmerge: #7203 - N-methylation is shown as available for Hyp even though it shouldn't be

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/TransientView/ModifyAminoAcidsView.ts
+++ b/packages/ketcher-core/src/application/render/renderers/TransientView/ModifyAminoAcidsView.ts
@@ -61,7 +61,8 @@ export class ModifyAminoAcidsView extends TransientView {
           .attr('x', 2)
           .attr('font-family', 'Courier New')
           .attr('font-size', '20px')
-          .attr('font-weight', '700');
+          .attr('font-weight', '700')
+          .attr('style', 'user-select: none');
 
         if (renderer.node.modified) {
           group

--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -334,7 +334,6 @@ export const canModifyAminoAcid = (
   modificationMonomerLibraryItem: MonomerItemType,
 ) => {
   return (
-    monomer.label !== modificationMonomerLibraryItem.label &&
     (monomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) ||
       modificationMonomerLibraryItem.props.MonomerCaps?.R1) &&
     (monomer.isAttachmentPointExistAndFree(AttachmentPointName.R2) ||
@@ -376,6 +375,7 @@ export const getAminoAcidsToModify = (
 
     if (
       modifiedMonomerItem &&
+      monomer.label !== modifiedMonomerItem.label &&
       canModifyAminoAcid(monomer, modifiedMonomerItem)
     ) {
       aminoAcidsToModify.set(monomer, modifiedMonomerItem);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

#7203 - N-methylation is shown as available for Hyp even though it shouldn't be

- fixed context menu items list collecting rules

#7202 - Incorrect order of amino acid modification options in context menu

- applied sorting for amino acid modification menu items

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request