### PR TITLE
 #7187 - IDT code shown wrong for SS3 chem  

### DIFF
--- a/packages/ketcher-core/src/application/editor/data/monomers.ket
+++ b/packages/ketcher-core/src/application/editor/data/monomers.ket
@@ -45804,7 +45804,7 @@
     "fullName": "Dipropanol-disulfide",
     "alias": "SS3",
     "idtAliases": {
-      "base": "ThioMC3-D",
+      "base": "3ThioMC3-D",
       "modifications": {
         "endpoint3": "3ThioMC3-D"
       }


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/7187

- [x]  IDT code is correct: 3ThioMC3-D 



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request