### PR TITLE
#7237 - Migrate to Indigo v1.32.0-rc.3 in-browser module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15877,9 +15877,9 @@
       }
     },
     "node_modules/indigo-ketcher": {
-      "version": "1.32.0-rc.2",
-      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.32.0-rc.2.tgz",
-      "integrity": "sha512-UJJD/StdTSWqvQqhMUmeifg9TittctX5gjQtv+I0fI5WmhUV5/jje+2u9fMqzg3LN3Za0Zh4zHOTFju0pKzhqA=="
+      "version": "1.32.0-rc.3",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.32.0-rc.3.tgz",
+      "integrity": "sha512-3ghWufJzKICwTuUJ7zn82EZ69xcg9QffZHpZwifJK6BgtEMR7xiApN2IxWVemKLR4D2rtP8+GTLfvEIDVAVoKQ=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -31737,7 +31737,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "3.4.0-rc.4",
+      "version": "3.4.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -31827,7 +31827,7 @@
       }
     },
     "packages/ketcher-macromolecules": {
-      "version": "3.4.0-rc.4",
+      "version": "3.4.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -33295,7 +33295,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "3.4.0-rc.4",
+      "version": "3.4.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -35028,11 +35028,11 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "3.4.0-rc.4",
+      "version": "3.4.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
-        "indigo-ketcher": "1.32.0-rc.2",
+        "indigo-ketcher": "1.32.0-rc.3",
         "ketcher-core": "*"
       },
       "devDependencies": {

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "3.4.0-rc.4",
+  "version": "3.4.0-rc.5",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "3.4.0-rc.4",
+  "version": "3.4.0-rc.5",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "3.4.0-rc.4",
+  "version": "3.4.0-rc.5",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "3.4.0-rc.4",
+  "version": "3.4.0-rc.5",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.10",
-    "indigo-ketcher": "1.32.0-rc.2",
+    "indigo-ketcher": "1.32.0-rc.3",
     "ketcher-core": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- updated indigo to 1.32.0-rc.3
- updated ketcher to 3.4.0-rc.5

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request