### PR TITLE
Backmerge: #7249 - Input fields for ion concentration and oligonucleotides become inactive after clearing or entering zero

### DIFF
--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -754,6 +754,10 @@ const PeptideProperties = (props: PeptidePropertiesProps) => {
   );
 };
 
+const containOnlyPartOfNumber = (value: number) => {
+  return !/[^0.,]/.test(String(value));
+};
+
 const RnaProperties = (props: DnaRnaPropertiesProps) => {
   const dispatch = useAppDispatch();
   const unipositiveIonsMeasurementUnit = useAppSelector(
@@ -809,7 +813,10 @@ const RnaProperties = (props: DnaRnaPropertiesProps) => {
             value={unipositiveIonsValue}
             options={['nM', 'μM', 'mM']}
             selectedOption={unipositiveIonsMeasurementUnit}
-            disabled={!isNumber(props.macromoleculesProperties.Tm)}
+            disabled={
+              !isNumber(props.macromoleculesProperties.Tm) &&
+              !containOnlyPartOfNumber(unipositiveIonsValue)
+            }
             onChangeOption={onChangeUnipositiveIonsMeasurementUnit}
             onChangeValue={onChangeUnipositiveIonsValue}
           />
@@ -818,7 +825,10 @@ const RnaProperties = (props: DnaRnaPropertiesProps) => {
             value={oligonucleotidesValue}
             options={['nM', 'μM', 'mM']}
             selectedOption={oligonucleotidesMeasurementUnit}
-            disabled={!isNumber(props.macromoleculesProperties.Tm)}
+            disabled={
+              !isNumber(props.macromoleculesProperties.Tm) &&
+              !containOnlyPartOfNumber(oligonucleotidesMeasurementUnit)
+            }
             onChangeOption={onChangeOligonucleotidesMeasurementUnit}
             onChangeValue={onChangeOligonucleotidesValue}
           />


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request