### PR TITLE
Backmerge: #7266 - Oligonucleotides input field becomes unresponsive after entering zero

### DIFF
--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -795,11 +795,11 @@ const RnaProperties = (props: DnaRnaPropertiesProps) => {
   };
 
   const onChangeUnipositiveIonsValue = (value: number) => {
-    dispatch(setUnipositiveIonsValue(value));
+    dispatch(setUnipositiveIonsValue(value.toString()));
   };
 
   const onChangeOligonucleotidesValue = (value: number) => {
-    dispatch(setOligonucleotidesValue(value));
+    dispatch(setOligonucleotidesValue(value.toString()));
   };
 
   return props.isError ? (
@@ -848,7 +848,7 @@ const RnaProperties = (props: DnaRnaPropertiesProps) => {
             selectedOption={oligonucleotidesMeasurementUnit}
             disabled={
               !isNumber(props.macromoleculesProperties.Tm) &&
-              !containOnlyPartOfNumber(oligonucleotidesMeasurementUnit)
+              !containOnlyPartOfNumber(oligonucleotidesValue)
             }
             onChangeOption={onChangeOligonucleotidesMeasurementUnit}
             onChangeValue={onChangeOligonucleotidesValue}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request