### PR TITLE
#7205 - Layout shift when changing mode from sequence to flex and back upon first macromolecules mode initialization 

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -89,6 +89,7 @@ export class SequenceMode extends BaseMode {
   private _isEditInRNABuilderMode = false;
   private _isAntisenseEditMode = false;
   private _isSyncEditMode = true;
+  private isFirstInit = true;
   private selectionStarted = false;
   private selectionStartCaretPosition = -1;
   private mousemoveCounter = 0;
@@ -192,9 +193,10 @@ export class SequenceMode extends BaseMode {
       chainsCollection.firstNode?.monomer.renderer as BaseSequenceItemRenderer
     )?.scaledMonomerPositionForSequence;
 
-    if (firstMonomerPosition && needScroll) {
+    if (firstMonomerPosition && needScroll && !this.isFirstInit) {
       zoom.scrollTo(firstMonomerPosition);
     }
+    this.isFirstInit = false;
 
     if (this.isEditMode) {
       const drawnStructuresElement =


### PR DESCRIPTION
- [x] Sequence don't change its position – either the layout shift has to be avoided or the initial sequence position has to be aligned with the one after layout shift.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request