### PR TITLE
#7279 - should handle undefined events property without throwing error

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.6.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.6.0-bugs.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('MacromoleculePropertiesWindow events access', () => {
+  test('should handle undefined events property without throwing error', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await page.goto(`${process.env.KETCHER_URL}/duo`);
+
+    await page.waitForLoadState('networkidle');
+
+    try {
+      await page.waitForSelector(
+        '[data-testid="macromolecule-properties-close"]',
+        {
+          state: 'attached',
+          timeout: 5000,
+        },
+      );
+    } catch (error) {
+      console.log(
+        'Component not found, but this is expected if there is no selection',
+      );
+    }
+
+    const WAIT_TIME_MS = 2000;
+    await page.waitForTimeout(WAIT_TIME_MS);
+
+    const allErrors = [...consoleErrors, ...pageErrors];
+
+    if (allErrors.length > 0) {
+      console.log('All errors caught:', allErrors);
+    }
+
+    const editorEventsErrors = allErrors.filter((error) =>
+      error.includes("Cannot read properties of undefined (reading 'events')"),
+    );
+
+    expect(editorEventsErrors.length).toBe(0);
+  });
+});


### PR DESCRIPTION

<img width="365" alt="Screenshot 2025-06-18 at 16 23 15" src="https://github.com/user-attachments/assets/93bd78f1-2838-49a1-9efb-203ae5ae58d6" />



## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request