### PR TITLE
#7117 – Chemical elements disappear when attempting to Expand the Structure in Micro mode after selecting one in Macro mode

### DIFF
--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -120,8 +120,13 @@ export const EditorEvents = () => {
     };
   }, [editor]);
 
+  /*
+   * Redux freezes payload object which lead to the issues on changing MonomerItem properties after showing preview
+   * TODO: Ideally perform a deep clone but now it leads to the error when cloning Struct class
+   */
   const dispatchShowPreview = useCallback(
-    (payload) => dispatch(showPreview(payload)),
+    (payload) =>
+      dispatch(showPreview({ ...payload, monomer: { ...payload.monomer } })),
     [dispatch],
   );
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request