### PR TITLE
#7318 – Bonds are overlapped by CIP labels when moving the structure or when the structure has small bond angles

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -715,7 +715,7 @@ class ReAtom extends ReObject {
         this.visel,
         cipGroup,
         ps,
-        true,
+        false,
       );
 
       this.cip = { path: cipGroup, text: cipText, rectangle: rect };

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -842,8 +842,8 @@ class ReStruct {
       if (item.togglePoints) item.togglePoints(false);
       item.additionalInfo?.hide();
       item.cip?.rectangle.attr({
-        fill: '#fff',
-        stroke: '#fff',
+        fill: 'none',
+        stroke: 'none',
       });
     }
   }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request