### PR TITLE
#7314 - Preview: Structure disappears after removing abbreviations and adding nucleotide component to phosphate group

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -375,7 +375,7 @@ class ReAtom extends ReObject {
           .text(
             position.x,
             position.y,
-            sgroup.data.name || SUPERATOM_CLASS_TEXT[sgroup.data.class],
+            sgroup.data.name || SUPERATOM_CLASS_TEXT[sgroup.data.class] || '',
           )
           .attr({
             'font-weight': 700,

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -47,6 +47,7 @@ import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import { attachmentPointNames } from 'domain/types';
 import { getAttachmentPointLabel } from 'domain/helpers/attachmentPointCalculations';
 import { VALENCE_MAP } from 'application/render/restruct/constants';
+import { SUPERATOM_CLASS_TEXT } from 'application/render/restruct/resgroup';
 
 interface ElemAttr {
   text: string;
@@ -371,7 +372,11 @@ class ReAtom extends ReObject {
           options.font.length,
         );
         const path = render.paper
-          .text(position.x, position.y, sgroup.data.name)
+          .text(
+            position.x,
+            position.y,
+            sgroup.data.name || SUPERATOM_CLASS_TEXT[sgroup.data.class],
+          )
           .attr({
             'font-weight': 700,
             'font-size': options.fontszInPx,

--- a/packages/ketcher-core/src/application/render/restruct/resgroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.ts
@@ -50,6 +50,12 @@ interface SGroupdrawBracketsOptions {
   superatomClass?: SUPERATOM_CLASS;
 }
 
+export const SUPERATOM_CLASS_TEXT = {
+  [SUPERATOM_CLASS.BASE]: 'Base',
+  [SUPERATOM_CLASS.SUGAR]: 'Sugar',
+  [SUPERATOM_CLASS.PHOSPHATE]: 'Phosphate',
+};
+
 class ReSGroup extends ReObject {
   public item: SGroup | undefined;
   public render!: Render;
@@ -107,7 +113,7 @@ class ReSGroup extends ReObject {
         }
         case 'SUP': {
           SGroupdrawBracketsOptions.lowerIndexText =
-            sgroup.data.name || sgroup.data.class;
+            sgroup.data.name || SUPERATOM_CLASS_TEXT[sgroup.data.class];
           SGroupdrawBracketsOptions.upperIndexText = null;
           SGroupdrawBracketsOptions.indexAttribute = { 'font-style': 'italic' };
           SGroupdrawBracketsOptions.superatomClass = sgroup.data.class;

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -29,9 +29,9 @@ import assert from 'assert';
 import { isNumber } from 'lodash';
 
 export enum SUPERATOM_CLASS {
-  SUGAR = 'Sugar',
-  BASE = 'Base',
-  PHOSPHATE = 'Phosphate',
+  SUGAR = 'SUGAR',
+  BASE = 'BASE',
+  PHOSPHATE = 'PHOSPHATE',
 }
 
 export class SGroupBracketParams {
@@ -68,6 +68,7 @@ export class SGroup {
     ANY: 'ANY',
     GEN: 'GEN',
     queryComponent: 'queryComponent',
+    nucleotideComponent: 'nucleotideComponent',
   };
 
   type: string;

--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -666,7 +666,10 @@ function fromContextType(id, editor, newSg, currSelection) {
   const sourceAtoms = (sg && sg.atoms) || currSelection.atoms || [];
   const context = newSg.attrs.context;
 
-  if (newSg.type === SGroup.TYPES.SUP) {
+  if (
+    newSg.type === SGroup.TYPES.SUP ||
+    newSg.type === SGroup.TYPES.nucleotideComponent
+  ) {
     newSg.attrs.expanded = true;
   }
 

--- a/packages/ketcher-react/src/script/ui/data/schema/struct-schema.js
+++ b/packages/ketcher-react/src/script/ui/data/schema/struct-schema.js
@@ -387,7 +387,8 @@ const sgroup = {
         type: { enum: ['nucleotideComponent'] },
         class: {
           title: 'Component',
-          enum: ['Sugar', 'Base', 'Phosphate'],
+          enum: ['SUGAR', 'BASE', 'PHOSPHATE'],
+          enumNames: ['Sugar', 'Base', 'Phosphate'],
           default: 'Sugar',
         },
       },


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added set expand = true to nucleotide component sgroups during creation (same as for superatoms)
- added usage of uppercase for nucleotide component class value

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request