### PR TITLE
#7365 - Console errors appear when using actions on structures with nucleotide component marking

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -42,11 +42,11 @@ import { openInfoModalWithCustomMessage } from '../shared';
 export default function initEditor(dispatch, getState) {
   const updateAction = debounce(100, () => dispatch({ type: 'UPDATE' }));
   const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
+  const state = getState();
 
   const resetToSelect =
     (force = false) =>
     async (dispatch) => {
-      const state = getState();
       const activeTool = state.actionState?.activeTool.tool;
       if (!activeTool || (activeTool === 'select' && !force)) return;
       const selectMode = state.toolbar.visibleTools.select;

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -42,11 +42,11 @@ import { openInfoModalWithCustomMessage } from '../shared';
 export default function initEditor(dispatch, getState) {
   const updateAction = debounce(100, () => dispatch({ type: 'UPDATE' }));
   const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
-  const state = getState();
 
   const resetToSelect =
     (force = false) =>
     async (dispatch) => {
+      const state = getState();
       const activeTool = state.actionState?.activeTool.tool;
       if (!activeTool || (activeTool === 'select' && !force)) return;
       const selectMode = state.toolbar.visibleTools.select;
@@ -64,9 +64,10 @@ export default function initEditor(dispatch, getState) {
     onChange: (action) => {
       if (action === undefined) sleep(0).then(() => dispatch(resetToSelect()));
       // Editor switched to view only mode
-      if (action === 'force') dispatch(resetToSelect(true));
+      if (action === 'force')
+        sleep(0).then(() => dispatch(resetToSelect(true)));
       // new tool in reducer
-      else dispatch(resetToSelect());
+      else sleep(0).then(() => dispatch(resetToSelect()));
     },
     onSelectionChange: () => {
       updateAction();

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -279,6 +279,8 @@ class StructEditor extends Component {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       ketcherId,
       /* eslint-disable @typescript-eslint/no-unused-vars */
+      prevKetcherId,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
       struct,
       indigoVerification,
       tool,


### PR DESCRIPTION
Closes:

#7365 - Console errors appear when using actions on structures with nucleotide component marking
#7386 - Delete operation causes exception: Uncaught (in promise) Error: Minified Redux error

## How the feature works? / How did you fix the issue?

- moved getState upper to scope

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request