### PR TITLE
#7283 - Context menu is wrong if clicked on top of sequence

### DIFF
--- a/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.module.less
+++ b/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.module.less
@@ -16,6 +16,7 @@
   opacity: 40%;
   text-align: center;
   will-change: transform;
+  pointer-events: auto;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
- [x]  Context menu has all options in place 
<img width="954" height="749" alt="Снимок экрана 2025-07-16 в 11 30 35" src="https://github.com/user-attachments/assets/b43ed28b-e345-4a30-be61-8e509ece34d2" />


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request