### PR TITLE
#7518 - Migrate to Indigo v1.35.0-rc.1 in-browser module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15923,9 +15923,9 @@
       }
     },
     "node_modules/indigo-ketcher": {
-      "version": "1.35.0-dev.1",
-      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.35.0-dev.1.tgz",
-      "integrity": "sha512-7Lfu7+JKuYbqh/SsUe081PiPKjGReevxqfJDJWeSqrINA30XU/s2p/NkgdlXQwpbCyor4TJP8I5H8HMIrniiig=="
+      "version": "1.35.0-rc.1",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.35.0-rc.1.tgz",
+      "integrity": "sha512-ta53LAQw+t4ZSTnRaBbgoa4IOjfdbcApvE2rSiNHYk2w8utULgqFNiXe6Uj5zrHXkwxkSJEgzhrYiF3bxmkPwA=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -31967,7 +31967,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "3.6.0-rc.1",
+      "version": "3.7.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -32057,7 +32057,7 @@
       }
     },
     "packages/ketcher-macromolecules": {
-      "version": "3.6.0-rc.1",
+      "version": "3.7.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -33525,7 +33525,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "3.6.0-rc.1",
+      "version": "3.7.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -35258,11 +35258,11 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "3.6.0-rc.1",
+      "version": "3.7.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
-        "indigo-ketcher": "1.35.0-dev.1",
+        "indigo-ketcher": "1.35.0-rc.1",
         "ketcher-core": "*"
       },
       "devDependencies": {

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "3.6.0-rc.1",
+  "version": "3.7.0-rc.1",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "3.6.0-rc.1",
+  "version": "3.7.0-rc.1",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "3.6.0-rc.1",
+  "version": "3.7.0-rc.1",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "3.6.0-rc.1",
+  "version": "3.7.0-rc.1",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.10",
-    "indigo-ketcher": "1.35.0-dev.1",
+    "indigo-ketcher": "1.35.0-rc.1",
     "ketcher-core": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- updated indigo to v1.35.0-rc.1
- updated ketcher to 3.7.0-rc.1

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request