### PR TITLE
Autotests: 7532-autotests-create-gettextlabellocator-method-in-the-same-manner-as-getmonomerlocator-or-getarrowlocator

### DIFF
--- a/added_test_ids_to_texts.patch
+++ b/added_test_ids_to_texts.patch
@@ -1,0 +1,22 @@
+Subject: [PATCH] added test ids to texts
+---
+Index: packages/ketcher-core/src/application/render/restruct/retext.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/packages/ketcher-core/src/application/render/restruct/retext.ts b/packages/ketcher-core/src/application/render/restruct/retext.ts
+--- a/packages/ketcher-core/src/application/render/restruct/retext.ts	(revision 237a61b1665ba1249ffb7e8809a9ad61646a43b8)
++++ b/packages/ketcher-core/src/application/render/restruct/retext.ts	(date 1754480225955)
+@@ -173,6 +173,11 @@
+             fill: '#000000',
+             ...styles,
+           });
++        path.node.setAttribute('data-testid', 'text');
++        path.node.setAttribute(
++          'data-text-id',
++          restruct.molecule.texts.keyOf(this.item),
++        );
+         path.translateAbs(shiftX, shiftY + (styles.shiftY || 0));
+         row.push(path);
+         shiftX += path.getBBox().width;

--- a/ketcher-autotests/tests/pages/molecules/canvas/TextEditorDialog.ts
+++ b/ketcher-autotests/tests/pages/molecules/canvas/TextEditorDialog.ts
@@ -80,6 +80,10 @@ export const TextEditorDialog = (page: Page) => {
       await locators.textEditor.click();
     },
 
+    async selectAllText() {
+      await locators.textEditor.selectText();
+    },
+
     async setText(text: string) {
       await locators.textEditor.fill(text);
     },

--- a/ketcher-autotests/tests/specs/Structure-Creating-&-Editing/Text-Tool/text-formating.spec.ts
+++ b/ketcher-autotests/tests/specs/Structure-Creating-&-Editing/Text-Tool/text-formating.spec.ts
@@ -23,6 +23,7 @@ import {
   addTextBoxToCanvas,
   TextEditorDialog,
 } from '@tests/pages/molecules/canvas/TextEditorDialog';
+import { getTextLabelLocator } from '@utils/canvas/text/getTextLabelLocator';
 
 test.describe('Text tools test cases', () => {
   test.beforeEach(async ({ page }) => {
@@ -38,7 +39,7 @@ test.describe('Text tools test cases', () => {
     await TextEditorDialog(page).selectFontSize(20);
     await TextEditorDialog(page).apply();
     await takeEditorScreenshot(page);
-    await page.getByText('TEST').dblclick();
+    await getTextLabelLocator(page, { text: 'TEST' }).dblclick();
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).selectFontSize(10);
     await TextEditorDialog(page).apply();
@@ -102,7 +103,7 @@ test.describe('Text tools test cases', () => {
       isSuperscript: true,
     });
     await takeEditorScreenshot(page);
-    await page.getByText('TEST123').dblclick();
+    await getTextLabelLocator(page, { text: 'TEST123' }).dblclick();
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).setOptions({
       isSubscript: true,
@@ -115,7 +116,6 @@ test.describe('Text tools test cases', () => {
     // Verify if possible to put different styles on the created text object
     await addTextBoxToCanvas(page);
     await TextEditorDialog(page).setText('TEST321');
-    await page.getByText('TEST321').dblclick();
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).setOptions({
       fontSize: 20,
@@ -138,7 +138,7 @@ test.describe('Text tools test cases', () => {
     await pasteFromClipboardAndAddToCanvas(page, fileContent);
     await clickInTheMiddleOfTheScreen(page);
     await takeEditorScreenshot(page);
-    await page.getByText('TEST321').dblclick();
+    await getTextLabelLocator(page, { text: 'TEST321' }).dblclick();
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).setOptions({
       isItalic: true,
@@ -178,7 +178,7 @@ test.describe('Text tools test cases', () => {
     // Test case: EPMLSOPKET-2274
     // Verify if its possible to select a text objects of any size by clicking on green frame
     await openFileAndAddToCanvas(page, 'KET/text-object.ket');
-    await page.getByText('TEXT').dblclick();
+    await getTextLabelLocator(page, { text: 'TEXT' }).dblclick();
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).setText('PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP');
     await TextEditorDialog(page).apply();

--- a/ketcher-autotests/tests/specs/Structure-Creating-&-Editing/Text-Tool/text-tools-modification-and-manipulation.spec.ts
+++ b/ketcher-autotests/tests/specs/Structure-Creating-&-Editing/Text-Tool/text-tools-modification-and-manipulation.spec.ts
@@ -23,6 +23,7 @@ import {
   TextEditorDialog,
 } from '@tests/pages/molecules/canvas/TextEditorDialog';
 import { LeftToolbar } from '@tests/pages/molecules/LeftToolbar';
+import { getTextLabelLocator } from '@utils/canvas/text/getTextLabelLocator';
 
 async function selectStructureWithSelectionTool(page: Page) {
   const point = { x: 97, y: 79 };
@@ -58,7 +59,7 @@ test.describe('Text tools test cases', () => {
     await TextEditorDialog(page).setText('TEST');
     await TextEditorDialog(page).apply();
     await takeEditorScreenshot(page);
-    await page.getByText('TEST').dblclick();
+    await getTextLabelLocator(page, { text: 'TEST' }).dblclick();
     await TextEditorDialog(page).setText('TEST123');
     await TextEditorDialog(page).apply();
     await takeEditorScreenshot(page);
@@ -71,7 +72,7 @@ test.describe('Text tools test cases', () => {
     await TextEditorDialog(page).setText('TEST');
     await TextEditorDialog(page).apply();
     await CommonLeftToolbar(page).selectEraseTool();
-    await page.getByText('TEST').click();
+    await getTextLabelLocator(page, { text: 'TEST' }).click();
     await CommonTopLeftToolbar(page).undo();
     await CommonTopLeftToolbar(page).redo();
     await CommonTopLeftToolbar(page).undo();
@@ -86,8 +87,7 @@ test.describe('Text tools test cases', () => {
     await CommonLeftToolbar(page).selectAreaSelectionTool(
       SelectionToolType.Lasso,
     );
-    await page.getByText('TEXT').hover();
-    await page.getByText('TEXT').click();
+    await getTextLabelLocator(page, { text: 'TEXT' }).click();
     await deleteByKeyboard(page);
     await CommonTopLeftToolbar(page).undo();
     await CommonTopLeftToolbar(page).redo();
@@ -100,10 +100,10 @@ test.describe('Text tools test cases', () => {
     page,
   }) => {
     await openFileAndAddToCanvas(page, 'KET/test-text-object.ket');
-    await page.getByText('TEST').dblclick();
+    await getTextLabelLocator(page, { text: 'TEST' }).dblclick();
     await pressButton(page, 'Cancel');
-    await page.getByText('TEST').dblclick();
-    await page.getByRole('dialog').getByText('TEST').dblclick();
+    await getTextLabelLocator(page, { text: 'TEST' }).dblclick();
+    await TextEditorDialog(page).selectAllText();
     await deleteByKeyboard(page);
     await pressButton(page, 'Apply');
     await takeEditorScreenshot(page);
@@ -148,29 +148,27 @@ test.describe('Text tools test cases', () => {
     );
     await TextEditorDialog(page).apply();
 
-    await page.getByText('+++').dblclick();
+    await getTextLabelLocator(page, { text: '+++' }).dblclick();
     await TextEditorDialog(page).setText('123');
     await TextEditorDialog(page).cancel();
 
-    await page.getByText('+++').dblclick();
+    await getTextLabelLocator(page, { text: '+++' }).dblclick();
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).setText('Test');
     await TextEditorDialog(page).apply();
     await takeEditorScreenshot(page);
 
-    await page
-      .getByText(
-        'Ketcher is a tool to draw molecular structures and chemical reactions',
-      )
-      .dblclick();
+    await getTextLabelLocator(page, {
+      text: 'Ketcher is a tool to draw molecular structures and chemical reactions',
+    }).dblclick();
+
     await TextEditorDialog(page).setText('123');
     await TextEditorDialog(page).cancel();
 
-    await page
-      .getByText(
-        'Ketcher is a tool to draw molecular structures and chemical reactions',
-      )
-      .dblclick();
+    await getTextLabelLocator(page, {
+      text: 'Ketcher is a tool to draw molecular structures and chemical reactions',
+    }).dblclick();
+
     await selectAllStructuresOnCanvas(page);
     await TextEditorDialog(page).setText('Super');
     await TextEditorDialog(page).apply();
@@ -186,8 +184,7 @@ test.describe('Text tools test cases', () => {
     await takeEditorScreenshot(page);
 
     await page.getByTestId('canvas').click({ position: { x: 100, y: 100 } });
-    const text2 = 'Ketcher is a coool tool';
-    await TextEditorDialog(page).setText(text2);
+    await TextEditorDialog(page).setText('Ketcher is a coool tool');
     await TextEditorDialog(page).apply();
     await takeEditorScreenshot(page);
   });
@@ -195,8 +192,7 @@ test.describe('Text tools test cases', () => {
   test('Text tool - Delete with Erase tool', async ({ page }) => {
     await openFileAndAddToCanvas(page, 'KET/two-different-text-objects.ket');
     await CommonLeftToolbar(page).selectEraseTool();
-    await page.getByText('&&&').hover();
-    await page.getByText('&&&').click();
+    await getTextLabelLocator(page, { text: '&&&' }).dblclick();
     await CommonTopLeftToolbar(page).undo();
     await CommonTopLeftToolbar(page).redo();
     await CommonTopLeftToolbar(page).undo();
@@ -206,13 +202,13 @@ test.describe('Text tools test cases', () => {
   test('Delete with and Lasso Selection Tool and "Delete" button on a keyboard', async ({
     page,
   }) => {
-    const text2 = 'Ketcher is a cool tool';
     await openFileAndAddToCanvas(page, 'KET/two-different-text-objects.ket');
     await CommonLeftToolbar(page).selectAreaSelectionTool(
       SelectionToolType.Lasso,
     );
-    await page.getByText(text2).hover();
-    await page.getByText(text2).click();
+    await getTextLabelLocator(page, {
+      text: 'Ketcher is a cool tool',
+    }).click();
     await deleteByKeyboard(page);
     await CommonTopLeftToolbar(page).undo();
     await CommonTopLeftToolbar(page).redo();
@@ -249,16 +245,13 @@ test.describe('Text tools test cases', () => {
     // Test case: EPMLSOPKET-2234
     // Verify if possible is to modify created ealier text object and moving it with use Selection Tool
     await addTextBoxToCanvas(page);
-    const text3 = 'Test123';
-    await TextEditorDialog(page).setText(text3);
+    await TextEditorDialog(page).setText('Test123');
     await TextEditorDialog(page).apply();
     await CommonTopLeftToolbar(page).undo();
     await CommonTopLeftToolbar(page).redo();
     await selectAllStructuresOnCanvas(page);
-    await page.getByText(text3).hover();
-    await waitForRender(page, async () => {
-      await moveStructureToNewPosition(page);
-    });
+    await getTextLabelLocator(page, { text: 'Test123' }).click();
+    await moveStructureToNewPosition(page);
     await takeEditorScreenshot(page);
   });
 
@@ -266,19 +259,16 @@ test.describe('Text tools test cases', () => {
     page,
   }) => {
     // Verify if possible is perform different manipulations with text objects using different tools (zoom)
-    const text4 = 'ABC123';
     await addTextBoxToCanvas(page);
-    await TextEditorDialog(page).setText(text4);
+    await TextEditorDialog(page).setText('ABC123');
     await TextEditorDialog(page).apply();
     await CommonTopLeftToolbar(page).undo();
     await CommonTopLeftToolbar(page).redo();
     await selectAllStructuresOnCanvas(page);
-    await page.getByText(text4).click();
+    await getTextLabelLocator(page, { text: 'ABC123' }).click();
     await moveStructureToNewPosition(page);
     await ZoomInByKeyboard(page, { repeat: 2 });
-
     await takeEditorScreenshot(page);
-
     await ZoomOutByKeyboard(page, { repeat: 2 });
     await takeEditorScreenshot(page);
   });
@@ -300,9 +290,7 @@ test.describe('Text tools test cases', () => {
       SelectionToolType.Lasso,
     );
     await selectStructureWithSelectionTool(page);
-    await waitForRender(page, async () => {
-      await moveStructureToNewPosition(page);
-    });
+    await moveStructureToNewPosition(page);
     await takeEditorScreenshot(page);
   });
 });

--- a/ketcher-autotests/tests/utils/canvas/text/getTextLabelLocator.ts
+++ b/ketcher-autotests/tests/utils/canvas/text/getTextLabelLocator.ts
@@ -1,0 +1,29 @@
+import { Page, Locator } from '@playwright/test';
+
+type TextLabelLocatorOptions = {
+  id?: string | number;
+  text?: string;
+};
+
+export function getTextLabelLocator(
+  page: Page,
+  options: TextLabelLocatorOptions,
+): Locator {
+  const attributes: Record<string, string> = {};
+
+  attributes['data-testid'] = 'text';
+
+  if (options.id !== undefined) {
+    attributes['data-text-id'] = String(options.id);
+  }
+
+  const attributeSelectors = Object.entries(attributes)
+    .map(([key, value]) => `[${key}="${value}"]`)
+    .join('');
+
+  if (options.text) {
+    return page.locator(`${attributeSelectors} >> text=${options.text}`);
+  }
+
+  return page.locator(attributeSelectors);
+}

--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -173,6 +173,11 @@ class ReText extends ReObject {
             fill: '#000000',
             ...styles,
           });
+        path.node.setAttribute('data-testid', 'text');
+        path.node.setAttribute(
+          'data-text-id',
+          restruct.molecule.texts.keyOf(this.item),
+        );
         path.translateAbs(shiftX, shiftY + (styles.shiftY || 0));
         row.push(path);
         shiftX += path.getBBox().width;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request