### PR TITLE
#7575 – Monomer creation wizard opens despite selection being connected via non simple bond

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -77,6 +77,7 @@ import {
   initHotKeys,
   KetcherLogger,
   keyNorm,
+  SettingsManager,
 } from 'utilities';
 import monomersDataRaw from './data/monomers.ket';
 import { EditorHistory, HistoryOperationType } from './EditorHistory';
@@ -275,8 +276,12 @@ export class CoreEditor {
       parseMonomersLibrary(monomersDataRaw);
     this._monomersLibrary = monomersLibrary;
     this._monomersLibraryParsedJson = monomersLibraryParsedJson;
-    persistentMonomersLibrary = monomersLibrary;
-    persistentMonomersLibraryParsedJson = monomersLibraryParsedJson;
+    const storedMonomerLibraryUpdates = SettingsManager.monomerLibraryUpdates;
+    storedMonomerLibraryUpdates.forEach((update) =>
+      this.updateMonomersLibrary(update),
+    );
+    persistentMonomersLibrary = this._monomersLibrary;
+    persistentMonomersLibraryParsedJson = this._monomersLibraryParsedJson;
   }
 
   public updateMonomersLibrary(monomersDataRaw: string | JSON) {

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -76,6 +76,7 @@ export class Ketcher {
   _indigo: Indigo;
   #eventBus: EventEmitter;
   changeEvent: Subscription;
+  libraryUpdateEvent: Subscription;
 
   get editor(): Editor {
     // we should assign editor exactly after ketcher creation
@@ -95,6 +96,7 @@ export class Ketcher {
     assert(formatterFactory != null);
     this._id = uniqueId();
     this.changeEvent = new Subscription();
+    this.libraryUpdateEvent = new Subscription();
     this.structService = structService;
     this.#formatterFactory = formatterFactory;
     this._indigo = new Indigo(this.structService);
@@ -661,6 +663,12 @@ export class Ketcher {
     }
 
     editor.updateMonomersLibrary(rawMonomersData);
+    SettingsManager.addMonomerLibraryUpdate(
+      typeof rawMonomersData !== 'string'
+        ? JSON.stringify(rawMonomersData)
+        : rawMonomersData,
+    );
+    this.libraryUpdateEvent.dispatch(editor.monomersLibrary);
   }
 
   public switchToMacromoleculesMode() {

--- a/packages/ketcher-core/src/utilities/SettingsManager.ts
+++ b/packages/ketcher-core/src/utilities/SettingsManager.ts
@@ -37,6 +37,7 @@ interface SavedSettings {
   selectionTool?: any;
   disableCustomQuery?: boolean;
   editorLineLength?: EditorLineLength;
+  monomerLibraryUpdates?: string[];
 }
 
 interface SavedOptions {
@@ -159,5 +160,27 @@ export class SettingsManager {
       ...options,
       ignoreChiralFlag,
     });
+  }
+
+  static get monomerLibraryUpdates() {
+    const { monomerLibraryUpdates } = this.getSettings();
+    return monomerLibraryUpdates || [];
+  }
+
+  static set monomerLibraryUpdates(monomerLibraryUpdates: string[]) {
+    const settings = this.getSettings();
+
+    this.saveSettings({
+      ...settings,
+      monomerLibraryUpdates,
+    });
+  }
+
+  static addMonomerLibraryUpdate(newUpdate: string) {
+    const updates = this.monomerLibraryUpdates;
+    if (!updates.includes(newUpdate)) {
+      updates.push(newUpdate);
+      this.monomerLibraryUpdates = updates;
+    }
   }
 }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -593,9 +593,13 @@ class Editor implements KetcherEditor {
         );
       });
 
-      this.singleBondsToOutsideOfSelection = bondsToOutside.filter(
-        (_, bond) => bond.type === Bond.PATTERN.TYPE.SINGLE,
-      );
+      if (
+        bondsToOutside.some((bond) => bond.type !== Bond.PATTERN.TYPE.SINGLE)
+      ) {
+        return false;
+      }
+
+      this.singleBondsToOutsideOfSelection = bondsToOutside;
 
       return (
         this.singleBondsToOutsideOfSelection.size > 0 &&

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1073,6 +1073,13 @@ class Editor implements KetcherEditor {
         break;
       }
 
+      case 'libraryUpdate': {
+        ketcherProvider
+          .getKetcher(this.ketcherId)
+          .libraryUpdateEvent.add(handler);
+        break;
+      }
+
       default:
         this.event[eventName].add(handler);
     }

--- a/packages/ketcher-react/src/script/editor/tool/create-monomer.ts
+++ b/packages/ketcher-react/src/script/editor/tool/create-monomer.ts
@@ -9,6 +9,10 @@ class CreateMonomerTool implements Tool {
   cancel() {
     this.editor.closeMonomerCreationWizard();
   }
+
+  mousemove() {
+    // No action needed on mouse move for this tool
+  }
 }
 
 export default CreateMonomerTool;

--- a/packages/ketcher-react/src/script/ui/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/action/index.ts
@@ -39,6 +39,9 @@ const disableIfViewOnly = (editor: Editor): boolean =>
 const disableIfMonomerCreationWizardActive = (editor: Editor): boolean =>
   editor.isMonomerCreationWizardActive;
 
+const combinedDisable = (editor: Editor) =>
+  disableIfViewOnly(editor) || disableIfMonomerCreationWizardActive(editor);
+
 const updateConfigItem = (item: UiAction): UiAction => {
   if (typeof item.disabled === 'boolean' || item.enabledInViewOnly === true) {
     return item;
@@ -54,7 +57,7 @@ const updateConfigItem = (item: UiAction): UiAction => {
   } else {
     return {
       ...item,
-      disabled: disableIfViewOnly || disableIfMonomerCreationWizardActive,
+      disabled: combinedDisable,
     };
   }
 };

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -77,12 +77,19 @@ const wizardReducer = (
   switch (action.type) {
     case 'SetFieldValue': {
       const { fieldId, value } = action;
+
+      const values = {
+        ...state.values,
+        [fieldId]: value,
+      };
+
+      if (fieldId === 'type') {
+        values.naturalAnalogue = '';
+      }
+
       return {
         ...state,
-        values: {
-          ...state.values,
-          [fieldId]: value,
-        },
+        values,
         errors: {
           ...state.errors,
           [fieldId]: undefined,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request