### PR TITLE
Backmerge: #7575 – Monomer creation wizard opens despite selection being connected via non simple bond

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -35,6 +35,7 @@ import {
 import {
   IKetMacromoleculesContent,
   IKetMonomerGroupTemplate,
+  KetMonomerClass,
   KetMonomerGroupTemplateClass,
   KetTemplateType,
 } from 'application/formatters';
@@ -77,6 +78,7 @@ import {
   initHotKeys,
   KetcherLogger,
   keyNorm,
+  SettingsManager,
 } from 'utilities';
 import monomersDataRaw from './data/monomers.ket';
 import { EditorHistory, HistoryOperationType } from './EditorHistory';
@@ -290,8 +292,12 @@ export class CoreEditor {
       parseMonomersLibrary(monomersDataRaw);
     this._monomersLibrary = monomersLibrary;
     this._monomersLibraryParsedJson = monomersLibraryParsedJson;
-    persistentMonomersLibrary = monomersLibrary;
-    persistentMonomersLibraryParsedJson = monomersLibraryParsedJson;
+    const storedMonomerLibraryUpdates = SettingsManager.monomerLibraryUpdates;
+    storedMonomerLibraryUpdates.forEach((update) =>
+      this.updateMonomersLibrary(update),
+    );
+    persistentMonomersLibrary = this._monomersLibrary;
+    persistentMonomersLibraryParsedJson = this._monomersLibraryParsedJson;
   }
 
   public updateMonomersLibrary(monomersDataRaw: string | JSON) {
@@ -364,6 +370,27 @@ export class CoreEditor {
 
   public get monomersLibrary() {
     return this._monomersLibrary;
+  }
+
+  public checkIfMonomerSymbolClassPairExists(
+    symbol: string,
+    monomerClass: KetMonomerClass | undefined,
+  ) {
+    if (!monomerClass) {
+      return true;
+    }
+
+    return this._monomersLibrary.some((monomerItem) => {
+      if (isAmbiguousMonomerLibraryItem(monomerItem)) {
+        return false;
+      }
+
+      const { props } = monomerItem;
+      return (
+        props.MonomerClass === monomerClass &&
+        (props.aliasHELM === symbol || props.MonomerName === symbol)
+      );
+    });
   }
 
   public get defaultRnaPresetsLibraryItems() {

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -76,6 +76,7 @@ export class Ketcher {
   _indigo: Indigo;
   readonly #eventBus: EventEmitter;
   changeEvent: Subscription;
+  libraryUpdateEvent: Subscription;
 
   get editor(): Editor {
     // we should assign editor exactly after ketcher creation
@@ -95,6 +96,7 @@ export class Ketcher {
     assert(formatterFactory != null);
     this._id = uniqueId();
     this.changeEvent = new Subscription();
+    this.libraryUpdateEvent = new Subscription();
     this.structService = structService;
     this.#formatterFactory = formatterFactory;
     this._indigo = new Indigo(this.structService);
@@ -661,6 +663,12 @@ export class Ketcher {
     }
 
     editor.updateMonomersLibrary(rawMonomersData);
+    SettingsManager.addMonomerLibraryUpdate(
+      typeof rawMonomersData !== 'string'
+        ? JSON.stringify(rawMonomersData)
+        : rawMonomersData,
+    );
+    this.libraryUpdateEvent.dispatch(editor.monomersLibrary);
   }
 
   public switchToMacromoleculesMode() {

--- a/packages/ketcher-core/src/domain/serializers/ket/helpers.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/helpers.ts
@@ -18,7 +18,7 @@ import { Axis, Axises, Struct, Vec2 } from 'domain/entities';
 import { cloneDeep, cloneDeepWith } from 'lodash';
 import { EditorSelection } from 'application/editor';
 import { KetMonomerClass, MonomerTransformation } from 'application/formatters';
-import { MONOMER_CONST } from 'domain/constants';
+import { MONOMER_CONST, RNA_DNA_NON_MODIFIED_PART } from 'domain/constants';
 
 const customizer = (value: any) => {
   if (typeof value === 'object' && value.y) {
@@ -57,6 +57,25 @@ export const getHELMClassByKetMonomerClass = (
   }
 
   return MONOMER_CONST.RNA;
+};
+
+export const fillNaturalAnalogueForPhosphateAndSugar = (
+  naturalAnalogue: string,
+  monomerClass: KetMonomerClass,
+) => {
+  if (naturalAnalogue !== '') {
+    return naturalAnalogue;
+  }
+
+  if (monomerClass === KetMonomerClass.Sugar) {
+    return RNA_DNA_NON_MODIFIED_PART.SUGAR_RNA;
+  }
+
+  if (monomerClass === KetMonomerClass.Phosphate) {
+    return RNA_DNA_NON_MODIFIED_PART.PHOSPHATE;
+  }
+
+  return naturalAnalogue;
 };
 
 const rotateCoordAxisBy180Degrees = (position: Vec2, axis: Axises): Vec2 => {

--- a/packages/ketcher-core/src/utilities/SettingsManager.ts
+++ b/packages/ketcher-core/src/utilities/SettingsManager.ts
@@ -37,6 +37,7 @@ interface SavedSettings {
   selectionTool?: any;
   disableCustomQuery?: boolean;
   editorLineLength?: EditorLineLength;
+  monomerLibraryUpdates?: string[];
 }
 
 interface SavedOptions {
@@ -159,5 +160,27 @@ export class SettingsManager {
       ...options,
       ignoreChiralFlag,
     });
+  }
+
+  static get monomerLibraryUpdates() {
+    const { monomerLibraryUpdates } = this.getSettings();
+    return monomerLibraryUpdates || [];
+  }
+
+  static set monomerLibraryUpdates(monomerLibraryUpdates: string[]) {
+    const settings = this.getSettings();
+
+    this.saveSettings({
+      ...settings,
+      monomerLibraryUpdates,
+    });
+  }
+
+  static addMonomerLibraryUpdate(newUpdate: string) {
+    const updates = this.monomerLibraryUpdates;
+    if (!updates.includes(newUpdate)) {
+      updates.push(newUpdate);
+      this.monomerLibraryUpdates = updates;
+    }
   }
 }

--- a/packages/ketcher-react/src/script/editor/tool/create-monomer.ts
+++ b/packages/ketcher-react/src/script/editor/tool/create-monomer.ts
@@ -9,6 +9,10 @@ class CreateMonomerTool implements Tool {
   cancel() {
     this.editor.closeMonomerCreationWizard();
   }
+
+  mousemove() {
+    // No action needed on mouse move for this tool
+  }
 }
 
 export default CreateMonomerTool;

--- a/packages/ketcher-react/src/script/ui/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/action/index.ts
@@ -39,6 +39,9 @@ const disableIfViewOnly = (editor: Editor): boolean =>
 const disableIfMonomerCreationWizardActive = (editor: Editor): boolean =>
   editor.isMonomerCreationWizardActive;
 
+const combinedDisable = (editor: Editor) =>
+  disableIfViewOnly(editor) || disableIfMonomerCreationWizardActive(editor);
+
 const updateConfigItem = (item: UiAction): UiAction => {
   if (typeof item.disabled === 'boolean' || item.enabledInViewOnly === true) {
     return item;
@@ -54,7 +57,7 @@ const updateConfigItem = (item: UiAction): UiAction => {
   } else {
     return {
       ...item,
-      disabled: disableIfViewOnly || disableIfMonomerCreationWizardActive,
+      disabled: combinedDisable,
     };
   }
 };

--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.module.less
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.module.less
@@ -102,12 +102,23 @@
     }
   }
 
+  :global(.MuiOutlinedInput-root.Mui-disabled .MuiSelect-select) {
+    &:hover {
+      border: 1px solid @color-border-input;
+    }
+  }
+
   :global(.Mui-focused .MuiSelect-select) {
     border-color: @color-primary;
   }
 
   :global(.MuiOutlinedInput-notchedOutline) {
     border: none;
+  }
+
+  :global(.Mui-error .MuiSelect-select) {
+    background-color: #FDE0DF;
+    border: 1px solid @color-secondary-red;
   }
 
   :global(.MuiSelect-icon) {

--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
@@ -39,6 +39,7 @@ interface Props {
   name?: string;
   placeholder?: string;
   'data-testid'?: string;
+  error?: boolean;
 }
 
 const ChevronIcon = ({ className }) => (
@@ -56,6 +57,7 @@ const Select = ({
   name,
   placeholder,
   'data-testid': testId,
+  error,
 }: Props) => {
   const [currentValue, setCurrentValue] = useState<Option>();
 
@@ -82,6 +84,7 @@ const Select = ({
       MenuProps={{ className: styles.dropdownList }}
       IconComponent={ChevronIcon}
       data-testid={testId}
+      error={error}
     >
       {options &&
         options.map((option) => {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -30,6 +30,8 @@ import {
   getMenuPropsForSelection,
 } from './ContextMenuTrigger.utils';
 import TemplateTool from 'src/script/editor/tool/template';
+import { WizardNotificationId } from '../MonomerCreationWizard/MonomerCreationWizard.types';
+import { MonomerCreationExternalNotificationAction } from '../MonomerCreationWizard/MonomerCreationWizard.constants';
 
 const ContextMenuTrigger: FC<PropsWithChildren> = ({ children }) => {
   const { ketcherId } = useAppContext();
@@ -78,6 +80,18 @@ const ContextMenuTrigger: FC<PropsWithChildren> = ({ children }) => {
 
       const ketcher = ketcherProvider.getKetcher(ketcherId);
       const editor = ketcher.editor as Editor;
+
+      if (editor.monomerCreationState !== null) {
+        window.dispatchEvent(
+          new CustomEvent<WizardNotificationId>(
+            MonomerCreationExternalNotificationAction,
+            {
+              detail: 'editingIsNotAllowed',
+            },
+          ),
+        );
+        return;
+      }
 
       if (editor.render.options.viewOnlyMode) {
         return;

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.constants.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.constants.ts
@@ -1,0 +1,46 @@
+import { KetMonomerClass } from 'ketcher-core';
+
+import {
+  MonomerTypeSelectItem,
+  WizardNotificationMessageMap,
+  WizardNotificationTypeMap,
+} from './MonomerCreationWizard.types';
+
+export const MonomerTypeSelectConfig: MonomerTypeSelectItem[] = [
+  {
+    value: KetMonomerClass.AminoAcid,
+    label: 'Amino acid',
+    iconName: 'peptide',
+  },
+  { value: KetMonomerClass.Sugar, label: 'Sugar', iconName: 'sugar' },
+  { value: KetMonomerClass.Base, label: 'Base', iconName: 'base' },
+  {
+    value: KetMonomerClass.Phosphate,
+    label: 'Phosphate',
+    iconName: 'phosphate',
+  },
+  { value: KetMonomerClass.RNA, label: 'Nucleotide', iconName: 'nucleotide' },
+  { value: KetMonomerClass.CHEM, label: 'CHEM', iconName: 'chem' },
+];
+
+export const NotificationMessages: WizardNotificationMessageMap = {
+  defaultAttachmentPoints:
+    'Attachment points are set by default with hydrogens as leaving groups.',
+  emptyMandatoryFields: 'Mandatory fields must be filled.',
+  invalidSymbol:
+    'The monomer symbol must consist only of uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and asterisks (*).',
+  symbolExists:
+    'The symbol must be unique amongst peptide, RNA, or CHEM monomers.',
+  editingIsNotAllowed: 'Editing of the structure is not allowed.',
+};
+
+export const NotificationTypes: WizardNotificationTypeMap = {
+  defaultAttachmentPoints: 'info',
+  emptyMandatoryFields: 'error',
+  invalidSymbol: 'error',
+  symbolExists: 'error',
+  editingIsNotAllowed: 'error',
+};
+
+export const MonomerCreationExternalNotificationAction =
+  'MonomerCreationExternalNotification';

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.module.less
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.module.less
@@ -8,6 +8,7 @@
   width: calc(100% - 62px);
   display: flex;
   justify-content: space-between;
+  gap: 8px;
   margin: 16px 11px;
   padding: 16px;
   border: 1px dashed #CAD3DD;
@@ -16,6 +17,7 @@
 }
 
 .leftColumn {
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -75,11 +77,11 @@
 
 .input {
   width: 200px;
+}
 
-  &.error {
-    background-color: #FDE0DF;
-    border: 1px solid @color-secondary-red;
-  }
+.error {
+  background-color: #FDE0DF !important;
+  border: 1px solid @color-secondary-red !important;
 }
 
 .divider {

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.types.ts
@@ -23,7 +23,13 @@ export type WizardNotificationId =
   | 'defaultAttachmentPoints'
   | 'emptyMandatoryFields'
   | 'invalidSymbol'
-  | 'symbolExists';
+  | 'symbolExists'
+  | 'editingIsNotAllowed';
+
+export type WizardNotificationTypeMap = Record<
+  WizardNotificationId,
+  WizardNotificationType
+>;
 
 export type WizardNotificationMessageMap = Record<WizardNotificationId, string>;
 
@@ -56,6 +62,10 @@ export type WizardAction =
   | {
       type: 'SetNotifications';
       notifications: WizardNotifications;
+    }
+  | {
+      type: 'AddNotification';
+      id: WizardNotificationId;
     }
   | {
       type: 'RemoveNotification';

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/NaturalAnaloguePicker/NaturalAnaloguePicker.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/NaturalAnaloguePicker/NaturalAnaloguePicker.tsx
@@ -13,6 +13,7 @@ interface ChipGridSelectProps {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  error?: boolean;
 }
 
 const ChevronIcon = ({ className }) => (
@@ -69,6 +70,7 @@ const NaturalAnaloguePicker: FC<ChipGridSelectProps> = ({
   value,
   onChange,
   className,
+  error,
 }) => {
   const disabled = !isNaturalAnalogueRequired(monomerType);
 
@@ -122,6 +124,7 @@ const NaturalAnaloguePicker: FC<ChipGridSelectProps> = ({
       IconComponent={ChevronIcon}
       data-testid="natural-analogue-picker"
       disabled={disabled}
+      error={error}
     >
       {options.map((option) => (
         <MenuItem

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/Notification/Notification.module.less
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/Notification/Notification.module.less
@@ -23,7 +23,7 @@
   &.info {
     background-color: #C3FFD7;
 
-    &Strip {
+    & .notificationStrip {
       background-color: #06A729;
     }
   }
@@ -31,14 +31,14 @@
   &.error {
     background-color: #FDE0DF;
 
-    &Strip {
+    .notificationStrip {
       background-color: @color-secondary-red;
     }
   }
 
   &Icon {
-    height: 18px;
-    width: 18px;
+    min-width: 18px;
+    min-height: 18px;
     color: @color-text-primary;
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request