### PR TITLE
Backmerge: #7627 – Selection tools stop working after creating first monomer via wizard when many structures are on canvas

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -736,7 +736,7 @@ class Editor implements KetcherEditor {
     });
 
     this._monomerCreationState = {
-      originalStruct: currentStruct.clone(),
+      originalStruct: currentStruct,
       attachmentAtomIdToLeavingAtomId: attachmentPoints,
     };
 
@@ -850,22 +850,43 @@ class Editor implements KetcherEditor {
 
     this.closeMonomerCreationWizard();
 
+    const sGroupAttachmentPoints =
+      MacromoleculesConverter.convertMonomerAttachmentPointsToSGroupAttachmentPoints(
+        monomer,
+        this.atomIdsMap,
+      );
+
+    this.singleBondsToOutsideOfSelection.forEach((bond) => {
+      const attachmentPointToBond = sGroupAttachmentPoints.find((point) => {
+        return point.atomId === bond.begin || point.atomId === bond.end;
+      });
+
+      if (attachmentPointToBond) {
+        bond.beginSuperatomAttachmentPointNumber =
+          attachmentPointToBond.attachmentPointNumber;
+      }
+    });
+
     const action = fromSgroupAddition(
       this.render.ctab,
       SGroup.TYPES.SUP,
       this.originalSelection.atoms,
       { expanded: true },
       this.render.ctab.molecule.sgroups.newId(),
-      MacromoleculesConverter.convertMonomerAttachmentPointsToSGroupAttachmentPoints(
-        monomer,
-        this.atomIdsMap,
-      ),
+      sGroupAttachmentPoints,
       monomer.position,
       true,
       monomer.monomerItem.props.MonomerName,
       null,
       monomer,
     );
+
+    this.originalSelection.atoms?.forEach((atomId) => {
+      const atom = this.render.ctab.molecule.atoms.get(atomId);
+      if (atom) {
+        atom.fragment = -1;
+      }
+    });
 
     this.update(action);
   }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request