### PR TITLE
#7571 - Ctrl+M does not open monomer creation wizard when selection meets conditions

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/action/index.ts
@@ -173,7 +173,7 @@ const config: Record<string, UiAction> = {
     hidden: (options) => isHidden(options, 'copy-image'),
   },
   'copy-mol': {
-    shortcut: 'Mod+m',
+    shortcut: 'Mod+Shift+m',
     enabledInViewOnly: true,
     title: 'Copy as MOL',
     action: () => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request