### PR TITLE
#7578 - Undo/Redo restores partial selection after cancelling monomer creation 

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -328,7 +328,7 @@ class Editor implements KetcherEditor {
   ): Struct {
     const action = fromNewCanvas(this.render.ctab, struct);
 
-    this.update(action);
+    this.update(action, this.isMonomerCreationWizardActive);
 
     if (needToCenterStruct) {
       this.centerStruct();
@@ -758,7 +758,7 @@ class Editor implements KetcherEditor {
     }
 
     this.render.monomerCreationRenderState = null;
-    this.struct(this._monomerCreationState.originalStruct);
+    this.struct(this._monomerCreationState.originalStruct, false);
     this._monomerCreationState = null;
 
     this.tool('select');


### PR DESCRIPTION
- [x] Wizard transitions do not hit Undo/Redo.
- [x] Center on open; restore position on close.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request