### PR TITLE
Backmerge: #7714 – System shouldn't allow to create monomer for selected structure that have any non-simple single bonds to non-selected parts of the structure

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -591,10 +591,12 @@ class Editor implements KetcherEditor {
         // Selection should not contain S-Groups, R-Groups or atoms from extended table
         return (
           atom.sgs.size > 0 ||
-          genericsList.includes(atom.label) ||
+          atom.rglabel !== null ||
+          atom.attachmentPoints !== null ||
           this.render.ctab.molecule.rgroups.some((rgroup) =>
             rgroup.frags.has(atom.fragment),
-          )
+          ) ||
+          genericsList.includes(atom.label)
         );
       });
 
@@ -618,8 +620,13 @@ class Editor implements KetcherEditor {
         );
       });
 
+      // Only simple single bonds are allowed to outside of selection
       if (
-        bondsToOutside.some((bond) => bond.type !== Bond.PATTERN.TYPE.SINGLE)
+        bondsToOutside.some(
+          (bond) =>
+            bond.type !== Bond.PATTERN.TYPE.SINGLE ||
+            bond.stereo !== Bond.PATTERN.STEREO.NONE,
+        )
       ) {
         return false;
       }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request