### PR TITLE
Backmerge: #7725 – Hand tool and Area Selection Tool buttons close Monomer creation wizard if pressed

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/create-monomer.ts
+++ b/packages/ketcher-react/src/script/editor/tool/create-monomer.ts
@@ -6,10 +6,6 @@ class CreateMonomerTool implements Tool {
     this.editor.openMonomerCreationWizard();
   }
 
-  cancel() {
-    this.editor.closeMonomerCreationWizard();
-  }
-
   mousemove() {
     // No action needed on mouse move for this tool
   }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request