### PR TITLE
#7581 - fUndo/Redo buttons become inactive and canvas Up, Bottom, Left and Right toolbars remain active inside Monomer Wizard

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/server.js
+++ b/packages/ketcher-react/src/script/ui/action/server.js
@@ -76,7 +76,8 @@ const config = {
     enabledInViewOnly: true,
     title: 'Calculated Values',
     action: { dialog: 'analyse' },
-    disabled: (editor, server, options) => !options.app.server,
+    disabled: (editor, server, options) =>
+      editor.isMonomerCreationWizardActive || !options.app.server,
     hidden: (options) => isHidden(options, 'analyse'),
   },
   recognize: {
@@ -91,6 +92,7 @@ const config = {
     title: '3D Viewer',
     enabledInViewOnly: true,
     action: { dialog: 'miew' },
+    disabled: (editor) => editor.isMonomerCreationWizardActive,
     hidden: (options) => isHidden(options, 'miew'),
   },
   'explicit-hydrogens': {


### PR DESCRIPTION
Issue => https://github.com/epam/ketcher/issues/7581 


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request