### PR TITLE
#7722 - Connection preview does not follow cursor and AP to AP connection is not possible

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -243,7 +243,7 @@ export class CoreEditor {
     editor = this;
     const ketcher = ketcherProvider.getKetcher(this.ketcherId);
     this.micromoleculesEditor = ketcher?.editor;
-    this.initializeEventListeners();
+    this.initializeGlobalEventListeners();
   }
 
   private resetCanvasOffset() {
@@ -255,9 +255,10 @@ export class CoreEditor {
       this.ketcherRootElement?.getBoundingClientRect();
   }
 
-  private initializeEventListeners(): void {
+  private initializeGlobalEventListeners(): void {
     document.addEventListener('visibilitychange', this.handleVisibilityChange);
     window.addEventListener('blur', this.handleWindowBlur);
+    window.addEventListener('resize', this.handleWindowResize);
   }
 
   private handleVisibilityChange = (): void => {
@@ -268,6 +269,11 @@ export class CoreEditor {
 
   private handleWindowBlur = (): void => {
     this.cancelActiveDrag();
+  };
+
+  private handleWindowResize = () => {
+    this.resetCanvasOffset();
+    this.resetKetcherRootElementOffset();
   };
 
   private cancelActiveDrag(): void {
@@ -1438,6 +1444,12 @@ export class CoreEditor {
     document.removeEventListener('keydown', this.keydownEventHandler);
     document.removeEventListener('contextmenu', this.contextMenuEventHandler);
     this.canvas.removeEventListener('mousedown', blurActiveElement);
+    document.removeEventListener(
+      'visibilitychange',
+      this.handleVisibilityChange,
+    );
+    window.removeEventListener('blur', this.handleWindowBlur);
+    window.removeEventListener('resize', this.handleWindowResize);
 
     this.cleanupsForDomEvents.forEach((cleanupFunction) => {
       cleanupFunction();

--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -24,6 +24,7 @@ export interface IEditorEvents {
   mouseOnMoveMonomer: Subscription;
   mouseLeaveMonomer: Subscription;
   mouseOverAttachmentPoint: Subscription;
+  mouseMoveAttachmentPoint: Subscription;
   mouseLeaveAttachmentPoint: Subscription;
   mouseUpAttachmentPoint: Subscription;
   mouseDownAttachmentPoint: Subscription;
@@ -97,6 +98,7 @@ export function resetEditorEvents() {
     mouseOnMoveMonomer: new Subscription(),
     mouseLeaveMonomer: new Subscription(),
     mouseOverAttachmentPoint: new Subscription(),
+    mouseMoveAttachmentPoint: new Subscription(),
     mouseLeaveAttachmentPoint: new Subscription(),
     mouseUpAttachmentPoint: new Subscription(),
     mouseDownAttachmentPoint: new Subscription(),

--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -486,6 +486,10 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
         this.editorEvents.mouseOnMoveMonomer.dispatch(event);
       })
       .on('mouseleave', (event) => {
+        if (event.relatedTarget?.__data__ instanceof AttachmentPoint) {
+          return;
+        }
+
         this.editorEvents.mouseLeaveDrawingEntity.dispatch(event);
         this.editorEvents.mouseLeaveMonomer.dispatch(event);
       })

--- a/packages/ketcher-core/src/domain/AttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/AttachmentPoint.ts
@@ -222,6 +222,9 @@ export class AttachmentPoint {
       .on('mouseleave', (event) => {
         this.editorEvents.mouseLeaveAttachmentPoint.dispatch(event);
       })
+      .on('mousemove', (event) => {
+        this.editorEvents.mouseMoveAttachmentPoint.dispatch(event);
+      })
       .on('mousedown', (event) => {
         event.attachmentPointName = this.attachmentPointName;
         this.editorEvents.mouseDownAttachmentPoint.dispatch(event);

--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -318,6 +318,8 @@ export const EditorEvents = () => {
   useEffect(() => {
     editor?.events.mouseOverMonomer.add(handleOpenPreview);
     editor?.events.mouseLeaveMonomer.add(handleClosePreview);
+    editor?.events.mouseLeaveAttachmentPoint.add(handleClosePreview);
+    editor?.events.mouseDownAttachmentPoint.add(handleClosePreview);
     editor?.events.mouseOverSequenceItem.add(handleOpenPreview);
     editor?.events.mouseLeaveSequenceItem.add(handleClosePreview);
     editor?.events.mouseOverPolymerBond.add(handleOpenPreview);
@@ -331,6 +333,7 @@ export const EditorEvents = () => {
       }
     };
     editor?.events.mouseOnMoveMonomer.add(onMoveHandler);
+    editor?.events.mouseMoveAttachmentPoint.add(onMoveHandler);
     editor?.events.mouseOnMoveSequenceItem.add(onMoveHandler);
     editor?.events.mouseOnMovePolymerBond.add(onMoveHandler);
 
@@ -339,12 +342,14 @@ export const EditorEvents = () => {
     return () => {
       editor?.events.mouseOverMonomer.remove(handleOpenPreview);
       editor?.events.mouseLeaveMonomer.remove(handleClosePreview);
+      editor?.events.mouseLeaveAttachmentPoint.remove(handleClosePreview);
       editor?.events.mouseOverSequenceItem.remove(handleOpenPreview);
       editor?.events.mouseLeaveSequenceItem.remove(handleClosePreview);
       editor?.events.mouseOverPolymerBond.remove(handleOpenPreview);
       editor?.events.mouseLeavePolymerBond.remove(handleClosePreview);
 
       editor?.events.mouseOnMoveMonomer.remove(onMoveHandler);
+      editor?.events.mouseMoveAttachmentPoint.remove(onMoveHandler);
       editor?.events.mouseOnMoveSequenceItem.remove(onMoveHandler);
       editor?.events.mouseOnMovePolymerBond.remove(onMoveHandler);
 

--- a/packages/ketcher-react/src/script/editor/HoverIcon.ts
+++ b/packages/ketcher-react/src/script/editor/HoverIcon.ts
@@ -61,7 +61,7 @@ export class HoverIcon {
 
   isOverLoader(event: MouseEvent) {
     const target = <HTMLDivElement>event?.relatedTarget || event.target;
-    return target?.classList.contains('loading-spinner');
+    return target?.classList?.contains('loading-spinner');
   }
 
   onMouseMove(event: MouseEvent) {


### PR DESCRIPTION
Closes:

#7722 - Connection preview does not follow cursor and AP to AP connection is not possible
#6581 - Monomer placement offset from cursor when Ketcher runs in a popup with increased browser zoom

## How the feature works? / How did you fix the issue?

- fixed error in firefox console related to HoverIcon (added safety check)
- added window resize handler in CoreEditor to reset canvas bbox data
- added additional check in monomer mouseleave handler to stop handler if mouse goes to attachment point (firefox issue)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request