### PR TITLE
#7770 - Pressing Right Scroll Arrow button of top menu cause exception to console

### DIFF
--- a/packages/ketcher-macromolecules/src/components/Layout/Layout.tsx
+++ b/packages/ketcher-macromolecules/src/components/Layout/Layout.tsx
@@ -143,20 +143,20 @@ const Top = (
   const { children, ...otherProps } = props;
   const scrollRef = useRef(null) as RefObject<HTMLDivElement | null>;
 
-  const scrollRight = () => {
+  const SCROLL_PX_PER_SEC = 300;
+
+  const scrollRight = (dtMs: number) => {
     if (!scrollRef.current) {
       return;
     }
-
-    scrollRef.current.scrollLeft += 30;
+    scrollRef.current.scrollLeft += (SCROLL_PX_PER_SEC * dtMs) / 1000;
   };
 
-  const scrollLeft = () => {
+  const scrollLeft = (dtMs: number) => {
     if (!scrollRef.current) {
       return;
     }
-
-    scrollRef.current.scrollLeft -= 30;
+    scrollRef.current.scrollLeft -= (SCROLL_PX_PER_SEC * dtMs) / 1000;
   };
 
   return (

--- a/packages/ketcher-macromolecules/src/components/Layout/Layout.tsx
+++ b/packages/ketcher-macromolecules/src/components/Layout/Layout.tsx
@@ -143,9 +143,7 @@ const Top = (
   const { children, ...otherProps } = props;
   const scrollRef = useRef(null) as RefObject<HTMLDivElement | null>;
 
-  const scrollRight = (e: Event) => {
-    e.stopPropagation();
-
+  const scrollRight = () => {
     if (!scrollRef.current) {
       return;
     }
@@ -153,9 +151,7 @@ const Top = (
     scrollRef.current.scrollLeft += 30;
   };
 
-  const scrollLeft = (e: Event) => {
-    e.stopPropagation();
-
+  const scrollLeft = () => {
     if (!scrollRef.current) {
       return;
     }

--- a/packages/ketcher-react/src/hooks/index.ts
+++ b/packages/ketcher-react/src/hooks/index.ts
@@ -18,5 +18,5 @@ export * from './useSettingsContext';
 export * from './useResizeObserver';
 export * from './useFormContext';
 export * from './useAppContext';
-export * from './useRaf';
+export * from './useRequestAnimationFrame';
 export * from './useSubscribtionOnEvents';

--- a/packages/ketcher-react/src/hooks/useRaf.ts
+++ b/packages/ketcher-react/src/hooks/useRaf.ts
@@ -14,9 +14,28 @@
  * limitations under the License.
  ***************************************************************************/
 
-export * from './useSettingsContext';
-export * from './useResizeObserver';
-export * from './useFormContext';
-export * from './useAppContext';
-export * from './useRaf';
-export * from './useSubscribtionOnEvents';
+import { useEffect, useRef } from 'react';
+
+export const useRaf = (active: boolean, onFrame: (dtMs: number) => void) => {
+  const callbackRef = useRef(onFrame);
+  useEffect(() => {
+    callbackRef.current = onFrame;
+  }, [onFrame]);
+
+  useEffect(() => {
+    if (!active) return;
+
+    let rafId = 0;
+    let previousTime = performance.now();
+
+    const loop = (now: number) => {
+      const dt = now - previousTime;
+      previousTime = now;
+      callbackRef.current(dt);
+      rafId = requestAnimationFrame(loop);
+    };
+
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, [active]);
+};

--- a/packages/ketcher-react/src/hooks/useRequestAnimationFrame.ts
+++ b/packages/ketcher-react/src/hooks/useRequestAnimationFrame.ts
@@ -16,7 +16,10 @@
 
 import { useEffect, useRef } from 'react';
 
-export const useRaf = (active: boolean, onFrame: (dtMs: number) => void) => {
+export const useRequestAnimationFrame = (
+  active: boolean,
+  onFrame: (deltaTimeInMilliseconds: number) => void,
+) => {
   const callbackRef = useRef(onFrame);
   useEffect(() => {
     callbackRef.current = onFrame;
@@ -25,17 +28,17 @@ export const useRaf = (active: boolean, onFrame: (dtMs: number) => void) => {
   useEffect(() => {
     if (!active) return;
 
-    let rafId = 0;
+    let requestAnimationFrameId = 0;
     let previousTime = performance.now();
 
     const loop = (now: number) => {
       const dt = now - previousTime;
       previousTime = now;
       callbackRef.current(dt);
-      rafId = requestAnimationFrame(loop);
+      requestAnimationFrameId = requestAnimationFrame(loop);
     };
 
-    rafId = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(rafId);
+    requestAnimationFrameId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(requestAnimationFrameId);
   }, [active]);
 };

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
@@ -17,7 +17,7 @@
 import classes from './ArrowScroll.module.less';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
-import { useRaf } from '../../../../../hooks';
+import { useRequestAnimationFrame } from '../../../../../hooks';
 
 interface ArrowScrollProps {
   startInView: boolean;
@@ -36,8 +36,8 @@ const ArrowScroll = ({
 }: ArrowScrollProps) => {
   const [isScrollDown, setScrollDown] = useState(false);
   const [isScrollUp, setScrollUp] = useState(false);
-  useRaf(isScrollDown, (dt) => scrollForward(dt));
-  useRaf(isScrollUp, (dt) => scrollBack(dt));
+  useRequestAnimationFrame(isScrollDown, (dt) => scrollForward(dt));
+  useRequestAnimationFrame(isScrollUp, (dt) => scrollBack(dt));
 
   useEffect(() => {
     return () => {

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
@@ -22,8 +22,8 @@ import { useRaf } from '../../../../../hooks';
 interface ArrowScrollProps {
   startInView: boolean;
   endInView: boolean;
-  scrollForward: (dtMs?: number) => void;
-  scrollBack: (dtMs?: number) => void;
+  scrollForward: (dtMs: number) => void;
+  scrollBack: (dtMs: number) => void;
   isLeftRight?: boolean;
 }
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
@@ -22,8 +22,8 @@ import { useInterval } from '../../../../../hooks';
 interface ArrowScrollProps {
   startInView: boolean;
   endInView: boolean;
-  scrollForward: any;
-  scrollBack: any;
+  scrollForward: () => void;
+  scrollBack: () => void;
   isLeftRight?: boolean;
 }
 
@@ -62,7 +62,10 @@ const ArrowScroll = ({
         <></>
       ) : (
         <button
-          onClick={scrollForward}
+          onClick={(e) => {
+            e.stopPropagation();
+            scrollForward();
+          }}
           onMouseUp={() => setScrollDown(false)}
           onMouseDown={() => setScrollDown(true)}
           className={clsx(
@@ -77,7 +80,10 @@ const ArrowScroll = ({
         <></>
       ) : (
         <button
-          onClick={scrollBack}
+          onClick={(e) => {
+            e.stopPropagation();
+            scrollBack();
+          }}
           onMouseUp={() => setScrollUp(false)}
           onMouseDown={() => setScrollUp(true)}
           className={clsx(

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ArrowScroll/ArrowScroll.tsx
@@ -17,13 +17,13 @@
 import classes from './ArrowScroll.module.less';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
-import { useInterval } from '../../../../../hooks';
+import { useRaf } from '../../../../../hooks';
 
 interface ArrowScrollProps {
   startInView: boolean;
   endInView: boolean;
-  scrollForward: () => void;
-  scrollBack: () => void;
+  scrollForward: (dtMs?: number) => void;
+  scrollBack: (dtMs?: number) => void;
   isLeftRight?: boolean;
 }
 
@@ -36,8 +36,8 @@ const ArrowScroll = ({
 }: ArrowScrollProps) => {
   const [isScrollDown, setScrollDown] = useState(false);
   const [isScrollUp, setScrollUp] = useState(false);
-  useInterval(scrollBack, isScrollDown ? 100 : null);
-  useInterval(scrollForward, isScrollUp ? 100 : null);
+  useRaf(isScrollDown, (dt) => scrollForward(dt));
+  useRaf(isScrollUp, (dt) => scrollBack(dt));
 
   useEffect(() => {
     return () => {
@@ -64,7 +64,7 @@ const ArrowScroll = ({
         <button
           onClick={(e) => {
             e.stopPropagation();
-            scrollForward();
+            scrollForward(100);
           }}
           onMouseUp={() => setScrollDown(false)}
           onMouseDown={() => setScrollDown(true)}
@@ -82,7 +82,7 @@ const ArrowScroll = ({
         <button
           onClick={(e) => {
             e.stopPropagation();
-            scrollBack();
+            scrollBack(100);
           }}
           onMouseUp={() => setScrollUp(false)}
           onMouseDown={() => setScrollUp(true)}


### PR DESCRIPTION
issue >> https://github.com/epam/ketcher/issues/7770

- Split top bar scroll logic in Layout into no-arg functions and pass to ArrowScroll
- ArrowScroll: stop event propagation in onClick handlers; type callbacks as () => void
- Fixes runtime error: \"Cannot read properties of undefined (reading 'stopPropagation')\" when holding the right arrow (useInterval calls without event)


## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request