### PR TITLE
#7791 – Highlight is not secured for clicked r label in monomer creation wizard

### DIFF
--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -33,6 +33,7 @@ export type MonomerCreationState = {
   // R-label mapping to [attachment atom id, leaving atom id]
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>;
   potentialAttachmentPoints: Map<number, number>;
+  clickedAttachmentPoint?: AttachmentPointName | null;
 } | null;
 
 export class Render {

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -687,17 +687,42 @@ class ReAtom extends ReObject {
           labelGroup.hover(
             // Mouse enter
             () => {
+              assert(render.monomerCreationState);
+
+              if (
+                render.monomerCreationState.clickedAttachmentPoint ===
+                attachmentPointName
+              ) {
+                return;
+              }
+
               background.attr({ opacity: 1 });
               rLabelElement.attr({ fill: '#ffffff' });
             },
             // Mouse leave
             () => {
+              assert(render.monomerCreationState);
+
+              if (
+                render.monomerCreationState.clickedAttachmentPoint ===
+                attachmentPointName
+              ) {
+                return;
+              }
+
               background.attr({ opacity: 0 });
               rLabelElement.attr({ fill: '#333333' });
             },
           );
 
           labelGroup.click((event: PointerEvent) => {
+            if (!render.monomerCreationState) {
+              return;
+            }
+
+            render.monomerCreationState.clickedAttachmentPoint =
+              attachmentPointName;
+
             const clickData: AttachmentPointClickData = {
               atomId: aid,
               atomLabel: this.a.label,

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1096,6 +1096,13 @@ class Editor implements KetcherEditor {
     this.render.update(true);
   }
 
+  cleanupCloseAttachmentPointEditPopup() {
+    assert(this.monomerCreationState);
+
+    this.monomerCreationState.clickedAttachmentPoint = null;
+    this.render.update(true);
+  }
+
   selection(ci?: any) {
     if (arguments.length === 0) {
       return this._selection; // eslint-disable-line

--- a/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
@@ -31,6 +31,7 @@ const attachmentPointAtomOptions: Array<Option> = [
   { value: AtomLabel.N, label: 'NH2' },
   { value: AtomLabel.Cl, label: 'Cl' },
   { value: AtomLabel.F, label: 'F' },
+  { value: AtomLabel.C, label: 'CH3' },
 ];
 
 const AttachmentPointEditPopup = ({

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeLeavingGroupAtomMenuItem.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeLeavingGroupAtomMenuItem.tsx
@@ -41,7 +41,7 @@ const useMakeLeavingGroupAtomMenuItem = ({
     (key) => {
       const atomsPair = assignedAttachmentPoints.get(key);
       assert(atomsPair);
-      return atomsPair.includes(selectedAtomId);
+      return atomsPair[1] === selectedAtomId;
     },
   );
 

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -409,12 +409,14 @@ const MonomerCreationWizard = () => {
       return {
         name: attachmentPointName,
         atomLabel: 'H',
+        implicitH: 0,
       };
     }
 
     return {
       name: attachmentPointName,
       atomLabel: atom.label,
+      implicitH: atom.implicitH,
     };
   });
 
@@ -524,13 +526,16 @@ const MonomerCreationWizard = () => {
                   Attachment points
                 </p>
                 <div className={styles.attachmentPoints}>
-                  {attachmentPointsData.map(({ name, atomLabel }) => (
-                    <AttachmentPoint
-                      name={name}
-                      atomLabel={atomLabel}
-                      key={name}
-                    />
-                  ))}
+                  {attachmentPointsData.map(
+                    ({ name, atomLabel, implicitH }) => (
+                      <AttachmentPoint
+                        name={name}
+                        atomLabel={atomLabel}
+                        implicitH={implicitH}
+                        key={name}
+                      />
+                    ),
+                  )}
                 </div>
               </div>
             </>

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -343,6 +343,7 @@ const MonomerCreationWizard = () => {
 
   const handleAttachmentPointEditPopupClose = () => {
     setAttachmentPointEditPopupData(null);
+    editor.cleanupCloseAttachmentPointEditPopup();
   };
 
   const handleDiscard = () => {

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPoint/AttachmentPoint.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPoint/AttachmentPoint.tsx
@@ -4,14 +4,24 @@ import styles from './AttachmentPoint.module.less';
 type Props = {
   name: AttachmentPointName;
   atomLabel: string;
+  implicitH: number;
 };
 
-const AttachmentPoint = ({ name, atomLabel }: Props) => {
+const AttachmentPoint = ({ name, atomLabel, implicitH }: Props) => {
   return (
     <div className={styles.attachmentPoint}>
       <p className={styles.attachmentPointText}>
         <span className={styles.attachmentPointIndex}>{name}</span>
-        &nbsp;({atomLabel})
+        &nbsp;
+        <span>
+          (
+          {implicitH > 0 && (
+            <>
+              H<sub>{implicitH}</sub>
+            </>
+          )}
+          {atomLabel})
+        </span>
       </p>
     </div>
   );


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request