### PR TITLE
Backmerge: #7782 - In Macro mode selection tool resets to Rectangle when switching between Flex, Snake, and Sequence modes

### DIFF
--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -9,6 +9,7 @@ export interface IEditorEvents {
   selectMonomer: Subscription;
   selectPreset: Subscription;
   selectTool: Subscription;
+  selectSelectionTool: Subscription;
   createBondViaModal: Subscription;
   cancelBondCreationViaModal: Subscription;
   selectMode: Subscription;
@@ -83,6 +84,7 @@ export function resetEditorEvents() {
     selectMonomer: new Subscription(),
     selectPreset: new Subscription(),
     selectTool: new Subscription(),
+    selectSelectionTool: new Subscription(),
     createBondViaModal: new Subscription(),
     cancelBondCreationViaModal: new Subscription(),
     selectMode: new Subscription(),
@@ -218,7 +220,7 @@ export const hotkeysConfiguration = {
     shortcut: ['Escape'],
     handler: (editor: CoreEditor) => {
       currentSelectToolIdx = 0;
-      editor.events.selectTool.dispatch([ToolName.selectRectangle]);
+      editor.events.selectSelectionTool.dispatch();
       editor.cancelLibraryItemDrag();
     },
   },

--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -56,7 +56,7 @@ export abstract class BaseMode {
     );
 
     if (needRemoveSelection) {
-      editor.events.selectTool.dispatch(['select-rectangle']);
+      editor.events.selectSelectionTool.dispatch();
     }
 
     return command;

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -459,7 +459,7 @@ export class Ketcher {
     const macromoleculesEditor = CoreEditor.provideEditorInstance();
     if (macromoleculesEditor?.isSequenceEditInRNABuilderMode) return;
 
-    runAsyncAction<void>(async () => {
+    await runAsyncAction<void>(async () => {
       assert(typeof structStr === 'string');
 
       if (window.isPolymerEditorTurnedOn) {
@@ -490,7 +490,7 @@ export class Ketcher {
   }
 
   async setHelm(helmStr: string): Promise<void | undefined> {
-    runAsyncAction<void>(async () => {
+    await runAsyncAction<void>(async () => {
       assert(typeof helmStr === 'string');
       const struct: Struct = await prepareStructToRender(
         helmStr,
@@ -512,7 +512,7 @@ export class Ketcher {
 
     if (macromoleculesEditor?.isSequenceEditInRNABuilderMode) return;
 
-    runAsyncAction<void>(async () => {
+    await runAsyncAction<void>(async () => {
       assert(typeof structStr === 'string');
 
       if (window.isPolymerEditorTurnedOn) {
@@ -546,13 +546,13 @@ export class Ketcher {
       throw new Error('Layout is not available in macro mode');
     }
 
-    runAsyncAction<void>(async () => {
+    await runAsyncAction<void>(async () => {
       const struct = await this._indigo.layout(
         this.editor.struct(),
         this.editor.serverSettings,
       );
       const ketSerializer = new KetSerializer();
-      this.setMolecule(ketSerializer.serialize(struct));
+      await this.setMolecule(ketSerializer.serialize(struct));
     }, this.eventBus);
   }
 

--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -19,6 +19,7 @@ import {
   selectEditor,
   selectEditorActiveTool,
   selectIsContextMenuActive,
+  selectLastSelectedSelectionMenuItem,
   selectTool,
   showPreview,
 } from 'state/common';
@@ -61,6 +62,9 @@ export const EditorEvents = () => {
   const dispatch = useAppDispatch();
   const presets = useAppSelector(selectAllPresets);
   const hasAtLeastOneAntisense = useAppSelector(hasAntisenseChains);
+  const lastSelectedSelectionMenuItem = useAppSelector(
+    selectLastSelectedSelectionMenuItem,
+  );
 
   const handleMonomersLibraryUpdate = useCallback(() => {
     dispatch(loadMonomerLibrary(editor?.monomersLibrary));
@@ -74,6 +78,21 @@ export const EditorEvents = () => {
       editor?.events.updateMonomersLibrary.remove(handleMonomersLibraryUpdate);
     };
   }, [editor]);
+
+  useEffect(() => {
+    const onSelectSelectionTool = () => {
+      editor?.events.selectTool.dispatch([lastSelectedSelectionMenuItem]);
+      dispatch(selectTool(lastSelectedSelectionMenuItem));
+    };
+
+    if (editor) {
+      editor.events.selectSelectionTool.add(onSelectSelectionTool);
+    }
+
+    return () => {
+      editor?.events.selectSelectionTool.remove(onSelectSelectionTool);
+    };
+  }, [dispatch, editor, lastSelectedSelectionMenuItem]);
 
   useEffect(() => {
     const handler = ([toolName]: [string]) => {

--- a/packages/ketcher-macromolecules/src/components/LeftMenuComponent/LeftMenuComponent.tsx
+++ b/packages/ketcher-macromolecules/src/components/LeftMenuComponent/LeftMenuComponent.tsx
@@ -18,6 +18,7 @@ import { Menu } from 'components/menu';
 import { useAppSelector, useLayoutMode } from 'hooks';
 import { selectEditor, selectEditorActiveTool } from 'state/common';
 import { hotkeysShortcuts } from 'components/ZoomControls/helpers';
+import { SELECT_SUBMENU_ID } from 'components/menu/constants';
 
 export function LeftMenuComponent() {
   const activeTool = useAppSelector(selectEditorActiveTool);
@@ -44,21 +45,22 @@ export function LeftMenuComponent() {
         <Menu.Group>
           <Menu.Submenu
             testId="select-drop-down-button"
+            subMenuId={SELECT_SUBMENU_ID}
             needOpenByMenuItemClick={false}
           >
             <Menu.Item
               itemId="select-rectangle"
-              title={`Select Rectangle (${hotkeysShortcuts.exit})`}
+              title={`Select Rectangle (${hotkeysShortcuts.switchSelectTool})`}
               testId="select-rectangle"
             />
             <Menu.Item
               itemId="select-lasso"
-              title={`Lasso selection (${hotkeysShortcuts.exit})`}
+              title={`Lasso selection (${hotkeysShortcuts.switchSelectTool})`}
               testId="select-lasso"
             />
             <Menu.Item
               itemId="select-fragment"
-              title={`Fragment selection (${hotkeysShortcuts.exit})`}
+              title={`Fragment selection (${hotkeysShortcuts.switchSelectTool})`}
               testId="select-fragment"
             />
           </Menu.Submenu>

--- a/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
+++ b/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
@@ -17,6 +17,7 @@
 import { Menu } from 'components/menu';
 import { useAppDispatch, useAppSelector } from 'hooks';
 import {
+  selectLastSelectedSelectionMenuItem,
   selectEditor,
   selectEditorActiveTool,
   selectIsSequenceEditInRNABuilderMode,
@@ -51,6 +52,9 @@ export function TopMenuComponent() {
     useState<IconName>();
   const activeMenuItems = [activeTool];
   const isDisabled = isSequenceEditInRNABuilderMode;
+  const lastSelectedSelectionMenuItem = useAppSelector(
+    selectLastSelectedSelectionMenuItem,
+  );
 
   useEffect(() => {
     const selectEntitiesHandler = (selectedEntities: BaseMonomer[]) => {
@@ -85,8 +89,8 @@ export function TopMenuComponent() {
       editor?.events.selectHistory.dispatch(name);
     } else if (name === 'clear') {
       editor?.events.selectTool.dispatch([name]);
-      dispatch(selectTool('select-rectangle'));
-      editor?.events.selectTool.dispatch(['select-rectangle']);
+      dispatch(selectTool(lastSelectedSelectionMenuItem));
+      editor?.events.selectTool.dispatch([lastSelectedSelectionMenuItem]);
       if (isSequenceEditInRNABuilderMode)
         resetRnaBuilderAfterSequenceUpdate(dispatch, editor);
     } else if (name === 'antisenseRnaStrand' || name === 'antisenseDnaStrand') {

--- a/packages/ketcher-macromolecules/src/components/menu/Menu.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/menu/Menu.test.tsx
@@ -46,6 +46,8 @@ const MenuContainer = () => {
 
 describe('Menu component', () => {
   it('should render menu component in a container', () => {
-    expect(render(withThemeProvider(<MenuContainer />))).toMatchSnapshot();
+    expect(
+      render(withThemeAndStoreProvider(<MenuContainer />)),
+    ).toMatchSnapshot();
   });
 });

--- a/packages/ketcher-macromolecules/src/components/menu/constants.ts
+++ b/packages/ketcher-macromolecules/src/components/menu/constants.ts
@@ -1,0 +1,1 @@
+export const SELECT_SUBMENU_ID = 'select-submenu';

--- a/packages/ketcher-macromolecules/src/components/menu/subMenu/SubMenu.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/menu/subMenu/SubMenu.test.tsx
@@ -40,11 +40,11 @@ const mockSubMenu = () => {
 
 describe('Test SubMenu component', () => {
   it('should be rendered without crashing', () => {
-    const { asFragment } = render(withThemeProvider(mockSubMenu()));
+    const { asFragment } = render(withThemeAndStoreProvider(mockSubMenu()));
     expect(asFragment).toMatchSnapshot();
   });
   it('should call provided callback when header icon is clicked', () => {
-    render(withThemeProvider(mockSubMenu()));
+    render(withThemeAndStoreProvider(mockSubMenu()));
     const button = screen.getByRole('button');
     fireEvent.click(button);
     expect(mockClickHandler).toHaveBeenCalled();

--- a/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
@@ -27,6 +27,7 @@ import { PreviewType } from 'state/types';
 import { ThemeType } from 'theming/defaultTheme';
 import { DeepPartial } from '../../types';
 import { PresetPosition } from 'ketcher-react';
+import { SELECT_SUBMENU_ID } from 'components/menu/constants';
 
 export enum MolarMeasurementUnit {
   nanoMol = 'nM',
@@ -64,6 +65,7 @@ interface EditorState {
   unipositiveIonsValue: number;
   oligonucleotidesValue: number;
   app: AppMeta;
+  selectedMenuGroupItems: Record<string, string>;
 }
 
 const initialState: EditorState = {
@@ -92,6 +94,7 @@ const initialState: EditorState = {
     indigoMachine: process.env.INDIGO_MACHINE || '',
     version: process.env.VERSION || '',
   },
+  selectedMenuGroupItems: {},
 };
 
 export const editorSlice: Slice<EditorState> = createSlice({
@@ -200,6 +203,15 @@ export const editorSlice: Slice<EditorState> = createSlice({
     setAppMeta: (state, action: PayloadAction<AppMeta>) => {
       state.app = action.payload;
     },
+    setSelectedMenuGroupItem: (
+      state,
+      action: PayloadAction<{ groupName: string; activeItemName: string }>,
+    ) => {
+      state.selectedMenuGroupItems = {
+        ...state.selectedMenuGroupItems,
+        [action.payload.groupName]: action.payload.activeItemName,
+      };
+    },
   },
 });
 
@@ -223,6 +235,7 @@ export const {
   setUnipositiveIonsValue,
   setOligonucleotidesValue,
   setAppMeta,
+  setSelectedMenuGroupItem,
 } = editorSlice.actions;
 
 export const selectShowPreview = (state: RootState): EditorStatePreview =>
@@ -293,5 +306,19 @@ export const selectEditorLineLength = (state: RootState): EditorLineLength =>
   state.editor.editorLineLength;
 
 export const selectAppMeta = (state: RootState): AppMeta => state.editor.app;
+
+export const selectSelectedMenuGroupItemsState = (state: RootState) =>
+  state.editor.selectedMenuGroupItems;
+
+export const selectSelectedMenuGroupItem =
+  (groupItemName: string) => (state: RootState) => {
+    return state.editor.selectedMenuGroupItems[groupItemName];
+  };
+
+export const selectLastSelectedSelectionMenuItem = (state): string => {
+  return (
+    state.editor.selectedMenuGroupItems[SELECT_SUBMENU_ID] || 'select-rectangle'
+  );
+};
 
 export const editorReducer = editorSlice.reducer;


### PR DESCRIPTION
Closes:

#7782 - In Macro mode selection tool resets to Rectangle when switching between Flex, Snake, and Sequence modes
#7777 - Incorrect shortcut displayed for selection tools in Macro mode
#7784 - In Sequence mode selection tool resets to Rectangle when entering or exiting sequence edit mode
#7785 - Clicking toolbar buttons resets selection tool from Lasso/Fragment to Rectangle
#7854 - Ketcher api doesn't work in proper order

## How the feature works? / How did you fix the issue?

- fixed async behaviour of ketcher api
- fixed selection tool state persistence in macro
- fixed shortcuts title for selection tool in macro

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request