### PR TITLE
Backmerge: #7152 - Copy keyboard shortcut works wrong for text content

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -471,9 +471,19 @@ export class CoreEditor {
 
   private setupCopyPasteEvent() {
     this.copyEventHandler = (event: ClipboardEvent) => {
+      // Need to add some abstraction for events handling to have a single point where we can disable events for macro mode
+      if (this._type === EditorType.Micromolecules) {
+        return;
+      }
+
       this.mode.onCopy(event);
     };
     this.pasteEventHandler = (event: ClipboardEvent) => {
+      // Need to add some abstraction for events handling to have a single point where we can disable events for macro mode
+      if (this._type === EditorType.Micromolecules) {
+        return;
+      }
+
       this.mode.onPaste(event);
     };
     document.addEventListener('copy', this.copyEventHandler);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added preventing for macro copy-paste events if editor is in micro mode

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request