### PR TITLE
#7837 - Unable to create monomer if molecule loaded from KET

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -77,6 +77,7 @@ import {
 } from './tool/Tool';
 import { getSelectionMap, getStructCenter } from './utils/structLayout';
 import assert from 'assert';
+import { isNumber } from 'lodash';
 
 const SCALE = provideEditorSettings().microModeScale;
 const HISTORY_SIZE = 32; // put me to options
@@ -968,7 +969,7 @@ class Editor implements KetcherEditor {
 
       const originalLeavingAtomId =
         this.selectedToOriginalAtomsIdMap.get(leavingAtomId);
-      assert(originalLeavingAtomId);
+      assert(isNumber(originalLeavingAtomId));
 
       const originalLeavingAtom = this.originalStruct.atoms.get(
         originalLeavingAtomId,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed casting 0 to false for leaving group atom id

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request