### PR TITLE
Backmerge: #7688 - Attached groups are lost when saving and reopening monomer created via Monomer Wizard in KET format

### DIFF
--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -792,8 +792,14 @@ export class Struct {
     const ids = new Pile<number>();
     while (list.length > 0) {
       const aid = list.pop()!;
-      ids.add(aid);
       const atom = this.atoms.get(aid)!;
+
+      if (this.isAtomFromMacromolecule(aid)) {
+        continue;
+      }
+
+      ids.add(aid);
+
       atom.neighbors.forEach((nei) => {
         const neiId = this.halfBonds.get(nei)!.end;
         if (!ids.has(neiId)) list.push(neiId);
@@ -819,7 +825,8 @@ export class Struct {
     this.atoms.forEach((atom, aid) => {
       if (
         (discardExistingFragments || atom.fragment < 0) &&
-        !addedAtoms.has(aid)
+        !addedAtoms.has(aid) &&
+        !this.isAtomFromMacromolecule(aid)
       ) {
         const component = this.findConnectedComponent(aid);
         components.push(component);
@@ -839,6 +846,13 @@ export class Struct {
       if (atom.stereoLabel) frag.updateStereoAtom(this, aid, fid, true);
       atom.fragment = fid;
     });
+  }
+
+  clearFragments() {
+    this.atoms.forEach((atom) => {
+      atom.fragment = -1;
+    });
+    this.frags.clear();
   }
 
   markFragments(properties?) {

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1022,6 +1022,9 @@ class Editor implements KetcherEditor {
       monomer,
     );
 
+    this.render.ctab.molecule.clearFragments();
+    this.render.ctab.molecule.markFragments();
+
     this.update(action);
 
     const { root: templateRoot, ...templateData } = monomerTemplate;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- added recalculation of fragments after monomer creation
- skipped connected component search for monomers

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request