### PR TITLE
#7359 - Stereochemistry dialog crashes Ketcher if only one stereo bond on the canvas

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
@@ -189,14 +189,14 @@ function maxOfAnds(stereLabels): number {
   const numbers = stereLabels.map((label) => {
     return label.match(/&/) ? +label.match(/\d+/)?.join() : 0;
   });
-  return Math.max(...numbers);
+  return numbers.length === 0 ? 0 : Math.max(...numbers);
 }
 
 function maxOfOrs(stereLabels): number {
   const numbers = stereLabels.map((label) => {
     return label.match(/or/) ? +label.match(/\d+/)?.join() : 0;
   });
-  return Math.max(...numbers);
+  return numbers.length === 0 ? 0 : Math.max(...numbers);
 }
 
 export default connect((state) => ({


### PR DESCRIPTION
issue >> https://github.com/epam/ketcher/issues/7359

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request