### PR TITLE
#7877 - Ketcher losts attachment point name on loading s-group from mol v3000

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/moleculeToStruct.ts
@@ -295,10 +295,13 @@ function sgroupAttachmentPointToStruct(
   const atomId = source.attachmentAtom;
   const leavingAtomId = source.leavingAtom;
   const attachmentId = source.attachmentId;
+
   return new SGroupAttachmentPoint(
     atomId,
     leavingAtomId,
     attachmentId,
-    attachmentId ? Number(attachmentId) : attachmentPointNumber,
+    attachmentId && !isNaN(Number(attachmentId))
+      ? Number(attachmentId)
+      : attachmentPointNumber,
   );
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request