### PR TITLE
#7804 – Incorrect atom label upon monomer saving when removing automatically assigned attachment point via R-group

### DIFF
--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -33,8 +33,8 @@ export type MonomerCreationState = {
   // R-label mapping to [attachment atom id, leaving atom id]
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>;
   potentialAttachmentPoints: Map<number, number>;
+  problematicAttachmentPoints: Set<AttachmentPointName>;
   clickedAttachmentPoint?: AttachmentPointName | null;
-  problematicAttachmentPoints?: Set<AttachmentPointName>;
 } | null;
 
 export class Render {

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -662,7 +662,7 @@ class ReAtom extends ReObject {
           const labelPos = ps.addScaled(direction, labelDistance);
 
           const isProblematic =
-            problematicAttachmentPoints?.has(attachmentPointName);
+            problematicAttachmentPoints.has(attachmentPointName);
 
           const rLabelElement = render.paper
             .text(labelPos.x, labelPos.y, attachmentPointName)

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -369,6 +369,7 @@ const MonomerCreationWizard = () => {
 
   const handleSubmit = () => {
     wizardStateDispatch({ type: 'ResetErrors' });
+    editor.setProblematicAttachmentPoints(new Set());
 
     const { errors: inputsErrors, notifications: inputsNotifications } =
       validateInputs(values);
@@ -406,7 +407,6 @@ const MonomerCreationWizard = () => {
     });
 
     resetWizard();
-    editor.setProblematicAttachmentPoints(new Set());
   };
 
   const monomerCreationState = useSelector(editorMonomerCreationStateSelector);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request