### PR TITLE
#7553 - Dropdown for switching between Macro and Micro modes does not appear in fullscreen mode

### DIFF
--- a/packages/ketcher-macromolecules/src/components/FullscreenButton/FullscreenButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/FullscreenButton/FullscreenButton.tsx
@@ -55,17 +55,53 @@ const ButtonContainer = styled.div`
   }
 `;
 
+const getFullscreenElement = (): HTMLElement => {
+  const ketcherRoot = document.querySelector(
+    '.Ketcher-root, .Ketcher-polymer-editor-root',
+  ) as HTMLElement;
+
+  if (ketcherRoot) {
+    const markedContainer = ketcherRoot.closest(
+      '[data-ketcher-fullscreen-container]',
+    );
+    if (markedContainer) {
+      return markedContainer as HTMLElement;
+    }
+
+    const editorRoot = ketcherRoot.closest('[data-ketcher-editor]');
+    if (editorRoot) {
+      const editorParent = editorRoot.parentElement;
+
+      if (
+        editorParent &&
+        editorParent !== document.body &&
+        editorParent !== document.documentElement
+      ) {
+        if (editorParent.id === 'root') {
+          return editorParent;
+        }
+        return editorParent;
+      }
+
+      const rootElement = editorRoot.closest('#root');
+      if (rootElement) {
+        return rootElement as HTMLElement;
+      }
+    }
+
+    const rootById = document.getElementById('root');
+    if (rootById) {
+      return rootById;
+    }
+  }
+
+  return document.getElementById('root') || document.documentElement;
+};
+
 export const FullscreenButton = (props) => {
   const [fullScreenMode, setFullScreenMode] = useState(isFullScreen());
   const toggleFullscreen = () => {
-    // Check if we're in popup mode (has MuiPaper-root with ketcher-dialog class)
-    const popupDialog = document.querySelector(
-      '.MuiPaper-root.ketcher-dialog',
-    ) as HTMLElement;
-    const fullscreenElement: HTMLElement =
-      popupDialog ||
-      document.getElementById('root') ||
-      document.documentElement;
+    const fullscreenElement = getFullscreenElement();
     fullScreenMode ? exitFullscreen() : requestFullscreen(fullscreenElement);
     setFullScreenMode(!fullScreenMode);
   };

--- a/packages/ketcher-macromolecules/src/components/FullscreenButton/FullscreenButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/FullscreenButton/FullscreenButton.tsx
@@ -14,10 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import {
-  KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR,
-  IconButton,
-} from 'ketcher-react';
+import { IconButton } from 'ketcher-react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
@@ -61,9 +58,13 @@ const ButtonContainer = styled.div`
 export const FullscreenButton = (props) => {
   const [fullScreenMode, setFullScreenMode] = useState(isFullScreen());
   const toggleFullscreen = () => {
-    // TODO: add selector / ref prop when will be shared component
+    // Check if we're in popup mode (has MuiPaper-root with ketcher-dialog class)
+    const popupDialog = document.querySelector(
+      '.MuiPaper-root.ketcher-dialog',
+    ) as HTMLElement;
     const fullscreenElement: HTMLElement =
-      document.querySelector(KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR) ||
+      popupDialog ||
+      document.getElementById('root') ||
       document.documentElement;
     fullScreenMode ? exitFullscreen() : requestFullscreen(fullscreenElement);
     setFullScreenMode(!fullScreenMode);

--- a/packages/ketcher-macromolecules/src/components/FullscreenButton/FullscreenButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/FullscreenButton/FullscreenButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { IconButton } from 'ketcher-react';
+import { IconButton, getFullscreenElement } from 'ketcher-react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
@@ -54,49 +54,6 @@ const ButtonContainer = styled.div`
     border-radius: 4px;
   }
 `;
-
-const getFullscreenElement = (): HTMLElement => {
-  const ketcherRoot = document.querySelector(
-    '.Ketcher-root, .Ketcher-polymer-editor-root',
-  ) as HTMLElement;
-
-  if (ketcherRoot) {
-    const markedContainer = ketcherRoot.closest(
-      '[data-ketcher-fullscreen-container]',
-    );
-    if (markedContainer) {
-      return markedContainer as HTMLElement;
-    }
-
-    const editorRoot = ketcherRoot.closest('[data-ketcher-editor]');
-    if (editorRoot) {
-      const editorParent = editorRoot.parentElement;
-
-      if (
-        editorParent &&
-        editorParent !== document.body &&
-        editorParent !== document.documentElement
-      ) {
-        if (editorParent.id === 'root') {
-          return editorParent;
-        }
-        return editorParent;
-      }
-
-      const rootElement = editorRoot.closest('#root');
-      if (rootElement) {
-        return rootElement as HTMLElement;
-      }
-    }
-
-    const rootById = document.getElementById('root');
-    if (rootById) {
-      return rootById;
-    }
-  }
-
-  return document.getElementById('root') || document.documentElement;
-};
 
 export const FullscreenButton = (props) => {
   const [fullScreenMode, setFullScreenMode] = useState(isFullScreen());

--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -121,6 +121,7 @@ export const Editor = (props: Props) => {
   return (
     <>
       <div
+        data-ketcher-editor
         className={styles.editorsWrapper}
         style={{
           display: showPolymerEditor ? undefined : 'none',
@@ -144,6 +145,7 @@ export const Editor = (props: Props) => {
         </Suspense>
       </div>
       <div
+        data-ketcher-editor
         className={styles.editorsWrapper}
         style={{
           display: showPolymerEditor ? 'none' : undefined,

--- a/packages/ketcher-react/src/index.tsx
+++ b/packages/ketcher-react/src/index.tsx
@@ -18,4 +18,5 @@ export * from './Editor';
 export * from './script';
 export * from './constants';
 export * from './components';
+export * from './utils';
 export { AppContext } from './contexts';

--- a/packages/ketcher-react/src/script/ui/action/fullscreen.ts
+++ b/packages/ketcher-react/src/script/ui/action/fullscreen.ts
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 import isHidden from './isHidden';
+import { getFullscreenElement } from '../../../utils';
 
 const requestFullscreen = (element: HTMLElement) => {
   (element.requestFullscreen && element.requestFullscreen()) ||
@@ -37,48 +38,6 @@ const getIfFullScreen = () => {
     document.webkitFullscreenElement ||
     document.msFullscreenElement
   );
-};
-
-const getFullscreenElement = (): HTMLElement => {
-  const ketcherRoot = document.querySelector(
-    '.Ketcher-root, .Ketcher-polymer-editor-root',
-  ) as HTMLElement;
-
-  if (ketcherRoot) {
-    const markedContainer = ketcherRoot.closest(
-      '[data-ketcher-fullscreen-container]',
-    );
-    if (markedContainer) {
-      return markedContainer as HTMLElement;
-    }
-
-    const editorRoot = ketcherRoot.closest('[data-ketcher-editor]');
-    if (editorRoot) {
-      const editorParent = editorRoot.parentElement;
-      if (
-        editorParent &&
-        editorParent !== document.body &&
-        editorParent !== document.documentElement
-      ) {
-        if (editorParent.id === 'root') {
-          return editorParent;
-        }
-        return editorParent;
-      }
-
-      const rootElement = editorRoot.closest('#root');
-      if (rootElement) {
-        return rootElement as HTMLElement;
-      }
-    }
-
-    const rootById = document.getElementById('root');
-    if (rootById) {
-      return rootById;
-    }
-  }
-
-  return document.getElementById('root') || document.documentElement;
 };
 
 const toggleFullscreen = () => {

--- a/packages/ketcher-react/src/script/ui/action/fullscreen.ts
+++ b/packages/ketcher-react/src/script/ui/action/fullscreen.ts
@@ -39,14 +39,50 @@ const getIfFullScreen = () => {
   );
 };
 
-const toggleFullscreen = () => {
-  // Check if we're in popup mode (has MuiPaper-root with ketcher-dialog class)
-  const popupDialog = document.querySelector(
-    '.MuiPaper-root.ketcher-dialog',
+const getFullscreenElement = (): HTMLElement => {
+  const ketcherRoot = document.querySelector(
+    '.Ketcher-root, .Ketcher-polymer-editor-root',
   ) as HTMLElement;
-  const fullscreenElement: HTMLElement =
-    popupDialog || document.getElementById('root') || document.documentElement;
 
+  if (ketcherRoot) {
+    const markedContainer = ketcherRoot.closest(
+      '[data-ketcher-fullscreen-container]',
+    );
+    if (markedContainer) {
+      return markedContainer as HTMLElement;
+    }
+
+    const editorRoot = ketcherRoot.closest('[data-ketcher-editor]');
+    if (editorRoot) {
+      const editorParent = editorRoot.parentElement;
+      if (
+        editorParent &&
+        editorParent !== document.body &&
+        editorParent !== document.documentElement
+      ) {
+        if (editorParent.id === 'root') {
+          return editorParent;
+        }
+        return editorParent;
+      }
+
+      const rootElement = editorRoot.closest('#root');
+      if (rootElement) {
+        return rootElement as HTMLElement;
+      }
+    }
+
+    const rootById = document.getElementById('root');
+    if (rootById) {
+      return rootById;
+    }
+  }
+
+  return document.getElementById('root') || document.documentElement;
+};
+
+const toggleFullscreen = () => {
+  const fullscreenElement = getFullscreenElement();
   getIfFullScreen() ? exitFullscreen() : requestFullscreen(fullscreenElement);
 };
 

--- a/packages/ketcher-react/src/script/ui/action/fullscreen.ts
+++ b/packages/ketcher-react/src/script/ui/action/fullscreen.ts
@@ -15,7 +15,6 @@
  ***************************************************************************/
 
 import isHidden from './isHidden';
-import { KETCHER_ROOT_NODE_CSS_SELECTOR } from 'src/constants';
 
 const requestFullscreen = (element: HTMLElement) => {
   (element.requestFullscreen && element.requestFullscreen()) ||
@@ -41,9 +40,13 @@ const getIfFullScreen = () => {
 };
 
 const toggleFullscreen = () => {
+  // Check if we're in popup mode (has MuiPaper-root with ketcher-dialog class)
+  const popupDialog = document.querySelector(
+    '.MuiPaper-root.ketcher-dialog',
+  ) as HTMLElement;
   const fullscreenElement: HTMLElement =
-    document.querySelector(KETCHER_ROOT_NODE_CSS_SELECTOR) ||
-    document.documentElement;
+    popupDialog || document.getElementById('root') || document.documentElement;
+
   getIfFullScreen() ? exitFullscreen() : requestFullscreen(fullscreenElement);
 };
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.tsx
@@ -18,6 +18,10 @@ import { useState, useRef } from 'react';
 import styled from '@emotion/styled';
 import { Button, Popover } from '@mui/material';
 import { Icon } from 'components';
+import {
+  KETCHER_ROOT_NODE_CSS_SELECTOR,
+  KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR,
+} from 'src/constants';
 
 interface IStyledIconProps {
   expanded?: boolean;
@@ -150,7 +154,6 @@ export const ModeControl = ({ toggle, isPolymerEditor }: ModeProps) => {
   const handleModeSwitch = (isPolymer: boolean) => {
     toggle(isPolymer);
     setIsExpanded(false);
-    // Простая очистка для восстановления интерактивности
     setTimeout(() => {
       if (btnRef.current) btnRef.current.blur();
       document.body.style.overflow = '';
@@ -168,6 +171,12 @@ export const ModeControl = ({ toggle, isPolymerEditor }: ModeProps) => {
   const title = isPolymerEditor
     ? 'Switch to Ketcher mode'
     : 'Switch to Macromolecule mode';
+
+  const ketcherEditorRootElement = document.querySelector(
+    isPolymerEditor
+      ? KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR
+      : KETCHER_ROOT_NODE_CSS_SELECTOR,
+  );
 
   return (
     <ElementAndDropdown title={title}>
@@ -197,7 +206,7 @@ export const ModeControl = ({ toggle, isPolymerEditor }: ModeProps) => {
           vertical: 'bottom',
           horizontal: 'left',
         }}
-        disablePortal
+        container={document.fullscreenElement || ketcherEditorRootElement}
       >
         <DropDownContent>
           <ModeControlButton

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.tsx
@@ -14,12 +14,10 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef } from 'react';
 import styled from '@emotion/styled';
 import { Button, Popover } from '@mui/material';
 import { Icon } from 'components';
-import { KETCHER_ROOT_NODE_CSS_SELECTOR } from 'src/constants';
-import { KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR } from 'ketcher-core';
 
 interface IStyledIconProps {
   expanded?: boolean;
@@ -149,64 +147,16 @@ export const ModeControl = ({ toggle, isPolymerEditor }: ModeProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const btnRef = useRef<HTMLButtonElement>(null);
 
-  const getIfFullScreen = useCallback(() => {
-    return !!(
-      document.fullscreenElement ||
-      document.mozFullScreenElement ||
-      document.webkitFullscreenElement ||
-      document.msFullscreenElement
-    );
-  }, []);
-
-  const switchModeWithFullscreen = useCallback(
-    (isPolymer: boolean) => {
-      const isCurrentlyFullscreen = getIfFullScreen();
-
-      if (isCurrentlyFullscreen) {
-        const targetSelector = isPolymer
-          ? KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR
-          : KETCHER_ROOT_NODE_CSS_SELECTOR;
-        const targetElement = document.querySelector(
-          targetSelector,
-        ) as HTMLElement;
-
-        console.log(targetElement, 'targetElement');
-        if (targetElement) {
-          //  exit from fullscreen
-          (document.exitFullscreen && document.exitFullscreen()) ||
-            (document.msExitFullscreen && document.msExitFullscreen()) ||
-            (document.mozCancelFullScreen && document.mozCancelFullScreen()) ||
-            (document.webkitExitFullscreen && document.webkitExitFullscreen());
-
-          // intrance in fullscreen
-          setTimeout(() => {
-            (targetElement.requestFullscreen &&
-              targetElement.requestFullscreen()) ||
-              (targetElement.msRequestFullscreen &&
-                targetElement.msRequestFullscreen()) ||
-              (targetElement.mozRequestFullScreen &&
-                targetElement.mozRequestFullScreen()) ||
-              (targetElement.webkitRequestFullscreen &&
-                targetElement.webkitRequestFullscreen());
-          }, 10);
-        }
-      }
-
-      // cleanup
+  const handleModeSwitch = (isPolymer: boolean) => {
+    toggle(isPolymer);
+    setIsExpanded(false);
+    // Простая очистка для восстановления интерактивности
+    setTimeout(() => {
+      if (btnRef.current) btnRef.current.blur();
       document.body.style.overflow = '';
       document.body.style.paddingRight = '';
       const canvas = document.querySelector('canvas') as HTMLElement;
       if (canvas) canvas.focus();
-    },
-    [getIfFullScreen],
-  );
-
-  const handleModeSwitch = (isPolymer: boolean) => {
-    toggle(isPolymer);
-    setIsExpanded(false);
-    setTimeout(() => {
-      if (btnRef.current) btnRef.current.blur();
-      switchModeWithFullscreen(isPolymer);
     }, 10);
   };
 

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.tsx
@@ -18,11 +18,6 @@ import { useState, useRef } from 'react';
 import styled from '@emotion/styled';
 import { Button, Popover } from '@mui/material';
 import { Icon } from 'components';
-import {
-  KETCHER_ROOT_NODE_CSS_SELECTOR,
-  KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR,
-} from 'src/constants';
-
 interface IStyledIconProps {
   expanded?: boolean;
   hidden?: boolean;
@@ -172,12 +167,6 @@ export const ModeControl = ({ toggle, isPolymerEditor }: ModeProps) => {
     ? 'Switch to Ketcher mode'
     : 'Switch to Macromolecule mode';
 
-  const ketcherEditorRootElement = document.querySelector(
-    isPolymerEditor
-      ? KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR
-      : KETCHER_ROOT_NODE_CSS_SELECTOR,
-  );
-
   return (
     <ElementAndDropdown title={title}>
       <DropDownButton
@@ -206,7 +195,7 @@ export const ModeControl = ({ toggle, isPolymerEditor }: ModeProps) => {
           vertical: 'bottom',
           horizontal: 'left',
         }}
-        container={document.fullscreenElement || ketcherEditorRootElement}
+        container={document.fullscreenElement}
       >
         <DropDownContent>
           <ModeControlButton

--- a/packages/ketcher-react/src/utils.ts
+++ b/packages/ketcher-react/src/utils.ts
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+/**
+ * Determines the appropriate HTML element for fullscreen mode based on the current DOM structure.
+ *
+ * Priority order:
+ * 1. Element with [data-ketcher-fullscreen-container] attribute (explicit user customization)
+ * 2. Parent of [data-ketcher-editor] element:
+ *    - If parent is #root -> return #root (standalone mode)
+ *    - If parent is custom container -> return parent (iframe/embedded mode)
+ * 3. Fallback to #root or documentElement
+ *
+ * @returns {HTMLElement} The element to be used for fullscreen mode
+ */
+export const getFullscreenElement = (): HTMLElement => {
+  const ketcherRoot = document.querySelector(
+    '.Ketcher-root, .Ketcher-polymer-editor-root',
+  ) as HTMLElement;
+
+  if (ketcherRoot) {
+    const markedContainer = ketcherRoot.closest(
+      '[data-ketcher-fullscreen-container]',
+    );
+    if (markedContainer) {
+      return markedContainer as HTMLElement;
+    }
+
+    const editorRoot = ketcherRoot.closest('[data-ketcher-editor]');
+    if (editorRoot) {
+      const editorParent = editorRoot.parentElement;
+
+      if (
+        editorParent &&
+        editorParent !== document.body &&
+        editorParent !== document.documentElement
+      ) {
+        if (editorParent.id === 'root') {
+          return editorParent;
+        }
+        return editorParent;
+      }
+
+      const rootElement = editorRoot.closest('#root');
+      if (rootElement) {
+        return rootElement as HTMLElement;
+      }
+    }
+
+    const rootById = document.getElementById('root');
+    if (rootById) {
+      return rootById;
+    }
+  }
+
+  return document.getElementById('root') || document.documentElement;
+};


### PR DESCRIPTION
issue >> https://github.com/epam/ketcher/issues/7553

## How the feature works? / How did you fix the issue?
stage 1
- Fix dropdown visibility in fullscreen mode
- Correct top-layer element switching between modes  
- Restore app interactivity after mode changes
- Cleanup and simplify fullscreen management code
stage 2
- Use .MuiPaper-root.ketcher-dialog as fullscreen element for popup mode
- Use div#root as fullscreen element for normal mode
- Ensure proper top-layer behavior in DevTools for both modes


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request