### PR TITLE
#7934 fix: correct monomer text display in SVG preview

### DIFF
--- a/packages/ketcher-macromolecules/src/components/modal/save/Save.styles.ts
+++ b/packages/ketcher-macromolecules/src/components/modal/save/Save.styles.ts
@@ -49,6 +49,15 @@ export const SvgPreview = styled('div')(({ theme }) => ({
   height: '100%',
   position: 'relative',
   border: `1px solid ${theme.ketcher.color.input.border.regular}`,
+  '& svg': {
+    width: '100%',
+    height: '100%',
+    '& .drawn-structures': {
+      '& .monomer': {
+        lineHeight: 'initial !important',
+      },
+    },
+  },
 }));
 
 export const PreviewContainer = styled('div')(({ theme }) => ({


### PR DESCRIPTION
issue >> https://github.com/epam/ketcher/issues/7934

## How the feature works? / How did you fix the issue?
<img width="441" height="415" alt="Screenshot 2025-09-29 at 10 46 00" src="https://github.com/user-attachments/assets/2527198a-99e0-4504-93b9-70923b2bece7" />

- Remove fixed line-height from monomer elements in SVG preview
- Add specific CSS selector targeting .monomer class within .drawn-structures
- Use !important to ensure style override


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request