### PR TITLE
#8013 Refactor: Use an object spread instead of Object.assign eg: { ...foo }

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
@@ -14,7 +14,7 @@ describe.skip('Bond Addition', () => {
 
   beforeAll(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const reStruct = Object.assign({}, restruct) as any;
+    const reStruct = { ...((restruct as any) || {}) } as any;
     reStruct.molecule.sgroups = [];
     reStruct.visibleAtoms = new Map();
     const [actionData, beginData, endData] = fromBondAddition(

--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -47,7 +47,7 @@ import assert from 'assert';
 import { SGroupAttachmentPointRemove } from '../operations/sgroup/sgroupAttachmentPoints';
 
 export function fromAtomAddition(restruct, pos, atom) {
-  atom = Object.assign({}, atom);
+  atom = { ...(atom || {}) };
   const action = new Action();
   atom.fragment = (
     action.addOp(new FragmentAdd().perform(restruct)) as FragmentAdd

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -72,7 +72,7 @@ export function fromSeveralSgroupAddition(
   }
 
   return descriptors.reduce((acc, fValue) => {
-    const localAttrs = Object.assign({}, attrs);
+    const localAttrs = { ...(attrs || {}) };
     localAttrs.fieldValue = fValue;
 
     return acc.mergeWith(

--- a/packages/ketcher-core/src/application/render/options.ts
+++ b/packages/ketcher-core/src/application/render/options.ts
@@ -129,7 +129,7 @@ function defaultOptions(renderOptions: RenderOptions): RenderOptions {
     viewOnlyMode: false,
   };
 
-  return Object.assign({}, defaultOptions, options);
+  return { ...(defaultOptions || {}), ...(options || {}) };
 }
 
 const measureMap = {

--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -84,12 +84,10 @@ function request(
   if (data && method === 'GET') requestUrl = parametrizeUrl(url, data);
   let response: any = fetch(requestUrl, {
     method,
-    headers: Object.assign(
-      {
-        Accept: 'application/json',
-      },
-      headers,
-    ),
+    headers: {
+      Accept: 'application/json',
+      ...(headers || {}),
+    },
     body: method !== 'GET' ? data : undefined,
     credentials: 'same-origin',
   });
@@ -119,8 +117,12 @@ function indigoCall(
     options,
     responseHandler?: (promise: Promise<any>) => Promise<any>,
   ) {
-    const body = Object.assign({}, data);
-    body.options = Object.assign(body.options || {}, defaultOptions, options);
+    const body = { ...(data || {}) };
+    body.options = {
+      ...(body.options || {}),
+      ...(defaultOptions || {}),
+      ...(options || {}),
+    };
     return request(
       method,
       baseUrl + url,

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -215,12 +215,10 @@ class Editor implements KetcherEditor {
   constructor(ketcherId, clientArea, options, serverSettings, prevEditor?) {
     this.render = new Render(
       clientArea,
-      Object.assign(
-        {
-          microModeScale: SCALE,
-        },
-        options,
-      ),
+      {
+        microModeScale: SCALE,
+        ...(options || {}),
+      },
       prevEditor?.render,
       options.reuseRestructIfExist !== false,
     );
@@ -419,7 +417,7 @@ class Editor implements KetcherEditor {
 
     this.render = new Render(
       this.render.clientArea,
-      Object.assign({ microModeScale: SCALE }, value),
+      { microModeScale: SCALE, ...(value || {}) },
     );
     this.updateToolAfterOptionsChange(wasViewOnlyEnabled);
     this.render.setMolecule(struct);
@@ -1069,7 +1067,7 @@ class Editor implements KetcherEditor {
     );
 
     // Create new object to trigger Redux state update in UI layer
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
 
     this.render.update(true);
   }
@@ -1134,7 +1132,7 @@ class Editor implements KetcherEditor {
     );
     this.monomerCreationState.potentialAttachmentPoints.delete(atomId);
 
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
 
     this.render.update(true);
   }
@@ -1348,7 +1346,7 @@ class Editor implements KetcherEditor {
 
     this.monomerCreationState.assignedAttachmentPoints.set(name, newAtomPair);
 
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
 
     this.render.update(true);
   }
@@ -1381,7 +1379,7 @@ class Editor implements KetcherEditor {
       this.monomerCreationState.assignedAttachmentPoints.delete(currentName);
     }
 
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
 
     this.render.update(true);
   }
@@ -1419,7 +1417,7 @@ class Editor implements KetcherEditor {
     this.preservedConnectionPointData.delete(attachmentAtomId);
     this.monomerCreationState.assignedAttachmentPoints.delete(name);
 
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
 
     this.render.update(true);
   }
@@ -1435,7 +1433,7 @@ class Editor implements KetcherEditor {
     assert(this.monomerCreationState);
 
     this.monomerCreationState.problematicAttachmentPoints = problematicPoints;
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
     this.render.update(true);
   }
 
@@ -1672,7 +1670,7 @@ class Editor implements KetcherEditor {
       }
     }
 
-    this.monomerCreationState = Object.assign({}, this.monomerCreationState);
+    this.monomerCreationState = { ...(this.monomerCreationState || {}) };
   }
 
   selection(ci?: any) {

--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -224,7 +224,7 @@ class AtomTool implements Tool {
         rnd.ctab,
         this.#bondProps,
         atomId,
-        Object.assign({}, atomProps),
+        { ...(atomProps || {}) },
         undefined,
         newAtomPos,
       )[0];

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -349,7 +349,7 @@ class BondTool implements Tool {
           delete this.dragCtx.existedBond;
         }
       } else if (dragCtx.item.map === 'bonds') {
-        const bondProps = Object.assign({}, this.bondProps);
+        const bondProps = { ...(this.bondProps || {}) };
         const bond = struct.bonds.get(dragCtx.item.id) as Bond;
 
         this.editor.update(

--- a/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
@@ -126,7 +126,7 @@ function propsDialog(editor, id, pos) {
   Promise.resolve(res)
     .then((elem) => {
       // TODO review: using Atom.attrlist as a source of default property values
-      elem = Object.assign({}, Atom.attrlist, elem);
+      elem = { ...Atom.attrlist, ...(elem || {}) };
 
       if (!id && id !== 0 && elem.rglabel) {
         editor.update(fromAtomAddition(editor.render.ctab, pos, elem));

--- a/packages/ketcher-react/src/script/editor/tool/rgroupfragment.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rgroupfragment.ts
@@ -118,10 +118,12 @@ class RGroupFragmentTool implements Tool {
         ? ci.id
         : RGroup.findRGroupByFragment(molecule.rgroups, ci.id);
 
-    const rg = Object.assign(
-      { label },
-      ci.map === 'frags' ? { fragId: ci.id } : molecule.rgroups.get(ci.id),
-    );
+    const rg = {
+      label,
+      ...(ci.map === 'frags'
+        ? { fragId: ci.id }
+        : molecule.rgroups.get(ci.id) || {}),
+    };
 
     const res = editor.event.rgroupEdit.dispatch(rg);
 

--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -348,7 +348,7 @@ async function handleRGroupAtomTool({ hoveredItemId, editor }: HandlersProps) {
       rglabel,
       fragId: atom ? atom.fragment : null,
     });
-    element = Object.assign({}, Atom.attrlist, element);
+    element = { ...Atom.attrlist, ...(element || {}) };
 
     if (!hoveredItemId && hoveredItemId !== 0 && element.rglabel) {
       editor.update(fromAtomAddition(editor.render.ctab, null, element));

--- a/packages/ketcher-react/src/script/ui/state/templates/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/templates/index.ts
@@ -88,7 +88,7 @@ export function editTmpl(tmpl) {
         (formData) => {
           tmpl.struct.name = formData ? formData.name.trim() : tmpl.struct.name;
           tmpl.props = formData
-            ? Object.assign({}, tmpl.props, formData.attach)
+            ? { ...(tmpl.props || {}), ...(formData.attach || {}) }
             : tmpl.props;
 
           if (tmpl.props.group === 'User Templates')
@@ -148,7 +148,7 @@ function updateLocalStore(lib) {
     .filter((item) => item.props.group === 'User Templates')
     .map((item) => ({
       struct: ketSerializer.serialize(item.struct),
-      props: Object.assign({}, omit(['group'], item.props)),
+      props: { ...(omit(['group'], item.props) || {}) },
     }));
 
   storage.setItem('ketcher-tmpls', userLib);
@@ -177,15 +177,15 @@ const attachActions = ['INIT_ATTACH', 'SET_ATTACH_POINTS', 'SET_TMPL_NAME'];
 
 function templatesReducer(state = initTmplsState, action) {
   if (tmplActions.includes(action.type))
-    return Object.assign({}, state, action.data);
+    return { ...state, ...(action.data || {}) };
 
   if (attachActions.includes(action.type)) {
-    const attach = Object.assign({}, state.attach, action.data);
+    const attach = { ...state.attach, ...(action.data || {}) };
     return { ...state, attach };
   }
 
   if (action.type === 'TMPL_DELETE') {
-    const currentState = Object.assign({}, state);
+    const currentState = { ...state };
     const lib = currentState.lib.filter((value) => value !== action.data.tmpl);
     return { ...currentState, lib };
   }


### PR DESCRIPTION
## Summary
- replace legacy Object.assign clones with object spread syntax across editor and UI logic
- ensure optional values are safely merged when constructing request payloads and template state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e49d924700832980ac42823a425689