### PR TITLE
Refactor: #8012 - Expected a for-of loop instead of a for loop with this simple iteration

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/rergroup.js
+++ b/packages/ketcher-core/src/application/render/restruct/rergroup.js
@@ -136,9 +136,9 @@ class ReRGroup extends ReObject {
     const logic = [rLogicToString(key, this.item)];
 
     let shift = labelBox.height / 2 + options.lineWidth / 2;
-    for (let i = 0; i < logic.length; ++i) {
+    for (const logicItem of logic) {
       const logicPath = render.paper
-        .text(p0.x, (p0.y + p1.y) / 2, logic[i])
+        .text(p0.x, (p0.y + p1.y) / 2, logicItem)
         .attr(logicStyle);
       const logicBox = util.relBox(logicPath.getBBox());
       shift += logicBox.height / 2;

--- a/packages/ketcher-core/src/application/render/restruct/visel.js
+++ b/packages/ketcher-core/src/application/render/restruct/visel.js
@@ -63,11 +63,11 @@ class Visel {
       const x = args[0];
       const y = args[1];
       const delta = new Vec2(x, y);
-      for (let i = 0; i < this.paths.length; ++i) {
-        this.paths[i].translateAbs(x, y);
+      for (const path of this.paths) {
+        path.translateAbs(x, y);
       }
-      for (let j = 0; j < this.boxes.length; ++j) {
-        this.boxes[j] = this.boxes[j].translate(delta);
+      for (const [index, box] of this.boxes.entries()) {
+        this.boxes[index] = box.translate(delta);
       }
       if (this.boundingBox !== null) {
         this.boundingBox = this.boundingBox.translate(delta);
@@ -80,12 +80,12 @@ class Visel {
    * @param {Vec2} center
    */
   rotate(degree, center) {
-    for (let i = 0; i < this.paths.length; ++i) {
-      this.paths[i].rotate(degree, center.x, center.y);
+    for (const path of this.paths) {
+      path.rotate(degree, center.x, center.y);
     }
 
-    for (let j = 0; j < this.boxes.length; ++j) {
-      this.boxes[j] = this.boxes[j].transform((point) =>
+    for (const [index, box] of this.boxes.entries()) {
+      this.boxes[index] = box.transform((point) =>
         point.rotateAroundOrigin(degree, center),
       );
     }

--- a/packages/ketcher-core/src/domain/serializers/mol/common.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/common.js
@@ -291,12 +291,21 @@ function saveGenToMolfile(sgroup, mol, sgMap, atomMap, bondMap) {
 function makeAtomBondLines(prefix, idstr, ids, map) {
   if (!ids) return [];
   const lines = [];
-  for (let i = 0; i < Math.floor((ids.length + 14) / 15); ++i) {
-    const rem = Math.min(ids.length - 15 * i, 15); // eslint-disable-line no-mixed-operators
+  const chunkSize = 15;
+  const idChunks = ids.reduce((chunks, id, index) => {
+    if (index % chunkSize === 0) {
+      chunks.push([]);
+    }
+    chunks[chunks.length - 1].push(id);
+    return chunks;
+  }, []);
+
+  for (const chunk of idChunks) {
+    const rem = Math.min(chunk.length, chunkSize); // eslint-disable-line no-mixed-operators
     let salLine = 'M  ' + prefix + ' ' + idstr + ' ' + utils.paddedNum(rem, 2);
-    for (let j = 0; j < rem; ++j) {
-      salLine += ' ' + utils.paddedNum(map[ids[i * 15 + j]], 3);
-    } // eslint-disable-line no-mixed-operators
+    for (const id of chunk) {
+      salLine += ' ' + utils.paddedNum(map[id], 3);
+    }
     lines.push(salLine);
   }
   return lines;
@@ -319,14 +328,13 @@ function bracketsToMolfile(mol, sg, idstr) {
     n,
   );
   const lines = [];
-  for (let i = 0; i < brackets.length; ++i) {
-    const bracket = brackets[i];
+  for (const bracket of brackets) {
     const a0 = bracket.c.addScaled(bracket.n, -0.5 * bracket.h).yComplement();
     const a1 = bracket.c.addScaled(bracket.n, 0.5 * bracket.h).yComplement();
     let line = 'M  SDI ' + idstr + utils.paddedNum(4, 3);
     const coord = [a0.x, a0.y, a1.x, a1.y];
-    for (let j = 0; j < coord.length; ++j) {
-      line += utils.paddedNum(coord[j], 10, 4);
+    for (const value of coord) {
+      line += utils.paddedNum(value, 10, 4);
     }
     lines.push(line);
   }
@@ -348,10 +356,11 @@ function partitionLine(
 ) {
   /* reader */
   const res = [];
-  for (let i = 0, shift = 0; i < parts.length; ++i) {
-    res.push(str.slice(shift, shift + parts[i]));
+  let shift = 0;
+  for (const part of parts) {
+    res.push(str.slice(shift, shift + part));
     if (withspace) shift++;
-    shift += parts[i];
+    shift += part;
   }
   return res;
 }

--- a/packages/ketcher-core/src/domain/serializers/mol/utils.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/utils.js
@@ -50,10 +50,11 @@ function partitionLine(
 ) {
   /* reader */
   const res = [];
-  for (let i = 0, shift = 0; i < parts.length; ++i) {
-    res.push(str.slice(shift, shift + parts[i]));
+  let shift = 0;
+  for (const part of parts) {
+    res.push(str.slice(shift, shift + part));
     if (withspace) shift++;
-    shift += parts[i];
+    shift += part;
   }
   return res;
 }
@@ -65,10 +66,13 @@ function partitionLineFixed(
 ) {
   /* reader */
   const res = [];
-  for (let shift = 0; shift < str.length; shift += itemLength) {
+  const slicesCount = Math.ceil(str.length / itemLength);
+  let shift = 0;
+  Array.from({ length: slicesCount }).forEach(() => {
     res.push(str.slice(shift, shift + itemLength));
     if (withspace) shift++;
-  }
+    shift += itemLength;
+  });
   return res;
 }
 
@@ -330,8 +334,7 @@ function rgMerge(scaffold, rgroups) /* Struct */ {
   Object.keys(rgroups).forEach((id) => {
     const rgid = parseInt(id, 10);
 
-    for (let j = 0; j < rgroups[rgid].length; ++j) {
-      const ctab = rgroups[rgid][j];
+    for (const ctab of rgroups[rgid]) {
       ctab.rgroups.set(rgid, new RGroup());
       const frag = new Fragment();
       const frid = ctab.frags.add(frag);

--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.js
@@ -104,9 +104,12 @@ function parseAtomListLine(/* string */ atomListLine) {
   const ids = atomListLine.slice(utils.fmtInfo.atomListHeaderLength);
   const list = [];
   const itemLength = utils.fmtInfo.atomListHeaderItemLength;
-  for (let i = 0; i < count; ++i) {
-    list[i] = utils.parseDecimalInt(
-      ids.slice(i * itemLength, (i + 1) * itemLength - 1),
+  const indices = Array.from({ length: count }, (_, index) => index);
+  for (const index of indices) {
+    list.push(
+      utils.parseDecimalInt(
+        ids.slice(index * itemLength, (index + 1) * itemLength - 1),
+      ),
     );
   }
 
@@ -177,8 +180,7 @@ function parsePropertyLines(ctab, ctabLines, shift, end, sGroups, rLogic) {
         const subLabels = props.get('substitutionCount');
         const arrs = sGroup.readKeyMultiValuePairs(propertyData);
 
-        for (let arri = 0; arri < arrs.length; arri++) {
-          const a2r = arrs[arri];
+        for (const a2r of arrs) {
           subLabels.set(a2r[0], a2r[1]);
         }
       } else if (type === 'UNS') {
@@ -191,8 +193,7 @@ function parsePropertyLines(ctab, ctabLines, shift, end, sGroups, rLogic) {
         if (!props.get('rglabel')) props.set('rglabel', new Pool());
         const rglabels = props.get('rglabel');
         const a2rs = sGroup.readKeyMultiValuePairs(propertyData);
-        for (let a2ri = 0; a2ri < a2rs.length; a2ri++) {
-          const a2r = a2rs[a2ri];
+        for (const a2r of a2rs) {
           rglabels.set(
             a2r[0],
             (rglabels.get(a2r[0]) || 0) | (1 << (a2r[1] - 1)),
@@ -434,8 +435,8 @@ function parseRg2000(
     for (const strId in fragmentLines) {
       const id = parseInt(strId, 10);
       frag[id] = [];
-      for (let j = 0; j < fragmentLines[id].length; ++j) {
-        frag[id].push(parseCTab(fragmentLines[id][j], ignoreChiralFlag));
+      for (const fragmentLine of fragmentLines[id]) {
+        frag[id].push(parseCTab(fragmentLine, ignoreChiralFlag));
       }
     }
   }
@@ -500,8 +501,8 @@ function parseCTab(
 function labelsListToIds(labels) {
   /* reader */
   const ids = [];
-  for (let i = 0; i < labels.length; ++i) {
-    const element = Elements.get(labels[i].trim());
+  for (const label of labels) {
+    const element = Elements.get(label.trim());
     if (element) {
       ids.push(element.number);
     }

--- a/packages/ketcher-react/src/script/ui/component/actionmenu.jsx
+++ b/packages/ketcher-react/src/script/ui/component/actionmenu.jsx
@@ -81,15 +81,7 @@ function ActionButton({
 }
 
 function findActiveMenuItem(menuItems, status) {
-  let activeMenuItem = null;
-  for (let index = 0; index < menuItems.length; index++) {
-    const current = menuItems[index];
-    if (status[current]?.selected) {
-      activeMenuItem = current;
-      break;
-    }
-  }
-  return activeMenuItem;
+  return menuItems.find((item) => status[item]?.selected) ?? null;
 }
 
 function isLeaf(menu) {


### PR DESCRIPTION
## Summary
- replace index-based loops with `for...of` iterations in rendering helpers
- refactor molfile serializers to iterate over collections without manual counters
- use array helpers in the action menu to locate the active item without index loops

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e49b693b38832988e9ce8e60782254