### PR TITLE
Refactor: #8018 - Unexpected var, use let or const instead

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/utils.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/utils.js
@@ -26,9 +26,7 @@ import {
 function paddedNum(number, width, precision) {
   const parsedNumber = parseFloat(number);
 
-  const numStr = parsedNumber
-    .toFixed(precision || 0)
-    .replace(',', '.'); // Really need to replace?
+  const numStr = parsedNumber.toFixed(precision || 0).replace(',', '.'); // Really need to replace?
   if (numStr.length > width) throw new Error('number does not fit');
 
   return numStr.padStart(width);

--- a/packages/ketcher-core/src/domain/serializers/mol/utils.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/utils.js
@@ -24,9 +24,11 @@ import {
 } from 'domain/entities';
 
 function paddedNum(number, width, precision) {
-  number = parseFloat(number);
+  const parsedNumber = parseFloat(number);
 
-  const numStr = number.toFixed(precision || 0).replace(',', '.'); // Really need to replace?
+  const numStr = parsedNumber
+    .toFixed(precision || 0)
+    .replace(',', '.'); // Really need to replace?
   if (numStr.length > width) throw new Error('number does not fit');
 
   return numStr.padStart(width);
@@ -151,10 +153,11 @@ function rxnMerge(
   const molReact = [];
   const molAgent = [];
   const molProd = [];
+  let mol;
   let j;
   const bondLengthData = { cnt: 0, totalLength: 0 };
   for (j = 0; j < mols.length; ++j) {
-    var mol = mols[j];
+    mol = mols[j];
     const bondLengthDataMol = mol.getBondLengthData();
     bondLengthData.cnt += bondLengthDataMol.cnt;
     bondLengthData.totalLength += bondLengthDataMol.totalLength;
@@ -176,7 +179,7 @@ function rxnMerge(
     const bb = mol.getCoordBoundingBoxObj();
     if (!bb) continue; // eslint-disable-line no-continue
 
-    var fragmentType =
+    const fragmentType =
       j < nReactants
         ? FRAGMENT.REACTANT // eslint-disable-line no-nested-ternary
         : j < nReactants + nProducts

--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.js
@@ -465,7 +465,7 @@ function parseRxn2000(
     while (n < ctabLines.length && ctabLines[n].substr(0, 4) !== '$MOL') n++;
 
     const lines = ctabLines.slice(0, n);
-    var struct;
+    let struct;
     if (lines[0].search('\\$MDL') === 0) {
       struct = parseRg2000(lines, /* boolean */ ignoreChiralFlag);
     } else {

--- a/packages/ketcher-core/src/domain/serializers/mol/v3000.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/v3000.js
@@ -305,7 +305,8 @@ function readRGroups3000(ctab, /* string */ ctabLines) /* Struct */ {
         continue; // eslint-disable-line no-continue
       }
       if (line !== 'M  V30 BEGIN CTAB') throw Error('CTAB V3000 invalid');
-      for (var i = 0; i < ctabLines.length; ++i) {
+      let i;
+      for (i = 0; i < ctabLines.length; ++i) {
         if (ctabLines[shift + i].trim() === 'M  V30 END CTAB') break;
       }
       const lines = ctabLines.slice(shift, shift + i + 1);
@@ -366,7 +367,7 @@ function parseRxn3000(
   const rGroups = [];
   for (let i = 0; i < ctabLines.length; ++i) {
     const line = ctabLines[i].trim();
-    var j;
+    let j;
 
     if (line.startsWith('M  V30 COUNTS')) {
       // do nothing
@@ -400,7 +401,7 @@ function parseRxn3000(
   const molLines = molLinesReactants
     .concat(molLinesProducts)
     .concat(molLinesAgents);
-  for (j = 0; j < molLines.length; ++j) {
+  for (let j = 0; j < molLines.length; ++j) {
     const mol = parseCTabV3000(molLines[j], countsSplit);
     mols.push(mol);
   }

--- a/packages/ketcher-core/src/domain/serializers/smi/smiles.js
+++ b/packages/ketcher-core/src/domain/serializers/smi/smiles.js
@@ -143,15 +143,15 @@ Smiles.prototype.saveMolecule = function (struct, ignoreErrors) {
 
   // fill up neighbor lists for the stereocenters calculation
   for (i = 0; i < walk.v_seq.length; i++) {
-    var seqEl = walk.v_seq[i];
-    var vIdx = seqEl.idx;
-    var eIdx = seqEl.parent_edge;
-    var vPrevIdx = seqEl.parent_vertex;
+    const seqEl = walk.v_seq[i];
+    const vIdx = seqEl.idx;
+    const eIdx = seqEl.parent_edge;
+    const vPrevIdx = seqEl.parent_vertex;
 
     if (eIdx >= 0) {
       const atom = this.atoms[vIdx];
 
-      var openingCycles = walk.numOpeningCycles(eIdx);
+      const openingCycles = walk.numOpeningCycles(eIdx);
 
       for (j = 0; j < openingCycles; j++) {
         this.atoms[vPrevIdx].neighbours.push({ aid: -1, bid: -1 });

--- a/packages/ketcher-core/src/domain/serializers/smi/smiles.js
+++ b/packages/ketcher-core/src/domain/serializers/smi/smiles.js
@@ -264,10 +264,10 @@ Smiles.prototype.saveMolecule = function (struct, ignoreErrors) {
   let firstComponent = true;
 
   for (i = 0; i < walk.v_seq.length; i++) {
-    seqEl = walk.v_seq[i];
-    vIdx = seqEl.idx;
-    eIdx = seqEl.parent_edge;
-    vPrevIdx = seqEl.parent_vertex;
+    const seqEl = walk.v_seq[i];
+    const vIdx = seqEl.idx;
+    const eIdx = seqEl.parent_edge;
+    const vPrevIdx = seqEl.parent_vertex;
     let writeAtom = true;
 
     if (vPrevIdx >= 0) {
@@ -280,7 +280,7 @@ Smiles.prototype.saveMolecule = function (struct, ignoreErrors) {
         }
       }
 
-      openingCycles = walk.numOpeningCycles(eIdx);
+      const openingCycles = walk.numOpeningCycles(eIdx);
 
       for (j = 0; j < openingCycles; j++) {
         for (k = 1; k < cycleNumbers.length; k++) {


### PR DESCRIPTION
## Summary
- replace legacy `var` declarations in mol serializer utilities with block scoped variables
- tighten rxn v2000/v3000 parsing loops to reuse shared bindings without relying on function scoping
- prefer const bindings during SMILES traversal for clearer intent

## Testing
- npm test -- --runInBand *(fails: prettier configuration depends on missing prettier-config-standard)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a555c8f88329ac6028dfe0fc8860