### PR TITLE
Refactor: #8019 - Move this array "sort" operation to a separate statement or replace it with "toSorted"

### DIFF
--- a/ketcher-autotests/tests/pages/molecules/canvas/SettingsDialog.ts
+++ b/ketcher-autotests/tests/pages/molecules/canvas/SettingsDialog.ts
@@ -446,9 +446,10 @@ export async function setSettingsOptions(
 
   let openedSection = SettingsSection.General;
 
-  for (const { option, value } of options.sort((a, b) =>
-    a.option.localeCompare(b.option),
-  )) {
+  const sortedOptions = [...options];
+  sortedOptions.sort((a, b) => a.option.localeCompare(b.option));
+
+  for (const { option, value } of sortedOptions) {
     const section = optionsToSectionMap.get(option) ?? SettingsSection.General;
     if (openedSection !== section) {
       await SettingsDialog(page).openSection(openedSection);

--- a/packages/ketcher-core/__tests__/domain/entities/atomList.test.ts
+++ b/packages/ketcher-core/__tests__/domain/entities/atomList.test.ts
@@ -35,9 +35,13 @@ describe('label', () => {
 describe('equals', () => {
   it.each([false, true])('should return true', (notList) => {
     const atomList = new AtomList(createParams({ notList }));
+    const sortedIds = [...ids];
+    sortedIds.sort((a, b) => a - b);
+    sortedIds.reverse();
+
     const dataWithReverseIds = {
       notList,
-      ids: [...ids].sort((a, b) => a - b).reverse(),
+      ids: sortedIds,
     };
     const atomList2 = new AtomList(dataWithReverseIds);
 
@@ -46,9 +50,13 @@ describe('equals', () => {
 
   it('should return false', () => {
     const atomList = new AtomList(createParams());
+    const sortedIds = [...ids];
+    sortedIds.sort((a, b) => a - b);
+    sortedIds.reverse();
+
     const dataWithReverseIds = {
       notList: true,
-      ids: [...ids].sort((a, b) => a - b).reverse(),
+      ids: sortedIds,
     };
     const atomList2 = new AtomList(dataWithReverseIds);
 

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -259,10 +259,13 @@ export function fromPaste(
 function getStructCenter(struct: Struct): Vec2 {
   const isOnlyOneSGroup = struct.sgroups.size === 1;
   if (isOnlyOneSGroup) {
-    const onlyOneStructsSgroupId = struct.sgroups.keys().next().value;
-    const sgroup = struct.sgroups.get(onlyOneStructsSgroupId) as SGroup;
-    if (sgroup.isContracted()) {
-      return sgroup.getContractedPosition(struct).position;
+    const sgroupIterator = struct.sgroups.keys().next();
+    if (!sgroupIterator.done) {
+      const onlyOneStructsSgroupId = sgroupIterator.value;
+      const sgroup = struct.sgroups.get(onlyOneStructsSgroupId);
+      if (sgroup?.isContracted()) {
+        return sgroup.getContractedPosition(struct).position;
+      }
     }
   }
   if (struct.atoms.size > 0) {

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -176,7 +176,8 @@ export function fromPaste(
       sg.data.name,
       sg,
     );
-    sgAction.operations.reverse().forEach((oper) => {
+    sgAction.operations.reverse();
+    sgAction.operations.forEach((oper) => {
       action.addOp(oper);
     });
   });

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -189,7 +189,8 @@ export function fromTemplateOnAtom(
       sg.type === 'SUP' ? sg.isExpanded() : null,
       sg.data.name,
     );
-    sgAction.operations.reverse().forEach((oper) => {
+    sgAction.operations.reverse();
+    sgAction.operations.forEach((oper) => {
       action.addOp(oper);
     });
   });

--- a/packages/ketcher-core/src/application/render/renderers/TransientView/DistanceSnapView.ts
+++ b/packages/ketcher-core/src/application/render/renderers/TransientView/DistanceSnapView.ts
@@ -23,7 +23,8 @@ export class DistanceSnapView extends TransientView {
       return;
     }
 
-    const sortedMonomers = alignedMonomers.sort((a, b) => {
+    const sortedMonomers = [...alignedMonomers];
+    sortedMonomers.sort((a, b) => {
       return alignment === 'horizontal'
         ? a.center.x - b.center.x
         : a.center.y - b.center.y;

--- a/packages/ketcher-core/src/application/render/view-model/ViewModel.ts
+++ b/packages/ketcher-core/src/application/render/view-model/ViewModel.ts
@@ -106,23 +106,24 @@ export class ViewModel {
 
   private sortAtomsHalfEdges() {
     this.atomsToHalfEdges.forEach((atomHalfEdges, atom) => {
-      atomHalfEdges
-        .sort((halfEdge1, halfEdge2) => halfEdge1.angle - halfEdge2.angle)
-        .forEach((halfEdge, halfEdgeIndex) => {
-          const nextHalfEdge =
-            atomHalfEdges[(halfEdgeIndex + 1) % atomHalfEdges.length];
+      atomHalfEdges.sort(
+        (halfEdge1, halfEdge2) => halfEdge1.angle - halfEdge2.angle,
+      );
+      atomHalfEdges.forEach((halfEdge, halfEdgeIndex) => {
+        const nextHalfEdge =
+          atomHalfEdges[(halfEdgeIndex + 1) % atomHalfEdges.length];
 
-          if (!halfEdge.oppositeHalfEdge) {
-            KetcherLogger.warn(
-              `Failed to sort HalfEdges for atom ${atom.id}. HalfEdge ${halfEdge.id} has no opposite halfEdge`,
-            );
+        if (!halfEdge.oppositeHalfEdge) {
+          KetcherLogger.warn(
+            `Failed to sort HalfEdges for atom ${atom.id}. HalfEdge ${halfEdge.id} has no opposite halfEdge`,
+          );
 
-            return;
-          }
+          return;
+        }
 
-          halfEdge.oppositeHalfEdge.nextHalfEdge = nextHalfEdge;
-          this.setHalfEdgesAngle(halfEdge, nextHalfEdge);
-        });
+        halfEdge.oppositeHalfEdge.nextHalfEdge = nextHalfEdge;
+        this.setHalfEdgesAngle(halfEdge, nextHalfEdge);
+      });
     });
   }
 

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -1555,22 +1555,21 @@ export class DrawingEntitiesManager {
       monomersGroupedByX?.set(x, monomer);
     });
 
-    const sortedGroupedMonomers = [...monomersGroupedByY.entries()]
-      .map(([y, groupedByX]) => {
+    const sortedGroupedMonomers = [...monomersGroupedByY.entries()].map(
+      ([y, groupedByX]) => {
         const groupedByYArray: [number, [number, BaseMonomer][]] = [
           y,
           [...groupedByX.entries()],
         ];
 
         return groupedByYArray;
-      })
-      .sort((a, b) => a[0] - b[0]);
+      },
+    );
+    sortedGroupedMonomers.sort((a, b) => a[0] - b[0]);
 
     sortedGroupedMonomers.forEach(([y, groupedByY], index) => {
-      sortedGroupedMonomers[index] = [
-        y,
-        groupedByY.sort((a, b) => Number(a[0]) - Number(b[0])),
-      ];
+      groupedByY.sort((a, b) => Number(a[0]) - Number(b[0]));
+      sortedGroupedMonomers[index] = [y, groupedByY];
     });
 
     const monomerXToIndexInMatrix = {};

--- a/packages/ketcher-core/src/domain/entities/multitailArrow.ts
+++ b/packages/ketcher-core/src/domain/entities/multitailArrow.ts
@@ -145,12 +145,11 @@ export class MultitailArrow extends BaseMicromoleculeEntity {
     const headY = FixedPrecisionCoordinates.fromFloatingPrecision(
       head.position.y,
     );
-    const tailsFixedPrecision = tails.pos
-      .map((tail) => ({
-        x: FixedPrecisionCoordinates.fromFloatingPrecision(tail.x),
-        y: FixedPrecisionCoordinates.fromFloatingPrecision(tail.y),
-      }))
-      .sort((a, b) => b.y.value - a.y.value);
+    const tailsFixedPrecision = tails.pos.map((tail) => ({
+      x: FixedPrecisionCoordinates.fromFloatingPrecision(tail.x),
+      y: FixedPrecisionCoordinates.fromFloatingPrecision(tail.y),
+    }));
+    tailsFixedPrecision.sort((a, b) => b.y.value - a.y.value);
 
     if (
       spineStartX.value !== spineEndX.value ||
@@ -223,7 +222,8 @@ export class MultitailArrow extends BaseMicromoleculeEntity {
     ).sub(spineTopY);
 
     const tailsYOffset = new Pool<FixedPrecisionCoordinates>();
-    const tails = data.tails.pos.sort((a, b) => a.y - b.y);
+    const tails = [...data.tails.pos];
+    tails.sort((a, b) => a.y - b.y);
     const tailsLength = spineTopX.sub(
       FixedPrecisionCoordinates.fromFloatingPrecision(tails[0].x),
     );
@@ -390,9 +390,11 @@ export class MultitailArrow extends BaseMicromoleculeEntity {
   getTailsDistance(
     tailsYOffsets: Array<FixedPrecisionCoordinates>,
   ): Array<TailDistance> {
-    const allTailsOffsets = tailsYOffsets
-      .concat([new FixedPrecisionCoordinates(0), this.height])
-      .sort((a, b) => a.sub(b).getFloatingPrecision());
+    const allTailsOffsets = tailsYOffsets.concat([
+      new FixedPrecisionCoordinates(0),
+      this.height,
+    ]);
+    allTailsOffsets.sort((a, b) => a.sub(b).getFloatingPrecision());
     return allTailsOffsets.reduce(
       (acc: Array<TailDistance>, item, index, array) => {
         if (index === 0) {
@@ -541,12 +543,13 @@ export class MultitailArrow extends BaseMicromoleculeEntity {
     const tailsWithoutCurrent = Array.from(this.tailsYOffset.entries())
       .filter(([key]) => key !== tailId)
       .map(([_, value]) => value);
-    const tailMinDistance = this.getTailsDistance(tailsWithoutCurrent)
-      .filter((item) => MultitailArrow.canAddTail(item.distance))
-      .sort(
-        (a, b) => getDistanceToTailDistance(a) - getDistanceToTailDistance(b),
-      )
-      .at(0);
+    const tailDistances = this.getTailsDistance(tailsWithoutCurrent).filter(
+      (item) => MultitailArrow.canAddTail(item.distance),
+    );
+    tailDistances.sort(
+      (a, b) => getDistanceToTailDistance(a) - getDistanceToTailDistance(b),
+    );
+    const tailMinDistance = tailDistances.at(0);
 
     if (!tailMinDistance) {
       return null;
@@ -592,9 +595,8 @@ export class MultitailArrow extends BaseMicromoleculeEntity {
         MultitailArrow.MIN_HEIGHT.value,
       ),
     );
-    const tailsOffset = Array.from(this.tailsYOffset.values()).sort(
-      (a, b) => a.value - b.value,
-    );
+    const tailsOffset = Array.from(this.tailsYOffset.values());
+    tailsOffset.sort((a, b) => a.value - b.value);
     const lastTail = tailsOffset.at(-1) || new FixedPrecisionCoordinates(0);
     const firstTail =
       tailsOffset.at(0) || new FixedPrecisionCoordinates(Infinity);

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -560,13 +560,14 @@ export class Struct {
     const atom = this.atoms.get(aid)!;
     const halfBonds = this.halfBonds;
 
-    atom.neighbors
-      .sort((nei, nei2) => halfBonds.get(nei)!.ang - halfBonds.get(nei2)!.ang)
-      .forEach((nei, i) => {
-        const nextNei = atom.neighbors[(i + 1) % atom.neighbors.length];
-        this.halfBonds.get(this.halfBonds.get(nei)!.contra)!.next = nextNei;
-        this.halfBondSetAngle(nextNei, nei);
-      });
+    atom.neighbors.sort(
+      (nei, nei2) => halfBonds.get(nei)!.ang - halfBonds.get(nei2)!.ang,
+    );
+    atom.neighbors.forEach((nei, i) => {
+      const nextNei = atom.neighbors[(i + 1) % atom.neighbors.length];
+      this.halfBonds.get(this.halfBonds.get(nei)!.contra)!.next = nextNei;
+      this.halfBondSetAngle(nextNei, nei);
+    });
   }
 
   sortNeighbors(list) {

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
@@ -561,24 +561,24 @@ export const selectMonomerGroups = (monomers: MonomerItemType[]) => {
   sortedGroupCodes.sort((a, b) => a.localeCompare(b));
 
   return sortedGroupCodes.reduce((result, code) => {
-      const group: Group = {
-        groupTitle:
-          code === NoNaturalAnalogueGroupCode
-            ? NoNaturalAnalogueGroupTitle
-            : code,
-        groupItems: [],
-      };
-      sortedPreparedData[code].forEach((item: MonomerItemType) => {
-        group.groupItems.push({
-          ...item,
-          props: { ...item.props },
-        });
+    const group: Group = {
+      groupTitle:
+        code === NoNaturalAnalogueGroupCode
+          ? NoNaturalAnalogueGroupTitle
+          : code,
+      groupItems: [],
+    };
+    sortedPreparedData[code].forEach((item: MonomerItemType) => {
+      group.groupItems.push({
+        ...item,
+        props: { ...item.props },
       });
-      if (group.groupItems.length) {
-        result.push(group);
-      }
-      return result;
-    }, preparedGroups);
+    });
+    if (group.groupItems.length) {
+      result.push(group);
+    }
+    return result;
+  }, preparedGroups);
 };
 
 export const selectCurrentTabIndex = (state) => state.library.selectedTabIndex;

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
@@ -540,9 +540,8 @@ export const selectMonomerGroups = (monomers: MonomerItemType[]) => {
 
   const sortedPreparedData = Object.entries(preparedData).reduce(
     (result, [code, monomers]) => {
-      const sortedMonomers = monomers.sort((a, b) =>
-        a.label.localeCompare(b.label),
-      );
+      const sortedMonomers = [...monomers];
+      sortedMonomers.sort((a, b) => a.label.localeCompare(b.label));
       const baseIndex = sortedMonomers.findIndex(
         (monomer) => monomer.label === code,
       );
@@ -558,9 +557,10 @@ export const selectMonomerGroups = (monomers: MonomerItemType[]) => {
 
   // generate list of monomer groups
   const preparedGroups: Group[] = [];
-  return Object.keys(sortedPreparedData)
-    .sort((a, b) => a.localeCompare(b))
-    .reduce((result, code) => {
+  const sortedGroupCodes = Object.keys(sortedPreparedData);
+  sortedGroupCodes.sort((a, b) => a.localeCompare(b));
+
+  return sortedGroupCodes.reduce((result, code) => {
       const group: Group = {
         groupTitle:
           code === NoNaturalAnalogueGroupCode

--- a/packages/ketcher-react/src/components/MonomerPreview/AmbiguousMonomerPreview/AmbiguousMonomerPreview.tsx
+++ b/packages/ketcher-react/src/components/MonomerPreview/AmbiguousMonomerPreview/AmbiguousMonomerPreview.tsx
@@ -53,7 +53,8 @@ const AmbiguousMonomerPreview = ({ className, preview, style }: Props) => {
   }, [fallback, monomers, presetMonomers, options]);
 
   const preparedPreviewData = useMemo(() => {
-    const sortedData = previewData.sort((a, b) => {
+    const sortedData = [...previewData];
+    sortedData.sort((a, b) => {
       if (isAlternatives) {
         return a.monomerName.localeCompare(b.monomerName);
       } else {


### PR DESCRIPTION
## Summary
- avoid assigning the return values of mutating sort/reverse calls across editor, rendering, and state modules
- preserve existing logic by copying arrays when non-mutating ordering is required
- update related tests and UI helpers to iterate using explicitly sorted collections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a6bc25748329b7714d525ec915f7