### PR TITLE
Improve multitail arrow validation feedback

### DIFF
--- a/packages/ketcher-core/__tests__/domain/serializers/ket/validate.test.ts
+++ b/packages/ketcher-core/__tests__/domain/serializers/ket/validate.test.ts
@@ -1,0 +1,74 @@
+import compiledSchema from 'domain/serializers/ket/compiledSchema';
+import { validate } from 'domain/serializers/ket/validate';
+import { MULTITAIL_ARROW_SERIALIZE_KEY } from 'domain/constants';
+import { MultitailArrow } from 'domain/entities';
+
+jest.mock('domain/serializers/ket/compiledSchema', () => {
+  const validateMock = jest.fn() as jest.Mock & {
+    errors: Array<unknown> | null;
+  };
+  validateMock.errors = null;
+
+  return validateMock;
+});
+
+describe('validate', () => {
+  const mockedCompiledSchema =
+    compiledSchema as unknown as jest.Mock & {
+      errors: Array<unknown> | null;
+    };
+  const baseKet = {
+    root: {
+      nodes: [
+        {
+          type: MULTITAIL_ARROW_SERIALIZE_KEY,
+          data: {},
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    mockedCompiledSchema.mockClear();
+    mockedCompiledSchema.mockReturnValue(true);
+    mockedCompiledSchema.errors = null;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns false when schema validation fails', () => {
+    mockedCompiledSchema.mockReturnValueOnce(false);
+    const spy = jest.spyOn(MultitailArrow, 'validateKetNode');
+
+    expect(validate(baseKet)).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns true when multitail arrows are valid', () => {
+    const spy = jest
+      .spyOn(MultitailArrow, 'validateKetNode')
+      .mockReturnValueOnce(null);
+
+    expect(validate(baseKet)).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mockedCompiledSchema.errors).toBeNull();
+  });
+
+  it('attaches detailed error when multitail arrow validation fails', () => {
+    const errorMessage = 'INCORRECT_HEAD';
+    jest
+      .spyOn(MultitailArrow, 'validateKetNode')
+      .mockReturnValueOnce(errorMessage);
+
+    expect(validate(baseKet)).toBe(false);
+    expect(mockedCompiledSchema.errors).toEqual([
+      expect.objectContaining({
+        keyword: 'multitailArrow',
+        message: `Invalid multitail arrow: ${errorMessage}`,
+        params: { error: errorMessage },
+      }),
+    ]);
+  });
+});

--- a/packages/ketcher-core/src/domain/serializers/ket/multitailArrowsValidator.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/multitailArrowsValidator.ts
@@ -2,20 +2,29 @@ import { KetFileNode } from 'domain/serializers';
 import { KetFileMultitailArrowNode, MultitailArrow } from 'domain/entities';
 import { MULTITAIL_ARROW_SERIALIZE_KEY } from 'domain/constants';
 
+export interface MultitailArrowsValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const validateMultitailArrows = (json: any): boolean => {
+export const validateMultitailArrows = (
+  json: any,
+): MultitailArrowsValidationResult => {
   const nodes: Array<KetFileNode<unknown | KetFileMultitailArrowNode>> =
     json.root.nodes;
-  return nodes.every((node) => {
+
+  for (const node of nodes) {
     if (node.type === MULTITAIL_ARROW_SERIALIZE_KEY) {
       const result = MultitailArrow.validateKetNode(
         node.data as KetFileMultitailArrowNode,
       );
+
       if (result !== null) {
-        console.info(result);
-        return null;
+        return { isValid: false, error: result };
       }
     }
-    return true;
-  });
+  }
+
+  return { isValid: true };
 };


### PR DESCRIPTION
## Summary
- capture multitail arrow validation failures as structured Ajv errors
- expose error messages from the multitail validator instead of silent console logging
- add unit tests covering schema failures, valid arrows, and invalid arrow error reporting

## Testing
- npm run test:unit --workspace=packages/ketcher-core -- validate

------
https://chatgpt.com/codex/tasks/task_e_68e4a91390888329b0483a35505be5bb