### PR TITLE
Refactor: #8027 - This assertion is unnecessary since it does not change the type of the expression (part 2)

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -141,7 +141,7 @@ class ReText extends ReObject {
   show(restruct: ReStruct, _id: number, options: any): void {
     const render = restruct.render;
     const paper = render.paper;
-    const paperScale = Scale.modelToCanvas(this.item.position!, options);
+    const paperScale = Scale.modelToCanvas(this.item.position, options);
 
     let shiftY = 0;
     this.paths = [];

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
@@ -126,7 +126,7 @@ export function replaceMonomer(
       drawingEntitiesManager.addMonomerToAtomBond(
         monomerToAtomBondInfo.monomer,
         monomerToAtomBondInfo.atom,
-        monomerToAtomBondInfo.attachmentPoint as AttachmentPointName,
+        monomerToAtomBondInfo.attachmentPoint,
       ),
     );
   }

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -199,7 +199,10 @@ export class SGroup {
 
       this.atoms.forEach((aid) => {
         const atom = struct.atoms.get(aid);
-        const pos = new Vec2(atom!.pp);
+        if (!atom) {
+          return;
+        }
+        const pos = new Vec2(atom.pp);
 
         const ext = new Vec2(0.05 * 3, 0.05 * 3);
         const bba = new Box2Abs(pos, pos).extend(ext, ext);
@@ -211,13 +214,22 @@ export class SGroup {
         [bba.p0.x, bba.p1.x].forEach((x) => {
           [bba.p0.y, bba.p1.y].forEach((y) => {
             const v = new Vec2(x, y);
-            bbb = !bbb ? new Box2Abs(v, v) : bbb!.include(v);
+            if (!bbb) {
+              bbb = new Box2Abs(v, v);
+            } else {
+              bbb = bbb.include(v);
+            }
           });
         });
-        contentBB = !contentBB ? bbb : Box2Abs.union(contentBB, bbb!);
+        if (bbb) {
+          contentBB = contentBB ? Box2Abs.union(contentBB, bbb) : bbb;
+        }
       });
 
-      topLeftPoint = isBondContent ? contentBB!.centre() : contentBB!.p0;
+      if (!contentBB) {
+        return;
+      }
+      topLeftPoint = isBondContent ? contentBB.centre() : contentBB.p0;
     } else {
       topLeftPoint = this.bracketBox.p1.add(new Vec2(0.5, 0.5));
     }

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
@@ -1,4 +1,3 @@
-import omit from 'lodash/omit';
 import {
   IRnaLabeledPreset,
   IRnaPreset,
@@ -8,15 +7,16 @@ import {
 
 // transform preset from IRnaPreset to IRnaLabeledPreset
 export const transformRnaPresetToRnaLabeledPreset = (rnaPreset: IRnaPreset) => {
-  const fieldsToLabel = ['sugar', 'base', 'phosphate'];
-  const rnaLabeledPreset = omit(
-    rnaPreset,
-    fieldsToLabel,
-  ) as Partial<IRnaLabeledPreset>;
+  const fieldsToLabel = ['sugar', 'base', 'phosphate'] as const;
+  const { sugar, base, phosphate, ...rest } = rnaPreset;
+  const monomerEntries = { sugar, base, phosphate };
+  const rnaLabeledPreset: IRnaLabeledPreset = {
+    ...rest,
+    templates: [],
+  };
 
-  rnaLabeledPreset.templates = [];
   for (const monomerName of fieldsToLabel) {
-    const monomerLibraryItem = rnaPreset[monomerName];
+    const monomerLibraryItem = monomerEntries[monomerName];
     const templateId = monomerLibraryItem?.props?.id || monomerLibraryItem?.id;
 
     if (!templateId) continue;
@@ -28,5 +28,5 @@ export const transformRnaPresetToRnaLabeledPreset = (rnaPreset: IRnaPreset) => {
     });
   }
 
-  return rnaLabeledPreset as IRnaLabeledPreset;
+  return rnaLabeledPreset;
 };

--- a/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
+++ b/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
@@ -46,12 +46,13 @@ class KetcherBuilder {
   }
 
   appendApiAsync(structServiceProvider: StructServiceProvider) {
-    this.structService = createApi(
+    const structService = createApi(
       structServiceProvider,
       DefaultStructServiceOptions,
     );
-    this.formatterFactory = new FormatterFactory(this.structService!);
-    return this.structService;
+    this.structService = structService;
+    this.formatterFactory = new FormatterFactory(structService);
+    return structService;
   }
 
   reinitializeApi(
@@ -114,6 +115,10 @@ class KetcherBuilder {
       editor: Editor;
       setServer: (structService: StructService) => void;
     }>((resolve) => {
+      if (!structService) {
+        throw new Error('Structure service is not initialized');
+      }
+
       cleanup = initApp(
         prevKetcherId,
         ketcherId,
@@ -128,7 +133,7 @@ class KetcherBuilder {
           buildNumber: process.env.BUILD_NUMBER || '',
           customButtons: customButtons || [],
         },
-        structService!,
+        structService,
         resolve,
         togglerComponent,
       );

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -192,7 +192,10 @@ class TemplateTool implements Tool {
     const targetId = this.findKeyOfRelatedGroupId(
       this.closestItem?.id as number,
     );
-    const functionalGroup = this.functionalGroups.get(targetId!);
+    if (targetId === undefined) {
+      return false;
+    }
+    const functionalGroup = this.functionalGroups.get(targetId);
 
     if (functionalGroup?.relatedSGroup instanceof MonomerMicromolecule) {
       return false;
@@ -291,7 +294,10 @@ class TemplateTool implements Tool {
 
     if (ci.map === 'bonds' && !this.isModeFunctionalGroup) {
       // calculate fragment center
-      const bond = this.struct.bonds.get(ci.id)!;
+      const bond = this.struct.bonds.get(ci.id);
+      if (!bond) {
+        return;
+      }
 
       // calculate default template flip
       dragCtx.sign1 = getBondFlipSign(this.struct, bond);
@@ -324,6 +330,9 @@ class TemplateTool implements Tool {
     /* moving when attached to bond */
     if (ci && ci.map === 'bonds' && !this.isModeFunctionalGroup) {
       const bond = this.struct.bonds.get(ci.id);
+      if (!bond) {
+        return true;
+      }
       let sign = getSign(this.struct, bond, eventPosition);
 
       if (dragCtx.sign1 * this.template.sign > 0) {
@@ -494,7 +503,10 @@ class TemplateTool implements Tool {
       this.targetGroupsIds.length
     ) {
       const restruct = this.editor.render.ctab;
-      const functionalGroupToReplace = this.struct.sgroups.get(ci.id)!;
+      const functionalGroupToReplace = this.struct.sgroups.get(ci.id);
+      if (!functionalGroupToReplace) {
+        return true;
+      }
 
       if (
         this.isSaltOrSolvent &&

--- a/packages/ketcher-react/src/script/ui/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/action/index.ts
@@ -40,7 +40,7 @@ const updateConfigItem = (item: UiAction): UiAction => {
   if (typeof item.disabled === 'boolean' || item.enabledInViewOnly === true) {
     return item;
   } else if (typeof item.disabled === 'function') {
-    const originalDisabled = item.disabled as GetActionState;
+    const originalDisabled = item.disabled;
     return {
       ...item,
       disabled: (...props) =>
@@ -139,10 +139,11 @@ const config: Record<string, UiAction> = {
   },
   // This is some dirty trick for `ClipboardControls.tsx` component
   copies: {
+    action: () => undefined,
     enabledInViewOnly: true,
     disabled: (editor) => !hasSelection(editor),
     hidden: (options) => isHidden(options, 'copies'),
-  } as UiAction,
+  },
   copy: {
     shortcut: 'Mod+c',
     enabledInViewOnly: true,
@@ -307,7 +308,7 @@ const configWithNonViewOnlyActionsDisabled: Tools = Object.entries({
 }).reduce(
   (acc, [key, item]) => ({
     ...acc,
-    [key]: updateConfigItem(item as UiAction),
+    [key]: updateConfigItem(item),
   }),
   {},
 ) as Tools;

--- a/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
+++ b/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
@@ -460,7 +460,11 @@ export function getDefaultOptions(): Record<string, any> {
   if (!optionsSchema.properties) return {};
 
   return Object.keys(optionsSchema.properties).reduce((res, prop) => {
-    res[prop] = (optionsSchema.properties[prop] as ExtendedSchema).default;
+    const property = optionsSchema.properties?.[prop];
+    if (!property || typeof property === 'boolean') {
+      return res;
+    }
+    res[prop] = property.default;
     return res;
   }, {});
 }

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
@@ -17,7 +17,6 @@ import React, { useCallback } from 'react';
 import { Menu, MenuProps } from 'react-contexify';
 import 'react-contexify/ReactContexify.css';
 import { useAppContext } from 'src/hooks';
-import Editor from 'src/script/editor';
 import styles from './ContextMenu.module.less';
 import { CONTEXT_MENU_ID } from './contextMenu.types';
 import AtomMenuItems from './menuItems/AtomMenuItems';
@@ -133,16 +132,14 @@ const ContextMenu: React.FC = () => {
 
   const trackVisibility = useCallback(
     (id: string, visible: boolean) => {
-      const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
+      const editor = ketcherProvider.getKetcher(ketcherId).editor;
       if (visible) {
         editor.hoverIcon.hide();
         const contextMenuElement = document.querySelector(
           '.contexify:last-of-type',
-        ) as HTMLDivElement | null;
-        const submenuElements = document.querySelectorAll(
-          '.contexify_submenu',
-        ) as NodeListOf<HTMLElement>;
-        if (contextMenuElement) {
+        );
+        const submenuElements = document.querySelectorAll('.contexify_submenu');
+        if (contextMenuElement instanceof HTMLDivElement) {
           // Timeout is needed to ensure that the context menu is rendered by react-contexify library.
           // Without timeout library overrides the position of the context menu which we set.
           setTimeout(() => resetMenuPosition(contextMenuElement), 0);
@@ -150,7 +147,9 @@ const ContextMenu: React.FC = () => {
 
         if (submenuElements.length) {
           submenuElements.forEach((submenuElement) => {
-            adjustSubmenuPosition(submenuElement);
+            if (submenuElement instanceof HTMLElement) {
+              adjustSubmenuPosition(submenuElement);
+            }
           });
         }
       }

--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx
@@ -26,13 +26,7 @@ import {
   convertToRaw,
   getDefaultKeyBinding,
 } from 'draft-js';
-import React, {
-  useCallback,
-  useState,
-  useRef,
-  useEffect,
-  RefObject,
-} from 'react';
+import React, { useCallback, useState, useRef, useEffect } from 'react';
 
 import { Dialog } from '../../../components';
 import { DialogParams } from '../../../../../../components/Dialog/Dialog';
@@ -153,7 +147,7 @@ const Text = (props: TextProps) => {
     },
   };
 
-  const refEditor = useRef(null) as RefObject<Editor | null>;
+  const refEditor = useRef<Editor | null>(null);
   const setFocusInEditor = useCallback(() => {
     refEditor.current?.focus();
     refEditor.current?.editor?.setAttribute('data-testid', 'text-editor');

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
@@ -24,7 +24,7 @@ function usePortalOpening([id, opened, options]: HookParams): [boolean] {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   useEffect(() => {
-    const currentId = (options.length && options![0].id) || '';
+    const currentId = options[0]?.id || '';
     const newState = opened === id || opened === currentId;
     setIsOpen(newState);
   }, [opened, options]);


### PR DESCRIPTION
## Summary
- remove redundant non-null assertions in core rendering utilities and s-group bounding box calculations
- refactor RNA preset transformation and builder logic to rely on inferred types instead of explicit casts
- clean up UI helpers by eliminating unnecessary assertions and adding guards around DOM access

## Testing
- npx tsc --noEmit *(fails: displays help output because no project configuration is available)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b47f66408329bee47eb30bb14507