### PR TITLE
Fix: replace deprecated browser APIs

### DIFF
--- a/packages/ketcher-core/src/utilities/keynorm.ts
+++ b/packages/ketcher-core/src/utilities/keynorm.ts
@@ -16,8 +16,27 @@
 
 import * as KN from 'w3c-keyname';
 
-const mac =
-  typeof navigator !== 'undefined' ? /Mac/.test(navigator.platform) : false; // eslint-disable-line no-undef
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
+const isMacPlatform = () => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const navigatorWithUAData = navigator as NavigatorWithUAData;
+  const platform =
+    navigatorWithUAData.userAgentData?.platform ??
+    navigatorWithUAData.userAgent ??
+    '';
+
+  return /mac/i.test(platform);
+};
+
+const mac = isMacPlatform();
 
 function normalizeKeyName(name) {
   const parts = name.split(/\+(?!$)/);


### PR DESCRIPTION
## Summary
- stop checking `KeyboardEvent.cancelBubble` and track propagation via patched handlers before delegating keyboard events
- replace the deprecated `circleToEllipse` helper with a typed converter when importing circle simple objects
- detect macOS through `navigator.userAgentData`/`navigator.userAgent` instead of the deprecated `navigator.platform`

## Testing
- npm run build:core

------
https://chatgpt.com/codex/tasks/task_e_68e4bc3e8dfc83299362bf4043646cf9