### PR TITLE
Refactor: #8032 - The signature '(event: MouseEvent | { clientX: number; clientY: number; }): Vec2' of 'rnd.page2obj' is deprecated

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -63,6 +63,7 @@ import {
   Struct,
   Vec2,
   OperationType,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import {
   DOMSubscription,
@@ -1925,7 +1926,7 @@ class Editor implements KetcherEditor {
   }
 
   findItem(event: any, maps: Array<string> | null, skip: any = null) {
-    const pos = new Vec2(this.render.page2obj(event));
+    const pos = CoordinateTransformation.pageToModel(event, this.render);
 
     return closest.item(this.render.ctab, pos, maps, skip, this.render.options);
   }

--- a/packages/ketcher-react/src/script/editor/tool/arrow/reactionArrowAdd.ts
+++ b/packages/ketcher-react/src/script/editor/tool/arrow/reactionArrowAdd.ts
@@ -133,7 +133,7 @@ export class ReactionArrowAddTool implements ArrowAddTool {
 
   private addNewArrowWithClicking(event) {
     const ci = this.editor.findItem(event, ['rxnArrows']);
-    const p0 = this.render.page2obj(event);
+    const p0 = CoordinateTransformation.pageToModel(event, this.render);
 
     if (!ci) {
       const pos = [p0, this.getArrowWithMinimalLengthEnd(p0, null)];

--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -28,6 +28,7 @@ import {
   ElementColor,
   vectorUtils,
   KetcherLogger,
+  CoordinateTransformation,
 } from 'ketcher-core';
 
 import Editor from '../Editor';
@@ -206,13 +207,16 @@ class AtomTool implements Tool {
     if (atomId !== undefined) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const atom = molecule.atoms.get(atomId)!;
-      let angle = vectorUtils.calcAngle(atom.pp, rnd.page2obj(event));
+      let angle = vectorUtils.calcAngle(
+        atom.pp,
+        CoordinateTransformation.pageToModel(event, rnd),
+      );
       if (!event.ctrlKey) angle = vectorUtils.fracAngle(angle, null);
       const degrees = vectorUtils.degrees(angle);
       editor.event.message.dispatch({ info: degrees + 'º' });
       const newAtomPos = vectorUtils.calcNewAtomPos(
         atom.pp,
-        rnd.page2obj(event),
+        CoordinateTransformation.pageToModel(event, rnd),
         event.ctrlKey,
       );
 
@@ -260,7 +264,11 @@ class AtomTool implements Tool {
 
     if ((!dragCtx.item || dragCtx?.isSaltOrSolvent) && !ci) {
       action.mergeWith(
-        fromAtomAddition(reStruct, rnd.page2obj(event), atomProps),
+        fromAtomAddition(
+          reStruct,
+          CoordinateTransformation.pageToModel(event, rnd),
+          atomProps,
+        ),
       );
     } else if (dragCtx.item && ci) {
       if (dragCtx.item.id === ci.id) {

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -26,6 +26,7 @@ import {
   Struct,
   vectorUtils,
   Atom,
+  CoordinateTransformation,
 } from 'ketcher-core';
 
 import Editor from '../Editor';
@@ -127,7 +128,7 @@ class BondTool implements Tool {
     this.editor.hover(null);
     this.editor.selection(null);
     this.dragCtx = {
-      xy0: rnd.page2obj(event),
+      xy0: CoordinateTransformation.pageToModel(event, rnd),
       item:
         attachmentAtomId === undefined
           ? ci
@@ -155,7 +156,7 @@ class BondTool implements Tool {
     if ('dragCtx' in this) {
       const dragCtx = this.dragCtx;
 
-      const pos = rnd.page2obj(event);
+      const pos = CoordinateTransformation.pageToModel(event, rnd);
       let angle = vectorUtils.calcAngle(dragCtx.xy0, pos);
       if (!event.ctrlKey) angle = vectorUtils.fracAngle(angle, null);
 
@@ -251,7 +252,7 @@ class BondTool implements Tool {
           endAtom = endAtom.id;
         } else {
           endAtom = this.atomProps;
-          const xy1 = rnd.page2obj(event);
+          const xy1 = CoordinateTransformation.pageToModel(event, rnd);
           dist = Vec2.dist(dragCtx.xy0, xy1);
           if (beginPos) {
             // rotation only, leght of bond = 1;
@@ -317,10 +318,13 @@ class BondTool implements Tool {
         const editorOptions = this.editor.options();
         const QUARTER_OF_BOND_WIDTH = 20;
         const QUARTER_OF_BOND_HEIGHT = 5;
-        const xy = render.page2obj({
-          clientX: event.clientX + QUARTER_OF_BOND_WIDTH * editorOptions.zoom,
-          clientY: event.clientY - QUARTER_OF_BOND_HEIGHT * editorOptions.zoom,
-        });
+        const xy = CoordinateTransformation.pageToModel(
+          {
+            clientX: event.clientX + QUARTER_OF_BOND_WIDTH * editorOptions.zoom,
+            clientY: event.clientY - QUARTER_OF_BOND_HEIGHT * editorOptions.zoom,
+          },
+          render,
+        );
         const v = new Vec2(1.0 / 2, 0).rotate(
           this.bondProps.type === Bond.PATTERN.TYPE.SINGLE ? -Math.PI / 6 : 0,
         );

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -321,7 +321,8 @@ class BondTool implements Tool {
         const xy = CoordinateTransformation.pageToModel(
           {
             clientX: event.clientX + QUARTER_OF_BOND_WIDTH * editorOptions.zoom,
-            clientY: event.clientY - QUARTER_OF_BOND_HEIGHT * editorOptions.zoom,
+            clientY:
+              event.clientY - QUARTER_OF_BOND_HEIGHT * editorOptions.zoom,
           },
           render,
         );

--- a/packages/ketcher-react/src/script/editor/tool/chain.ts
+++ b/packages/ketcher-react/src/script/editor/tool/chain.ts
@@ -26,6 +26,7 @@ import {
   SGroup,
   vectorUtils,
   removeInfoLabelFromAtoms,
+  CoordinateTransformation,
 } from 'ketcher-core';
 
 import { atomLongtapEvent } from './atom';
@@ -118,7 +119,7 @@ class ChainTool implements Tool {
 
     this.editor.hover(null);
     this.dragCtx = {
-      xy0: rnd.page2obj(event),
+      xy0: CoordinateTransformation.pageToModel(event, rnd),
       item: ci,
     };
 
@@ -176,7 +177,7 @@ class ChainTool implements Tool {
 
       const pos0 = dragCtx.item ? atoms.get(dragCtx.item.id)?.pp : dragCtx.xy0;
 
-      const pos1 = editor.render.page2obj(event);
+      const pos1 = CoordinateTransformation.pageToModel(event, editor.render);
       const sectCount = Math.ceil(Vec2.diff(pos1, pos0).length());
 
       const angle = event.ctrlKey

--- a/packages/ketcher-react/src/script/editor/tool/hand.ts
+++ b/packages/ketcher-react/src/script/editor/tool/hand.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import Editor from '../Editor';
-import { Vec2 } from 'ketcher-core';
+import { CoordinateTransformation, Vec2 } from 'ketcher-core';
 import { Tool } from './Tool';
 
 class HandTool implements Tool {
@@ -70,7 +70,7 @@ class HandTool implements Tool {
   mouseup(event) {
     if (this.begPos === null) return;
     const rnd = this.editor.render;
-    this.endPos = rnd.page2obj(event);
+    this.endPos = CoordinateTransformation.pageToModel(event, rnd);
     this.begPos = null;
     this.endPos = null;
     rnd.update(false);

--- a/packages/ketcher-react/src/script/editor/tool/helper/lasso.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/lasso.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Scale } from 'ketcher-core';
+import { CoordinateTransformation, Scale } from 'ketcher-core';
 import locate from './locate';
 import Editor from '../../Editor';
 
@@ -47,7 +47,7 @@ class LassoHelper {
 
   begin(event) {
     const rnd = this.editor.render;
-    this.points = [rnd.page2obj(event)];
+    this.points = [CoordinateTransformation.pageToModel(event, rnd)];
     if (this.mode === 1) {
       this.points.push(this.points[0]);
     }
@@ -65,9 +65,12 @@ class LassoHelper {
     const rnd = this.editor.render;
 
     if (this.mode === 0) {
-      this.points.push(rnd.page2obj(event));
+      this.points.push(CoordinateTransformation.pageToModel(event, rnd));
     } else if (this.mode === 1) {
-      this.points = [this.points[0], rnd.page2obj(event)];
+      this.points = [
+        this.points[0],
+        CoordinateTransformation.pageToModel(event, rnd),
+      ];
     }
 
     this.update();

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -26,6 +26,7 @@ import {
   Struct,
   Vec2,
   vectorUtils,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import Editor from '../Editor';
 import { dropAndMerge } from './helper/dropAndMerge';
@@ -70,12 +71,16 @@ class PasteTool implements Tool {
 
     const rnd = this.editor.render;
     const { clientHeight, clientWidth } = rnd.clientArea;
+    const clientAreaRect = rnd.clientArea.getBoundingClientRect();
     const point = this.editor.lastEvent
-      ? rnd.page2obj(this.editor.lastEvent)
-      : rnd.page2obj({
-          pageX: clientWidth / 2,
-          pageY: clientHeight / 2,
-        } as MouseEvent);
+      ? CoordinateTransformation.pageToModel(this.editor.lastEvent, rnd)
+      : CoordinateTransformation.pageToModel(
+          {
+            clientX: clientAreaRect.left + clientWidth / 2,
+            clientY: clientAreaRect.top + clientHeight / 2,
+          },
+          rnd,
+        );
 
     const [action, pasteItems] = fromPaste(rnd.ctab, this.struct, point);
     this.action = action;
@@ -119,7 +124,7 @@ class PasteTool implements Tool {
       const [action] = fromPaste(
         this.restruct,
         this.struct,
-        this.editor.render.page2obj(event),
+        CoordinateTransformation.pageToModel(event, this.editor.render),
       );
       this.action = action;
       return;
@@ -129,7 +134,7 @@ class PasteTool implements Tool {
     this.action = null;
 
     this.dragCtx = {
-      xy0: this.editor.render.page2obj(event),
+      xy0: CoordinateTransformation.pageToModel(event, this.editor.render),
       item: closestGroupItem,
     };
   }
@@ -148,7 +153,10 @@ class PasteTool implements Tool {
     if (this.dragCtx) {
       // template-like logic for group-on-group actions
       let pos0: Vec2 | null | undefined = null;
-      const pos1 = this.editor.render.page2obj(event);
+      const pos1 = CoordinateTransformation.pageToModel(
+        event,
+        this.editor.render,
+      );
 
       const extraBond = true;
 
@@ -205,7 +213,7 @@ class PasteTool implements Tool {
       const [action, pasteItems] = fromPaste(
         this.restruct,
         this.struct,
-        this.editor.render.page2obj(event),
+        CoordinateTransformation.pageToModel(event, this.editor.render),
       );
       this.action = action;
       this.editor.update(this.action, true);

--- a/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Action, Scale, fromAtomsAttrs } from 'ketcher-core';
+import {
+  Action,
+  Scale,
+  fromAtomsAttrs,
+  CoordinateTransformation,
+} from 'ketcher-core';
 import Editor from '../Editor';
 import { Tool } from './Tool';
 
@@ -37,7 +42,7 @@ class ReactionMapTool implements Tool {
       this.editor.hover(null);
       this.dragCtx = {
         item: closestItem,
-        xy0: rnd.page2obj(event),
+        xy0: CoordinateTransformation.pageToModel(event, rnd),
       };
     }
   }
@@ -64,7 +69,7 @@ class ReactionMapTool implements Tool {
         editor.hover(null);
         this.updateLine(
           atoms.get(this.dragCtx.item.id)?.pp,
-          rnd.page2obj(event),
+          CoordinateTransformation.pageToModel(event, rnd),
         );
       }
     } else {

--- a/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { fromMultipleMove, fromPlusAddition } from 'ketcher-core';
+import {
+  fromMultipleMove,
+  fromPlusAddition,
+  CoordinateTransformation,
+} from 'ketcher-core';
 import Editor from '../Editor';
 import { Tool } from './Tool';
 import { handleMovingPosibilityCursor } from '../utils';
@@ -35,7 +39,7 @@ class ReactionPlusTool implements Tool {
     if (ci && ci.map === 'rxnPluses') {
       this.editor.hover(null);
       this.editor.selection({ rxnPluses: [ci.id] });
-      this.dragCtx = { xy0: rnd.page2obj(event) };
+      this.dragCtx = { xy0: CoordinateTransformation.pageToModel(event, rnd) };
     }
   }
 
@@ -51,7 +55,9 @@ class ReactionPlusTool implements Tool {
       this.dragCtx.action = fromMultipleMove(
         rnd.ctab,
         this.editor.selection() || {},
-        rnd.page2obj(event).sub(this.dragCtx.xy0),
+        CoordinateTransformation.pageToModel(event, rnd).sub(
+          this.dragCtx.xy0,
+        ),
       );
       editor.update(this.dragCtx.action, true);
     } else {
@@ -84,7 +90,12 @@ class ReactionPlusTool implements Tool {
     const ci = this.editor.findItem(event, ['rxnPluses']);
 
     if (!ci) {
-      this.editor.update(fromPlusAddition(rnd.ctab, rnd.page2obj(event)));
+      this.editor.update(
+        fromPlusAddition(
+          rnd.ctab,
+          CoordinateTransformation.pageToModel(event, rnd),
+        ),
+      );
     }
   }
 }

--- a/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
@@ -55,9 +55,7 @@ class ReactionPlusTool implements Tool {
       this.dragCtx.action = fromMultipleMove(
         rnd.ctab,
         this.editor.selection() || {},
-        CoordinateTransformation.pageToModel(event, rnd).sub(
-          this.dragCtx.xy0,
-        ),
+        CoordinateTransformation.pageToModel(event, rnd).sub(this.dragCtx.xy0),
       );
       editor.update(this.dragCtx.action, true);
     } else {

--- a/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rgroupatom.ts
@@ -20,6 +20,7 @@ import {
   fromAtomsAttrs,
   FunctionalGroup,
   KetcherLogger,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import Editor from '../Editor';
 import { Tool } from './Tool';
@@ -93,7 +94,11 @@ class RGroupAtomTool implements Tool {
     if (!ci) {
       //  ci.type == 'Canvas'
       this.editor.hover(null);
-      propsDialog(this.editor, null, rnd.page2obj(event));
+      propsDialog(
+        this.editor,
+        null,
+        CoordinateTransformation.pageToModel(event, rnd),
+      );
       return true;
     } else if (ci.map === 'atoms') {
       const struct = this.editor.render.ctab.molecule;

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -806,7 +806,10 @@ class RotateController {
     event.stopPropagation();
 
     this.isMovingCenter = false;
-    this.originalCenter = CoordinateTransformation.pageToModel(event, this.render);
+    this.originalCenter = CoordinateTransformation.pageToModel(
+      event,
+      this.render,
+    );
   };
 
   private dragCrossEndOUtOfBounding = (_event: MouseEvent) => {

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.ts
@@ -697,8 +697,10 @@ class RotateController {
           return;
         }
 
-        this.handleCenter = this.render
-          .page2obj(event)
+        this.handleCenter = CoordinateTransformation.pageToModel(
+          event,
+          this.render,
+        )
           .scaled(this.render.options.microModeScale)
           .add(this.render.options.offset);
 
@@ -789,7 +791,10 @@ class RotateController {
         return;
       }
 
-      this.originalCenter = this.render.page2obj(event);
+      this.originalCenter = CoordinateTransformation.pageToModel(
+        event,
+        this.render,
+      );
 
       this.drawCross('move');
       this.drawLink('moveCenter');
@@ -801,7 +806,7 @@ class RotateController {
     event.stopPropagation();
 
     this.isMovingCenter = false;
-    this.originalCenter = this.render.page2obj(event);
+    this.originalCenter = CoordinateTransformation.pageToModel(event, this.render);
   };
 
   private dragCrossEndOUtOfBounding = (_event: MouseEvent) => {

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -31,6 +31,7 @@ import {
   getRelSGroupsBySelection,
   MonomerMicromolecule,
   RotateMonomerOperation,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import assert from 'assert';
 import { intersection, throttle } from 'lodash';
@@ -196,7 +197,10 @@ class RotateTool implements Tool {
 
     const dragCtx = this.dragCtx;
 
-    const mousePos = this.editor.render.page2obj(event);
+    const mousePos = CoordinateTransformation.pageToModel(
+      event,
+      this.editor.render,
+    );
     const mouseMoveAngle =
       vectorUtils.calcAngle(dragCtx.xy0, mousePos) - dragCtx.angle1;
 

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -258,7 +258,7 @@ class SelectTool implements Tool {
         !selection.bonds;
       if (shouldDisplayDegree) {
         // moving selected objects
-        const pos = rnd.page2obj(event);
+        const pos = CoordinateTransformation.pageToModel(event, rnd);
         const angle = vectorUtils.calcAngle(dragCtx.xy0, pos);
         const degrees = vectorUtils.degrees(angle);
         editor.event.message.dispatch({ info: degrees + 'º' });
@@ -304,7 +304,9 @@ class SelectTool implements Tool {
       dragCtx.action = fromMultipleMove(
         restruct,
         expSel,
-        editor.render.page2obj(event).sub(dragCtx.xy0),
+        CoordinateTransformation.pageToModel(event, editor.render).sub(
+          dragCtx.xy0,
+        ),
       );
 
       const visibleSelectedItems = filterNotInContractedSGroup(
@@ -712,7 +714,7 @@ function getResizingProps(
   dragCtx,
   event,
 ): [ReStruct, number, Vec2, Vec2, any] {
-  const current = editor.render.page2obj(event);
+  const current = CoordinateTransformation.pageToModel(event, editor.render);
   const diff = current.sub(dragCtx.xy0);
   return [editor.render.ctab, dragCtx.item.id, diff, current, dragCtx.item.ref];
 }

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -1,3 +1,4 @@
+packages / ketcher - react / src / script / editor / tool / atom.ts;
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -1,4 +1,3 @@
-packages / ketcher - react / src / script / editor / tool / atom.ts;
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *

--- a/packages/ketcher-react/src/script/editor/tool/simpleobject.ts
+++ b/packages/ketcher-react/src/script/editor/tool/simpleobject.ts
@@ -20,6 +20,7 @@ import {
   fromSimpleObjectDeletion,
   fromSimpleObjectResizing,
   SimpleObjectMode,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import Editor from '../Editor';
 import { Tool } from './Tool';
@@ -37,7 +38,7 @@ class SimpleObjectTool implements Tool {
 
   mousedown(event) {
     const rnd = this.editor.render;
-    const p0 = rnd.page2obj(event);
+    const p0 = CoordinateTransformation.pageToModel(event, rnd);
     this.dragCtx = { p0 };
 
     const ci = this.editor.findItem(event, ['simpleObjects']);
@@ -56,7 +57,7 @@ class SimpleObjectTool implements Tool {
     const rnd = this.editor.render;
 
     if (this.dragCtx) {
-      const current = rnd.page2obj(event);
+      const current = CoordinateTransformation.pageToModel(event, rnd);
       const diff = current.sub(this.dragCtx.p0);
       this.dragCtx.previous = current;
 

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -34,6 +34,7 @@ import {
   BondAttr,
   AtomAttr,
   MonomerMicromolecule,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import Editor from '../Editor';
 import { getGroupIdsFromItemArrays } from './helper/getGroupIdsFromItems';
@@ -276,7 +277,7 @@ class TemplateTool implements Tool {
     this.editor.hover(null);
 
     this.dragCtx = {
-      xy0: this.editor.render.page2obj(event),
+      xy0: CoordinateTransformation.pageToModel(event, this.editor.render),
       item: this.editor.findItem(this.event, this.findItems),
     };
 
@@ -317,7 +318,10 @@ class TemplateTool implements Tool {
       return true;
     }
 
-    const eventPosition = this.editor.render.page2obj(event);
+    const eventPosition = CoordinateTransformation.pageToModel(
+      event,
+      this.editor.render,
+    );
     const dragCtx = this.dragCtx;
     const ci = dragCtx.item;
     let targetPos: Vec2 | null | undefined = null;

--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -23,6 +23,7 @@ import {
   Action,
   fromTemplateOnCanvas,
   fromMultipleMove,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import Editor from '../Editor';
 import { MODES } from 'src/constants';
@@ -96,7 +97,10 @@ class TemplatePreview {
   }
 
   movePreview(event: PointerEvent) {
-    this.position = this.editor.render.page2obj(event);
+    this.position = CoordinateTransformation.pageToModel(
+      event,
+      this.editor.render,
+    );
 
     const struct = this.editor.struct();
     const previewTarget = this.getPreviewTarget();

--- a/packages/ketcher-react/src/script/editor/tool/text.ts
+++ b/packages/ketcher-react/src/script/editor/tool/text.ts
@@ -23,6 +23,7 @@ import {
   fromTextDeletion,
   fromTextUpdating,
   KetcherLogger,
+  CoordinateTransformation,
 } from 'ketcher-core';
 import { Tool } from './Tool';
 import { handleMovingPosibilityCursor } from '../utils';
@@ -50,7 +51,7 @@ class TextTool implements Tool {
       this.editor.hover(null);
       this.editor.selection({ texts: [closestItem.id] });
       this.dragCtx = {
-        xy0: render.page2obj(event),
+        xy0: CoordinateTransformation.pageToModel(event, render),
         action: new Action(),
       };
     }
@@ -67,7 +68,9 @@ class TextTool implements Tool {
       this.dragCtx.action = fromMultipleMove(
         render.ctab,
         this.editor.selection() || {},
-        render.page2obj(event).sub(this.dragCtx.xy0),
+        CoordinateTransformation.pageToModel(event, render).sub(
+          this.dragCtx.xy0,
+        ),
       );
       this.editor.update(this.dragCtx.action, true);
     } else {
@@ -96,7 +99,12 @@ class TextTool implements Tool {
     this.editor.hover(null);
 
     if (!closestItem) {
-      propsDialog(this.editor, null, render.page2obj(event), []);
+      propsDialog(
+        this.editor,
+        null,
+        CoordinateTransformation.pageToModel(event, render),
+        [],
+      );
     }
 
     return true;


### PR DESCRIPTION
## Summary
- replace render.page2obj calls in editor tools with CoordinateTransformation.pageToModel to drop the deprecated helper
- update paste tool initial placement logic to compute client area center via bounding rectangle

## Testing
- npm run test:types -w packages/ketcher-react *(fails: ../ketcher-core/src/domain/serializers/ket/validate.ts:17:28 - error TS2307: Cannot find module './compiledSchema')*

------
https://chatgpt.com/codex/tasks/task_e_68e4c885ad18832994ebd11b8d498f38