### PR TITLE
Remove redundant TypeScript assertions across codebase

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -141,13 +141,13 @@ class ReText extends ReObject {
   show(restruct: ReStruct, _id: number, options: any): void {
     const render = restruct.render;
     const paper = render.paper;
-    const paperScale = Scale.modelToCanvas(this.item.position!, options);
+    const paperScale = Scale.modelToCanvas(this.item.position, options);
 
     let shiftY = 0;
     this.paths = [];
     // TODO: create parser in ketcher-core package
     const rawContentState: RawDraftContentState | null = this.item.content
-      ? (JSON.parse(this.item.content) as RawDraftContentState)
+      ? JSON.parse(this.item.content)
       : null;
     if (!rawContentState) {
       return;

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
@@ -50,9 +50,14 @@ export function replaceMonomer(
       return bond.monomer === monomer;
     })
     .map(([id, bond]) => {
-      const attachmentPoint = Object.entries(
-        monomer.attachmentPointsToBonds,
-      ).find(([_ap, apBond]) => apBond === bond)?.[0] as AttachmentPointName;
+      const attachmentPoint = Object.values(AttachmentPointName).find(
+        (attachmentPointName) =>
+          monomer.attachmentPointsToBonds[attachmentPointName] === bond,
+      );
+
+      if (!attachmentPoint) {
+        throw new Error('Attachment point is not defined for the bond');
+      }
       return {
         id,
         monomer: bond.monomer,
@@ -126,7 +131,7 @@ export function replaceMonomer(
       drawingEntitiesManager.addMonomerToAtomBond(
         monomerToAtomBondInfo.monomer,
         monomerToAtomBondInfo.atom,
-        monomerToAtomBondInfo.attachmentPoint as AttachmentPointName,
+        monomerToAtomBondInfo.attachmentPoint,
       ),
     );
   }

--- a/packages/ketcher-macromolecules/src/constants.ts
+++ b/packages/ketcher-macromolecules/src/constants.ts
@@ -73,4 +73,4 @@ export const LIBRARY_TAB_INDEX = {
   CHEM: 3,
 } as const;
 
-export const FavoriteStarSymbol = '★' as const;
+export const FavoriteStarSymbol = '★';

--- a/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
+++ b/packages/ketcher-react/src/script/builders/ketcher/KetcherBuilder.ts
@@ -46,12 +46,13 @@ class KetcherBuilder {
   }
 
   appendApiAsync(structServiceProvider: StructServiceProvider) {
-    this.structService = createApi(
+    const structService = createApi(
       structServiceProvider,
       DefaultStructServiceOptions,
     );
-    this.formatterFactory = new FormatterFactory(this.structService!);
-    return this.structService;
+    this.structService = structService;
+    this.formatterFactory = new FormatterFactory(structService);
+    return structService;
   }
 
   reinitializeApi(
@@ -108,6 +109,9 @@ class KetcherBuilder {
     setServer: (structService: StructService) => void;
   }> {
     const { structService } = this;
+    if (!structService) {
+      throw new Error('Structure service is not initialized');
+    }
     let cleanup: ReturnType<typeof initApp> | null = null;
 
     const { editor, setServer } = await new Promise<{
@@ -128,7 +132,7 @@ class KetcherBuilder {
           buildNumber: process.env.BUILD_NUMBER || '',
           customButtons: customButtons || [],
         },
-        structService!,
+        structService,
         resolve,
         togglerComponent,
       );

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -1,11 +1,5 @@
 import assert from 'assert';
-import {
-  Bond,
-  MonomerMicromolecule,
-  SGroup,
-  Struct,
-  UnresolvedMonomer,
-} from 'ketcher-core';
+import { MonomerMicromolecule, SGroup, Struct, UnresolvedMonomer } from 'ketcher-core';
 import Editor from '../Editor';
 
 let showTooltipTimer: ReturnType<typeof setTimeout> | null = null;
@@ -66,8 +60,7 @@ function makeBonds(
   struct: Struct,
   atomsIdMapping: Map<number, number>,
 ) {
-  Array.from(existingStruct.bonds).forEach((value) => {
-    const [_, bond] = value as [number, Bond];
+  existingStruct.bonds.forEach((bond) => {
     const clonedBond = bond.clone(atomsIdMapping);
     const isInsideSGroup =
       sGroup.atoms.includes(bond.begin) || sGroup.atoms.includes(bond.end);

--- a/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
+++ b/packages/ketcher-react/src/script/ui/data/schema/options-schema.ts
@@ -459,10 +459,16 @@ export default optionsSchema;
 export function getDefaultOptions(): Record<string, any> {
   if (!optionsSchema.properties) return {};
 
-  return Object.keys(optionsSchema.properties).reduce((res, prop) => {
-    res[prop] = (optionsSchema.properties[prop] as ExtendedSchema).default;
-    return res;
-  }, {});
+  return Object.keys(optionsSchema.properties).reduce<Record<string, any>>(
+    (res, prop) => {
+      const propertySchema = optionsSchema.properties?.[prop];
+      if (propertySchema && typeof propertySchema !== 'boolean') {
+        res[prop] = propertySchema.default;
+      }
+      return res;
+    },
+    {},
+  );
 }
 
 export function validation(settings): Record<string, string> | null {

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -391,14 +391,13 @@ const onModalClose = (props, dispatch) => {
 };
 
 export default connect(
-  (store) => ({
-    ...omit(['attach'], (store as any).templates),
-    initialTab: (store as any).modal?.prop?.tab,
-    renderOptions: (store as any).editor?.render?.options,
+  (store: any) => ({
+    ...omit(['attach'], store.templates),
+    initialTab: store.modal?.prop?.tab,
+    renderOptions: store.editor?.render?.options,
     functionalGroups: functionalGroupsSelector(store),
     saltsAndSolvents: saltsAndSolventsSelector(store),
-    isMonomerCreationWizardActive: (store as any).editor
-      ?.isMonomerCreationWizardActive,
+    isMonomerCreationWizardActive: store.editor?.isMonomerCreationWizardActive,
   }),
   (dispatch: Dispatch<any>, props: Props) => ({
     onFilter: (filter) => dispatch(changeFilter(filter)),

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
@@ -199,7 +199,7 @@ function maxOfOrs(stereLabels): number {
   return numbers.length === 0 ? 0 : Math.max(...numbers);
 }
 
-export default connect((state) => ({
-  formState: (state as any).modal.form || { result: {}, valid: false },
-  struct: (state as any).editor.struct(),
+export default connect((state: any) => ({
+  formState: state.modal.form || { result: {}, valid: false },
+  struct: state.editor.struct(),
 }))(EnhancedStereo);

--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx
@@ -26,13 +26,7 @@ import {
   convertToRaw,
   getDefaultKeyBinding,
 } from 'draft-js';
-import React, {
-  useCallback,
-  useState,
-  useRef,
-  useEffect,
-  RefObject,
-} from 'react';
+import React, { useCallback, useState, useRef, useEffect } from 'react';
 
 import { Dialog } from '../../../components';
 import { DialogParams } from '../../../../../../components/Dialog/Dialog';
@@ -76,7 +70,7 @@ const buttons: Array<{ command: TextCommand; name: IconName }> = [
 const Text = (props: TextProps) => {
   const { formState, position, id } = props;
   const rawContentState: RawDraftContentState | null = props.content
-    ? (JSON.parse(props.content) as RawDraftContentState)
+    ? JSON.parse(props.content)
     : null;
   const [editorState, setEditorState] = useState<EditorState>(
     EditorState.moveFocusToEnd(
@@ -153,7 +147,7 @@ const Text = (props: TextProps) => {
     },
   };
 
-  const refEditor = useRef(null) as RefObject<Editor | null>;
+  const refEditor = useRef<Editor | null>(null);
   const setFocusInEditor = useCallback(() => {
     refEditor.current?.focus();
     refEditor.current?.editor?.setAttribute('data-testid', 'text-editor');
@@ -211,4 +205,4 @@ const Text = (props: TextProps) => {
   );
 };
 
-export default connect((store) => ({ formState: (store as any).modal }))(Text);
+export default connect((store: any) => ({ formState: store.modal }))(Text);

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
@@ -24,7 +24,7 @@ function usePortalOpening([id, opened, options]: HookParams): [boolean] {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   useEffect(() => {
-    const currentId = (options.length && options![0].id) || '';
+    const currentId = options.length > 0 ? options[0].id : '';
     const newState = opened === id || opened === currentId;
     setIsOpen(newState);
   }, [opened, options]);


### PR DESCRIPTION
## Summary
- remove redundant type and non-null assertions in core rendering and entity management code
- improve optional handling in template tooling and helper utilities to avoid unsafe casts
- clean up builder, schema, and React connectors to rely on guards instead of type assertions

## Testing
- npm run lint *(fails: script not defined in workspace)*
- npm run test:types --workspaces *(fails: repository lacks generated schemas and workspace dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e5582ac754832988407f8b338a57f1