### PR TITLE
Fix sync toggle initialization after antisense chain creation

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -3174,6 +3174,7 @@ export class DrawingEntitiesManager {
       antisenseBaseLabel,
       node.monomer.position.add(new Vec2(0, 3)),
       sugarName,
+      true,
     );
   }
 

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -71,15 +71,24 @@ export class Nucleoside {
     );
     const modelChanges = new Command();
 
+    const sugarMonomerItem =
+      isAntisense
+        ? { ...sugarLibraryItem, isAntisense: true, isSense: false }
+        : sugarLibraryItem;
+    const rnaBaseMonomerItem =
+      isAntisense
+        ? { ...rnaBaseLibraryItem, isAntisense: true, isSense: false }
+        : rnaBaseLibraryItem;
+
     modelChanges.merge(
       editor.drawingEntitiesManager.addMonomer(
-        { ...sugarLibraryItem, isAntisense },
+        sugarMonomerItem,
         isAntisense ? bottomItemPosition : topLeftItemPosition,
       ),
     );
     modelChanges.merge(
       editor.drawingEntitiesManager.addMonomer(
-        { ...rnaBaseLibraryItem, isAntisense },
+        rnaBaseMonomerItem,
         isAntisense ? topLeftItemPosition : bottomItemPosition,
       ),
     );

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -18,6 +18,7 @@ import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { SugarRenderer } from 'application/render';
 import { KetMonomerClass } from 'application/formatters';
 import { SnakeLayoutCellWidth } from 'domain/constants';
+import { MonomerItemType } from 'domain/types';
 
 export class Nucleotide {
   constructor(
@@ -59,6 +60,7 @@ export class Nucleotide {
     rnaBaseName: string,
     position: Vec2,
     sugarName: RNA_DNA_NON_MODIFIED_PART = RNA_DNA_NON_MODIFIED_PART.SUGAR_RNA,
+    isAntisense = false,
   ) {
     const editor = CoreEditor.provideEditorInstance();
     const isDnaSugar = sugarName === RNA_DNA_NON_MODIFIED_PART.SUGAR_DNA;
@@ -89,13 +91,23 @@ export class Nucleotide {
       ),
     );
 
+    const buildMonomerItem = (monomerItem?: MonomerItemType) => {
+      if (!monomerItem) {
+        return monomerItem;
+      }
+
+      return isAntisense
+        ? { ...monomerItem, isAntisense: true, isSense: false }
+        : monomerItem;
+    };
+
     const { command: modelChanges, monomers } =
       editor.drawingEntitiesManager.addRnaPreset({
-        sugar: sugarLibraryItem,
+        sugar: buildMonomerItem(sugarLibraryItem),
         sugarPosition: topLeftItemPosition,
-        rnaBase: rnaBaseLibraryItem,
+        rnaBase: buildMonomerItem(rnaBaseLibraryItem),
         rnaBasePosition: bottomItemPosition,
-        phosphate: phosphateLibraryItem,
+        phosphate: buildMonomerItem(phosphateLibraryItem),
         phosphatePosition: topLeftItemPosition.add(
           Coordinates.canvasToModel(new Vec2(SnakeLayoutCellWidth, 0)),
         ),


### PR DESCRIPTION
## Summary
- mark newly created antisense nucleosides and nucleotides with antisense metadata
- propagate the antisense flag when generating complementary chains so the sync toggle becomes available

## Testing
- npm run test --workspace=packages/ketcher-core *(fails: prettier-config-standard configuration module is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee98e33d9c83299f3b7f2229449a03