### PR TITLE
Backmerge: #8296 - Create Monomer tool can not be hidden by toolbar buttons config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31535,7 +31535,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "3.9.0-rc.2",
+      "version": "3.9.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -31650,7 +31650,7 @@
       }
     },
     "packages/ketcher-macromolecules": {
-      "version": "3.9.0-rc.2",
+      "version": "3.9.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -33303,7 +33303,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "3.9.0-rc.2",
+      "version": "3.9.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -35217,7 +35217,7 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "3.9.0-rc.2",
+      "version": "3.9.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "3.9.0-rc.2",
+  "version": "3.9.0-rc.3",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "3.9.0-rc.2",
+  "version": "3.9.0-rc.3",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "3.9.0-rc.2",
+  "version": "3.9.0-rc.3",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/src/script/builders/ketcher/ButtonName.ts
+++ b/packages/ketcher-react/src/script/builders/ketcher/ButtonName.ts
@@ -74,4 +74,5 @@ export type ButtonName =
   // text group
   | 'text'
   // right
-  | 'enhanced-stereo';
+  | 'enhanced-stereo'
+  | 'create-monomer';

--- a/packages/ketcher-react/src/script/ui/action/tools.js
+++ b/packages/ketcher-react/src/script/ui/action/tools.js
@@ -350,6 +350,7 @@ const toolActions = {
     disabled: (editor) =>
       editor.isMonomerCreationWizardActive ||
       !editor.isMonomerCreationWizardEnabled,
+    hidden: (options) => isHidden(options, CREATE_MONOMER_TOOL_NAME),
   },
   shapes: {
     disabled: (editor) => editor.isMonomerCreationWizardActive,

--- a/packages/ketcher-react/src/script/ui/state/options/selectors/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/options/selectors/index.ts
@@ -1,0 +1,19 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+export const optionsSelector = (state) => {
+  return state.options;
+};

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
@@ -17,7 +17,10 @@ import {
 import { getIconName, Icon } from 'components';
 import { useAppContext } from 'src/hooks';
 import HighlightMenu from 'src/script/ui/action/highlightColors/HighlightColors';
-import { ketcherProvider } from 'ketcher-core';
+import { CREATE_MONOMER_TOOL_NAME, ketcherProvider } from 'ketcher-core';
+import isHidden from '../../../../action/isHidden';
+import { useSelector } from 'react-redux';
+import { optionsSelector } from '../../../../state/options/selectors';
 
 const bondNames = getBondNames(tools);
 
@@ -45,6 +48,7 @@ const SelectionMenuItems: FC<MenuItemsProps<SelectionContextMenuProps>> = (
       color: color === '' ? 'transparent' : color,
     });
   };
+  const options = useSelector(optionsSelector);
 
   return (
     <>
@@ -83,14 +87,17 @@ const SelectionMenuItems: FC<MenuItemsProps<SelectionContextMenuProps>> = (
           );
         })}
       </Submenu>
-      <Item
-        {...props}
-        data-testid="Create a monomer-option"
-        onClick={handleCreateMonomer}
-        disabled={createMonomerDisabled}
-      >
-        Create a monomer
-      </Item>
+
+      {!isHidden(options, CREATE_MONOMER_TOOL_NAME) && (
+        <Item
+          {...props}
+          data-testid="Create a monomer-option"
+          onClick={handleCreateMonomer}
+          disabled={createMonomerDisabled}
+        >
+          Create a monomer
+        </Item>
+      )}
 
       <Item
         {...props}

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "3.9.0-rc.2",
+  "version": "3.9.0-rc.3",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- made create-monomer functionality disableable using buttons config
- bumped ketcher to 3.9.0-rc.3

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request