### PR TITLE
#8335 - Preview: Modification list overflows tooltip boundaries when three or more modification types are added 

### DIFF
--- a/packages/ketcher-macromolecules/src/components/preview/components/MonomerPreviewProperties/MonomerPreviewProperties.styles.ts
+++ b/packages/ketcher-macromolecules/src/components/preview/components/MonomerPreviewProperties/MonomerPreviewProperties.styles.ts
@@ -40,5 +40,7 @@ export const MonomerPreviewTitle = styled.span`
 
 export const MonomerPreviewList = styled.span`
   color: #585858;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 `;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

- [x] All modification types displayed within the tooltip boundaries, with text wrapping or automatic resizing applied to prevent overflow.


https://github.com/user-attachments/assets/c3be6157-c2bc-4ece-87aa-135ec48b64bc



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request