### PR TITLE
#5361 - getInChIKey returns just the InChI string as JSON

### DIFF
--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -28,6 +28,7 @@ import {
   CalculateResult,
   CheckData,
   CheckResult,
+  ChemicalMimeType,
   CleanData,
   CleanResult,
   ConvertData,
@@ -189,7 +190,7 @@ export class RemoteStructService implements StructService {
     )(
       {
         struct,
-        output_format: 'chemical/x-inchi-key',
+        output_format: ChemicalMimeType.InChIKey,
       },
       {},
     );


### PR DESCRIPTION
FIX: Change output format to InChI Key

Update output format from InChI to InChI Key for structure conversion service.

## How the feature works? / How did you fix the issue?

I noticed this bug hadn't been fixed for a long time, so I went ahead and fixed it. This now produces the expected InChIKey.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request