### PR TITLE
#7995 - Unable to create more than one attachment point per atom

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeAttachmentPointMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeAttachmentPointMenuItems.tsx
@@ -38,6 +38,13 @@ const useMakeAttachmentPointMenuItems = ({
     );
   });
 
+  const isAtomAlreadyLeavingAtom = Array.from(
+    assignedAttachmentPoints.values(),
+  ).some((atomPair) => {
+    const [, leavingAtomId] = atomPair;
+    return selectedAtomId === leavingAtomId;
+  });
+
   const implicitHydrogen = editor.struct().atoms.get(selectedAtomId)?.implicitH;
 
   const isPotentialLeavingGroupAtom = Array.from(
@@ -87,7 +94,7 @@ const useMakeAttachmentPointMenuItems = ({
       disabled={
         attachmentPointsLimitReached ||
         !isPotentialAttachmentAtom ||
-        isAtomInAssignedAttachmentPoint
+        isAtomAlreadyLeavingAtom
       }
       data-testid="mark-as-connection-point"
       key="mark-as-connection-point"


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- [x] Mark as connection point option is present in context menu and operational, creation of second attachment point is possible

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request