### PR TITLE
Backmerge: #8414 - System should throw The following string cannot be interpreted as an AxoLabs string. error if symbols without brackets cannot be interpreted

### DIFF
--- a/packages/ketcher-core/src/application/formatters/constants.ts
+++ b/packages/ketcher-core/src/application/formatters/constants.ts
@@ -13,6 +13,6 @@ export const macromoleculesFilesInputFormats = {
     peptide: 'chemical/x-peptide-fasta',
   },
   idt: 'chemical/x-idt',
-  axolabs: 'chemical/x-axo-labs',
+  'axo-labs': 'chemical/x-axo-labs',
   helm: 'chemical/x-helm',
 };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request