### PR TITLE
Backmerge: #8418 - All monomers from SDF loaded via updateMonomersLibrary appear in Base group instead of their correct classes

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/hooks/useGroupsData.ts
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/hooks/useGroupsData.ts
@@ -1,9 +1,5 @@
 import { useMemo } from 'react';
-import {
-  LibraryNameType,
-  MonomerCodeToGroup,
-  MonomerGroups,
-} from 'src/constants';
+import { LibraryNameType, MonomerGroups } from 'src/constants';
 import {
   RnaBuilderPresetsItem,
   selectFilteredPresets,
@@ -35,36 +31,38 @@ export const useGroupsData = (libraryName: LibraryNameType) => {
       {
         groupName: MonomerGroups.SUGARS,
         iconName: 'sugar',
-        groups: groups.filter(
-          (group) =>
-            MonomerCodeToGroup[group.groupTitle as string] ===
-            MonomerGroups.SUGARS,
-        ),
+        groups: groups
+          .map((group) => ({
+            ...group,
+            groupItems: group.groupItems.filter(
+              (item) => item.props?.MonomerClass === KetMonomerClass.Sugar,
+            ),
+          }))
+          .filter((group) => group.groupItems.length),
       },
       {
         groupName: MonomerGroups.BASES,
         iconName: 'base',
         groups: groups
-          .filter(
-            (group) =>
-              MonomerCodeToGroup[group.groupTitle as string] ===
-              MonomerGroups.BASES,
-          )
           .map((group) => ({
             ...group,
             groupItems: group.groupItems.filter(
-              (item) => item.props?.MonomerClass !== KetMonomerClass.RNA,
+              (item) => item.props?.MonomerClass === KetMonomerClass.Base,
             ),
-          })),
+          }))
+          .filter((group) => group.groupItems.length),
       },
       {
         groupName: MonomerGroups.PHOSPHATES,
         iconName: 'phosphate',
-        groups: groups.filter(
-          (group) =>
-            MonomerCodeToGroup[group.groupTitle as string] ===
-            MonomerGroups.PHOSPHATES,
-        ),
+        groups: groups
+          .map((group) => ({
+            ...group,
+            groupItems: group.groupItems.filter(
+              (item) => item.props?.MonomerClass === KetMonomerClass.Phosphate,
+            ),
+          }))
+          .filter((group) => group.groupItems.length),
       },
       {
         groupName: MonomerGroups.NUCLEOTIDES,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request