### PR TITLE
#7776 - In Macro mode clicking on Selection tool icon does not open dropdown menu as in Micro mode 

### DIFF
--- a/packages/ketcher-macromolecules/src/components/LeftMenuComponent/LeftMenuComponent.tsx
+++ b/packages/ketcher-macromolecules/src/components/LeftMenuComponent/LeftMenuComponent.tsx
@@ -46,7 +46,7 @@ export function LeftMenuComponent() {
           <Menu.Submenu
             testId="select-drop-down-button"
             subMenuId={SELECT_SUBMENU_ID}
-            needOpenByMenuItemClick={false}
+            needOpenByMenuItemClick={true}
           >
             <Menu.Item
               itemId="select-rectangle"


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
- Clicking on the Selection tool icon (both in Macro and Micro modes) open the dropdown menu with all selection tools, providing a consistent user experience.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request