### PR TITLE
#4645 - In the “Modify RNA Builder” mode, when hovering over the buttons “Yes” and “Cancel” in the “Update Sequence” window, tooltips are displayed

### DIFF
--- a/packages/ketcher-macromolecules/src/components/modal/UpdateSequenceInRNABuilder/UpdateSequenceInRNABuilder.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/UpdateSequenceInRNABuilder/UpdateSequenceInRNABuilder.test.tsx
@@ -63,7 +63,7 @@ describe('UpdateSequenceInRNABuilder modal component', () => {
         },
       }),
     );
-    const cancelButton = screen.getByTitle('Cancel');
+    const cancelButton = screen.getByTestId('update-sequence-cancel-button');
     fireEvent.click(cancelButton);
     expect(mockProps.onClose).toHaveBeenCalled();
   });
@@ -84,7 +84,7 @@ describe('UpdateSequenceInRNABuilder modal component', () => {
         },
       }),
     );
-    const yesButton = screen.getByTitle('Yes');
+    const yesButton = screen.getByTestId('update-sequence-yes-button');
     fireEvent.click(yesButton);
     expect(mockProps.onClose).toHaveBeenCalled();
   });

--- a/packages/ketcher-macromolecules/src/components/modal/UpdateSequenceInRNABuilder/UpdateSequenceInRNABuilder.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/UpdateSequenceInRNABuilder/UpdateSequenceInRNABuilder.tsx
@@ -71,15 +71,17 @@ const UpdateSequenceInRNABuilder = ({ isModalOpen, onClose }: Props) => {
         <ActionButton
           key="cancel"
           clickHandler={cancelHandler}
-          title=""
           label="Cancel"
           styleType="secondary"
+          title=""
+          data-testid="update-sequence-cancel-button"
         />
         <ActionButton
           key="update"
           clickHandler={updateHandler}
-          title=""
           label="Yes"
+          title=""
+          data-testid="update-sequence-yes-button"
         />
       </Modal.Footer>
     </Modal>

--- a/packages/ketcher-macromolecules/src/components/modal/UpdateSequenceInRNABuilder/__snapshots__/UpdateSequenceInRNABuilder.test.tsx.snap
+++ b/packages/ketcher-macromolecules/src/components/modal/UpdateSequenceInRNABuilder/__snapshots__/UpdateSequenceInRNABuilder.test.tsx.snap
@@ -86,8 +86,9 @@ Object {
           >
             <button
               class="MuiButtonBase-root css-fevlc0-MuiButtonBase-root"
+              data-testid="update-sequence-cancel-button"
               tabindex="0"
-              title="Cancel"
+              title=""
               type="button"
             >
               Cancel
@@ -97,8 +98,9 @@ Object {
             </button>
             <button
               class="MuiButtonBase-root css-1gvl3mi-MuiButtonBase-root"
+              data-testid="update-sequence-yes-button"
               tabindex="0"
-              title="Yes"
+              title=""
               type="button"
             >
               Yes


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


https://github.com/user-attachments/assets/d196e01a-204a-447a-9ee8-a1502bee074a




## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request