### PR TITLE
#7578 - Undo/Redo restores partial selection after cancelling monomer creation 

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1183,12 +1183,12 @@ class Editor implements KetcherEditor {
 
     this.unsubscribeFromChangeEventInMonomerCreationWizard();
 
-    this.monomerCreationState = null;
-
     this.historyStack = this.originalHistoryStack;
     this.historyPtr = this.originalHistoryPointer;
 
     this.struct(this.originalStruct, false);
+
+    this.monomerCreationState = null;
 
     this.tool('select');
   }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?


https://github.com/user-attachments/assets/792d9b8d-31d0-4b2a-b6a6-ca2f057d09ad



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request