### PR TITLE
#6090 - Antisense creating doesn't work if ambiguous phosphate present in the chain selection 

### DIFF
--- a/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
@@ -86,10 +86,14 @@ export class AmbiguousMonomer extends BaseMonomer implements IVariantMonomer {
     return monomerClass;
   }
 
-  private static getAttachmentPoints(monomers: BaseMonomer[]) {
-    const monomersAttachmentPoints = monomers.map(
-      (monomer) => monomer.listOfAttachmentPoints,
-    );
+  private static getAttachmentPoints(monomers: BaseMonomer[] | undefined) {
+    if (!monomers?.length) {
+      return [];
+    }
+
+    const monomersAttachmentPoints = monomers.map((monomer) => {
+      return monomer.listOfAttachmentPoints;
+    });
     const possibleAttachmentPoints = monomersAttachmentPoints.flat();
     const attachmentPoints = possibleAttachmentPoints.filter(
       (attachmentPointName) => {

--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -272,7 +272,12 @@ export const isRnaBaseVariantMonomer = (
 export function isAmbiguousMonomerLibraryItem(
   monomer?: MonomerOrAmbiguousType,
 ): monomer is AmbiguousMonomerType {
-  return Boolean(monomer && monomer.isAmbiguous);
+  return Boolean(
+    monomer &&
+      monomer.isAmbiguous &&
+      Array.isArray((monomer as AmbiguousMonomerType).monomers) &&
+      (monomer as AmbiguousMonomerType).monomers.length > 0,
+  );
 }
 
 export const isLibraryItemRnaPreset = (


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


https://github.com/user-attachments/assets/ae77d32d-82cc-4d7b-b155-e91d369e2b11


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request