### PR TITLE
Refactor: Potential fix for code scanning alert no. 22: Unvalidated dynamic method call

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.js
+++ b/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.js
@@ -184,34 +184,39 @@ function postLoadAny(_sgroup) {
   // TODO: Implement after adding ANY type support
 }
 
-function loadSGroup(mol, sg, atomMap) {
-  const postLoadMap = {
-    SUP: postLoadSup,
-    MUL: postLoadMul,
-    SRU: postLoadSru,
-    MON: postLoadMon,
-    MER: postLoadMer,
-    COP: postLoadCop,
-    CRO: postLoadCro,
-    MOD: postLoadMod,
-    GRA: postLoadGra,
-    COM: postLoadCom,
-    MIX: postLoadMix,
-    FOR: postLoadFor,
-    DAT: postLoadDat,
-    ANY: postLoadAny,
-    GEN: postLoadGen,
-  };
+// Map of allowed SGroup types to their post-load handlers
+const postLoadMap = {
+  SUP: postLoadSup,
+  MUL: postLoadMul,
+  SRU: postLoadSru,
+  MON: postLoadMon,
+  MER: postLoadMer,
+  COP: postLoadCop,
+  CRO: postLoadCro,
+  MOD: postLoadMod,
+  GRA: postLoadGra,
+  COM: postLoadCom,
+  MIX: postLoadMix,
+  FOR: postLoadFor,
+  DAT: postLoadDat,
+  ANY: postLoadAny,
+  GEN: postLoadGen,
+};
 
+// Set of allowed SGroup types for validation to prevent unvalidated dynamic method calls
+const allowedSGroupTypes = new Set(Object.keys(postLoadMap));
+
+function loadSGroup(mol, sg, atomMap) {
   // add the group to the molecule
   sg.id = mol.sgroups.add(sg);
 
   // apply type-specific post-processing
-  const handler = Object.prototype.hasOwnProperty.call(postLoadMap, sg.type)
-    ? postLoadMap[sg.type]
-    : null;
-  if (typeof handler === 'function') {
-    handler(sg, mol, atomMap);
+  // Only call handlers for explicitly allowed types
+  if (allowedSGroupTypes.has(sg.type)) {
+    const handler = postLoadMap[sg.type];
+    if (typeof handler === 'function') {
+      handler(sg, mol, atomMap);
+    }
   }
   // mark atoms in the group as belonging to it
   for (const atomId of sg.atoms) {


### PR DESCRIPTION
Potential fix for [https://github.com/epam/ketcher/security/code-scanning/22](https://github.com/epam/ketcher/security/code-scanning/22)

In general, to fix unvalidated dynamic method calls, you should ensure that the key used for lookup is constrained to a known safe set and that the looked-up value is actually a function before calling it. This often means whitelisting allowed keys or adding explicit checks and a fallback path when the key is unknown or the value is not callable.

For this specific case in `packages/ketcher-core/src/domain/serializers/mol/parseSGroup.js`, the best fix without changing intended functionality is:

- Keep `postLoadMap` as-is (the mapping of known S-group types to their handlers).
- Before calling `postLoadMap[sg.type](sg, mol, atomMap)`, verify that:
  - `Object.prototype.hasOwnProperty.call(postLoadMap, sg.type)` is `true` (so the property exists as an own property and not via the prototype chain), and
  - `typeof postLoadMap[sg.type] === 'function'`.
- If the check fails (unknown or non-function type), either:
  - Skip the post-load step for that S-group (most conservative behavior, avoids throwing), or
  - Throw a controlled, descriptive error instead of allowing a `TypeError` from calling `undefined`.

Given the existing behavior, the least intrusive change is to skip post-processing when the type is unknown/non-callable. All currently defined S-group types (`SUP`, `MUL`, `SRU`, etc.) will still be processed exactly as before; only malformed or new types will differ by no longer causing a `TypeError`. Implementation details:

- Only `loadSGroup` in `parseSGroup.js` needs to be modified.
- No new imports are necessary.
- Update the invocation at line 210 to perform the existence and function-type checks and only call the handler if safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
