### PR TITLE
Backmerge: #9047 - Leaving group atom position is incorrect for nucleotides created in monomer wizard

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1174,6 +1174,7 @@ class Editor implements KetcherEditor {
     monomerStructure?: Selection,
     forceAddNewLeavingGroupAtom = false,
     leavingAtomLabel: AtomLabel = AtomLabel.H,
+    leavingAtomPosition?: Vec2,
   ) {
     assert(this.monomerCreationState);
 
@@ -1210,6 +1211,8 @@ class Editor implements KetcherEditor {
         { type: Bond.PATTERN.TYPE.SINGLE, stereo: Bond.PATTERN.STEREO.NONE },
         atomId,
         { label: leavingAtomLabel },
+        undefined,
+        leavingAtomPosition,
       );
 
       additionalAction = bondAdditionAction;

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -1393,30 +1393,42 @@ const MonomerCreationWizard = () => {
           ...bondsBetweenSugarAndPhosphate.values(),
         ][0];
 
-        const sugarR3AttachmentPointAtom = sugarStructure?.atoms?.includes(
+        const sugarR3AttachmentPointAtomId = sugarStructure?.atoms?.includes(
           bondBetweenSugarAndBase.begin,
         )
           ? bondBetweenSugarAndBase.begin
           : bondBetweenSugarAndBase.end;
-        const sugarR2AttachmentPointAtom = sugarStructure?.atoms?.includes(
+        const sugarR3AttachmentAtom = struct.atoms.get(
+          sugarR3AttachmentPointAtomId,
+        );
+        const sugarR2AttachmentPointAtomId = sugarStructure?.atoms?.includes(
           bondBetweenSugarAndPhosphate.begin,
         )
           ? bondBetweenSugarAndPhosphate.begin
           : bondBetweenSugarAndPhosphate.end;
-        const baseR1AttachmentPointAtom = baseStructure?.atoms?.includes(
+        const sugarR2AttachmentAtom = struct.atoms.get(
+          sugarR2AttachmentPointAtomId,
+        );
+        const baseR1AttachmentPointAtomId = baseStructure?.atoms?.includes(
           bondBetweenSugarAndBase.begin,
         )
           ? bondBetweenSugarAndBase.begin
           : bondBetweenSugarAndBase.end;
-        const phosphateR1AttachmentPointAtom =
+        const baseR1AttachmentAtom = struct.atoms.get(
+          baseR1AttachmentPointAtomId,
+        );
+        const phosphateR1AttachmentPointAtomId =
           phosphateStructure?.atoms?.includes(
             bondBetweenSugarAndPhosphate.begin,
           )
             ? bondBetweenSugarAndPhosphate.begin
             : bondBetweenSugarAndPhosphate.end;
+        const phosphateR1AttachmentAtom = struct.atoms.get(
+          phosphateR1AttachmentPointAtomId,
+        );
 
         editor.assignConnectionPointAtom(
-          baseR1AttachmentPointAtom,
+          baseR1AttachmentPointAtomId,
           AttachmentPointName.R1,
           assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.base),
           rnaPresetWizardState.base.structure,
@@ -1425,9 +1437,10 @@ const MonomerCreationWizard = () => {
             KetMonomerClass.Base,
             AttachmentPointName.R1,
           ),
+          sugarR3AttachmentAtom?.pp,
         );
         editor.assignConnectionPointAtom(
-          sugarR2AttachmentPointAtom,
+          sugarR2AttachmentPointAtomId,
           AttachmentPointName.R2,
           assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.sugar),
           rnaPresetWizardState.sugar.structure,
@@ -1436,9 +1449,10 @@ const MonomerCreationWizard = () => {
             KetMonomerClass.Sugar,
             AttachmentPointName.R2,
           ),
+          phosphateR1AttachmentAtom?.pp,
         );
         editor.assignConnectionPointAtom(
-          sugarR3AttachmentPointAtom,
+          sugarR3AttachmentPointAtomId,
           AttachmentPointName.R3,
           assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.sugar),
           rnaPresetWizardState.sugar.structure,
@@ -1447,9 +1461,10 @@ const MonomerCreationWizard = () => {
             KetMonomerClass.Sugar,
             AttachmentPointName.R3,
           ),
+          baseR1AttachmentAtom?.pp,
         );
         editor.assignConnectionPointAtom(
-          phosphateR1AttachmentPointAtom,
+          phosphateR1AttachmentPointAtomId,
           AttachmentPointName.R1,
           assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.phosphate),
           rnaPresetWizardState.phosphate.structure,
@@ -1458,6 +1473,7 @@ const MonomerCreationWizard = () => {
             KetMonomerClass.Phosphate,
             AttachmentPointName.R1,
           ),
+          sugarR2AttachmentAtom?.pp,
         );
       }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- fixed leaving group atom position for nucleotides in monomer creation wizard

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request