### PR TITLE
Backmerge: #9032 - Flex mode icon is active after ketcher close and open again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33478,7 +33478,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "3.12.0-rc.1",
+      "version": "3.12.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -33593,7 +33593,7 @@
       }
     },
     "packages/ketcher-macromolecules": {
-      "version": "3.12.0-rc.1",
+      "version": "3.12.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -35178,7 +35178,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "3.12.0-rc.1",
+      "version": "3.12.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -37024,7 +37024,7 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "3.12.0-rc.1",
+      "version": "3.12.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "3.12.0-rc.1",
+  "version": "3.12.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "3.12.0-rc.1",
+  "version": "3.12.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/src/hooks/stateHooks.ts
+++ b/packages/ketcher-macromolecules/src/hooks/stateHooks.ts
@@ -68,6 +68,7 @@ export function useLayoutMode() {
     editor?.events.layoutModeChange.add(onLayoutModeChange);
 
     return () => {
+      onLayoutModeChange(DEFAULT_LAYOUT_MODE);
       editor?.events.layoutModeChange.remove(onLayoutModeChange);
     };
   }, [onLayoutModeChange, editor]);

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "3.12.0-rc.1",
+  "version": "3.12.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "3.12.0-rc.1",
+  "version": "3.12.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request