### PR TITLE
Backmerge: #9084 - Ketcher saves incorrect attachment points configuration for new nucleotides

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.constants.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.constants.ts
@@ -42,6 +42,8 @@ export const NotificationMessages: WizardNotificationMessageMap = {
   noAttachmentPoints: 'The monomer must have at least one attachment point.',
   incorrectAttachmentPointsOrder:
     'Attachment point numbers must be in order, but R1 and R2 may be skipped.',
+  attachmentPointsNotUnique:
+    'Only one attachment point can have the same number.',
   creationSuccessful: 'The monomer was successfully added to the library.',
   creationRNASuccessful: 'The preset was successfully added to the library.',
   incontinuousStructure: 'All monomers must have a continuous structure.',
@@ -72,6 +74,7 @@ export const NotificationTypes: WizardNotificationTypeMap = {
   editingIsNotAllowed: 'error',
   noAttachmentPoints: 'error',
   incorrectAttachmentPointsOrder: 'error',
+  attachmentPointsNotUnique: 'error',
   creationSuccessful: 'info',
   creationRNASuccessful: 'info',
   incontinuousStructure: 'error',

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -1134,6 +1134,37 @@ const MonomerCreationWizard = () => {
       });
     }
 
+    if (
+      assignedAttachmentPointsByMonomer
+        .get(rnaPresetWizardState.sugar)
+        ?.get(AttachmentPointName.R2) ||
+      assignedAttachmentPointsByMonomer
+        .get(rnaPresetWizardState.phosphate)
+        ?.get(AttachmentPointName.R1) ||
+      assignedAttachmentPointsByMonomer
+        .get(rnaPresetWizardState.sugar)
+        ?.get(AttachmentPointName.R3) ||
+      assignedAttachmentPointsByMonomer
+        .get(rnaPresetWizardState.base)
+        ?.get(AttachmentPointName.R1)
+    ) {
+      needSaveMonomers = false;
+      rnaPresetWizardStateDispatch({
+        type: 'SetNotifications',
+        notifications: new Map([
+          [
+            'invalidRnaPresetStructure',
+            {
+              type: 'error',
+              message: NotificationMessages.attachmentPointsNotUnique,
+            },
+          ],
+        ]),
+        rnaComponentKey: 'preset',
+        editor,
+      });
+    }
+
     // check rna preset code
     const presetCode = rnaPresetWizardState.preset.name?.trim();
     if (!presetCode) {

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.types.ts
@@ -47,6 +47,7 @@ export type WizardNotificationId =
   | 'editingIsNotAllowed'
   | 'noAttachmentPoints'
   | 'incorrectAttachmentPointsOrder'
+  | 'attachmentPointsNotUnique'
   | 'creationSuccessful'
   | 'creationRNASuccessful'
   | 'incontinuousStructure'


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request