### PR TITLE
#9193 - Refactor:(TypeScript) Objects and classes converted or coerced t…

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -9,7 +9,6 @@ import {
   MonomerToAtomBond,
   Nucleotide,
   Phosphate,
-  Pool,
   Sugar,
   Vec2,
 } from 'domain/entities';
@@ -1263,43 +1262,4 @@ export class SequenceRenderer {
   private static removeDelegatedEvents() {
     SequenceEventDelegationManager.instance.removeDelegatedEvents();
   }
-}
-
-const getCustomToString = (value: object): string | undefined => {
-  const toStringCandidate = (value as { toString: () => string }).toString;
-  if (
-    typeof toStringCandidate === 'function' &&
-    toStringCandidate !== Object.prototype.toString
-  ) {
-    return toStringCandidate.call(value);
-  }
-  return undefined;
-};
-
-export function sequenceReplacer(key: string, value: unknown): unknown {
-  if (key === 'renderer') {
-    return `<${typeof value}>`;
-  } else if (key === 'baseRenderer') {
-    return `<${typeof value}>`;
-  } else if (['R1', 'R2', 'R3'].includes(key)) {
-    return `<${typeof value}>`;
-  } else if (value instanceof Pool) {
-    return {
-      // eslint-disable-next-line dot-notation
-      nextId: value['nextId'],
-      items: Array.from(value),
-    };
-  } else if (
-    value instanceof Object &&
-    !['Object', 'Array'].includes(value.constructor.name)
-  ) {
-    const valueObj = value as object;
-    const repr = getCustomToString(valueObj);
-    return {
-      ctor: value.constructor.name,
-      ...(repr && { repr }),
-      ...value,
-    };
-  }
-  return value;
 }


### PR DESCRIPTION
Problem:
Objects and classes converted or coerced to strings should define a toString() method

Why is this an issue?

When an object without a custom toString() implementation is converted to a string, JavaScript uses Object.prototype.toString() and returns "[object Object]". This is usually not meaningful and may indicate unintended behavior. Sonar flags these cases because string coercion should produce useful output.


How to fix it?
You can simply define a toString() method for the object or class.
Noncompliant code example (class):
```
class Foo {};
const foo = new Foo();

foo + ''; // Noncompliant - evaluates to "[object Object]"
Foo: ${foo}; // Noncompliant - evaluates to "Foo: [object Object]"
foo.toString(); // Noncompliant - evaluates to "[object Object]"

const foo = {};
foo + ''; // Noncompliant - evaluates to "[object Object]"
Foo: ${foo}; // Noncompliant - evaluates to "Foo: [object Object]"
foo.toString(); // Noncompliant - evaluates to "[object Object]"

```
Compliant solution

```
class Foo {
toString() {
return 'Foo';
}
}
const foo = new Foo();

foo + '';
Foo: ${foo};
foo.toString();

const foo = {
toString: () => {
return 'Foo';
}
}
foo + '';
Foo: ${foo};
foo.toString();
```
Problem locations:
packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts