### PR TITLE
#9203 - Refactor: Objects should not be created to be dropped immediately without being used

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/tools/ClearTool.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/tools/ClearTool.test.ts
@@ -106,8 +106,9 @@ describe('Clear Tool', () => {
     // Try to clear empty canvas - verify hasDrawingEntities is false
     expect(editor.drawingEntitiesManager.hasDrawingEntities).toBe(false);
 
-    // eslint-disable-next-line no-new
-    new ClearTool(editor);
+    const clearTool = new ClearTool(editor);
+
+    expect(clearTool).toBeInstanceOf(ClearTool);
 
     // transientDrawingView.clear should not be called because we return early
     expect(clearSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
### Motivation
- Fix a test that created a `ClearTool` instance without using it, which triggers a static-analysis warning about objects created and immediately dropped and may mask missing behavior.

### Description
- Replace `new ClearTool(editor);` with `const clearTool = new ClearTool(editor);` and add `expect(clearTool).toBeInstanceOf(ClearTool);` so the instance is assigned and explicitly asserted in the test.

### Testing
- Ran `npm run ajv -w packages/ketcher-core` to generate schema artifacts (succeeded) and ran `npm run test:unit -w packages/ketcher-core -- __tests__/application/editor/tools/ClearTool.test.ts` which reported both tests in the suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69942cc603148332b43997668c0164d6)