### PR TITLE
#9210 - refactor reEmage and resimpleObject toggle points logic

### DIFF
--- a/packages/ketcher-core/__tests__/application/render/restruct/restruct.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/restruct/restruct.test.ts
@@ -19,7 +19,8 @@ describe('show selection', () => {
     ],
   };
   const reSimpleObject = new ReSimpleObject(ellipse);
-  reSimpleObject.togglePoints = jest.fn();
+  reSimpleObject.showPoints = jest.fn();
+  reSimpleObject.hidePoints = jest.fn();
   const option = {
     microModeScale: 20,
     width: 100,
@@ -29,11 +30,11 @@ describe('show selection', () => {
   const restruct = new ReStruct(new Struct(), render);
   it('should show selection simple objects correctly when selected', () => {
     restruct.showItemSelection(reSimpleObject, true);
-    expect(reSimpleObject.togglePoints).toHaveBeenCalled();
+    expect(reSimpleObject.showPoints).toHaveBeenCalled();
   });
   it('should show selection simple objects correctly when unselected', () => {
     restruct.showItemSelection(reSimpleObject, false);
-    expect(reSimpleObject.togglePoints).toHaveBeenCalled();
+    expect(reSimpleObject.hidePoints).toHaveBeenCalled();
   });
 });
 

--- a/packages/ketcher-core/src/application/render/restruct/reImage.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reImage.ts
@@ -246,10 +246,12 @@ export class ReImage extends ReObject {
     );
   }
 
-  togglePoints(displayFlag: boolean) {
-    displayFlag
-      ? this.selectionPointsSet?.show()
-      : this.selectionPointsSet?.hide();
+  showPoints() {
+    this.selectionPointsSet?.show();
+  }
+
+  hidePoints() {
+    this.selectionPointsSet?.hide();
   }
 
   calculateDistanceToPoint(point: Vec2, renderOptions: RenderOptions): number {

--- a/packages/ketcher-core/src/application/render/restruct/resimpleObject.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resimpleObject.ts
@@ -402,10 +402,12 @@ class ReSimpleObject extends ReObject {
     return this.selectionSet;
   }
 
-  togglePoints(displayFlag: boolean) {
-    displayFlag
-      ? this.selectionPointsSet?.show()
-      : this.selectionPointsSet?.hide();
+  showPoints() {
+    this.selectionPointsSet?.show();
+  }
+
+  hidePoints() {
+    this.selectionPointsSet?.hide();
   }
 
   show(restruct: ReStruct, options: any): void {

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -909,11 +909,11 @@ class ReStruct {
           fill: '#7f7',
           stroke: '#7f7',
         });
-        if (item.togglePoints) item.togglePoints(true);
+        item.showPoints?.();
       }
     } else if (exists && item.selectionPlate) {
       item.selectionPlate.hide();
-      if (item.togglePoints) item.togglePoints(false);
+      item.hidePoints?.();
       item.additionalInfo?.hide();
       item.cip?.rectangle.attr({
         fill: '#fff',


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
togglePoints method in reEmage and resimpleObject classes was refactored into 2(showPoints, hidePoints)


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request