### PR TITLE
#9160 - Refactor: (TypeScript) Unused assignments should be removed

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/form/form.jsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.jsx
@@ -27,7 +27,7 @@ import { connect } from 'react-redux';
 import { getSelectOptionsFromSchema } from '../../../utils';
 import { updateFormState } from '../../../state/modal/form';
 import { useFormContext } from '../../../../../hooks';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, omit } from 'lodash';
 import { Icon, IconButton } from 'components';
 import { Tooltip } from '@mui/material';
 
@@ -418,11 +418,12 @@ function propSchema(schema, { customValid, serialize = {}, deserialize = {} }) {
     Object.entries(customValid).forEach(([formatName, formatValidator]) => {
       ajv.addFormat(formatName, formatValidator);
 
-      const rest = { ...schemaCopy.properties[formatName] };
-      delete rest.pattern;
-      delete rest.maxLength;
-      delete rest.enum;
-      delete rest.enumNames;
+      const rest = omit(schemaCopy.properties[formatName], [
+        'pattern',
+        'maxLength',
+        'enum',
+        'enumNames',
+      ]);
 
       schemaCopy.properties[formatName] = {
         ...rest,

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
@@ -21,6 +21,7 @@ import { LoadingCircles } from '../Spinner/LoadingCircles';
 import classes from './StructEditor.module.less';
 import clsx from 'clsx';
 import { upperFirst } from 'lodash/fp';
+import { omit } from 'lodash';
 import { FloatingToolContainer } from '../../toolbars';
 import { ContextMenu, ContextMenuTrigger } from '../ContextMenu';
 import InfoPanel from './InfoPanel';
@@ -285,15 +286,7 @@ class StructEditor extends Component {
   }
 
   render() {
-    const {
-      Tag = 'div',
-      className,
-      indigoVerification,
-      ...restProps
-    } = this.props;
-
-    const props = { ...restProps };
-    [
+    const omittedProps = [
       'ketcherId',
       'prevKetcherId',
       'struct',
@@ -324,9 +317,14 @@ class StructEditor extends Component {
       'onUpdateFloatingTools',
       'onShowMacromoleculesErrorMessage',
       'serverSettings',
-    ].forEach((propName) => {
-      delete props[propName];
-    });
+    ];
+
+    const {
+      Tag = 'div',
+      className,
+      indigoVerification,
+      ...props
+    } = omit(this.props, omittedProps);
 
     const { clientX = 0, clientY = 0, tooltip } = this.state;
     const lastCursorPosition = this.editor?.lastCursorPosition;


### PR DESCRIPTION
Problem: (TypeScript) Unused assignments should be removed.

What is the potential impact?
Dead code
An unused variable or local function usually occurs because some logic is no longer required after a code change. In that case, such code becomes unused and never executed.

Also, if you are writing code for the front-end, every unused variable or function remaining in your codebase is just extra bytes you have to send over the wire to your users. Unused code bloats your codebase unnecessarily and impacts the performance of your application.

Wrong logic
It could happen that due to a bad copy-paste or autocompletion, the wrong variable is used, while the right one is only declared. In that case, the unused variable should be used instead of deleted from the codebase.

Memory leaks
Finally, unused functions can also cause memory leaks. For example, an unused function can create a closure over a variable that would otherwise be released to the garbage collector.
```
let theThing = null;
const replaceThing = function () {
  const originalThing = theThing;
  const unused = function () {
    if (originalThing) {
      console.log("hi");
    }
  };
  theThing = {
    longStr: new Array(1000000).join("*"),
    someMethod: function () {
      console.log(someMessage);
    },
  };
};
setInterval(replaceThing, 1000);
```
How fix it?
Usually, the fix for this issue is straightforward, you just need to remove the unused variable declaration, or its name from the declaration statement if it is declared along with other variables.

Noncompliant code example
```
function numberOfMinutes(hours) {
  var seconds = 0;   // seconds is never used
  return hours * 60;
}
```
Compliant solution

```
function numberOfMinutes(hours) {
  return hours * 60;
}
```
Noncompliant code example
When an array destructuring is used and some element of the array is never referenced, one might simply remove it from the destructuring.

```
const [_, params] = url.split(path);
```
Compliant solution
```
const [, params] = url.split(path);
```
Problem locations:
packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.jsx
packages/ketcher-react/src/script/ui/component/form/form/form.jsx
