### PR TITLE
Refactor: #9151-(TypeScript) Fields that are only assigned in the constructor should be 'readonly'

### DIFF
--- a/packages/ketcher-core/src/domain/entities/EmptySequenceNode.ts
+++ b/packages/ketcher-core/src/domain/entities/EmptySequenceNode.ts
@@ -5,9 +5,9 @@ import { BaseMonomer } from 'domain/entities/BaseMonomer';
 
 export class EmptySequenceNode {
   public renderer?: BaseSequenceItemRenderer = undefined;
-  public monomer = new EmptyMonomer();
+  public readonly monomer = new EmptyMonomer();
   // when iterating over large amount of nodes, this saves a lot of GC time
-  private monomersCache = [this.monomer];
+  private readonly monomersCache = [this.monomer];
 
   public get SubChainConstructor() {
     return EmptySubChain;

--- a/packages/ketcher-core/src/domain/entities/MonomerSequenceNode.ts
+++ b/packages/ketcher-core/src/domain/entities/MonomerSequenceNode.ts
@@ -1,8 +1,8 @@
 import { BaseMonomer } from 'domain/entities/BaseMonomer';
 
 export class MonomerSequenceNode {
-  private monomersCache: BaseMonomer[] = [];
-  constructor(public monomer: BaseMonomer) {
+  private readonly monomersCache: BaseMonomer[] = [];
+  constructor(public readonly monomer: BaseMonomer) {
     this.monomersCache = [monomer];
   }
 

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -21,8 +21,11 @@ import { KetMonomerClass } from 'application/formatters';
 import { SnakeLayoutCellWidth } from 'domain/constants';
 
 export class Nucleoside {
-  private monomersCache: BaseMonomer[] = [];
-  constructor(public sugar: Sugar, public rnaBase: RNABase | AmbiguousMonomer) {
+  private readonly monomersCache: BaseMonomer[] = [];
+  constructor(
+    public readonly sugar: Sugar,
+    public readonly rnaBase: RNABase | AmbiguousMonomer,
+  ) {
     this.monomersCache = [sugar, rnaBase];
   }
 

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -20,11 +20,11 @@ import { KetMonomerClass } from 'application/formatters';
 import { SnakeLayoutCellWidth } from 'domain/constants';
 
 export class Nucleotide {
-  private monomersCache: BaseMonomer[] = [];
+  private readonly monomersCache: BaseMonomer[] = [];
   constructor(
-    public sugar: Sugar,
-    public rnaBase: RNABase | AmbiguousMonomer,
-    public phosphate: Phosphate,
+    public readonly sugar: Sugar,
+    public readonly rnaBase: RNABase | AmbiguousMonomer,
+    public readonly phosphate: Phosphate,
   ) {
     this.monomersCache = [sugar, rnaBase, phosphate];
   }

--- a/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
+++ b/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
@@ -83,7 +83,7 @@ interface ClipAreaListeners {
 }
 
 class ClipArea extends Component<ClipAreaProps> {
-  private textAreaRef: RefObject<HTMLTextAreaElement | null>;
+  private readonly textAreaRef: RefObject<HTMLTextAreaElement | null>;
   private target: HTMLElement | null = null;
   private listeners: ClipAreaListeners | null = null;
 

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
@@ -233,9 +233,9 @@ const PreviewContent = ({
 class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
   static contextType = ErrorsContext;
   declare context: React.ContextType<typeof ErrorsContext>;
-  private isRxn: boolean;
-  private textAreaRef: RefObject<HTMLTextAreaElement | null>;
-  private saveSchema: typeof saveSchema;
+  private readonly isRxn: boolean;
+  private readonly textAreaRef: RefObject<HTMLTextAreaElement | null>;
+  private readonly saveSchema: typeof saveSchema;
 
   constructor(props: SaveDialogProps) {
     super(props);


### PR DESCRIPTION
Problem: (TypeScript) Fields that are only assigned in the constructor should be "readonly"

Why is this an issue?
readonly fields can only be assigned in a class constructor. If a class has a field that’s not marked readonly but is only set in the constructor, it could cause confusion about the field’s intended use. To avoid confusion, such fields should be marked readonly to make their intended use explicit, and to prevent future maintainers from inadvertently changing their use.
How to fix it ?

Mark the given field with the readonly modifier.
Noncompliant code example
```
class Person {
  private birthYear: number; // Noncompliant

  constructor(birthYear: number) {
    this.birthYear = birthYear;
  }
}
```
Compliant solution
```
class Person {
  private readonly birthYear: number;

  constructor(birthYear: number) {
    this.birthYear = birthYear;
  }
}
```
Problem locations:
src/main/webapp/app/app.component.ts
src/main/webapp/app/authorization/auth.service.ts
src/main/webapp/app/authorization/login/login.component.ts
src/main/webapp/app/core/dialog/dialog-manager.service.ts
src/main/webapp/app/core/notification/notification.service.ts
src/main/webapp/app/shared/header/header.component.ts
src/main/webapp/app/users/shared/users.service.ts
packages/ketcher-core/src/application/editor/operations/monomerCreation/RemoveAttachmentPointOperation.ts
packages/ketcher-core/src/application/render/renderers/sequence/SequenceEventDelegationManager.ts
packages/ketcher-core/src/domain/entities/EmptySequenceNode.ts
packages/ketcher-core/src/domain/entities/MonomerSequenceNode.ts
packages/ketcher-core/src/domain/entities/Nucleoside.ts
packages/ketcher-core/src/domain/entities/Nucleotide.ts
packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx