### PR TITLE
#9254 - Refactor: Classes should not be empty

### DIFF
--- a/packages/ketcher-core/src/domain/entities/snake-layout-model/EmptySnakeLayoutNode.ts
+++ b/packages/ketcher-core/src/domain/entities/snake-layout-model/EmptySnakeLayoutNode.ts
@@ -1,1 +1,3 @@
-export class EmptySnakeLayoutNode {}
+export class EmptySnakeLayoutNode {
+  public readonly kind = 'empty';
+}


### PR DESCRIPTION
### Motivation
- Replace the empty class `EmptySnakeLayoutNode` with a non-empty marker to satisfy the rule against empty classes while preserving existing `instanceof` semantics.

### Description
- Added a readonly marker property by updating `packages/ketcher-core/src/domain/entities/snake-layout-model/EmptySnakeLayoutNode.ts` to `export class EmptySnakeLayoutNode { public readonly kind = 'empty'; }`, with no other behavioral changes.

### Testing
- Ran `pnpm -C packages/ketcher-core run test:types` which failed due to unrelated pre-existing TypeScript errors, and attempted `pnpm -C packages/ketcher-core run test:eslint -- src/domain/entities/snake-layout-model/EmptySnakeLayoutNode.ts` which could not run in this environment due to an ESLint configuration mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e7e18f948332bbef40dec6b10144)