### PR TITLE
Update auto_assign.yml to simplify assignee groups

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,8 +6,3 @@ reviewGroups:
   core:
     - svvald
     - rrodionov91
-  developers:
-    - NataliaLoginova
-  QA:
-    - Zhirnoff
-    - AlexeyGirin


### PR DESCRIPTION
[]
Removed developers and QA groups from auto assign configuration.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request