### PR TITLE
Fixed context menu

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -129,9 +129,6 @@ const debouncedTurnOffScrollAnimation = debounce(
   SCROLL_SMOOTHNESS_IM_MS,
 );
 
-interface KetcherTarget extends EventTarget {
-  parent: HTMLElement | SVGElement | null; // Define what parent actually is
-}
 interface ICoreEditorConstructorParams {
   ketcherId?: string;
   theme;
@@ -613,13 +610,9 @@ export class CoreEditor {
     document.addEventListener('keydown', this.hotKeyEventHandler);
   }
 
-  isKetcherTarget(target: EventTarget | null): target is KetcherTarget {
-    return target !== null && 'parent' in target;
-  }
-
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
-      if (!this.isKetcherTarget(event?.currentTarget)) {
+      if (!this.ketcherRootElement?.contains(event.currentTarget as Node)) {
         return;
       }
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -129,6 +129,9 @@ const debouncedTurnOffScrollAnimation = debounce(
   SCROLL_SMOOTHNESS_IM_MS,
 );
 
+interface KetcherTarget extends EventTarget {
+  parent: HTMLElement | SVGElement | null; // Define what parent actually is
+}
 interface ICoreEditorConstructorParams {
   ketcherId?: string;
   theme;
@@ -610,8 +613,16 @@ export class CoreEditor {
     document.addEventListener('keydown', this.hotKeyEventHandler);
   }
 
+  isKetcherTarget(target: EventTarget | null): target is KetcherTarget {
+    return target !== null && 'parent' in target;
+  }
+
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
+      if (!this.isKetcherTarget(event?.currentTarget)) {
+        return;
+      }
+
       event.preventDefault();
 
       if (this.libraryItemDragState) {


### PR DESCRIPTION
**The Problem**: Ketcher was attaching a contextmenu event listener (likely to a global object) that was calling event.preventDefault() unconditionally. This resulted in two issues:

**Scope Creep**: Right-clicking anywhere in the host app (outside Ketcher) was blocked.

**Persistence Bug**: Because the listener wasn't being properly scoped or removed, the context menu remained blocked even after Ketcher was unmounted from the DOM.

**The Fix**:
The `setupContextMenuEvents` has been updated to include a guard clause. The handler now verifies that the event target is contained within this.ketcherRootElement.

**Impact**:

If the user right-clicks outside of Ketcher, the event is ignored by this handler, allowing the global context menu to work.

If Ketcher is unmounted, this.ketcherRootElement will be null/absent, preventing the "zombie" listener from blocking clicks on the rest of the application.