### PR TITLE
#9267 - Refactor: "Array.prototype.sort()" and "Array.prototype.toSorted()" should use a compare function

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1290,7 +1290,9 @@ class Editor implements KetcherEditor {
 
     const attachmentPoints: IKetAttachmentPoint[] = [];
     const sortedAttachmentPointsData = new Map<string, [number, number]>(
-      [...data.attachmentPoints].sort(),
+      [...data.attachmentPoints].sort(([leftName], [rightName]) =>
+        leftName.localeCompare(rightName),
+      ),
     );
 
     sortedAttachmentPointsData.forEach(


### PR DESCRIPTION
### Motivation
- Ensure `Array.prototype.sort()` is called with an explicit compare function for attachment point entries to avoid default lexicographic behavior and address issue #9267.

### Description
- Replace `[...]data.attachmentPoints.sort()` with `[...]data.attachmentPoints.sort(([leftName],[rightName]) => leftName.localeCompare(rightName))` in `Editor.saveNewMonomer` so attachment points are ordered by name using `localeCompare`.

### Testing
- Ran `pnpm -s eslint packages/ketcher-react/src/script/editor/Editor.ts`, which failed in this environment because the ESLint config `standard` (e.g. `eslint-config-standard`) could not be resolved, and pre-commit hooks also failed due to missing `lint-staged`/husky tooling, so no further linting succeeded here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996d01e5e608332bd70bd656beb966c)