### PR TITLE
#9298: Refactor: (TypeScript) Two branches in a conditional structure should not have exactly the same implementation

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -668,16 +668,11 @@ export class CoreEditor {
       ) {
         this.events.rightClickPolymerBond.dispatch([event, eventData]);
       } else if (
-        eventData instanceof BaseMonomerRenderer &&
-        eventData.monomer.selected
+        (eventData instanceof BaseMonomerRenderer &&
+          eventData.monomer.selected) ||
+        (hasSelectedEntities && eventData?.drawingEntity?.selected)
       ) {
-        this.events.rightClickSelectedMonomers.dispatch([event]);
-        this.events.rightClickSelectedMonomers.dispatch([
-          event,
-          selectedMonomers,
-        ]);
-      } else if (hasSelectedEntities && eventData?.drawingEntity?.selected) {
-        // Handle right-click on selected microstructures (atoms, bonds, arrows, etc.)
+        // Handle right-click on selected entities (monomers and microstructures).
         this.events.rightClickSelectedMonomers.dispatch([event]);
         this.events.rightClickSelectedMonomers.dispatch([
           event,

--- a/packages/ketcher-core/src/domain/entities/atom.ts
+++ b/packages/ketcher-core/src/domain/entities/atom.ts
@@ -339,7 +339,7 @@ export class Atom extends BaseMicromoleculeEntity {
   }
 
   static getAttrHash(atom: Atom) {
-    const attrs: any = {};
+    const attrs: Partial<Record<keyof typeof Atom.attrlist, unknown>> = {};
     for (const attr in Atom.attrlist) {
       if (typeof atom[attr] !== 'undefined') attrs[attr] = atom[attr];
     }
@@ -767,16 +767,14 @@ export class Atom extends BaseMicromoleculeEntity {
       let valence = connectionCount;
       let hydrogenCount = 0;
 
-      if (charge === -1) {
-        if (connectionCount <= 2) {
-          valence = 2;
-          hydrogenCount = 2 - radicalCount - connectionCount - absCharge;
-        }
+      if (
+        (charge === -1 || charge === 0 || charge === 2) &&
+        connectionCount <= 2
+      ) {
+        valence = 2;
+        hydrogenCount = 2 - radicalCount - connectionCount - absCharge;
       } else if (charge === 0 || charge === 2) {
-        if (connectionCount <= 2) {
-          valence = 2;
-          hydrogenCount = 2 - radicalCount - connectionCount - absCharge;
-        } else if (connectionCount <= 4) {
+        if (connectionCount <= 4) {
           valence = 4;
           hydrogenCount = 4 - radicalCount - connectionCount - absCharge;
         } else if (charge === 0 && connectionCount <= 6) {
@@ -1088,12 +1086,12 @@ export class Atom extends BaseMicromoleculeEntity {
   }
 }
 
-export function radicalElectrons(radical: any) {
-  radical -= 0;
-  if (radical === Atom.PATTERN.RADICAL.DOUPLET) return 1;
+export function radicalElectrons(radical: unknown) {
+  const normalizedRadical = Number(radical);
+  if (normalizedRadical === Atom.PATTERN.RADICAL.DOUPLET) return 1;
   else if (
-    radical === Atom.PATTERN.RADICAL.SINGLET ||
-    radical === Atom.PATTERN.RADICAL.TRIPLET
+    normalizedRadical === Atom.PATTERN.RADICAL.SINGLET ||
+    normalizedRadical === Atom.PATTERN.RADICAL.TRIPLET
   ) {
     return 2;
   } else {


### PR DESCRIPTION
Problem : Two branches in a conditional structure should not have exactly the same implementation.
Why is this an issue?
When the same code is duplicated in two or more separate branches of a conditional, it can make the code harder to understand, maintain, and can potentially introduce bugs if one instance of the code is changed but others are not.
Having two cases in a switch statement or two branches in an if chain with the same implementation is at best duplicate code, and at worst a coding error.
```
if (a >= 0 && a < 10) {
  doFirstThing();
  doTheThing();
}
else if (a >= 10 && a < 20) {
  doTheOtherThing();
}
else if (a >= 20 && a < 50) {
  doFirstThing();
  doTheThing();  // Noncompliant; duplicates first condition
}
else {
  doTheRest();
}

switch (i) {
  case 1:
    doFirstThing();
    doSomething();
    break;
  case 2:
    doSomethingDifferent();
    break;
  case 3:  // Noncompliant; duplicates case 1's implementation
    doFirstThing();
    doSomething();
    break;
  default:
    doTheRest();
}
```
If the same logic is truly needed for both instances, then:

in an if chain they should be combined

```
if ((a >= 0 && a < 10) || (a >= 20 && a < 50)) { // Compliant
  doFirstThing();
  doTheThing();
}
else if (a >= 10 && a < 20) {
  doTheOtherThing();
}
else {
  doTheRest();
}
```
for a switch, one should fall through to the other
```
switch (i) {
  case 1:
  case 3: // Compliant
    doFirstThing();
    doSomething();
    break;
  case 2:
    doSomethingDifferent();
    break;
  default:
    doTheRest();
}
```
When all blocks are identical, either this rule will trigger if there is no default clause or rule [S3923](https://sonar.epam.com/sonarqube/coding_rules#rule_key=javascript%3AS3923) will raise if there is a default clause.
Exceptions
Unless all blocks are identical, blocks in an if chain that contain a single line of code are ignored. The same applies to blocks in a switch statement that contains a single line of code with or without a following break.
```
if (a == 1) {
  doSomething();  // Compliant, usually this is done on purpose to increase the readability
} else if (a == 2) {
  doSomethingElse();
} else {
  doSomething();
}
```
Problem Locations:
packages/ketcher-core/src/application/editor/Editor.ts
packages/ketcher-core/src/domain/entities/atom.ts