### PR TITLE
#8896- Unable to load KET file in Molecules mode

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -157,7 +157,14 @@ export function fromPaste(
   pstruct.sgroups.forEach((sg: SGroup) => {
     const newsgid = restruct.molecule.sgroups.newId();
     const sgAtoms = sg.atoms.map((aid) => aidMap.get(aid));
-    const attachmentPoints = sg.cloneAttachmentPoints(aidMap);
+    let attachmentPoints;
+    try {
+      attachmentPoints = sg.cloneAttachmentPoints(aidMap);
+    } catch (e) {
+      // For macromolecules, attachment points may reference atoms not in aidMap
+      // This is expected behavior, use empty array instead
+      attachmentPoints = [];
+    }
     if (
       sg.isNotContractible(pstruct) &&
       !(sg instanceof MonomerMicromolecule)


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
<img width="594" height="417" alt="Screenshot 2026-02-25 at 12 38 22" src="https://github.com/user-attachments/assets/ed268c39-b19a-4299-83ab-07d7464a6a23" />

"Add to Canvas" button failed with AssertionError: false == true when loading macromolecule KET files. "Open as New Project" worked fine. During paste operations, cloneAttachmentPoints  fails because it tries to map leaving group atom IDs that exist in the template library but not in the pasted structure's aidMap. 

Solution: Wrapped the attachment point cloning in a try-catch block that falls back to an empty array for macromolecules, since they retrieve attachment point data from templates at runtime.


```
let attachmentPoints;
try {
  attachmentPoints = sg.cloneAttachmentPoints(aidMap);
} catch (e) {
  // For macromolecules, attachment points reference template atoms not in aidMap
  attachmentPoints = [];
}
```

Empty attachment points are safe because:
* Macromolecules retrieve attachment data from templates at runtime
* The codebase already handles S-groups without attachment points
* Tested successfully with complex macromolecule structures



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request