### PR TITLE
#9342 - Refactor: replace logical AND checks with optional chaining

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -469,7 +469,7 @@ export class RenderersManager {
     const viewModel = editor.viewModel;
     const canvas = ZoomTool.instance?.canvas;
 
-    if (!canvas || !canvas.selectAll) {
+    if (!canvas?.selectAll) {
       return;
     }
 

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
@@ -426,10 +426,7 @@ export const selectFilteredMonomers = createSelector(
 
           return (
             idtBase?.endsWith(aliasRest) ||
-            (idtModifications &&
-              idtModifications
-                .split(' ')
-                .some((mod) => mod.endsWith(aliasRest)))
+            idtModifications?.split(' ').some((mod) => mod.endsWith(aliasRest))
           );
         }
 

--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -539,7 +539,7 @@ class SGroupTool implements Tool {
     functionalGroups,
     result: Array<number>,
   ) {
-    if (!atomsResult || !atomsResult.length) {
+    if (!atomsResult?.length) {
       return;
     }
 
@@ -560,7 +560,7 @@ class SGroupTool implements Tool {
     molecule,
     result: Array<number>,
   ) {
-    if (!bondsResult || !bondsResult.length) {
+    if (!bondsResult?.length) {
       return;
     }
 


### PR DESCRIPTION
Replace `foo && foo.bar` patterns with `foo?.bar` optional chaining in RenderersManager.ts, librarySlice.ts, and sgroup.ts.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request