### PR TITLE
#9405 - Refactor: Objects should not be created to be dropped immediately without being used

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/tools/ZoomTool.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/tools/ZoomTool.test.ts
@@ -37,8 +37,8 @@ describe('Zoom Tool', () => {
   it('should zoom in when scroll mouse wheel up and press CTRL', () => {
     jest.spyOn(ZoomTool.prototype, 'zoomAction').mockImplementation(zoomed);
 
-    // eslint-disable-next-line no-new
-    new CoreEditor({
+    // @ts-expect-error TS6133: Instantiated for side effects (singleton registration)
+    const _editor = new CoreEditor({
       theme: polymerEditorTheme,
       canvas,
     });

--- a/packages/ketcher-core/__tests__/domain/serializers/ket/KetSerializer.test.ts
+++ b/packages/ketcher-core/__tests__/domain/serializers/ket/KetSerializer.test.ts
@@ -44,8 +44,8 @@ const ket = new KetSerializer();
 
 describe('deserialize (ToStruct)', () => {
   const canvas = createPolymerEditorCanvas();
-  // eslint-disable-next-line no-new
-  new CoreEditor({ canvas, theme: {} });
+  // @ts-expect-error TS6133: Instantiated for side effects (singleton registration)
+  const _editor = new CoreEditor({ canvas, theme: {} });
   const parsedPrepareContent = JSON.parse(preparedKet);
   const deserData = ket.deserialize(preparedKet);
   it('correct work with atoms', () => {
@@ -180,8 +180,8 @@ describe('deserialize (ToStruct)', () => {
 
 describe('serialize (ToKet)', () => {
   const canvas = createPolymerEditorCanvas();
-  // eslint-disable-next-line no-new
-  new CoreEditor({ canvas, theme: {} });
+  // @ts-expect-error TS6133: Instantiated for side effects (singleton registration)
+  const _editor = new CoreEditor({ canvas, theme: {} });
   const parsedNewPrepareStruct = JSON.parse(ket.serialize(prepareStruct));
   const parsedPrepareContent = JSON.parse(preparedKet);
   it('correct work with atoms', () => {

--- a/packages/ketcher-core/__tests__/mock-data.ts
+++ b/packages/ketcher-core/__tests__/mock-data.ts
@@ -775,10 +775,10 @@ export const getFinishedPolymerBond = (x1, y1, x2, y2) => {
   const peptide2 = new Peptide(peptideMonomerItem);
   peptide.moveAbsolute(new Vec2(x1, y1));
   peptide2.moveAbsolute(new Vec2(x2, y2));
-  // eslint-disable-next-line no-new
-  new PeptideRenderer(peptide);
-  // eslint-disable-next-line no-new
-  new PeptideRenderer(peptide2);
+  // @ts-expect-error TS6133: Instantiated for side effects (renderer self-registers with monomer)
+  const _renderer1 = new PeptideRenderer(peptide);
+  // @ts-expect-error TS6133: Instantiated for side effects (renderer self-registers with monomer)
+  const _renderer2 = new PeptideRenderer(peptide2);
 
   const polymerBond = new PolymerBond(peptide);
   polymerBond.setSecondMonomer(peptide2);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Replaced bare `new` expressions (flagged by static analysis rule S1848 / `no-new`) with variable assignments in
   test files
 - `CoreEditor` and `PeptideRenderer` constructors are called for side effects only (singleton registration and
   renderer-to-monomer binding), so the resulting objects are intentionally unused
 - Used `_`-prefixed variable names to satisfy ESLint `no-unused-vars` (`varsIgnorePattern: "^_"`) and
   `@ts-expect-error TS6133` to satisfy TypeScript `noUnusedLocals`


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request