### PR TITLE
#9102 - Incorrect selection a part of structure for phosphate when moving mouse from top to bottom

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -282,7 +282,7 @@ const rnaPresetWizardReducer = (
       ...state,
       [rnaComponentKey]: {
         ...state[rnaComponentKey],
-        structure: restAction.editor?.selection(),
+        structure: restAction.editor?.explicitSelected(),
       },
     };
   }

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
@@ -101,7 +101,7 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
   const handleClickCreateComponent = useCallback(
     (rnaComponentKey: RnaPresetComponentKey) => {
       // Get the current selection from the editor
-      const selection = editor.selection();
+      const selection = editor.explicitSelected();
       const atomIds = selection?.atoms || [];
       const bondIds = selection?.bonds || [];
 


### PR DESCRIPTION
Fix: RNA preset wizard fails non-deterministically when selecting atoms top-to-bottom

Problem
When using the RNA preset (Nucleotide preset) wizard and selecting atoms for a component (Base/Sugar/Phosphate) via rubber-band selection, clicking Submit would sometimes show:

"Structure of rna preset component contains issues. Please adjust the structure."
"All monomers must have a continuous structure."

The failure was non-deterministic — the same selection could succeed or fail depending on mouse speed and direction.

Root Cause
The rubber-band selection engine (getElementsInRectangle in locate.ts) only includes a bond in the selection if its midpoint falls strictly inside the selection rectangle. This midpoint is evaluated at the last mousemove event before mouseup.

Because mousemove fires at a rate proportional to mouse speed:

Slow drag → many events → final rectangle closely matches the atoms → bond midpoints land inside → bonds included ✅
Fast drag → fewer events → final rectangle is coarser → bond midpoints may land outside → bonds missing ❌


Fix
// Before — bond midpoint must be inside rectangle (mouse-speed dependent)
`structure: restAction.editor?.selection()`

// After — any bond with both atoms selected is included
`structure: restAction.editor?.explicitSelected()`

Affected Files
- MonomerCreationWizard.tsx
- RnaPresetTabs.tsx


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request