### PR TITLE
#9136 - Gray arrows and tooltips are missing when hovering an already marked component in the Monomer Creation Wizard

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -554,7 +554,9 @@ class ReBond extends ReObject {
   public drawFragmentSelectionPreview(
     render: Render,
     atomIdToDrawArrows: number,
+    isDisabled = false,
   ) {
+    const color = isDisabled ? '#B3B3B3' : '#365CFF';
     this.hovering?.node?.remove();
 
     const halfBond1 =
@@ -616,7 +618,7 @@ class ReBond extends ReObject {
         contourSize.y,
         contourBorderRadius,
       )
-      .attr({ fill: 'none', stroke: '#365CFF', 'stroke-width': 0.7 });
+      .attr({ fill: 'none', stroke: color, 'stroke-width': 0.7 });
 
     render.ctab.addReObjectPath(LayerMap.additionalInfo, newVisel, contour);
     // TODO find another way instead of this.visel.paths[0] to move by Z only bond skeleton without selection, hover etc
@@ -662,7 +664,7 @@ class ReBond extends ReObject {
             }`,
         )
         .attr({
-          stroke: '#365CFF',
+          stroke: color,
           'stroke-width': 2,
         });
 

--- a/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
+++ b/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
@@ -1,5 +1,6 @@
 import {
   CoordinateTransformation,
+  MonomerMicromolecule,
   Struct,
   Vec2,
   Visel,
@@ -130,6 +131,7 @@ export default class FragmentSelectionTool implements Tool {
   private removeBondPreview() {
     if (this.bondPreview) {
       this.bondPreview.paths.forEach((path) => path.remove());
+      this.bondPreview = null;
     }
   }
 
@@ -211,6 +213,11 @@ export default class FragmentSelectionTool implements Tool {
 
     if (componentData.componentAtoms.has(startAtomId)) {
       this.setDisabledState(COMPONENT_TOOLTIP);
+      this.bondPreview = reBond.drawFragmentSelectionPreview(
+        this.editor.render,
+        startAtomId,
+        true,
+      );
       return;
     }
 
@@ -417,6 +424,13 @@ export default class FragmentSelectionTool implements Tool {
     rnaComponentAtoms?.forEach((component) => {
       component.atoms?.forEach((atomId) => componentAtoms.add(atomId));
       component.bonds?.forEach((bondId) => componentBonds.add(bondId));
+    });
+
+    // Atoms belonging to a MonomerMicromolecule sgroup are already-marked components
+    struct.sgroups.forEach((sgroup) => {
+      if (sgroup instanceof MonomerMicromolecule) {
+        sgroup.atoms.forEach((atomId) => componentAtoms.add(atomId));
+      }
     });
 
     if (componentAtoms.size) {


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

When hovering over a bond in the Fragment Selection Tool where the first
atom in the hovered direction belongs to an already-marked component,
gray arrows and a tooltip were not shown.

Root cause 1: When componentAtoms.has(startAtomId) was true,
setDisabledState() was called but drawFragmentSelectionPreview() was
never called, so no arrows were rendered at all.

Root cause 2: getComponentData() only checked rnaComponentAtoms
(populated only via RNA Preset Wizard clicks). For KET files with
expanded monomers, atoms live in MonomerMicromolecule SGroups in the
struct and were never added to componentAtoms.

Fix:
- Add isDisabled param to drawFragmentSelectionPreview() in rebond.ts
  to support gray (#B3B3B3) vs active (#365CFF) color
- Call drawFragmentSelectionPreview() with isDisabled=true in the
  already-marked-component branch in fragmentSelection.ts
- Detect MonomerMicromolecule SGroup atoms in getComponentData() so
  KET-loaded monomers are treated as already-marked components
- Set this.bondPreview = null after cleanup in removeBondPreview()

<img width="626" height="528" alt="Screenshot 2026-03-17 at 09 55 25" src="https://github.com/user-attachments/assets/1861a3c3-33da-40b2-ae85-093c69972e3a" />


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request