### PR TITLE
#9435-Refactor: Explicit Any type clean up (part 2.2)

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-2.27.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-2.27.0-bugs.spec.ts
@@ -9,7 +9,6 @@ import {
   pasteFromClipboardAndAddToMacromoleculesCanvas,
   MacroFileType,
   openFileAndAddToCanvasAsNewProjectMacro,
-  takePageScreenshot,
   openFileAndAddToCanvasAsNewProject,
   takeLeftToolbarMacromoleculeScreenshot,
   takeMonomerLibraryScreenshot,

--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.4.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.4.0-bugs.spec.ts
@@ -15,7 +15,6 @@ import {
   takeTopToolbarScreenshot,
   SdfFileFormat,
   clickInTheMiddleOfTheScreen,
-  takePageScreenshot,
   MolFileFormat,
   clickOnCanvas,
   openFile,

--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.6.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.6.0-bugs.spec.ts
@@ -18,7 +18,6 @@ import {
   openFile,
   readFileContent,
   MolFileFormat,
-  takePageScreenshot,
 } from '@utils';
 import { waitForSpinnerFinishedWork } from '@utils/common';
 import {

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/RNA-Builder/rna-layout.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/RNA-Builder/rna-layout.spec.ts
@@ -1,10 +1,10 @@
 import { Page, test } from '@fixtures';
 import { waitForPageInit } from '@utils/common';
-import { takeMonomerLibraryScreenshot, takePageScreenshot } from '@utils';
+import { takeMonomerLibraryScreenshot } from '@utils';
 import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 import { Library } from '@tests/pages/macromolecules/Library';
 
-/* 
+/*
 Test case: #3063 - Add e2e tests for Macromolecule editor
 */
 async function createRNA(page: Page) {

--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
@@ -33,7 +33,7 @@ interface Props {
   options: Array<Option>;
   onChange: (value: string) => void;
   className?: string;
-  value?: string;
+  value?: string | number;
   multiple?: boolean;
   disabled?: boolean;
   formName?: string;

--- a/packages/ketcher-react/src/script/ui/state/store.types.ts
+++ b/packages/ketcher-react/src/script/ui/state/store.types.ts
@@ -45,7 +45,24 @@ export interface ModalState {
   };
 }
 
+export interface AnalyseValues {
+  gross?: string;
+  'molecular-weight'?: number;
+  'monoisotopic-mass'?: number;
+  'mass-composition'?: string;
+  [key: string]: string | number | undefined;
+}
+
+export interface AnalyseState {
+  values: AnalyseValues | null;
+  loading: boolean;
+  roundWeight: number;
+  roundMass: number;
+  roundElAnalysis: number;
+}
+
 export interface OptionsState {
+  analyse: AnalyseState;
   settings: Record<string, unknown>;
 }
 

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Analyse/Analyse.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Analyse/Analyse.tsx
@@ -26,6 +26,8 @@ import { connect } from 'react-redux';
 import { range } from 'lodash/fp';
 import Select from '../../../../../component/form/Select';
 import { getSelectOptionsFromSchema } from '../../../../../utils';
+import { Action } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 
 interface AnalyseValues {
   gross?: string;
@@ -175,8 +177,7 @@ function AnalyseDialog({
                 <span>Decimal places</span>
                 <Select
                   options={selectOptions}
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  value={round[item.round] as any}
+                  value={round[item.round]}
                   onChange={(val) => {
                     if (item.round) {
                       onChangeRound(item.round, val);
@@ -194,8 +195,21 @@ function AnalyseDialog({
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mapStateToProps = (state: any) => ({
+interface AnalyseState {
+  values: AnalyseValues | null;
+  loading: boolean;
+  roundWeight: number;
+  roundMass: number;
+  roundElAnalysis: number;
+}
+
+interface RootState {
+  options: {
+    analyse: AnalyseState;
+  };
+}
+
+const mapStateToProps = (state: RootState) => ({
   values: state.options.analyse.values,
   loading: state.options.analyse.loading,
   round: {
@@ -205,18 +219,14 @@ const mapStateToProps = (state: any) => ({
   },
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mapDispatchToProps = (dispatch: any) => ({
+type AppDispatch = ThunkDispatch<RootState, unknown, Action<string>>;
+
+const mapDispatchToProps = (dispatch: AppDispatch) => ({
   onAnalyse: () => dispatch(analyse()),
   onChangeRound: (roundName: string, val: string) =>
     dispatch(changeRound(roundName, val)),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const Analyse = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-)(AnalyseDialog as any) as any;
+const Analyse = connect(mapStateToProps, mapDispatchToProps)(AnalyseDialog);
 
 export default Analyse;

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Analyse/Analyse.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Analyse/Analyse.tsx
@@ -17,25 +17,18 @@
 import { FormulaInput, FrozenInput } from './components';
 
 import { ReactElement, useEffect } from 'react';
+import { Action } from 'redux';
+import { connect } from 'react-redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { range } from 'lodash/fp';
 import { Dialog } from '../../../../components';
 import { DialogParams } from '../../../../../../../components/Dialog/Dialog';
 import { analyse } from '../../../../../state/server';
 import { changeRound } from '../../../../../state/options';
-import classes from './Analyse.module.less';
-import { connect } from 'react-redux';
-import { range } from 'lodash/fp';
 import Select from '../../../../../component/form/Select';
 import { getSelectOptionsFromSchema } from '../../../../../utils';
-import { Action } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
-
-interface AnalyseValues {
-  gross?: string;
-  'molecular-weight'?: number;
-  'monoisotopic-mass'?: number;
-  'mass-composition'?: string;
-  [key: string]: string | number | undefined;
-}
+import { AnalyseValues, StoreState } from '../../../../../state/store.types';
+import classes from './Analyse.module.less';
 
 interface RoundSettings {
   roundWeight: number;
@@ -195,21 +188,7 @@ function AnalyseDialog({
   );
 }
 
-interface AnalyseState {
-  values: AnalyseValues | null;
-  loading: boolean;
-  roundWeight: number;
-  roundMass: number;
-  roundElAnalysis: number;
-}
-
-interface RootState {
-  options: {
-    analyse: AnalyseState;
-  };
-}
-
-const mapStateToProps = (state: RootState) => ({
+const mapStateToProps = (state: StoreState) => ({
   values: state.options.analyse.values,
   loading: state.options.analyse.loading,
   round: {
@@ -219,7 +198,7 @@ const mapStateToProps = (state: RootState) => ({
   },
 });
 
-type AppDispatch = ThunkDispatch<RootState, unknown, Action<string>>;
+type AppDispatch = ThunkDispatch<StoreState, unknown, Action<string>>;
 
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   onAnalyse: () => dispatch(analyse()),


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
- Removed all usages of "any" type from "Analyse.tsx".
- Added explicit typing and interfaces for Analyse state and mapping.
- Modified Select.tsx to accept both `string` and `number` as value to align with actual implementation in Analyse.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request