### PR TITLE
#9444 - Refactor: Empty collections should not be accessed or iterated

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -362,7 +362,6 @@ export function setExpandMonomerSGroup(
   });
 
   const sameLine = new Set<number>();
-  const complementaryLine = new Set<number>();
 
   sGroupsToMove.forEach((sGroupIds) => {
     sGroupIds.forEach((sGroupId) => {
@@ -473,8 +472,7 @@ export function setExpandMonomerSGroup(
       const moveUp = movableSGroupCenter.y < sGroupCenter.y;
       const moveRight = movableSGroupCenter.x > sGroupCenter.x;
       const moveLeft = movableSGroupCenter.x < sGroupCenter.x;
-      const moveHorizontally =
-        sameLine.has(sGroupId) || complementaryLine.has(sGroupId);
+      const moveHorizontally = sameLine.has(sGroupId);
       const moveVertically = !moveHorizontally;
 
       let horizontalDirection = 0;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

**Changes:**
- Removed the `complementaryLine` variable (it was never populated)
- Simplified `moveHorizontally` to use only `sameLine.has(sGroupId)`

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request