### PR TITLE
#9446 - Refactor: Variables are missing in props validation (let's rewrite JS to TS) 31

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.tsx
@@ -61,8 +61,6 @@ interface StructEditorProps {
 
 interface StructEditorState {
   enableCursor: boolean;
-  clientX: number;
-  clientY: number;
   tooltip: string;
 }
 
@@ -123,8 +121,6 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
     super(props);
     this.state = {
       enableCursor: false,
-      clientX: 0,
-      clientY: 0,
       tooltip: '',
     };
     this.editorRef = createRef();
@@ -261,8 +257,6 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
     });
 
     this.editor.event.cursor.add((csr) => {
-      let clientX, clientY;
-
       switch (csr.status) {
         case 'enable': {
           this.editorRef.current?.classList.add(classes.enableCursor);
@@ -274,8 +268,8 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
               bottom: 0,
             };
 
-          clientX = csr.cursorPosition.clientX;
-          clientY = csr.cursorPosition.clientY;
+          const clientX = csr.cursorPosition.clientX;
+          const clientY = csr.cursorPosition.clientY;
 
           const handShouldBeShown =
             clientX >= left &&
@@ -294,8 +288,6 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
           this.editorRef.current?.classList.add(classes.enableCursor);
           this.setState({
             enableCursor: true,
-            clientX,
-            clientY,
           });
           break;
         }
@@ -371,24 +363,14 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
     const remaining = omit(this.props, omittedProps) as StructEditorProps;
     const { Tag = 'div', className, indigoVerification, ...props } = remaining;
 
-    const { clientX = 0, clientY = 0, tooltip } = this.state;
+    const { tooltip } = this.state;
     const lastCursorPosition = this.editor?.lastCursorPosition;
 
     const TagComponent = (Tag || 'div') as ElementType;
 
-    const infoPanelProps = {
-      clientX,
-      clientY,
-      render: this.props.render,
-      groupStruct: this.props.groupStruct,
-      sGroup: this.props.sGroup,
-    };
-    // @ts-expect-error ownProps not exposed by connected component types
-    const infoPanel = <InfoPanel {...infoPanelProps} />;
-    // @ts-expect-error ownProps not exposed by connected component types
-    const infoTooltip = <InfoTooltip render={this.props.render} />;
+    const infoPanel = <InfoPanel />;
+    const infoTooltip = <InfoTooltip />;
     const tooltipElement = (
-      // @ts-expect-error Tooltip return type includes falsy value
       <Tooltip
         message={tooltip}
         position={{

--- a/packages/ketcher-react/src/script/ui/views/components/Tooltip/Tooltip.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/Tooltip/Tooltip.tsx
@@ -23,7 +23,7 @@ export interface TooltipProps {
 const OFFSET_FROM_POSITION = 10;
 
 export const Tooltip = (props: TooltipProps) =>
-  props.message && (
+  props.message ? (
     <div
       className={`${styles.container}`}
       style={{
@@ -34,4 +34,4 @@ export const Tooltip = (props: TooltipProps) =>
     >
       {props.message}
     </div>
-  );
+  ) : null;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Converted StructEditor.jsx to TypeScript (StructEditor.tsx)
  - Added StructEditorProps interface defining all component props including ketcherId, struct, tool, toolOpts, options,
   event handlers (onZoomIn, onZoomOut, onInit, etc.), and an index signature for dynamic on[Event] props
  - Added StructEditorState interface for component state (enableCursor, clientX, clientY, tooltip)
  - Typed class fields (editor, editorRef, logRef), all lifecycle methods, and helper functions (setupEditor,
  removeEditorHandlers)
  - Typed handleWheel event handler with WheelEvent
  - Used optional chaining for ref access instead of non-null assertions
  - Added null-safe fallback for getBoundingClientRect() when ref may be null
  - Fixed Tooltip position to use nullish coalescing (?? 0) for optional cursor coordinates
  - Guarded logRef.current with early return in message handler

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request