### PR TITLE
#9141 - System removes atoms that holds unoccopied leaving groups if user removes abbreviation from monomer on molecules canvas

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -647,21 +647,38 @@ export function fromSgroupDeletion(restruct: Restruct, id, needPerform = true) {
 
   // After SGroup is deleted, resolve leaving groups on plain structure
   if (sG instanceof MonomerMicromolecule) {
+    const isExpanded = sG.isExpanded();
     const monomerCaps = sG.monomer?.monomerItem?.props?.MonomerCaps || {};
     cachedAttachmentPoints?.forEach((attachmentPoint) => {
       const leaveAtomId = attachmentPoint.leaveAtomId;
       const attachmentAtomId = attachmentPoint.atomId;
 
       if (isNumber(leaveAtomId) && isNumber(attachmentAtomId)) {
+        const apNumber = attachmentPoint.attachmentPointNumber;
         const isOccupied = Array.from(struct.bonds.values()).some(
-          ({ begin: bondBegin, end: bondEnd }: BondAttributes) => {
+          ({
+            begin: bondBegin,
+            end: bondEnd,
+            beginSuperatomAttachmentPointNumber,
+            endSuperatomAttachmentPointNumber,
+          }: BondAttributes) => {
             const isAttached =
               bondBegin === attachmentAtomId || bondEnd === attachmentAtomId;
             if (!isAttached) return false;
             const otherAtomId =
               bondBegin === attachmentAtomId ? bondEnd : bondBegin;
             if (otherAtomId === leaveAtomId) return false;
-            return !atoms.includes(otherAtomId);
+            if (!atoms.includes(otherAtomId)) {
+              const bondApNumber =
+                bondBegin === attachmentAtomId
+                  ? beginSuperatomAttachmentPointNumber
+                  : endSuperatomAttachmentPointNumber;
+              if (isNumber(bondApNumber) && isNumber(apNumber)) {
+                return bondApNumber === apNumber;
+              }
+              return true;
+            }
+            return false;
           },
         );
 
@@ -677,6 +694,8 @@ export function fromSgroupDeletion(restruct: Restruct, id, needPerform = true) {
             },
           );
           action.addOp(new AtomDelete(leaveAtomId));
+        } else if (isExpanded) {
+          action.addOp(new AtomAttr(leaveAtomId, 'rglabel', null));
         } else {
           const apLabel = `R${attachmentPoint.attachmentPointNumber ?? 0}`;
           const newLabel = monomerCaps?.[apLabel] || 'H';


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

When multiple attachment points share the same atom (e.g. phosphate R1
and R2 both use the same P atom), the isOccupied check was incorrectly
treating all attachment points as occupied if any one of them had an
inter-monomer bond. This caused leaving group atoms to be deleted even
for unoccupied attachment points.

Fix by using beginSuperatomAttachmentPointNumber /
endSuperatomAttachmentPointNumber stored on the inter-monomer bond to
match the bond to the specific attachment point being evaluated.

Also handle the expanded monomer case for unoccupied attachment points:
clear rglabel only, since the atom already has the correct element label
when the monomer is expanded.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request