### PR TITLE
#9462 - Refactor: Explicit Any type clean up (part 4.2)

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
+++ b/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
@@ -1,4 +1,5 @@
 import {
+  Action,
   CoordinateTransformation,
   Struct,
   Vec2,
@@ -8,6 +9,7 @@ import {
   getItemsToFuse,
 } from 'ketcher-core';
 import { dropAndMerge } from '../tool/helper/dropAndMerge';
+import { ClosestItemWithMap } from '../shared/closest.types';
 
 import Editor from '../Editor';
 import { Tool } from './Tool';
@@ -37,14 +39,11 @@ export default class FragmentSelectionTool implements Tool {
   private dragCtx?: {
     item?: { map: string; id: number };
     xy0: Vec2;
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    action?: any;
+    action?: Action | null;
     mergeItems?: ReturnType<typeof getItemsToFuse>;
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    copyAction?: any;
+    copyAction?: Action;
     stopTapping?: () => void;
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    closestItem?: any;
+    closestItem?: ClosestItemWithMap | null;
   } | null;
 
   constructor(editor: Editor) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

### Summary
Replaced `any` types in `fragmentSelection.ts` with concrete types to improve type safety and remove eslint-disable comments.

### Changes
- **`action`**: `any` → `Action | null` (from `ketcher-core`)
- **`copyAction`**: `any` → `Action` (from `ketcher-core`)
- **`closestItem`**: `any` → `ClosestItemWithMap | null` (from `../shared/closest.types`)

### Technical details
- Added imports: `Action` from `ketcher-core`, `ClosestItemWithMap` from `../shared/closest.types`
- Removed three `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments
- Types align with existing usage: `action`/`copyAction` for `dropAndMerge` and `editor.update`, `closestItem` for `findItem`-style results

### Verification
- `npm run test:types` passes


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request