### PR TITLE
#9485 - Refactor: remove duplicate condition in filterBugsInTests (#9485)

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/new-sequence-representation1-1.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/new-sequence-representation1-1.spec.ts
@@ -1395,7 +1395,6 @@ function filterBugsInTests(
       item.SequenceId === undefined || item.SequenceId.includes(sequenceId);
     const replaceMonomerIdMatch =
       item.MonomerId === undefined ||
-      item.MonomerId === undefined ||
       (monomerId !== undefined && item.MonomerId.includes(monomerId));
 
     return testNameMatch && sequenceIdMatch && replaceMonomerIdMatch;


### PR DESCRIPTION
Remove duplicate 'item.MonomerId === undefined' check in test filter function to resolve SonarQube finding about identical sub-expressions on both sides of operator.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request