### PR TITLE
#6772 - SYNC mode button is absent if sense/antisense chain pasted from clipboard

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-2.27.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-2.27.0-bugs.spec.ts
@@ -9,7 +9,6 @@ import {
   pasteFromClipboardAndAddToMacromoleculesCanvas,
   MacroFileType,
   openFileAndAddToCanvasAsNewProjectMacro,
-  takePageScreenshot,
   openFileAndAddToCanvasAsNewProject,
   takeLeftToolbarMacromoleculeScreenshot,
   takeMonomerLibraryScreenshot,

--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.4.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.4.0-bugs.spec.ts
@@ -15,7 +15,6 @@ import {
   takeTopToolbarScreenshot,
   SdfFileFormat,
   clickInTheMiddleOfTheScreen,
-  takePageScreenshot,
   MolFileFormat,
   clickOnCanvas,
   openFile,

--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.6.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.6.0-bugs.spec.ts
@@ -18,7 +18,6 @@ import {
   openFile,
   readFileContent,
   MolFileFormat,
-  takePageScreenshot,
 } from '@utils';
 import { waitForSpinnerFinishedWork } from '@utils/common';
 import {

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/RNA-Builder/rna-layout.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/RNA-Builder/rna-layout.spec.ts
@@ -1,10 +1,10 @@
 import { Page, test } from '@fixtures';
 import { waitForPageInit } from '@utils/common';
-import { takeMonomerLibraryScreenshot, takePageScreenshot } from '@utils';
+import { takeMonomerLibraryScreenshot } from '@utils';
 import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 import { Library } from '@tests/pages/macromolecules/Library';
 
-/* 
+/*
 Test case: #3063 - Add e2e tests for Macromolecule editor
 */
 async function createRNA(page: Page) {

--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -183,6 +183,7 @@ export abstract class BaseMode {
     editor.drawingEntitiesManager.detectBondsOverlappedByMonomers();
     editor.renderersContainer.update(modelChanges);
     EditorHistory.getInstance(editor).update(modelChanges);
+    editor.events.mouseLeaveSequenceItem.dispatch();
     this.scrollForView();
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Added `editor.events.mouseLeaveSequenceItem.dispatch();` to `pasteFromClipboard` handler following the same logic as existing `onKeyDown` handler has.
Event triggers editor re-render without any visible side effects, thus resolving the issue.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request