### PR TITLE
#7141 System shows molecular mass and molecular formula even if few chains on the canvas

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Calculate-Properties/calculate-properties.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Calculate-Properties/calculate-properties.spec.ts
@@ -1914,34 +1914,4 @@ test.describe('Calculate Properties tests', () => {
 
     await page.setViewportSize(originalViewport);
   });
-
-  test('Case 63: Verify that Calculate Properties shows blank values and error message when two standalone small molecules are on canvas with no selection', async () => {
-    /*
-     * Test case: https://github.com/epam/ketcher/issues/7141
-     * Description: When two standalone small molecule structures (e.g. benzene ring + standalone atom)
-     * are loaded from KET and Calculate Properties is opened without any selection,
-     * the window should show blank values and the error message "Select monomer, chain or part of a chain".
-     * Each standalone molecule/atom counts as a separate chain.
-     * Scenario:
-     * 1. Go to Macro - Flex
-     * 2. Load KET file with two standalone small molecules (benzene + standalone carbon atom)
-     * 3. Open the "Calculate Properties" window without any selection
-     * 4. Verify molecular formula and mass are blank
-     * 5. Verify error message is shown
-     */
-    await MacromoleculesTopToolbar(page).selectLayoutModeTool(LayoutMode.Flex);
-    await openFileAndAddToCanvasAsNewProjectMacro(
-      page,
-      'KET/two-standalone-small-molecules.ket',
-    );
-    await MacromoleculesTopToolbar(page).calculateProperties();
-    await waitForCalculateProperties(page);
-
-    await expect(page.getByTestId('Gross-formula')).not.toBeVisible();
-    await expect(page.getByTestId('Molecular-Mass-Value')).not.toBeVisible();
-    await expect(
-      page.getByText('Select monomer, chain or part of a chain'),
-    ).toBeVisible();
-    await takePageScreenshot(page);
-  });
 });

--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -1,7 +1,7 @@
 import { IndigoProvider } from 'ketcher-react';
 import {
-  Chain,
   ChainsCollection,
+  Chain,
   getAllConnectedMonomersRecursively,
   KetcherLogger,
   KetSerializer,
@@ -57,19 +57,16 @@ export const useRecalculateMacromoleculeProperties = () => {
         0,
       ) <= getAllConnectedMonomersRecursively(firstMonomer).length;
 
-    const allMonomers = [
-      ...drawingEntitiesManagerToCalculateProperties.monomers.values(),
-    ];
-    const firstMonomerFromAll = allMonomers[0];
-    const areAllEntitiesInSingleChain =
-      !firstMonomerFromAll ||
-      allMonomers.length <=
-        getAllConnectedMonomersRecursively(firstMonomerFromAll).length;
+    const hasNoChainsButMultipleFragments =
+      chainsCollection.chains.length === 0 &&
+      [...drawingEntitiesManagerToCalculateProperties.monomers.values()].filter(
+        (monomer) => monomer.monomerItem.props.isMicromoleculeFragment,
+      ).length > 1;
 
     if (
       !drawingEntitiesManagerToCalculateProperties.hasDrawingEntities ||
       !areAllMonomersConnectedByCovalentOrHydrogenBonds ||
-      (hasNoSelection && !areAllEntitiesInSingleChain)
+      (hasNoSelection && hasNoChainsButMultipleFragments)
     ) {
       dispatch(setMacromoleculesProperties(undefined));
 


### PR DESCRIPTION
…as with no selection

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

### Fix incorrect molecular properties for multiple standalone micromolecules

When two or more standalone small molecules were loaded from KET and **Calculate Properties** was opened without any selection, the system incorrectly displayed the molecular formula and mass for only one structure.

#### Root cause
`ChainsCollection.fromMonomers()` filters out micromolecule fragments. As a result, the chain count defaulted to `0`, preventing the multi-chain guard from being triggered.

#### Fix
Added a connectivity check across all monomers, including micromolecule fragments, to properly detect multiple chains when no selection is made.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request