### PR TITLE
#8660 - Refactor mousemove (event) function to reduce its Cognitive Complexity from 97 to the 15 allowed

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -208,7 +208,8 @@ class BondTool implements Tool {
       beginPos,
     ));
 
-    const dist = endPos !== undefined ? Vec2.dist(dragCtx.xy0, endPos) : 0;
+    const dist =
+      endPos !== undefined ? Vec2.dist(dragCtx.xy0, endPos) : Number.MAX_VALUE;
     this.applyBondAction(event, dragCtx, rnd, molecule, {
       beginAtom,
       endAtom,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Refactored BondTool.mousemove to reduce cognitive complexity from 97 to within allowed limits
  - Extracted deeply nested logic into focused private methods, each handling a single responsibility:
    - handleDragMove — drag state setup and angle calculation
    - handleBondDrag — orchestrates bond creation during drag
    - resolveAtomDragTarget — resolves begin/end atoms when dragging from an atom
    - adjustEndAtomForSGroup — handles sgroup contraction and attachment point logic
    - resolveCanvasDragTarget — resolves atoms when dragging from canvas
    - collectFunctionalGroupIdsForAtom — collects functional group IDs for removal
    - resolveEndAtomFromFunctionalGroup — resolves attachment atom from functional group
    - resolveEndAtomPosition — calculates end atom position and coordinates
    - applyBondAction — applies bond addition/deletion action
  - No behavioral changes — pure refactoring

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request