### PR TITLE
#8960 - Number associated with symbol is visible

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
@@ -401,7 +401,8 @@ export abstract class BaseSequenceItemRenderer extends BaseSequenceRenderer {
           !this.hasAntisenseInChain ||
           !(
             this.counterNumber > 9 &&
-            this.isNextSymbolEditing(editingNodeIndexOverall)
+            (this.isNextSymbolEditing(editingNodeIndexOverall) ||
+              this.isEditingSymbol(editingNodeIndexOverall))
           )) &&
           (this.isNthNodeInChain || this.isLastMonomerInChain)))
     );


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Fixed sequence position numbers >9 (e.g., "10") overlapping with the editing caret in sync edit mode
  - The existing logic in needDisplayCounter only hid numbers when the caret was positioned after the symbol
  (isNextSymbolEditing), missing the case when the caret is on the symbol itself (e.g., after pressing arrow left)
  - Added isEditingSymbol check so numbers >9 are hidden when the caret is either at or to the right of the associated
  symbol

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request