### PR TITLE
fix: Remove autoFocus from cliparea to prevent scroll on page load

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
+++ b/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
@@ -260,7 +260,6 @@ class ClipArea extends Component<ClipAreaProps> {
         className={clsx(CLIP_AREA_BASE_CLASS, classes.cliparea)}
         data-cliparea
         contentEditable
-        autoFocus // eslint-disable-line jsx-a11y/no-autofocus
         suppressContentEditableWarning={true}
       />
     );


### PR DESCRIPTION
Removed autoFocus from the cliparea textarea in cliparea.tsx. 
On page load, browsers scroll to bring any focused element into view — when Ketcher is embedded and not fully visible in the viewport (e.g. small screens), this causes unwanted scroll. 
This also removes a deliberate jsx-a11y/no-autofocus eslint suppression.
