### PR TITLE
#9493 Refactor: ternary operators should not be nested

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
+++ b/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
@@ -387,12 +387,14 @@ export class RotationView extends TransientView {
           const textRadius = radius + STYLE.DEGREE_TEXT_MARGIN + tickLength;
           const textX = center.x + textRadius * Math.cos(angle);
           const textY = center.y + textRadius * Math.sin(angle);
-          const textFill =
-            diff > 90
-              ? 'none'
-              : degree !== 0 && degree === currentDegrees
-              ? STYLE.ACTIVE_COLOR
-              : STYLE.INITIAL_COLOR;
+          let textFill: string;
+          if (diff > 90) {
+            textFill = 'none';
+          } else if (degree !== 0 && degree === currentDegrees) {
+            textFill = STYLE.ACTIVE_COLOR;
+          } else {
+            textFill = STYLE.INITIAL_COLOR;
+          }
 
           transientLayer
             .append('text')

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -1604,18 +1604,22 @@ export class DrawingEntitiesManager {
           previousMonomer.monomerItem,
           monomer.monomerItem,
         );
-        const attPointStart = connectionTemplate
-          ? connectionTemplate.endpoint1.templateId ===
-            getMonomerTemplateRefFromMonomerItem(previousMonomer.monomerItem)
+        let attPointStart;
+        let attPointEnd;
+        if (connectionTemplate) {
+          const isEndpoint1 =
+            connectionTemplate.endpoint1.templateId ===
+            getMonomerTemplateRefFromMonomerItem(previousMonomer.monomerItem);
+          attPointStart = isEndpoint1
             ? connectionTemplate.endpoint1.attachmentPointId
-            : connectionTemplate.endpoint2.attachmentPointId
-          : previousMonomer.getValidSourcePoint(monomer);
-        const attPointEnd = connectionTemplate
-          ? connectionTemplate.endpoint1.templateId ===
-            getMonomerTemplateRefFromMonomerItem(previousMonomer.monomerItem)
+            : connectionTemplate.endpoint2.attachmentPointId;
+          attPointEnd = isEndpoint1
             ? connectionTemplate.endpoint2.attachmentPointId
-            : connectionTemplate.endpoint1.attachmentPointId
-          : monomer.getValidSourcePoint(previousMonomer);
+            : connectionTemplate.endpoint1.attachmentPointId;
+        } else {
+          attPointStart = previousMonomer.getValidSourcePoint(monomer);
+          attPointEnd = monomer.getValidSourcePoint(previousMonomer);
+        }
 
         assert(attPointStart);
         assert(attPointEnd);
@@ -1723,18 +1727,22 @@ export class DrawingEntitiesManager {
           monomer.monomerItem,
         );
         // requirements are: use connectionTemplate if exist. If no then Base(R1)-(R3)Sugar(R2)-(R1)Phosphate
-        const attPointStart = connectionTemplate
-          ? connectionTemplate.endpoint1.templateId ===
-            getMonomerTemplateRefFromMonomerItem(previousMonomer.monomerItem)
+        let attPointStart;
+        let attPointEnd;
+        if (connectionTemplate) {
+          const isEndpoint1 =
+            connectionTemplate.endpoint1.templateId ===
+            getMonomerTemplateRefFromMonomerItem(previousMonomer.monomerItem);
+          attPointStart = isEndpoint1
             ? connectionTemplate.endpoint1.attachmentPointId
-            : connectionTemplate.endpoint2.attachmentPointId
-          : previousMonomer.getValidSourcePoint(monomer);
-        const attPointEnd = connectionTemplate
-          ? connectionTemplate.endpoint1.templateId ===
-            getMonomerTemplateRefFromMonomerItem(previousMonomer.monomerItem)
+            : connectionTemplate.endpoint2.attachmentPointId;
+          attPointEnd = isEndpoint1
             ? connectionTemplate.endpoint2.attachmentPointId
-            : connectionTemplate.endpoint1.attachmentPointId
-          : monomer.getValidSourcePoint(previousMonomer);
+            : connectionTemplate.endpoint1.attachmentPointId;
+        } else {
+          attPointStart = previousMonomer.getValidSourcePoint(monomer);
+          attPointEnd = monomer.getValidSourcePoint(previousMonomer);
+        }
 
         assert(attPointStart);
         assert(attPointEnd);

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -361,12 +361,14 @@ export class KetSerializer implements Serializer<Struct> {
 
     return Object.entries(attachmentPointsDict).map(
       ([key, attachmentPoint]) => {
-        const normalizedLabel =
-          attachmentPoint.type === 'left'
-            ? AttachmentPointName.R1
-            : attachmentPoint.type === 'right'
-            ? AttachmentPointName.R2
-            : undefined;
+        let normalizedLabel: AttachmentPointName | undefined;
+        if (attachmentPoint.type === 'left') {
+          normalizedLabel = AttachmentPointName.R1;
+        } else if (attachmentPoint.type === 'right') {
+          normalizedLabel = AttachmentPointName.R2;
+        } else {
+          normalizedLabel = undefined;
+        }
 
         return {
           ...attachmentPoint,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Refactor: Replace nested ternary operators with if/else statements

  Refactored nested ternary expressions in RotationView.ts, DrawingEntitiesManager.ts, and ketSerializer.ts to use if/else blocks for improved readability. No logic was changed.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request