### PR TITLE
#9529 - Refactor: Remove unnecessary type assertions

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/actionmenu.tsx
+++ b/packages/ketcher-react/src/script/ui/component/actionmenu.tsx
@@ -104,7 +104,7 @@ function isMenuItemWithComponent(
     typeof item === 'object' &&
     item !== null &&
     'component' in item &&
-    typeof (item as MenuItemWithComponent).component === 'function'
+    typeof item.component === 'function'
   );
 }
 

--- a/packages/ketcher-react/src/script/ui/state/modal/sdata.ts
+++ b/packages/ketcher-react/src/script/ui/state/modal/sdata.ts
@@ -120,8 +120,7 @@ const onContextChange = (
   const radiobuttons = String(
     payload.radiobuttons || state.result.radiobuttons,
   );
-  const type =
-    (payload.type as SdataResult['type'] | undefined) ?? state.result.type;
+  const type = payload.type ?? state.result.type;
 
   const fieldName = getSdataDefaultValue(sdataCustomSchema, 'fieldName');
 
@@ -151,8 +150,7 @@ const onFieldNameChange = (
   const radiobuttons = String(
     payload.radiobuttons || state.result.radiobuttons,
   );
-  const type =
-    (payload.type as SdataResult['type'] | undefined) ?? state.result.type;
+  const type = payload.type ?? state.result.type;
 
   let fieldValue = String(payload.fieldValue || '');
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

This PR removes unnecessary type assertions across the codebase that do not change the expression type, addressing code quality issues identified by SonarQube.

### Changes:
- Removed unnecessary `as` type assertions in `actionmenu.tsx` where the type was already correctly inferred
- Removed redundant type assertions in `sdata.ts` modal state management

These changes improve code clarity without affecting functionality, as the assertions were redundant (the compiler already knew the correct types).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request