### PR TITLE
#7826 - Editing of atoms shouldn't be allowed in Create monomer wizard

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -427,6 +427,11 @@ class SelectTool implements Tool {
 
   dblclick(event) {
     const editor = this.editor;
+
+    if (editor.isMonomerCreationWizardActive) {
+      return false;
+    }
+
     const struct = editor.render.ctab;
     const { molecule, sgroups } = struct;
     const functionalGroups = molecule.functionalGroups;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

This PR fixes an issue in the Create Monomer flow where double-clicking the central atom still opened the Atom Properties dialog. In this mode, users should not be able to edit atom properties by double click, so the dialog should not appear.

The root cause was that after opening the Create Monomer wizard, the editor switches back to the regular select tool. Because of that, the normal SelectTool.dblclick() handler was still active and continued to trigger the atom edit flow.

To fix this, I added a guard in SelectTool.dblclick() to stop the atom editing action when the monomer creation wizard is active. This keeps the existing select behavior unchanged in normal editing mode, while preventing Atom Properties from opening during monomer creation.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request