### PR TITLE
#7827 - Editing of bonds shouldn't be allowed in Create monomer wizard

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -39,6 +39,17 @@ const ContextMenuTrigger: FC<PropsWithChildren> = ({ children }) => {
   const { ketcherId } = useAppContext();
   const { show } = useContextMenu<ContextMenuProps>();
 
+  const shouldBlockMonomerCreationContextMenu = useCallback(
+    (editor: Editor, showProps: ContextMenuProps | null) => {
+      if (!editor.isMonomerCreationWizardActive || !showProps) {
+        return false;
+      }
+
+      return showProps.id === CONTEXT_MENU_ID.FOR_BONDS + ketcherId;
+    },
+    [ketcherId],
+  );
+
   const getSelectedGroupsInfo = useCallback(() => {
     const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
     const struct = editor.struct();
@@ -189,6 +200,10 @@ const ContextMenuTrigger: FC<PropsWithChildren> = ({ children }) => {
         }
       }
 
+      if (shouldBlockMonomerCreationContextMenu(editor, showProps)) {
+        return;
+      }
+
       showProps &&
         show({
           id: showProps.id,
@@ -196,7 +211,12 @@ const ContextMenuTrigger: FC<PropsWithChildren> = ({ children }) => {
           props: { ...showProps, ketcherId },
         });
     },
-    [getSelectedGroupsInfo, show, ketcherId],
+    [
+      getSelectedGroupsInfo,
+      shouldBlockMonomerCreationContextMenu,
+      show,
+      ketcherId,
+    ],
   );
 
   return (


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


This PR fixes an issue in the Create Monomer flow where right-clicking a bond-only selection still opened the regular bond context menu with bond editing options.

When the Create Monomer wizard was active, the context menu trigger still resolved a bond selection to the standard bond context menu. As a result, users could see bond edit actions in a mode where those actions should not be available.

A guard was added in `ContextMenuTrigger.tsx` to prevent the bond context menu from opening while the monomer creation wizard is active.

Now, when the Create Monomer wizard is active and the user selects bonds and right-clicks, nothing happens instead of showing the regular bond edit context menu.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request