### PR TITLE
#8402: Scrollbar appears unnecessarily in “Create Monomer” attributes panel after selecting Type, and disappears when expanding Aliases

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.module.less
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.module.less
@@ -152,6 +152,10 @@
   color: #fff;
 }
 
+.accordionContainer {
+  overflow: hidden;
+}
+
 .accordion {
   &:global(.MuiAccordion-root) {
     background: none;

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
@@ -227,7 +227,7 @@ const MonomerCreationWizardFields = (
         <>
           <div className={styles.divider} />
 
-          <div>
+          <div className={styles.accordionContainer}>
             <Accordion
               className={clsx(accordionClasses.accordion, styles.accordion)}
               square
@@ -294,7 +294,7 @@ const MonomerCreationWizardFields = (
         <>
           <div className={styles.divider} />
 
-          <div>
+          <div className={styles.accordionContainer}>
             <Accordion
               className={clsx(accordionClasses.accordion, styles.accordion)}
               square


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

### Problem
Expanding the "Modifications" and "Aliases" accordions showed unnecessary scrollbars despite sufficient vertical space.

### Solution
Added `overflow: hidden` to accordion container elements.

### Files Modified
- `MonomerCreationWizard.module.less` - New .accordionContainer class
- `MonomerCreationWizardFields.tsx` - Applied class to accordion wrappers

<img width="325" height="367" alt="image" src="https://github.com/user-attachments/assets/d28d42fa-ed8b-4504-b5b2-81231dc5ddfc" />



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request