### PR TITLE
#9545 Refactor: Redundant casts and non-null assertions should be avoided

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/actionmenu.tsx
+++ b/packages/ketcher-react/src/script/ui/component/actionmenu.tsx
@@ -104,7 +104,7 @@ function isMenuItemWithComponent(
     typeof item === 'object' &&
     item !== null &&
     'component' in item &&
-    typeof (item as MenuItemWithComponent).component === 'function'
+    typeof item.component === 'function'
   );
 }
 

--- a/packages/ketcher-react/src/script/ui/state/modal/sdata.ts
+++ b/packages/ketcher-react/src/script/ui/state/modal/sdata.ts
@@ -120,8 +120,7 @@ const onContextChange = (
   const radiobuttons = String(
     payload.radiobuttons || state.result.radiobuttons,
   );
-  const type =
-    (payload.type as SdataResult['type'] | undefined) ?? state.result.type;
+  const type = payload.type ?? state.result.type;
 
   const fieldName = getSdataDefaultValue(sdataCustomSchema, 'fieldName');
 
@@ -151,8 +150,7 @@ const onFieldNameChange = (
   const radiobuttons = String(
     payload.radiobuttons || state.result.radiobuttons,
   );
-  const type =
-    (payload.type as SdataResult['type'] | undefined) ?? state.result.type;
+  const type = payload.type ?? state.result.type;
 
   let fieldValue = String(payload.fieldValue || '');
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Remove unnecessary type assertions in actionmenu.tsx and sdata.ts where TypeScript already infers the correct type from context. These redundant casts add noise without providing any type safety benefit.

Changes:
actionmenu.tsx:107 — removed redundant as MenuItemWithComponent cast inside a type guard where 'component' in item already narrows the type
sdata.ts:124 and sdata.ts:155 — removed redundant as SdataResult['type'] | undefined cast since payload is already typed as Partial<SdataResult> & Record<string, unknown>

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request