### PR TITLE
#4248: The “File format” drop-down does not open in the “Save Structure” window in the full-screen mode

### DIFF
--- a/packages/ketcher-macromolecules/src/components/shared/dropDown/dropDown.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/dropDown/dropDown.tsx
@@ -115,6 +115,11 @@ export const DropDown = ({
 }: DropDownProps) => {
   const [expanded, setExpanded] = useState(false);
 
+  const isFullscreen = !!document.fullscreenElement;
+  const portalContainer = isFullscreen
+    ? document.querySelector('#root')
+    : undefined;
+
   const renderLabelById = (value: unknown) => {
     const selectedOption = options.filter(
       (option) => option.id === (value as typeof currentSelection),
@@ -154,6 +159,7 @@ export const DropDown = ({
         fullWidth
         data-testid={testId ?? 'dropdown-select'}
         MenuProps={{
+          container: portalContainer,
           PaperProps: {
             style: { ...stylesForExpanded, ...customStylesForExpanded },
           },

--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
@@ -61,6 +61,10 @@ const Select = ({
   error,
 }: Props) => {
   const [currentValue, setCurrentValue] = useState<Option>();
+  const isFullscreen = !!document.fullscreenElement;
+  const portalContainer = isFullscreen
+    ? document.querySelector('#root')
+    : undefined;
 
   useEffect(() => {
     let option;
@@ -90,7 +94,10 @@ const Select = ({
       multiple={multiple}
       disabled={disabled}
       placeholder={placeholder}
-      MenuProps={{ className: styles.dropdownList }}
+      MenuProps={{
+        container: portalContainer,
+        className: styles.dropdownList,
+      }}
       IconComponent={ChevronIcon}
       data-testid={testId}
       error={error}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Fix fullscreen dropdown layering issue

When in fullscreen mode, dropdown menus (Material-UI Select components) were being covered by other UI elements due to top-layer position of root container. This change ensures that dropdown menus are rendered within the root container when in fullscreen mode, keeping them within the proper stacking context and preventing them from being hidden behind other elements.

Changes:

Modified `DropDown` and `Select` components to detect fullscreen mode and render dropdown menus within the #root container instead of the default `document.body`
.
This ensures dropdowns remain visible and interactive in fullscreen mode


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request