### PR TITLE
#5198 - Feat: Added a darker hover state for selected sequence items in Sequence Layout Mode.

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
@@ -811,10 +811,11 @@ export abstract class BaseSequenceItemRenderer extends BaseSequenceRenderer {
       return;
     }
 
-    this.backgroundElement?.attr(
-      'fill',
-      this.node.monomer.selected ? 'none' : '#E1E8E9',
-    );
+    if (this.node.monomer.selected) {
+      this.selectionRectangle?.attr('fill', '#35f073');
+    } else {
+      this.backgroundElement?.attr('fill', '#E1E8E9');
+    }
 
     if (this.node.modified) {
       this.drawModification();
@@ -822,7 +823,14 @@ export abstract class BaseSequenceItemRenderer extends BaseSequenceRenderer {
   }
 
   public removeBackgroundElementHover() {
-    this.backgroundElement?.attr('fill', 'none');
+    if (this.node.monomer.selected) {
+      this.selectionRectangle?.attr(
+        'fill',
+        this.isSequenceEditInRnaBuilderModeTurnedOn ? '#99D6DC' : '#57FF8F',
+      );
+    } else {
+      this.backgroundElement?.attr('fill', 'none');
+    }
 
     if (this.node.modified) {
       this.drawModification();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Added a darker hover state for selected sequence items in Sequence Layout Mode.

**Root cause:**

When a sequence item was selected, its rect was filled with `#57FF8F`. On hover, `drawBackgroundElementHover()` only updated the `backgroundElement`, which was set to `'none'` during selection — so the hover had no visible effect on already-selected items.

**Changes made:**

**`BaseSequenceItemRenderer.ts`**
- **`drawBackgroundElementHover()`** — When the monomer is selected, the `selectionRectangle` fill is changed to `#35f073` (a darker green) on hover, making the hover state visually distinct from the selected-only state.
- **`removeBackgroundElementHover()`** — When the cursor leaves, the `selectionRectangle` fill is restored to its original selection color (`#57FF8F` in normal mode, `#99D6DC` in RNA Builder mode).

**Color states after the fix:**

| State | Color |
|---|---|
| Default | `transparent` |
| Hovered only | `#E1E8E9` |
| Selected only | `#57FF8F` |
| Selected + Hovered | `#35f073` (darker green) |



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request