### PR TITLE
#4309: Delete and Backspace hotkeys deletes elements under mouse cursor (hover), but not selected ones

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -225,8 +225,12 @@ function handleHotkeyGroup(
   if (clipArea.actions.indexOf(actName) === -1) {
     let newAction = getNextAction(actName);
     const hoveredItem = getHoveredItem(render.ctab);
+    const selectedItems = getSelectedItems(render.ctab);
 
-    if (shouldHandleItemDirectly(hoveredItem, newAction)) {
+    // For erase action, prioritize selected items over hovered item
+    if (actName === 'erase' && selectedItems) {
+      dispatch(onAction(newAction));
+    } else if (shouldHandleItemDirectly(hoveredItem, newAction)) {
       newAction = getCurrentAction(group[index]) || newAction;
       handleHotkeyOverItem({
         hoveredItem,
@@ -330,6 +334,30 @@ function getHoveredItem(
   }
 
   return Object.keys(hoveredItem).length ? hoveredItem : null;
+}
+
+function getSelectedItems(
+  ctab: Record<string, Map<number, Record<string, unknown>>>,
+): Record<string, number> | null {
+  const selectedItems = {};
+
+  for (const ctabItem in ctab) {
+    if (Object.keys(selectedItems).length) {
+      break;
+    }
+
+    if (!(ctab[ctabItem] instanceof Map)) {
+      continue;
+    }
+
+    ctab[ctabItem].forEach((item, id) => {
+      if (item.selected) {
+        selectedItems[ctabItem] = id;
+      }
+    });
+  }
+
+  return Object.keys(selectedItems).length ? selectedItems : null;
 }
 
 function checkGroupOnTool(group, actionTool) {

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -225,10 +225,11 @@ function handleHotkeyGroup(
   if (clipArea.actions.indexOf(actName) === -1) {
     let newAction = getNextAction(actName);
     const hoveredItem = getHoveredItem(render.ctab);
-    const selectedItems = getSelectedItems(render.ctab);
+    const { atoms, bonds } = editor.selection() ?? {};
+    const hasSelection = Boolean(atoms?.length) || Boolean(bonds?.length);
 
     // For erase action, prioritize selected items over hovered item
-    if (actName === 'erase' && selectedItems) {
+    if (actName === 'erase' && hasSelection) {
       dispatch(onAction(newAction));
     } else if (shouldHandleItemDirectly(hoveredItem, newAction)) {
       newAction = getCurrentAction(group[index]) || newAction;
@@ -334,30 +335,6 @@ function getHoveredItem(
   }
 
   return Object.keys(hoveredItem).length ? hoveredItem : null;
-}
-
-function getSelectedItems(
-  ctab: Record<string, Map<number, Record<string, unknown>>>,
-): Record<string, number> | null {
-  const selectedItems = {};
-
-  for (const ctabItem in ctab) {
-    if (Object.keys(selectedItems).length) {
-      break;
-    }
-
-    if (!(ctab[ctabItem] instanceof Map)) {
-      continue;
-    }
-
-    ctab[ctabItem].forEach((item, id) => {
-      if (item.selected) {
-        selectedItems[ctabItem] = id;
-      }
-    });
-  }
-
-  return Object.keys(selectedItems).length ? selectedItems : null;
 }
 
 function checkGroupOnTool(group, actionTool) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
- Prioritize selected entities over hovered entity for `erase` hotkey within `handleHotkeyGroup`.
- Added helper getSelectedItems to detect selection in current `render.ctab`.
- Kept existing handleHotkeyOverItem path unchanged for non-erase/hover behavior.

What changed:
1. New helper:
- `getSelectedItems(render.ctab)` added
- mirrors getHoveredItem, checks `item.selected`
2. handleHotkeyGroup(...) now:
- computes selectedItems and hoveredItem
- if actName === 'erase' && selectedItems → direct `dispatch(onAction(newAction))`
- else existing hover/selection logic remains

Result:
- `Delete` / `Backspace` with multiple selected items now acts on selection first.
- hover fallback only used when no selection.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request