### PR TITLE
Fix selection of OR or AND in Enhanced Stereochemistry menu

### DIFF
--- a/ketcher-autotests/tests/specs/Indigo-Tools/Enhanced-Stereochemistry/enhanced-stereo-radio-selection.spec.ts
+++ b/ketcher-autotests/tests/specs/Indigo-Tools/Enhanced-Stereochemistry/enhanced-stereo-radio-selection.spec.ts
@@ -1,0 +1,127 @@
+/* eslint-disable no-magic-numbers */
+import { Page, test, expect } from '@fixtures';
+import { LeftToolbar } from '@tests/pages/molecules/LeftToolbar';
+import { openFileAndAddToCanvas } from '@utils';
+import { EnhancedStereochemistry } from '@tests/pages/molecules/canvas/EnhancedStereochemistry';
+import { getAtomLocator } from '@utils/canvas/atoms/getAtomLocator/getAtomLocator';
+
+let page: Page;
+
+test.describe('Enhanced Stereochemistry - Radio button selection', () => {
+  test.beforeAll(async ({ initMoleculesCanvas }) => {
+    page = await initMoleculesCanvas();
+  });
+  test.afterAll(async ({ closePage }) => {
+    await closePage();
+  });
+  test.beforeEach(async ({ MoleculesCanvas: _ }) => {});
+  test.afterEach(async () => {
+    if (await EnhancedStereochemistry(page).isVisible()) {
+      await EnhancedStereochemistry(page).closeWindow();
+    }
+  });
+
+  test('ABS radio is checked by default when opening dialog', async () => {
+    await openFileAndAddToCanvas(
+      page,
+      'Molfiles-V2000/stereo-structure-enchanced.mol',
+    );
+    await getAtomLocator(page, { atomLabel: 'C', atomId: 21 }).click({
+      force: true,
+    });
+    await LeftToolbar(page).stereochemistry();
+
+    const dialog = EnhancedStereochemistry(page);
+    await expect(dialog.absRadio).toBeChecked();
+    await expect(dialog.newAndGroupRadio).not.toBeChecked();
+    await expect(dialog.newOrGroupRadio).not.toBeChecked();
+  });
+
+  test('Clicking Create new AND Group updates radio checked state', async () => {
+    await openFileAndAddToCanvas(
+      page,
+      'Molfiles-V2000/stereo-structure-enchanced.mol',
+    );
+    await getAtomLocator(page, { atomLabel: 'C', atomId: 21 }).click({
+      force: true,
+    });
+    await LeftToolbar(page).stereochemistry();
+
+    const dialog = EnhancedStereochemistry(page);
+    await dialog.newAndGroupRadio.click();
+
+    await expect(dialog.newAndGroupRadio).toBeChecked();
+    await expect(dialog.absRadio).not.toBeChecked();
+    await expect(dialog.newOrGroupRadio).not.toBeChecked();
+  });
+
+  test('Clicking Create new OR Group updates radio checked state', async () => {
+    await openFileAndAddToCanvas(
+      page,
+      'Molfiles-V2000/stereo-structure-enchanced.mol',
+    );
+    await getAtomLocator(page, { atomLabel: 'C', atomId: 21 }).click({
+      force: true,
+    });
+    await LeftToolbar(page).stereochemistry();
+
+    const dialog = EnhancedStereochemistry(page);
+    await dialog.newOrGroupRadio.click();
+
+    await expect(dialog.newOrGroupRadio).toBeChecked();
+    await expect(dialog.absRadio).not.toBeChecked();
+    await expect(dialog.newAndGroupRadio).not.toBeChecked();
+  });
+
+  test('Switching between all radio options updates checked state correctly', async () => {
+    await openFileAndAddToCanvas(
+      page,
+      'Molfiles-V2000/stereo-structure-enchanced.mol',
+    );
+    await getAtomLocator(page, { atomLabel: 'C', atomId: 21 }).click({
+      force: true,
+    });
+    await LeftToolbar(page).stereochemistry();
+
+    const dialog = EnhancedStereochemistry(page);
+
+    await dialog.newAndGroupRadio.click();
+    await expect(dialog.newAndGroupRadio).toBeChecked();
+    await expect(dialog.absRadio).not.toBeChecked();
+
+    await dialog.newOrGroupRadio.click();
+    await expect(dialog.newOrGroupRadio).toBeChecked();
+    await expect(dialog.newAndGroupRadio).not.toBeChecked();
+
+    await dialog.absRadio.click();
+    await expect(dialog.absRadio).toBeChecked();
+    await expect(dialog.newOrGroupRadio).not.toBeChecked();
+  });
+
+  test('Radio selection persists until Apply is clicked', async () => {
+    await openFileAndAddToCanvas(
+      page,
+      'Molfiles-V2000/stereo-structure-enchanced.mol',
+    );
+    await getAtomLocator(page, { atomLabel: 'C', atomId: 21 }).click({
+      force: true,
+    });
+    await LeftToolbar(page).stereochemistry();
+
+    const dialog = EnhancedStereochemistry(page);
+
+    await dialog.newOrGroupRadio.click();
+    await expect(dialog.newOrGroupRadio).toBeChecked();
+
+    await dialog.apply();
+
+    await getAtomLocator(page, { atomLabel: 'C', atomId: 21 }).click({
+      force: true,
+    });
+    await LeftToolbar(page).stereochemistry();
+
+    const reopenedDialog = EnhancedStereochemistry(page);
+    await expect(reopenedDialog.addToOrGroupRadio).toBeChecked();
+    await expect(reopenedDialog.absRadio).not.toBeChecked();
+  });
+});

--- a/packages/ketcher-react/src/script/editor/tool/enhanced-stereo.ts
+++ b/packages/ketcher-react/src/script/editor/tool/enhanced-stereo.ts
@@ -16,7 +16,7 @@
 
 import {
   findStereoAtoms,
-  fromAtomsAttrs,
+  fromStereoAtomAttrs,
   fromStereoFlagUpdate,
 } from 'ketcher-core';
 
@@ -69,26 +69,44 @@ class EnhancedStereoTool implements Tool {
         return null;
       }
 
-      const action = stereoAtoms.reduce(
-        (acc, stereoAtom) => {
-          const frid = struct.atoms.get(stereoAtom)?.fragment;
-          const frag =
-            frid !== undefined ? restruct.molecule.frags.get(frid) : null;
+      const [firstStereoAtom, ...restStereoAtoms] = stereoAtoms;
+      if (firstStereoAtom === undefined) {
+        return null;
+      }
 
-          if (frag?.stereoAtoms) {
-            return acc.mergeWith(fromStereoFlagUpdate(restruct, frid));
-          }
-          return acc;
-        },
-        fromAtomsAttrs(
+      const action = restStereoAtoms.reduce(
+        (acc, stereoAtom) =>
+          acc.mergeWith(
+            fromStereoAtomAttrs(
+              restruct,
+              stereoAtom,
+              {
+                stereoLabel,
+              },
+              false,
+            ),
+          ),
+        fromStereoAtomAttrs(
           restruct,
-          stereoAtoms,
+          firstStereoAtom,
           {
             stereoLabel,
           },
           false,
         ),
       );
+
+      const fragmentIds = new Set<number>();
+      stereoAtoms.forEach((stereoAtom) => {
+        const frid = struct.atoms.get(stereoAtom)?.fragment;
+        if (frid !== undefined) {
+          fragmentIds.add(frid);
+        }
+      });
+
+      fragmentIds.forEach((frid) => {
+        action.mergeWith(fromStereoFlagUpdate(restruct, frid));
+      });
       action.operations.reverse();
       return action;
     });

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.test.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.test.tsx
@@ -1,0 +1,272 @@
+import { screen, fireEvent, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import ConnectedEnhancedStereo from './enhancedStereo';
+
+jest.mock('../../../views/components', () => ({
+  Dialog: ({ children, result, valid, params }: any) => (
+    <div data-testid="mock-dialog">
+      {children}
+      <button
+        data-testid="apply-button"
+        disabled={valid ? !valid() : false}
+        onClick={() => params?.onOk?.(result?.())}
+      >
+        Apply
+      </button>
+      <button data-testid="cancel-button" onClick={() => params?.onCancel?.()}>
+        Cancel
+      </button>
+    </div>
+  ),
+}));
+
+function createMockStruct(
+  atoms: Array<{ id: number; stereoLabel: string | null }>,
+) {
+  const atomsMap = new Map<number, { stereoLabel: string | null }>();
+  atoms.forEach(({ id, stereoLabel }) => {
+    atomsMap.set(id, { stereoLabel });
+  });
+  return { atoms: atomsMap };
+}
+
+function renderEnhancedStereo(
+  struct: ReturnType<typeof createMockStruct>,
+  init = { type: 'abs', andNumber: 1, orNumber: 1 },
+) {
+  const onOk = jest.fn();
+  const onCancel = jest.fn();
+
+  // TODO suppressed after upgrade to react 19. Need to fix
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const store = createStore(
+    (state) => state,
+    { editor: { struct: () => struct } },
+  );
+
+  const EnhancedStereo: any = ConnectedEnhancedStereo;
+  const utils = render(
+    <Provider store={store}>
+      <EnhancedStereo init={init} onOk={onOk} onCancel={onCancel} />
+    </Provider>,
+  );
+
+  return { ...utils, onOk, onCancel };
+}
+
+describe('EnhancedStereo dialog', () => {
+  describe('initial rendering', () => {
+    it('shows ABS, Create new AND Group, and Create new OR Group when no groups exist', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      renderEnhancedStereo(struct);
+
+      expect(screen.getByTestId('abs-radio')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('create-new-and-group-radio'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('create-new-or-group-radio'),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByTestId('add-to-and-group-radio'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('add-to-or-group-radio'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('checks ABS radio by default when init type is abs', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      renderEnhancedStereo(struct);
+
+      const absRadio = screen.getByTestId('abs-radio') as HTMLInputElement;
+      expect(absRadio.checked).toBe(true);
+
+      const newAndRadio = screen.getByTestId(
+        'create-new-and-group-radio',
+      ) as HTMLInputElement;
+      expect(newAndRadio.checked).toBe(false);
+
+      const newOrRadio = screen.getByTestId(
+        'create-new-or-group-radio',
+      ) as HTMLInputElement;
+      expect(newOrRadio.checked).toBe(false);
+    });
+
+    it('shows Add to AND option when AND groups exist in structure', () => {
+      const struct = createMockStruct([
+        { id: 0, stereoLabel: '&1' },
+        { id: 1, stereoLabel: 'abs' },
+      ]);
+      renderEnhancedStereo(struct, {
+        type: 'abs',
+        andNumber: 1,
+        orNumber: 1,
+      });
+
+      expect(
+        screen.getByTestId('add-to-and-group-radio'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('add-to-or-group-radio'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows Add to OR option when OR groups exist in structure', () => {
+      const struct = createMockStruct([
+        { id: 0, stereoLabel: 'or1' },
+        { id: 1, stereoLabel: 'abs' },
+      ]);
+      renderEnhancedStereo(struct, {
+        type: 'abs',
+        andNumber: 1,
+        orNumber: 1,
+      });
+
+      expect(
+        screen.queryByTestId('add-to-and-group-radio'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('add-to-or-group-radio'),
+      ).toBeInTheDocument();
+    });
+
+    it('pre-selects Add to AND when init type is &', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: '&1' }]);
+      renderEnhancedStereo(struct, {
+        type: '&',
+        andNumber: 1,
+        orNumber: 1,
+      });
+
+      const addToAndRadio = screen.getByTestId(
+        'add-to-and-group-radio',
+      ) as HTMLInputElement;
+      expect(addToAndRadio.checked).toBe(true);
+
+      const absRadio = screen.getByTestId('abs-radio') as HTMLInputElement;
+      expect(absRadio.checked).toBe(false);
+    });
+  });
+
+  describe('radio selection', () => {
+    it('updates checked state when clicking Create new AND Group', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      renderEnhancedStereo(struct);
+
+      const newAndRadio = screen.getByTestId(
+        'create-new-and-group-radio',
+      ) as HTMLInputElement;
+      fireEvent.click(newAndRadio);
+
+      const updatedAndRadio = screen.getByTestId(
+        'create-new-and-group-radio',
+      ) as HTMLInputElement;
+      expect(updatedAndRadio.checked).toBe(true);
+
+      const absRadio = screen.getByTestId('abs-radio') as HTMLInputElement;
+      expect(absRadio.checked).toBe(false);
+    });
+
+    it('updates checked state when clicking Create new OR Group', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      renderEnhancedStereo(struct);
+
+      const newOrRadio = screen.getByTestId(
+        'create-new-or-group-radio',
+      ) as HTMLInputElement;
+      fireEvent.click(newOrRadio);
+
+      const updatedOrRadio = screen.getByTestId(
+        'create-new-or-group-radio',
+      ) as HTMLInputElement;
+      expect(updatedOrRadio.checked).toBe(true);
+
+      const absRadio = screen.getByTestId('abs-radio') as HTMLInputElement;
+      expect(absRadio.checked).toBe(false);
+    });
+
+    it('allows switching back to ABS after selecting another option', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      renderEnhancedStereo(struct);
+
+      fireEvent.click(screen.getByTestId('create-new-and-group-radio'));
+      fireEvent.click(screen.getByTestId('abs-radio'));
+
+      const absRadio = screen.getByTestId('abs-radio') as HTMLInputElement;
+      expect(absRadio.checked).toBe(true);
+
+      const newAndRadio = screen.getByTestId(
+        'create-new-and-group-radio',
+      ) as HTMLInputElement;
+      expect(newAndRadio.checked).toBe(false);
+    });
+  });
+
+  describe('Apply result', () => {
+    it('returns abs type when ABS is selected', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      const { onOk } = renderEnhancedStereo(struct);
+
+      fireEvent.click(screen.getByTestId('apply-button'));
+
+      expect(onOk).toHaveBeenCalledWith({
+        type: 'abs',
+        andNumber: 1,
+        orNumber: 1,
+      });
+    });
+
+    it('returns AND type when Create new AND Group is selected', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      const { onOk } = renderEnhancedStereo(struct);
+
+      fireEvent.click(screen.getByTestId('create-new-and-group-radio'));
+      fireEvent.click(screen.getByTestId('apply-button'));
+
+      expect(onOk).toHaveBeenCalledWith({
+        type: '&1',
+        andNumber: 1,
+        orNumber: 1,
+      });
+    });
+
+    it('returns OR type when Create new OR Group is selected', () => {
+      const struct = createMockStruct([{ id: 0, stereoLabel: 'abs' }]);
+      const { onOk } = renderEnhancedStereo(struct);
+
+      fireEvent.click(screen.getByTestId('create-new-or-group-radio'));
+      fireEvent.click(screen.getByTestId('apply-button'));
+
+      expect(onOk).toHaveBeenCalledWith({
+        type: 'or1',
+        andNumber: 1,
+        orNumber: 1,
+      });
+    });
+
+    it('returns Add to AND type with correct group number', () => {
+      const struct = createMockStruct([
+        { id: 0, stereoLabel: '&1' },
+        { id: 1, stereoLabel: 'abs' },
+      ]);
+      const { onOk } = renderEnhancedStereo(struct, {
+        type: 'abs',
+        andNumber: 1,
+        orNumber: 1,
+      });
+
+      fireEvent.click(screen.getByTestId('add-to-and-group-radio'));
+      fireEvent.click(screen.getByTestId('apply-button'));
+
+      expect(onOk).toHaveBeenCalledWith({
+        type: '&',
+        andNumber: 1,
+        orNumber: 1,
+      });
+    });
+  });
+});

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/enhancedStereo/enhancedStereo.tsx
@@ -14,44 +14,35 @@
  * limitations under the License.
  ***************************************************************************/
 
-import Form, { Field } from '../../../component/form/form/form';
 import { StereoLabel, Struct } from 'ketcher-core';
 
 import { Dialog } from '../../../views/components';
-import { FC } from 'react';
+import { ChangeEvent, FC, useState } from 'react';
 import classes from './enhancedStereo.module.less';
 import { connect } from 'react-redux';
 import { range } from 'lodash';
+import inputClasses from '../../../component/form/Input/Input.module.less';
 
 interface EnhancedStereoResult {
   andNumber: number;
   orNumber: number;
-  type: StereoLabel;
-}
-
-interface EnhancedStereoFormState {
-  result: EnhancedStereoResult;
-  valid: boolean;
-  errors: string[];
+  type: string;
 }
 
 interface EnhancedStereoProps {
-  className: string;
   init: EnhancedStereoResult & { init?: true };
-  formState: EnhancedStereoFormState;
   struct: Struct;
 }
 
 interface EnhancedStereoCallProps {
   onCancel: () => void;
-  onOk: (res: any) => void;
+  onOk: (res: unknown) => void;
 }
 
 type Props = EnhancedStereoProps & EnhancedStereoCallProps;
 
 const EnhancedStereo: FC<Props> = (props) => {
-  const { struct, formState, init, ...rest } = props;
-  const { result, valid } = formState;
+  const { struct, init, ...rest } = props;
 
   const stereoLabels: Array<string> = findStereLabels(
     struct,
@@ -61,21 +52,30 @@ const EnhancedStereo: FC<Props> = (props) => {
   const maxAnd: number = maxOfAnds(stereoLabels);
   const maxOr: number = maxOfOrs(stereoLabels);
 
-  const enhancedStereoSchema = {
-    title: 'Enhanced Stereo',
-    type: 'object',
-    properties: {
-      type: {
-        type: 'string',
-      },
-      andNumber: {
-        type: 'integer',
-      },
-      orNumber: {
-        type: 'integer',
-      },
-    },
+  const [type, setType] = useState<string>(init?.type ?? StereoLabel.Abs);
+  const [andNumber, setAndNumber] = useState<number>(init?.andNumber ?? 1);
+  const [orNumber, setOrNumber] = useState<number>(init?.orNumber ?? 1);
+
+  const result = {
+    type,
+    andNumber,
+    orNumber,
   };
+  const valid = Boolean(type);
+
+  const onAndNumberChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setAndNumber(Number(event.target.value));
+  };
+
+  const onOrNumberChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setOrNumber(Number(event.target.value));
+  };
+
+  const isAbs = type === StereoLabel.Abs;
+  const isAnd = type === StereoLabel.And;
+  const isOr = type === StereoLabel.Or;
+  const isNewAnd = type === `${StereoLabel.And}${maxAnd + 1}`;
+  const isNewOr = type === `${StereoLabel.Or}${maxOr + 1}`;
 
   return (
     <Dialog
@@ -88,91 +88,108 @@ const EnhancedStereo: FC<Props> = (props) => {
       buttons={['Cancel', 'OK']}
       buttonsNameMap={{ OK: 'Apply' }}
     >
-      <Form schema={enhancedStereoSchema} init={init} {...formState}>
-        <fieldset>
-          {/* eslint-disable jsx-a11y/label-has-associated-control */}
-          <label>
-            {/* eslint-enable jsx-a11y/label-has-associated-control */}
-            <Field
-              name="type"
-              labelPos={false}
+      <fieldset key={type}>
+        <label className={inputClasses.fieldSetLabel}>
+          <input
+            type="radio"
+            name="enhanced-stereo-type"
+            value={StereoLabel.Abs}
+            checked={isAbs}
+            onChange={() => setType(StereoLabel.Abs)}
+            onClick={() => setType(StereoLabel.Abs)}
+            className={inputClasses.input}
+            data-testid="abs-radio"
+          />
+          <span className={inputClasses.radioButton} />
+          ABS
+        </label>
+        {maxAnd !== 0 && (
+          <label className={inputClasses.fieldSetLabel}>
+            <input
               type="radio"
-              value={StereoLabel.Abs}
-              checked={result.type === StereoLabel.Abs}
-              data-testid="abs-radio"
+              name="enhanced-stereo-type"
+              value={StereoLabel.And}
+              checked={isAnd}
+              onChange={() => setType(StereoLabel.And)}
+              onClick={() => setType(StereoLabel.And)}
+              className={inputClasses.input}
+              data-testid="add-to-and-group-radio"
             />
-            ABS
+            <span className={inputClasses.radioButton} />
+            Add to AND
+            <select
+              value={andNumber}
+              onChange={onAndNumberChange}
+              className={classes.labelGroupSelect}
+              data-testid="add-to-and-group"
+            >
+              {range(1, maxAnd + 1).map((num) => (
+                <option key={num} value={num}>
+                  {num}
+                </option>
+              ))}
+            </select>
+            Group
           </label>
-          {maxAnd !== 0 && (
-            <label>
-              {/* eslint-disable jsx-a11y/label-has-associated-control */}
-              <Field
-                name="type"
-                labelPos={false}
-                type="radio"
-                value={StereoLabel.And}
-                checked={result.type === StereoLabel.And}
-                data-testid="add-to-and-group-radio"
-              />
-              Add to AND
-              <Field
-                name="andNumber"
-                schema={range(1, maxAnd + 1)}
-                type="text"
-                className={classes.labelGroupSelect}
-                data-testid="add-to-and-group"
-              />
-              Group
-            </label>
-          )}
-          {maxOr !== 0 && (
-            <label>
-              {/* eslint-disable jsx-a11y/label-has-associated-control */}
-              <Field
-                name="type"
-                labelPos={false}
-                type="radio"
-                value={StereoLabel.Or}
-                checked={result.type === StereoLabel.Or}
-                data-testid="add-to-or-group-radio"
-              />
-              Add to OR
-              <Field
-                name="orNumber"
-                schema={range(1, maxOr + 1)}
-                type="text"
-                className={classes.labelGroupSelect}
-                data-testid="add-to-or-group"
-              />
-              Group
-            </label>
-          )}
-          <label>
-            {/* eslint-disable jsx-a11y/label-has-associated-control */}
-            <Field
-              name="type"
-              labelPos={false}
+        )}
+        {maxOr !== 0 && (
+          <label className={inputClasses.fieldSetLabel}>
+            <input
               type="radio"
-              value={`${StereoLabel.And}${maxAnd + 1}`}
-              checked={result.type === `${StereoLabel.And}${maxAnd + 1}`}
-              data-testid="create-new-and-group-radio"
+              name="enhanced-stereo-type"
+              value={StereoLabel.Or}
+              checked={isOr}
+              onChange={() => setType(StereoLabel.Or)}
+              onClick={() => setType(StereoLabel.Or)}
+              className={inputClasses.input}
+              data-testid="add-to-or-group-radio"
             />
-            Create new AND Group
+            <span className={inputClasses.radioButton} />
+            Add to OR
+            <select
+              value={orNumber}
+              onChange={onOrNumberChange}
+              className={classes.labelGroupSelect}
+              data-testid="add-to-or-group"
+            >
+              {range(1, maxOr + 1).map((num) => (
+                <option key={num} value={num}>
+                  {num}
+                </option>
+              ))}
+            </select>
+            Group
           </label>
-          <label>
-            {/* eslint-disable jsx-a11y/label-has-associated-control */}
-            <Field
-              name="type"
-              labelPos={false}
-              type="radio"
-              value={`${StereoLabel.Or}${maxOr + 1}`}
-              checked={result.type === `${StereoLabel.Or}${maxOr + 1}`}
-              data-testid="create-new-or-group-radio"
-            />
-            Create new OR Group
-          </label>
-        </fieldset>
-      </Form>
+        )}
+        <label className={inputClasses.fieldSetLabel}>
+          <input
+            type="radio"
+            name="enhanced-stereo-type"
+            value={`${StereoLabel.And}${maxAnd + 1}`}
+            checked={isNewAnd}
+            onChange={() => setType(`${StereoLabel.And}${maxAnd + 1}`)}
+            onClick={() => setType(`${StereoLabel.And}${maxAnd + 1}`)}
+            className={inputClasses.input}
+            data-testid="create-new-and-group-radio"
+          />
+          <span className={inputClasses.radioButton} />
+          Create new AND Group
+        </label>
+        <label className={inputClasses.fieldSetLabel}>
+          <input
+            type="radio"
+            name="enhanced-stereo-type"
+            value={`${StereoLabel.Or}${maxOr + 1}`}
+            checked={isNewOr}
+            onChange={() => setType(`${StereoLabel.Or}${maxOr + 1}`)}
+            onClick={() => setType(`${StereoLabel.Or}${maxOr + 1}`)}
+            className={inputClasses.input}
+            data-testid="create-new-or-group-radio"
+          />
+          <span className={inputClasses.radioButton} />
+          Create new OR Group
+        </label>
+      </fieldset>
     </Dialog>
   );
 };
@@ -200,6 +217,5 @@ function maxOfOrs(stereLabels): number {
 }
 
 export default connect((state: any) => ({
-  formState: state.modal.form || { result: {}, valid: false },
   struct: state.editor.struct(),
-}))(EnhancedStereo);
+}))(EnhancedStereo as any);


### PR DESCRIPTION
## Fix Enhanced Stereochemistry dialog radio selection

### Problem

Right-clicking a stereocenter atom and opening the "Enhanced Stereochemistry" dialog allowed only the default ABS option to appear selected. Clicking "Create new AND Group" or "Create new OR Group" updated internal state correctly (Apply worked), but the radio button visual never moved — the DOM `checked` property stayed stuck on ABS.

Two independent issues contributed:

1. **Dialog component used `Form`/`Field` abstraction that didn't reliably sync radio state.** The generic form system managed its own Redux-backed state, but the controlled radio inputs inside the modal never reflected selection changes in the DOM.

2. **React 19 reconciliation does not reliably update the `checked` DOM property on named radio inputs during re-render.** When controlled radios share a `name` attribute, the browser's native radio group management interferes with React's property patching, preventing `input.checked` from updating even though the component re-renders with the correct value.

### Solution

#### `enhancedStereo.tsx` — Dialog component rewrite

- Replaced the `Form`/`Field` abstraction with direct controlled `<input type="radio">` elements and local React state (`useState` for `type`, `andNumber`, `orNumber`).
- Added `key={type}` on the `<fieldset>` so that changing the selection forces React to unmount/remount the radio group with fresh DOM elements that have the correct `checked` values from mount. This sidesteps the React 19 reconciliation issue entirely.
- Added both `onChange` and `onClick` handlers on each radio input to ensure state updates reliably in all modal interaction flows.
- Removed the `formState` Redux dependency — the dialog is now self-contained.
- Used existing `Input.module.less` CSS classes (`fieldSetLabel`, `input`, `radioButton`) for consistent styling with the rest of the application.

#### `enhanced-stereo.ts` — Stereo label application

- Replaced `fromAtomsAttrs` with `fromStereoAtomAttrs`, the stereo-specific action from `ketcher-core` that correctly handles stereo label assignment and validation.
- Added `fromStereoFlagUpdate` calls for each affected fragment to ensure stereo flags (abs/and/or indicators on the canvas) update after label changes.

### Test plan

#### Unit tests (`enhancedStereo.test.tsx` — 12 tests)

- [x] Renders ABS, Create new AND, Create new OR when no groups exist
- [x] Hides "Add to AND/OR" options when no groups exist
- [x] Shows "Add to AND" when AND groups exist in structure
- [x] Shows "Add to OR" when OR groups exist in structure
- [x] ABS radio checked by default with `init.type = 'abs'`
- [x] Pre-selects "Add to AND" when `init.type = '&'`
- [x] Clicking Create new AND Group updates `checked` state
- [x] Clicking Create new OR Group updates `checked` state
- [x] Switching back to ABS after another selection works
- [x] Apply returns `{ type: 'abs' }` for ABS selection
- [x] Apply returns `{ type: '&1' }` for Create new AND selection
- [x] Apply returns `{ type: 'or1' }` for Create new OR selection
- [x] Apply returns `{ type: '&' }` with correct `andNumber` for Add to AND

#### E2E tests (`enhanced-stereo-radio-selection.spec.ts` — 5 tests)

- [ ] ABS radio is checked by default when opening dialog
- [ ] Clicking Create new AND Group updates radio checked state
- [ ] Clicking Create new OR Group updates radio checked state
- [ ] Switching between all radio options updates checked state correctly
- [ ] Radio selection persists after Apply — reopening shows correct pre-selection

### Manual testing

1. Draw a structure with a stereocenter (e.g., a chiral carbon with a wedge bond).
2. Right-click the stereocenter atom → "Enhanced Stereochemistry".
3. Verify ABS is selected by default and the radio circle is filled.
4. Click "Create new AND Group" → radio visually moves to AND.
5. Click "Create new OR Group" → radio visually moves to OR.
6. Click Apply → the stereo label on the canvas updates to the selected group.
7. Reopen the dialog → the previously applied label is pre-selected.
