### PR TITLE
#9554 Refactor: Clean up TODO comments and minor code quality issues in editor operations

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/action.ts
+++ b/packages/ketcher-core/src/application/editor/actions/action.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../operations/base';
+import { BaseOperation } from '../operations/BaseOperation';
 import { ReStruct } from '../../render';
 //
 // Undo/redo actions

--- a/packages/ketcher-core/src/application/editor/actions/helpers.ts
+++ b/packages/ketcher-core/src/application/editor/actions/helpers.ts
@@ -1,6 +1,19 @@
 import { Atom, Bond, Neighbor, StereoLabel, Struct } from 'domain/entities';
 import { StereoValidator } from 'domain/helpers';
 
+function resetStereoAtomIfNotCorrect(
+  stereoAtomsMap: Map<number, unknown>,
+  correctAtomIds: Array<number>,
+  atomId: number,
+) {
+  if (!correctAtomIds.includes(atomId)) {
+    stereoAtomsMap.set(atomId, {
+      stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
+      stereoLabel: null,
+    });
+  }
+}
+
 export function getStereoAtomsMap(
   struct: Struct,
   bonds: Array<Bond>,
@@ -38,37 +51,16 @@ export function getStereoAtomsMap(
         }
         correctAtomIds.push(bond.begin);
       } else {
-        if (!correctAtomIds.includes(bond.begin)) {
-          stereoAtomsMap.set(bond.begin, {
-            stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-            stereoLabel: null,
-          });
-        }
-        if (!correctAtomIds.includes(bond.end)) {
-          stereoAtomsMap.set(bond.end, {
-            stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-            stereoLabel: null,
-          });
-        }
+        resetStereoAtomIfNotCorrect(stereoAtomsMap, correctAtomIds, bond.begin);
+        resetStereoAtomIfNotCorrect(stereoAtomsMap, correctAtomIds, bond.end);
       }
     }
   });
 
-  // in case the stereo band is flipped, changed or removed
-  // TODO the duplication of the code below should be fixed, mayby by function
+  // In case the stereo band is flipped, changed or removed, reset both endpoints.
   if (bond) {
-    if (!correctAtomIds.includes(bond.begin)) {
-      stereoAtomsMap.set(bond.begin, {
-        stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-        stereoLabel: null,
-      });
-    }
-    if (!correctAtomIds.includes(bond.end)) {
-      stereoAtomsMap.set(bond.end, {
-        stereoParity: Atom.PATTERN.STEREO_PARITY.NONE,
-        stereoLabel: null,
-      });
-    }
+    resetStereoAtomIfNotCorrect(stereoAtomsMap, correctAtomIds, bond.begin);
+    resetStereoAtomIfNotCorrect(stereoAtomsMap, correctAtomIds, bond.end);
   }
 
   return stereoAtomsMap;

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -289,7 +289,7 @@ function getStructCenter(struct: Struct): Vec2 {
       xmax = Math.max(xmax, atom.pp.x);
       ymax = Math.max(ymax, atom.pp.y);
     });
-    return new Vec2((xmin + xmax) / 2, (ymin + ymax) / 2); // TODO: check
+    return new Vec2((xmin + xmax) / 2, (ymin + ymax) / 2);
   }
   // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
   if (struct.rxnArrows.size > 0) return struct.rxnArrows.get(0)!.center();

--- a/packages/ketcher-core/src/application/editor/operations/BaseOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/BaseOperation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  ***************************************************************************/
 
-// todo: rename file in another PR
 import { ReStruct, StereLabelStyleType } from '../../render';
 
 import { OperationType } from './OperationType';
@@ -27,6 +26,7 @@ class BaseOperation {
   private _inverted: BaseOperation | undefined;
   type: OperationType;
   priority: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- operation payload shape varies by operation type
   data: any;
 
   constructor(type: OperationType, priority = 0) {
@@ -132,6 +132,7 @@ class BaseOperation {
     restruct: ReStruct,
     mapName: keyof typeof ReStruct.maps,
     id: number,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches legacy invalidate depth flag
     level?: any,
   ) {
     if (mapName === 'atoms') {

--- a/packages/ketcher-core/src/application/editor/operations/CanvasLoad.ts
+++ b/packages/ketcher-core/src/application/editor/operations/CanvasLoad.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 import { Struct } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/EnhancedFlagClear.ts
+++ b/packages/ketcher-core/src/application/editor/operations/EnhancedFlagClear.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import { Vec2 } from 'domain/entities';
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/EnhancedFlagMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/EnhancedFlagMove.ts
@@ -16,7 +16,7 @@
 
 import { Fragment, Vec2 } from 'domain/entities';
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/FragmentStereoFlag.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentStereoFlag.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationPriority, OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/LoopMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/LoopMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/editor/operations/Text/TextCreateDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/Text/TextCreateDelete.ts
@@ -18,7 +18,7 @@
 import { ReStruct, ReText } from '../../../render';
 import { Text, Vec2 } from 'domain/entities';
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 
 interface TextCreateData {

--- a/packages/ketcher-core/src/application/editor/operations/Text/TextMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/Text/TextMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/editor/operations/Text/TextUpdate.ts
+++ b/packages/ketcher-core/src/application/editor/operations/Text/TextUpdate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAttr.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/editor/operations/atom/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/index.ts
@@ -18,7 +18,7 @@
 import { Atom, Pile, Vec2 } from 'domain/entities';
 import { ReAtom, ReStruct } from '../../../render';
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 
 // todo: separate classes: now here is circular dependency in `invert` method

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/editor/operations/bond/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/index.ts
@@ -17,7 +17,7 @@
 
 import { ReBond, ReStruct } from '../../../render';
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { Bond } from 'domain/entities';
 import { OperationPriority, OperationType } from '../OperationType';
 

--- a/packages/ketcher-core/src/application/editor/operations/calcimplicitH.ts
+++ b/packages/ketcher-core/src/application/editor/operations/calcimplicitH.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationPriority, OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/descriptors.ts
+++ b/packages/ketcher-core/src/application/editor/operations/descriptors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 import { Vec2 } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/fragment.ts
+++ b/packages/ketcher-core/src/application/editor/operations/fragment.ts
@@ -17,7 +17,7 @@
 
 import { ReEnhancedFlag, ReFrag, ReStruct } from '../../render';
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { Fragment, StructProperty } from 'domain/entities';
 import { OperationType } from './OperationType';
 
@@ -45,7 +45,8 @@ class FragmentAdd extends BaseOperation {
       struct.frags.set(this.frid, frag);
     }
 
-    restruct.frags.set(this.frid, new ReFrag(frag)); // TODO add restruct.notifyFragmentAdded
+    restruct.frags.set(this.frid, new ReFrag(frag));
+    restruct.markItem('frags', this.frid, 1); // notifyFragmentAdded
     restruct.enhancedFlags.set(this.frid, new ReEnhancedFlag());
   }
 
@@ -98,7 +99,8 @@ class FragmentDelete extends BaseOperation {
 
     BaseOperation.invalidateItem(restruct, 'frags', this.frid, 1);
     restruct.frags.delete(this.frid);
-    struct.frags.delete(this.frid); // TODO add restruct.notifyFragmentRemoved
+    restruct.markItemRemoved(); // notifyFragmentRemoved
+    struct.frags.delete(this.frid);
 
     const enhancedFalg = restruct.enhancedFlags.get(this.frid);
     if (!enhancedFalg) return;

--- a/packages/ketcher-core/src/application/editor/operations/fragmentStereoAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/fragmentStereoAtom.ts
@@ -13,29 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationPriority, OperationType } from './OperationType';
 import { ReStruct } from '../../render';
-
-// todo: separate classes: now here is circular dependency in `invert` method
 
 type Data = {
   frid: any;
   aid: any;
 };
 
-// todo : merge add and delete stereo atom
-class FragmentAddStereoAtom extends BaseOperation {
+class FragmentStereoAtom extends BaseOperation {
   readonly data: Data;
+  private readonly add: boolean;
 
-  constructor(fragmentId: any, atomId: any) {
+  constructor(fragmentId: any, atomId: any, add: boolean) {
     super(
-      OperationType.FRAGMENT_ADD_STEREO_ATOM,
-      OperationPriority.FRAGMENT_ADD_STEREO_ATOM,
+      add
+        ? OperationType.FRAGMENT_ADD_STEREO_ATOM
+        : OperationType.FRAGMENT_DELETE_STEREO_ATOM,
+      add
+        ? OperationPriority.FRAGMENT_ADD_STEREO_ATOM
+        : OperationPriority.FRAGMENT_DELETE_STEREO_ATOM,
     );
     this.data = { frid: fragmentId, aid: atomId };
+    this.add = add;
   }
 
   execute(restruct: ReStruct) {
@@ -43,43 +45,26 @@ class FragmentAddStereoAtom extends BaseOperation {
 
     const frag = restruct.molecule.frags.get(frid);
     if (frag) {
-      frag.updateStereoAtom(restruct.molecule, aid, frid, true);
-
+      frag.updateStereoAtom(restruct.molecule, aid, frid, this.add);
       BaseOperation.invalidateEnhancedFlag(restruct, frid);
     }
   }
 
   invert() {
-    return new FragmentDeleteStereoAtom(this.data.frid, this.data.aid);
+    return new FragmentStereoAtom(this.data.frid, this.data.aid, !this.add);
   }
 }
 
-class FragmentDeleteStereoAtom extends BaseOperation {
-  readonly data: Data;
-
+class FragmentAddStereoAtom extends FragmentStereoAtom {
   constructor(fragmentId: any, atomId: any) {
-    super(
-      OperationType.FRAGMENT_DELETE_STEREO_ATOM,
-      OperationPriority.FRAGMENT_DELETE_STEREO_ATOM,
-    );
-    this.data = { frid: fragmentId, aid: atomId };
-  }
-
-  execute(restruct: ReStruct) {
-    const { aid, frid } = this.data;
-
-    const frag = restruct.molecule.frags.get(frid);
-    if (frag) {
-      frag.updateStereoAtom(restruct.molecule, aid, frid, false);
-
-      BaseOperation.invalidateEnhancedFlag(restruct, frid);
-    }
-  }
-
-  invert() {
-    const { aid, frid } = this.data;
-    return new FragmentAddStereoAtom(frid, aid);
+    super(fragmentId, atomId, true);
   }
 }
 
-export { FragmentAddStereoAtom, FragmentDeleteStereoAtom };
+class FragmentDeleteStereoAtom extends FragmentStereoAtom {
+  constructor(fragmentId: any, atomId: any) {
+    super(fragmentId, atomId, false);
+  }
+}
+
+export { FragmentStereoAtom, FragmentAddStereoAtom, FragmentDeleteStereoAtom };

--- a/packages/ketcher-core/src/application/editor/operations/highlight.ts
+++ b/packages/ketcher-core/src/application/editor/operations/highlight.ts
@@ -18,7 +18,7 @@
 import { Highlight } from 'domain/entities';
 import { ReStruct } from '../../render';
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 
 type Data = {

--- a/packages/ketcher-core/src/application/editor/operations/ifThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/ifThen.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { BaseOperation } from './base';
+import { BaseOperation } from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReStruct } from '../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/image/imageMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageMove.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { Vec2 } from 'domain/entities';
 import { OperationType } from 'application/editor';
 import { ReStruct } from 'application/render';

--- a/packages/ketcher-core/src/application/editor/operations/image/imageResize.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageResize.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { ImageReferenceName, Vec2 } from 'domain/entities';
 import { ReStruct } from 'application/render';
 import { OperationType } from 'application/editor';

--- a/packages/ketcher-core/src/application/editor/operations/image/imageUpsertDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageUpsertDelete.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { Image } from 'domain/entities/image';
 import { ReStruct } from 'application/render';

--- a/packages/ketcher-core/src/application/editor/operations/monomer/FlipMonomerOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/FlipMonomerOperation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import BaseOperation from 'application/editor/operations/base';
+import BaseOperation from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { ReStruct } from 'application/render';
 import type { FlipDirection } from 'application/editor/shared/utils.types';

--- a/packages/ketcher-core/src/application/editor/operations/monomer/RotateMonomerOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/RotateMonomerOperation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import BaseOperation from 'application/editor/operations/base';
+import BaseOperation from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { ReStruct } from 'application/render';
 import { MonomerMicromolecule } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/monomer/ShiftMonomerOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/ShiftMonomerOperation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import BaseOperation from 'application/editor/operations/base';
+import BaseOperation from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { ReStruct } from 'application/render';
 import { MonomerMicromolecule } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignAttachmentAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignAttachmentAtomOperation.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { MonomerCreationState, ReStruct } from 'application/render';
 import {
   OperationType,

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { MonomerCreationState, ReStruct } from 'application/render';
 import {
   OperationType,

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { MonomerCreationState } from 'application/render';
 import { OperationType } from 'application/editor';
 import assert from 'assert';

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { MonomerCreationState, ReStruct } from 'application/render';
 import assert from 'assert';

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/RemoveAttachmentPointOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/RemoveAttachmentPointOperation.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { MonomerCreationState } from 'application/render';
 import {
   OperationType,

--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowAddRemoveTail.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowAddRemoveTail.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-non-null-assertion */
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { ReStruct } from 'application/render';
 import { FixedPrecisionCoordinates } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowMove.ts
@@ -2,7 +2,7 @@ import { Vec2 } from 'domain/entities';
 import { OperationType } from 'application/editor';
 import { Scale } from 'domain/helpers';
 import { ReStruct } from 'application/render';
-import BaseOperation from 'application/editor/operations/base';
+import BaseOperation from 'application/editor/operations/BaseOperation';
 
 export class MultitailArrowMove extends BaseOperation {
   constructor(private readonly id: number, private readonly offset: Vec2) {

--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowMoveHeadTail.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowMoveHeadTail.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { MultitailArrowRefName, ReStruct } from 'application/render';
 import { MULTITAIL_ARROW_KEY } from 'domain/constants';

--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowResizeTailHead.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowResizeTailHead.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor';
 import { ReStruct } from 'application/render';
 import { MULTITAIL_ARROW_KEY } from 'domain/constants';

--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowUpsertDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowUpsertDelete.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-use-before-define */
-import { BaseOperation } from 'application/editor/operations/base';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { MultitailArrow } from 'domain/entities/multitailArrow';
 import { OperationType } from 'application/editor';
 import { ReStruct, ReMultitailArrow } from 'application/render';

--- a/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupFragment.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupFragment.ts
@@ -16,7 +16,7 @@
 
 import { ReRGroup, ReStruct } from '../../../render';
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { RGroup } from 'domain/entities';
 

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointAdd.ts
@@ -6,7 +6,7 @@ import {
 } from 'domain/entities';
 import { RGroupAttachmentPointRemove } from '.';
 import { OperationPriority, OperationType } from '../OperationType';
-import BaseOperation from '../base';
+import BaseOperation from '../BaseOperation';
 
 type Data = {
   atomId: number;

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
@@ -2,7 +2,7 @@ import { ReStruct } from 'application/render';
 import assert from 'assert';
 import { RGroupAttachmentPointAdd } from '.';
 import { OperationPriority, OperationType } from '../OperationType';
-import BaseOperation from '../base';
+import BaseOperation from '../BaseOperation';
 
 type Data = { atomId: number; attachmentPointType; attachmentPointId: number };
 

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import Base from '../base';
+import Base from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { Scale } from 'domain/helpers';
 

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowResize.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowResize.ts
@@ -20,7 +20,7 @@ import { RxnArrow, Vec2 } from 'domain/entities';
 import { Scale } from 'domain/helpers';
 import { tfx } from 'utilities';
 import { OperationType } from '../OperationType';
-import Base from '../base';
+import Base from '../BaseOperation';
 
 export const ARROW_MAX_SNAPPING_ANGLE = Math.PI / 36; // 5°
 

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowRotate.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowRotate.ts
@@ -2,7 +2,7 @@ import utils from 'application/editor/shared/utils';
 import { ReStruct } from 'application/render';
 import { Vec2 } from 'domain/entities';
 import { OperationType } from '../OperationType';
-import Base from '../base';
+import Base from '../BaseOperation';
 
 interface RxnArrowRotateData {
   id: number;

--- a/packages/ketcher-core/src/application/editor/operations/rxn/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/index.ts
@@ -17,7 +17,7 @@
 
 import { RxnArrow, RxnArrowMode, Vec2 } from 'domain/entities';
 
-import Base from '../base';
+import Base from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { ReRxnArrow } from '../../../render';
 import { KetcherLogger } from 'utilities';

--- a/packages/ketcher-core/src/application/editor/operations/rxn/plus/RxnPlusMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/plus/RxnPlusMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../../base';
+import { BaseOperation } from '../../BaseOperation';
 import { OperationType } from '../../OperationType';
 import { ReStruct } from '../../../../render';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/editor/operations/rxn/plus/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/plus/index.ts
@@ -18,7 +18,7 @@
 import { ReRxnPlus, ReStruct } from '../../../../render';
 import { RxnPlus, Vec2 } from 'domain/entities';
 
-import { BaseOperation } from '../../base';
+import { BaseOperation } from '../../BaseOperation';
 import { OperationType } from '../../OperationType';
 
 // todo: separate classes: now here is circular dependency in `invert` method

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupAttr.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 import { MonomerMicromolecule } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupDataMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupDataMove.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/index.ts
@@ -18,7 +18,7 @@
 import { BaseMonomer, FunctionalGroup, SGroup, Vec2 } from 'domain/entities';
 import { ReSGroup, ReStruct } from '../../../render';
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAtom.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 import { SGroup } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAttachmentPoints.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAttachmentPoints.ts
@@ -1,4 +1,4 @@
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 import { SGroupAttachmentPoint } from 'domain/entities';

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { BaseOperation } from '../base';
+import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { ReStruct } from '../../../render';
 

--- a/packages/ketcher-core/src/application/editor/operations/simpleObject.ts
+++ b/packages/ketcher-core/src/application/editor/operations/simpleObject.ts
@@ -17,7 +17,7 @@
 
 import { SimpleObject, SimpleObjectMode, Vec2 } from 'domain/entities';
 
-import Base from './base';
+import Base from './BaseOperation';
 import { OperationType } from './OperationType';
 import { ReSimpleObject } from '../../render';
 import { Scale } from 'domain/helpers';


### PR DESCRIPTION
…clean up editor TODOs

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

This change addresses the “Type 1” technical-debt items in the editor: real refactors and clarifications, not comment-only removals.

Rename base.ts → BaseOperation.ts
Aligns the filename with the exported class and updates every import (./base, ../base, application/editor/operations/base, rxn/plus, actions/action.ts, etc.) so the package builds and typechecks cleanly.

Merge fragment stereo atom operations
Introduces a shared FragmentStereoAtom implementation (add vs delete via a boolean); FragmentAddStereoAtom and FragmentDeleteStereoAtom remain as thin subclasses so existing new FragmentAddStereoAtom(...) call sites are unchanged.

Deduplicate stereo map logic in getStereoAtomsMap
Extracts resetStereoAtomIfNotCorrect to remove repeated “clear stereo atom if not a correct center” blocks.

Fragment add/delete invalidation
After adding a fragment, calls restruct.markItem('frags', frid, 1) (same idea as atom add marking). After deleting a fragment, calls restruct.markItemRemoved() (aligned with atom delete).

Paste anchor
Drops the obsolete // TODO: check on the bounding-box center calculation; the midpoint formula is correct for the atom-bounds case.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request