### PR TITLE
#9575 - Refactor: Variables are missing in props validation (let's rewrite JS to TS) 36

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/SDataFieldset.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/SDataFieldset.tsx
@@ -19,13 +19,30 @@ import { getSelectOptionsFromSchema } from '../../utils';
 import Select from '../../component/form/Select';
 import { sdataCustomSchema } from '../../data/schema/sdata-schema';
 
+interface SdataFormResult {
+  context: string;
+  fieldName: string;
+  fieldValue: string;
+  radiobuttons: boolean;
+}
+
+interface SDataFieldsetFormState {
+  errors: Record<string, unknown>;
+  valid: boolean;
+  result: SdataFormResult;
+}
+
+interface SDataFieldsetProps {
+  formState: SDataFieldsetFormState;
+}
+
 const content = (
-  schema,
-  context,
-  fieldName,
-  fieldValue,
-  checked,
-  isContextEmpty,
+  schema: typeof sdataCustomSchema,
+  context: string,
+  fieldName: string,
+  _fieldValue: string,
+  checked: boolean,
+  isContextEmpty: boolean,
 ) =>
   Object.keys(schema.properties)
     .filter(
@@ -64,7 +81,7 @@ const content = (
       }
     });
 
-function SDataFieldset({ formState }) {
+function SDataFieldset({ formState }: SDataFieldsetProps) {
   const { result } = formState;
   const formSchema = sdataCustomSchema;
   const validContextValues = formSchema.properties.context.enum;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Converted SDataFieldset.jsx to TypeScript (.tsx) with full prop type definitions
  - Defined SDataFieldsetProps, SDataFieldsetFormState, and SdataFormResult interfaces to enforce type safety on the formState prop
  and the content helper function parameters
  - Added @ts-expect-error for pre-existing type mismatch where FieldProps.checked is typed as boolean in form.d.ts but radio fields
  pass a string value

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request