### PR TITLE
#9576 Refactor: Variables are missing in props validation (let's rewrite JS to TS) 37

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/SGroupFieldset.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/SGroupFieldset.tsx
@@ -27,6 +27,12 @@ type PropMappingValue = {
   type?: string;
 };
 
+enum SGroupPropType {
+  Connectivity = 'connectivity',
+  Class = 'class',
+  Subtype = 'subtype',
+}
+
 const propMapping: Record<string, PropMappingValue> = {
   name: { maxLength: 15 },
   fieldName: { maxLength: 30 },
@@ -38,7 +44,11 @@ const content = (type: string): JSX.Element[] =>
   Object.keys(schemes[type].properties)
     .filter((prop) => prop !== 'type')
     .map((prop) => {
-      if (prop === 'connectivity' || prop === 'class' || prop === 'subtype') {
+      if (
+        prop === SGroupPropType.Connectivity ||
+        prop === SGroupPropType.Class ||
+        prop === SGroupPropType.Subtype
+      ) {
         return (
           <Field
             name={prop}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Renamed SGroupFieldset.jsx → SGroupFieldset.tsx via git mv to preserve git
  history
  - Added SGroupFieldsetProps interface typed against the existing
  BaseProps['formState'] from modal.types.ts to avoid duplication
  - Typed propMapping as Record<string, PropMappingValue> with a local
  PropMappingValue type
  - Typed the content helper function parameter (string) and return value
  (JSX.Element[])

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request