### PR TITLE
Bind example static servers to 127.0.0.1 for safer public deployments

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -30,8 +30,8 @@
     "test:prettier": "prettier --check \"./**/*.{js,ts,jsx,tsx,json}\"",
     "prettier:write": "prettier --write \"./**/*.{js,jsx,json,ts,tsx}\"",
     "stylelint:fix": "stylelint \"./**/*.{css,less}\" --formatter verbose --fix",
-    "serve:remote": "serve dist/remote -c serve.json -p 4001",
-    "serve:standalone": "serve dist/standalone -c serve.json -p 4002",
+    "serve:remote": "serve dist/remote -c serve.json -l tcp://127.0.0.1:4001",
+    "serve:standalone": "serve dist/standalone -c serve.json -l tcp://127.0.0.1:4002",
     "eject": "react-scripts eject"
   },
   "dependencies": {


### PR DESCRIPTION
Bind the example static servers to `127.0.0.1` instead of all interfaces by default.

This makes local/example deployment safer on shared or public hosts by reducing accidental network exposure.