### PR TITLE
Add selected SMILES indicator with one-click copy

### DIFF
--- a/packages/ketcher-react/src/script/ui/App/App.tsx
+++ b/packages/ketcher-react/src/script/ui/App/App.tsx
@@ -40,6 +40,7 @@ import { useAppDispatch } from '../state/hooks';
 import { selectSnackbarNotificationText } from '../state/notifications';
 import { useSelector } from 'react-redux';
 import { IconButton } from 'components';
+import { SelectedSmiles } from '../views/components/SelectedSmiles';
 
 interface AppCallProps {
   checkServer: () => void;
@@ -118,6 +119,7 @@ const App = (props: Props) => {
         <LeftToolbarContainer className={classes.left} />
         <BottomToolbarContainer className={classes.bottom} />
         <RightToolbarContainer className={classes.right} />
+        <SelectedSmiles />
 
         {
           // TODO suppressed after upgrade to react 19. Need to fix

--- a/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/SelectedSmiles.module.less
+++ b/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/SelectedSmiles.module.less
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+.container {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(460px, calc(100% - 56px));
+  padding: 6px 10px;
+  border: 1px solid #d7dce5;
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 2px 6px rgba(103, 104, 132, 0.15);
+}
+
+.label {
+  flex-shrink: 0;
+  color: #6f7892;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.button {
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #1d3557;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+
+  &:hover .value {
+    color: #0b65c2;
+    text-decoration: underline;
+  }
+}
+
+.value {
+  display: block;
+  overflow: hidden;
+  color: #2f405f;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/SelectedSmiles.test.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/SelectedSmiles.test.tsx
@@ -1,0 +1,188 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { getStructure, ketcherProvider } from 'ketcher-core';
+import { showSnackbarNotification } from '../../../state/notifications';
+import { SelectedSmiles } from './SelectedSmiles';
+
+const mockDispatch = jest.fn();
+
+jest.mock('src/hooks', () => ({
+  useAppContext: () => ({
+    ketcherId: 'test-ketcher-id',
+  }),
+}));
+
+jest.mock('../../../state/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+}));
+
+jest.mock('ketcher-core', () => ({
+  SupportedFormat: {
+    smiles: 'smiles',
+  },
+  getStructure: jest.fn(),
+  ketcherProvider: {
+    getKetcher: jest.fn(),
+  },
+  KetcherLogger: {
+    error: jest.fn(),
+  },
+}));
+
+const getStructureMock = getStructure as jest.Mock;
+const getKetcherMock = ketcherProvider.getKetcher as jest.Mock;
+
+function createSelectedStruct({
+  atomsSize = 2,
+  componentsCount = 1,
+  simpleObjectsSize = 0,
+  textsSize = 0,
+  imagesSize = 0,
+  rxnPlusesSize = 0,
+  hasRxnArrow = false,
+  hasMultitailArrow = false,
+}: Partial<{
+  atomsSize: number;
+  componentsCount: number;
+  simpleObjectsSize: number;
+  textsSize: number;
+  imagesSize: number;
+  rxnPlusesSize: number;
+  hasRxnArrow: boolean;
+  hasMultitailArrow: boolean;
+}> = {}) {
+  return {
+    atoms: { size: atomsSize },
+    simpleObjects: { size: simpleObjectsSize },
+    texts: { size: textsSize },
+    images: { size: imagesSize },
+    rxnPluses: { size: rxnPlusesSize },
+    isBlank: () => atomsSize === 0,
+    hasRxnArrow: () => hasRxnArrow,
+    hasMultitailArrow: () => hasMultitailArrow,
+    findConnectedComponents: () =>
+      Array.from({ length: componentsCount }, () => new Set([1])),
+  };
+}
+
+describe('SelectedSmiles', () => {
+  const subscribeMock = jest.fn();
+  const unsubscribeMock = jest.fn();
+  const selectionMock = jest.fn();
+  const explicitSelectedMock = jest.fn();
+  const structSelectedMock = jest.fn();
+  const errorHandlerMock = jest.fn();
+  const writeTextMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Object.defineProperty(window, 'isPolymerEditorTurnedOn', {
+      configurable: true,
+      value: false,
+      writable: true,
+    });
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+
+    selectionMock.mockReturnValue({ atoms: [1], bonds: [] });
+    explicitSelectedMock.mockReturnValue({
+      atoms: [1],
+      bonds: [],
+      simpleObjects: [],
+      texts: [],
+      images: [],
+      rxnArrows: [],
+      rxnPluses: [],
+    });
+    subscribeMock.mockImplementation(
+      (_eventName: string, handler: () => void) => ({ handler }),
+    );
+
+    getKetcherMock.mockReturnValue({
+      id: 'test-ketcher-id',
+      formatterFactory: {},
+      editor: {
+        subscribe: subscribeMock,
+        unsubscribe: unsubscribeMock,
+        selection: selectionMock,
+        explicitSelected: explicitSelectedMock,
+        structSelected: structSelectedMock,
+        errorHandler: errorHandlerMock,
+      },
+    });
+  });
+
+  it('renders selected SMILES for a single connected molecule', async () => {
+    structSelectedMock.mockReturnValue(createSelectedStruct());
+    getStructureMock.mockResolvedValue('CCO');
+
+    render(<SelectedSmiles />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-smiles-button')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('selected-smiles-button')).toHaveTextContent(
+      'CCO',
+    );
+  });
+
+  it('does not render anything for a disconnected selection', async () => {
+    structSelectedMock.mockReturnValue(
+      createSelectedStruct({ componentsCount: 2 }),
+    );
+
+    render(<SelectedSmiles />);
+
+    await waitFor(() => {
+      expect(structSelectedMock).toHaveBeenCalled();
+    });
+
+    expect(getStructureMock).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId('selected-smiles-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('copies selected SMILES and shows a snackbar notification on click', async () => {
+    structSelectedMock.mockReturnValue(createSelectedStruct());
+    getStructureMock.mockResolvedValue('CCO');
+    writeTextMock.mockResolvedValue(undefined);
+
+    render(<SelectedSmiles />);
+
+    const button = await screen.findByTestId('selected-smiles-button');
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith('CCO');
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      showSnackbarNotification('SMILES copied'),
+    );
+  });
+});

--- a/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/SelectedSmiles.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/SelectedSmiles.tsx
@@ -1,0 +1,236 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { FC, useEffect, useState } from 'react';
+import {
+  getStructure,
+  KetcherLogger,
+  ketcherProvider,
+  SupportedFormat,
+  type Struct,
+} from 'ketcher-core';
+import { useAppContext } from 'src/hooks';
+import { ketcherInitEventName } from 'src/constants';
+import { useAppDispatch } from '../../../state/hooks';
+import { showSnackbarNotification } from '../../../state/notifications';
+import classes from './SelectedSmiles.module.less';
+
+const COPY_SUCCESS_MESSAGE = 'SMILES copied';
+const COPY_ERROR_MESSAGE = 'This feature is not available in your browser';
+
+type BasicSelection = {
+  atoms?: number[];
+  bonds?: number[];
+} | null;
+
+function hasSelectedAtomsOrBonds(selection: BasicSelection): boolean {
+  return Boolean(selection?.atoms?.length || selection?.bonds?.length);
+}
+
+function isSingleMoleculeSelection(selectedStruct: Struct): boolean {
+  if (
+    selectedStruct.isBlank() ||
+    selectedStruct.atoms.size === 0 ||
+    selectedStruct.simpleObjects.size > 0 ||
+    selectedStruct.texts.size > 0 ||
+    selectedStruct.images.size > 0 ||
+    selectedStruct.hasRxnArrow() ||
+    selectedStruct.rxnPluses.size > 0 ||
+    selectedStruct.hasMultitailArrow()
+  ) {
+    return false;
+  }
+
+  return selectedStruct.findConnectedComponents(true).length === 1;
+}
+
+export const SelectedSmiles: FC = () => {
+  const dispatch = useAppDispatch();
+  const { ketcherId } = useAppContext();
+  const [selectedSmiles, setSelectedSmiles] = useState<string | null>(null);
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    let selectionSubscriber: unknown;
+    let changeSubscriber: unknown;
+    let isSubscribed = false;
+
+    const updateRevision = () => {
+      setRevision((currentRevision) => currentRevision + 1);
+    };
+
+    const subscribe = () => {
+      if (isSubscribed) {
+        return;
+      }
+
+      try {
+        const editor = ketcherProvider.getKetcher(ketcherId).editor;
+
+        if (!editor) {
+          return;
+        }
+
+        selectionSubscriber = editor.subscribe(
+          'selectionChange',
+          updateRevision,
+        );
+        changeSubscriber = editor.subscribe('change', updateRevision);
+        isSubscribed = true;
+        updateRevision();
+      } catch {
+        // Ketcher instance is not ready yet. Subscription will be retried on init event.
+      }
+    };
+
+    const unsubscribe = () => {
+      if (!isSubscribed) {
+        return;
+      }
+
+      try {
+        const editor = ketcherProvider.getKetcher(ketcherId).editor;
+
+        editor.unsubscribe('selectionChange', selectionSubscriber);
+        editor.unsubscribe('change', changeSubscriber);
+      } catch {
+        // Ketcher instance was already disposed.
+      } finally {
+        isSubscribed = false;
+      }
+    };
+
+    const initEventName = ketcherInitEventName(ketcherId);
+
+    window.addEventListener(initEventName, subscribe);
+    subscribe();
+
+    return () => {
+      unsubscribe();
+      window.removeEventListener(initEventName, subscribe);
+    };
+  }, [ketcherId]);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const updateSelectedSmiles = async () => {
+      try {
+        if (window.isPolymerEditorTurnedOn) {
+          if (!isCancelled) {
+            setSelectedSmiles(null);
+          }
+
+          return;
+        }
+
+        const ketcher = ketcherProvider.getKetcher(ketcherId);
+        const editor = ketcher.editor;
+        const selection = editor.selection();
+
+        if (!selection) {
+          if (!isCancelled) {
+            setSelectedSmiles(null);
+          }
+
+          return;
+        }
+
+        const explicitSelection = editor.explicitSelected();
+
+        if (!hasSelectedAtomsOrBonds(explicitSelection)) {
+          if (!isCancelled) {
+            setSelectedSmiles(null);
+          }
+
+          return;
+        }
+
+        const selectedStruct = editor.structSelected();
+
+        if (!isSingleMoleculeSelection(selectedStruct)) {
+          if (!isCancelled) {
+            setSelectedSmiles(null);
+          }
+
+          return;
+        }
+
+        const smiles = await getStructure(
+          ketcher.id,
+          ketcher.formatterFactory,
+          selectedStruct,
+          SupportedFormat.smiles,
+        );
+
+        if (!isCancelled) {
+          setSelectedSmiles(smiles.trim() || null);
+        }
+      } catch (error) {
+        KetcherLogger.error('SelectedSmiles.tsx::updateSelectedSmiles', error);
+
+        if (!isCancelled) {
+          setSelectedSmiles(null);
+        }
+      }
+    };
+
+    updateSelectedSmiles();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [ketcherId, revision]);
+
+  const handleCopy = async () => {
+    if (!selectedSmiles) {
+      return;
+    }
+
+    try {
+      if (typeof navigator?.clipboard?.writeText !== 'function') {
+        throw new Error(COPY_ERROR_MESSAGE);
+      }
+
+      await navigator.clipboard.writeText(selectedSmiles);
+      dispatch(showSnackbarNotification(COPY_SUCCESS_MESSAGE));
+    } catch (error) {
+      KetcherLogger.error('SelectedSmiles.tsx::handleCopy', error);
+      ketcherProvider
+        .getKetcher(ketcherId)
+        .editor.errorHandler?.(COPY_ERROR_MESSAGE);
+    }
+  };
+
+  if (!selectedSmiles) {
+    return null;
+  }
+
+  return (
+    <div className={classes.container}>
+      <span className={classes.label}>SMILES</span>
+      <button
+        className={classes.button}
+        onClick={handleCopy}
+        title={selectedSmiles}
+        type="button"
+        data-testid="selected-smiles-button"
+      >
+        <span className={classes.value}>{selectedSmiles}</span>
+      </button>
+    </div>
+  );
+};

--- a/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/index.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/SelectedSmiles/index.ts
@@ -1,0 +1,17 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+export * from './SelectedSmiles';


### PR DESCRIPTION
Add a bottom-right SMILES indicator for the current selected molecule.

When a single connected molecule is selected, its SMILES is shown and can be copied to the clipboard with one click.