### PR TITLE
#8818 Add/Remove explicit hydrogens operation inside create monomer wizard causes exception: process is not defined

### DIFF
--- a/packages/ketcher-macromolecules/rollup.config.js
+++ b/packages/ketcher-macromolecules/rollup.config.js
@@ -34,6 +34,13 @@ export const valuesToReplace = {
   ),
   // TODO: add logic to init BUILD_NUMBER
   'process.env.BUILD_NUMBER': JSON.stringify(undefined),
+  'process.env.HELP_LINK': JSON.stringify(process.env.HELP_LINK || 'master'),
+  'process.env.INDIGO_VERSION': JSON.stringify(
+    process.env.INDIGO_VERSION || '',
+  ),
+  'process.env.INDIGO_MACHINE': JSON.stringify(
+    process.env.INDIGO_MACHINE || '',
+  ),
 };
 
 const config = {

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -31,7 +31,6 @@ import { supportedSGroupTypes } from './constants';
 import { setAnalyzingFile } from './request';
 import tools from '../action/tools';
 import { isNumber } from 'lodash';
-import assert from 'assert';
 
 export function onAction(action) {
   if (action?.dialog) {
@@ -156,10 +155,9 @@ export function load(struct: Struct, options?) {
 
       if (
         method === 'toggleExplicitHydrogens' &&
-        editor.isMonomerCreationWizardActive
+        editor.isMonomerCreationWizardActive &&
+        editor.monomerCreationState
       ) {
-        assert(editor.monomerCreationState);
-
         // If toggle explicit hydrogen is called, we should not apply it for marked leaving group atoms in monomer creation wizard
         const { assignedAttachmentPoints } = editor.monomerCreationState;
 
@@ -196,10 +194,13 @@ export function load(struct: Struct, options?) {
           (bondId) => !newBondsToLeavingGroupAtoms.has(bondId),
         );
 
-        // Rewrite leaving atoms in new struct by their original versions to persist implicit hydrogen count
+        // Rewrite leaving atoms in new struct by their original versions to persist implicit hydrogen count.
+        // Atom ids may diverge after Indigo transformations, so skip stale ids defensively.
         leavingGroupAtoms.forEach((_, atomId) => {
           const originalAtom = currentStruct.atoms.get(atomId);
-          assert(originalAtom);
+          if (!originalAtom || !parsedStruct.atoms.has(atomId)) {
+            return;
+          }
           parsedStruct.atoms.set(atomId, originalAtom);
         });
       }

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
@@ -4,7 +4,6 @@ import {
   getAttachmentPointNumberFromLabel,
 } from 'ketcher-core';
 import { Editor } from '../../../../../editor';
-import assert from 'assert';
 import { Option } from '../../../../component/form/Select';
 
 export type AttachmentPointSelectData = {
@@ -47,14 +46,20 @@ export const useAttachmentPointSelectsData = (
   const { assignedAttachmentPoints } = editor.monomerCreationState;
 
   const atomPair = assignedAttachmentPoints.get(attachmentPointName);
-  assert(atomPair);
+  if (!atomPair) {
+    return null;
+  }
 
   const [attachmentAtomId, leavingAtomId] = atomPair;
   const attachmentAtom = editor.struct().atoms.get(attachmentAtomId);
-  assert(attachmentAtom);
+  if (!attachmentAtom) {
+    return null;
+  }
 
   const leavingAtom = editor.struct().atoms.get(leavingAtomId);
-  assert(leavingAtom);
+  if (!leavingAtom) {
+    return null;
+  }
 
   const usedNumbers = Array.from(assignedAttachmentPoints.keys()).map((name) =>
     getAttachmentPointNumberFromLabel(name),


### PR DESCRIPTION
How the issue was fixed
This bug had two independent crash sources in this flow:
process is not defined in browser runtime
Root cause: ketcher-macromolecules bundle contained unreplaced process.env.* usages.
Fix: added missing Rollup replacements in packages/ketcher-macromolecules/rollup.config.js for:
process.env.HELP_LINK
process.env.INDIGO_VERSION
process.env.INDIGO_MACHINE
Result: browser no longer tries to access Node process at runtime.
Assertion crashes after repeated explicit-H toggles
Root cause: monomer wizard code assumed attachment/leaving atom IDs always remain synchronized after Indigo transformation and used strict assert(...).
Fixes:
useAttachmentPointSelectsData now returns null safely when attachment-point pair or referenced atoms are missing/stale, instead of throwing.
shared.ts explicit-H postprocessing now uses defensive guards (skip stale IDs) instead of hard assertions when restoring leaving atoms.
Result: repeated toggle no longer crashes, wizard remains usable, and expected structure behavior is preserved.
<img width="1899" height="904" alt="image" src="https://github.com/user-attachments/assets/fa60e6b3-568d-48a6-ba11-3bb9165352bd" />
<img width="1876" height="947" alt="image" src="https://github.com/user-attachments/assets/ec33d6a1-7773-4535-ba17-fa7c465fd6ad" />
