### PR TITLE
#9578 Refactor: Variables are missing in props validation (let's rewrite JS to TS) 39

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/form/form.d.ts
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.d.ts
@@ -26,6 +26,10 @@ export interface FieldProps {
   onChange?: (value: string) => void;
   placeholder?: string;
   checked?: boolean;
+  multiple?: boolean;
+  testId?: string;
+  disabledIds?: unknown[];
+  classes?: Record<string, string | undefined>;
 }
 
 export interface FieldWithModalProps extends FieldProps {

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/rgroup/rgroup.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/rgroup/rgroup.tsx
@@ -22,7 +22,37 @@ import classes from './rgroup.module.less';
 import { connect } from 'react-redux';
 import { rgroupSchema } from '../../../data/schema/struct-schema';
 
-function RGroup({ disabledIds, values, formState, type, ...props }) {
+interface RGroupResult {
+  values: number[];
+}
+
+interface RGroupFormState {
+  result: RGroupResult;
+  valid: boolean;
+  errors: Record<string, string>;
+}
+
+interface RGroupProps {
+  disabledIds: number[];
+  values: number[];
+  formState: RGroupFormState;
+  type: 'atom' | 'fragment';
+}
+
+interface RGroupCallProps {
+  onCancel: () => void;
+  onOk: (result: unknown) => void;
+}
+
+interface RGroupStoreState {
+  modal: {
+    form: RGroupFormState;
+  };
+}
+
+type Props = RGroupProps & RGroupCallProps;
+
+function RGroup({ disabledIds, values, formState, type, ...props }: Props) {
   return (
     <Dialog
       title="R-Group"
@@ -48,4 +78,6 @@ function RGroup({ disabledIds, values, formState, type, ...props }) {
   );
 }
 
-export default connect((store) => ({ formState: store.modal.form }))(RGroup);
+export default connect((state: RGroupStoreState) => ({
+  formState: state.modal.form,
+}))(RGroup);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

  Converted `rgroup.jsx` to `rgroup.tsx` by adding TypeScript type definitions for all component props.

  ### New interfaces

  - `RGroupResult` — form result shape (`values: number[]`)
  - `RGroupFormState` — modal form state (`result`, `valid`, `errors`)
  - `RGroupProps` — component own props (`disabledIds`, `values`, `formState`, `type`)
  - `RGroupCallProps` — dialog callbacks (`onCancel`, `onOk`)
  - `RGroupStoreState` — Redux store slice shape used in `connect`

  ### Related changes

  - `form.d.ts` — added missing `FieldProps` entries: `multiple`, `testId`, `disabledIds`, `classes` (pass-through props forwarded to the custom `component`)
  - Replaced `FC<Props>` with a plain function declaration to avoid a React 19 / react-redux type incompatibility (`ComponentType<never>` error caused by `bigint` in the newer `ReactNode` definition)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request