### PR TITLE
#9579 - Refactor: Variables are missing in props validation (let's rewrite JS to TS) 40

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.test.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.test.tsx
@@ -56,9 +56,27 @@ describe('Copolymer S-Group type availability', () => {
   });
 });
 
+describe('S-Group DAT type rendering', () => {
+  it('should render SDataFieldset when type is DAT', () => {
+    renderWithMockStore(<SGroup type="DAT" />, {
+      modal: {
+        form: {
+          result: {
+            type: 'DAT',
+            context: 'Fragment',
+            fieldName: 'Field name',
+            fieldValue: 'Field value',
+          },
+        },
+      },
+    });
+    expect(screen.getByText('S-Group Properties')).toBeInTheDocument();
+  });
+});
+
 function renderWithMockStore(
   component,
-  initialState = {
+  initialState: Record<string, unknown> = {
     modal: {
       form: {
         result: {

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.tsx
@@ -17,13 +17,38 @@
 import Form, { SelectOneOf } from '../../component/form/form/form';
 import { connect } from 'react-redux';
 import { sgroupMap as schemes } from '../../data/schema/struct-schema';
-import { Dialog } from '../../views/components';
+import { Dialog, type DialogParams } from '../../views/components';
 import SDataFieldset from './SDataFieldset';
 import classes from './sgroup.module.less';
 import SGroupFieldset from './SGroupFieldset';
 import { useMemo } from 'react';
 
-function Sgroup({ formState, ...props }) {
+interface SgroupFormResult {
+  type: string;
+  context?: string;
+  fieldName?: string;
+  fieldValue?: string | string[];
+  radiobuttons?: string;
+  [key: string]: unknown;
+}
+
+interface SgroupFormState {
+  errors: Record<string, unknown>;
+  valid: boolean;
+  result: SgroupFormResult;
+}
+
+interface SgroupOwnProps extends DialogParams {
+  type?: string;
+  selectedSruCount?: number;
+  [key: string]: unknown;
+}
+
+interface SgroupProps extends SgroupOwnProps {
+  formState: SgroupFormState;
+}
+
+function Sgroup({ formState, ...props }: Readonly<SgroupProps>) {
   const { result, valid } = formState;
 
   const type = result.type;
@@ -65,20 +90,25 @@ function Sgroup({ formState, ...props }) {
       params={props}
     >
       <Form
-        serialize={serialize}
         schema={schemes[type]}
         init={props}
-        {...formState}
+        {...({ serialize, ...formState } as Record<string, unknown>)}
       >
         <SelectOneOf
-          title="Type"
           name="type"
           schema={availableSchemes}
           data-testid="s-group-type"
+          {...({ title: 'Type' } as Record<string, unknown>)}
         />
 
         {type === 'DAT' ? (
-          <SDataFieldset formState={formState} />
+          <SDataFieldset
+            formState={
+              formState as unknown as Parameters<
+                typeof SDataFieldset
+              >[0]['formState']
+            }
+          />
         ) : (
           <SGroupFieldset formState={formState} />
         )}
@@ -87,4 +117,6 @@ function Sgroup({ formState, ...props }) {
   );
 }
 
-export default connect((store) => ({ formState: store.modal.form }))(Sgroup);
+export default connect((store: { modal: { form: SgroupFormState } }) => ({
+  formState: store.modal.form,
+}))(Sgroup);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Convert `sgroup.jsx` to TypeScript (`.tsx`) with full prop type definitions
  - Define `SgroupFormResult`, `SgroupFormState`, `SgroupOwnProps`, and `SgroupProps` interfaces
  - Mark component props as `Readonly<SgroupProps>`
  - Type the Redux `connect` call with proper store shape
  - Extend `DialogParams` for dialog callback props (`onCancel`, `onOk`)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request