### PR TITLE
#9671 - Context menu works wrong for embedded Ketcher

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -24,7 +24,7 @@ describe('CoreEditor', () => {
 
   it('should track dom events and trigger handlers', () => {
     const canvas = createPolymerEditorCanvas();
-    const editor: CoreEditor = new CoreEditor({
+    const editor = new CoreEditor({
       canvas,
       theme: {},
     });
@@ -61,11 +61,6 @@ describe('CoreEditor', () => {
 
   it('should prevent default context menu inside standalone editor canvas', () => {
     const canvas = createPolymerEditorCanvas();
-
-    new CoreEditor({
-      canvas,
-      theme: {},
-    });
 
     const insideEvent = new MouseEvent('contextmenu', {
       bubbles: true,

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -59,6 +59,24 @@ describe('CoreEditor', () => {
     expect(outsideEvent.defaultPrevented).toBe(false);
   });
 
+  it('should prevent default context menu inside standalone editor canvas', () => {
+    const canvas = createPolymerEditorCanvas();
+
+    new CoreEditor({
+      canvas,
+      theme: {},
+    });
+
+    const insideEvent = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    canvas.dispatchEvent(insideEvent);
+
+    expect(insideEvent.defaultPrevented).toBe(true);
+  });
+
   it('should not block context menu after macromolecules root is removed', () => {
     const { root } = createMacromoleculesEditor();
     const outsideElement = document.createElement('div');

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -1,9 +1,27 @@
-import { CoreEditor, ToolName } from 'application/editor';
+import { CoreEditor, EditorClassName, ToolName } from 'application/editor';
 import { MonomerTool } from 'application/editor/tools/Monomer';
 import { createPolymerEditorCanvas } from '../../helpers/dom';
 import { KetcherLogger } from 'utilities';
 
 describe('CoreEditor', () => {
+  const createMacromoleculesEditor = () => {
+    const root = document.createElement('div');
+
+    root.className = EditorClassName;
+    document.body.appendChild(root);
+
+    const canvas = createPolymerEditorCanvas();
+
+    root.appendChild(canvas);
+
+    const editor: CoreEditor = new CoreEditor({
+      canvas,
+      theme: {},
+    });
+
+    return { canvas, editor, root };
+  };
+
   it('should track dom events and trigger handlers', () => {
     const canvas = createPolymerEditorCanvas();
     const editor: CoreEditor = new CoreEditor({
@@ -17,6 +35,45 @@ describe('CoreEditor', () => {
     editor.selectTool(ToolName.monomer);
     canvas.dispatchEvent(new Event('mousemove', { bubbles: true }));
     expect(onMousemove).toHaveBeenCalled();
+  });
+
+  it('should prevent default context menu only inside macromolecules root', () => {
+    const { canvas } = createMacromoleculesEditor();
+    const outsideElement = document.createElement('div');
+
+    document.body.appendChild(outsideElement);
+
+    const insideEvent = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const outsideEvent = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    canvas.dispatchEvent(insideEvent);
+    outsideElement.dispatchEvent(outsideEvent);
+
+    expect(insideEvent.defaultPrevented).toBe(true);
+    expect(outsideEvent.defaultPrevented).toBe(false);
+  });
+
+  it('should not block context menu after macromolecules root is removed', () => {
+    const { root } = createMacromoleculesEditor();
+    const outsideElement = document.createElement('div');
+
+    document.body.appendChild(outsideElement);
+    root.remove();
+
+    const outsideEvent = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    outsideElement.dispatchEvent(outsideEvent);
+
+    expect(outsideEvent.defaultPrevented).toBe(false);
   });
 
   describe('updateMonomersLibrary', () => {

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -129,9 +129,6 @@ const debouncedTurnOffScrollAnimation = debounce(
   SCROLL_SMOOTHNESS_IM_MS,
 );
 
-interface KetcherTarget extends EventTarget {
-  parent: HTMLElement | SVGElement | null; // Define what parent actually is
-}
 interface ICoreEditorConstructorParams {
   ketcherId?: string;
   theme;
@@ -613,13 +610,9 @@ export class CoreEditor {
     document.addEventListener('keydown', this.hotKeyEventHandler);
   }
 
-  isKetcherTarget(target: EventTarget | null): target is KetcherTarget {
-    return target !== null && 'parent' in target;
-  }
-
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
-      if (!this.isKetcherTarget(event?.currentTarget)) {
+      if (!this.ketcherRootElement?.contains(event.currentTarget as Node)) {
         return;
       }
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -129,6 +129,9 @@ const debouncedTurnOffScrollAnimation = debounce(
   SCROLL_SMOOTHNESS_IM_MS,
 );
 
+interface KetcherTarget extends EventTarget {
+  parent: HTMLElement | SVGElement | null; // Define what parent actually is
+}
 interface ICoreEditorConstructorParams {
   ketcherId?: string;
   theme;
@@ -610,8 +613,16 @@ export class CoreEditor {
     document.addEventListener('keydown', this.hotKeyEventHandler);
   }
 
+  isKetcherTarget(target: EventTarget | null): target is KetcherTarget {
+    return target !== null && 'parent' in target;
+  }
+
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
+      if (!this.isKetcherTarget(event?.currentTarget)) {
+        return;
+      }
+
       event.preventDefault();
 
       if (this.libraryItemDragState) {

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -613,10 +613,16 @@ export class CoreEditor {
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
       const eventTarget = event.target;
+      const contextMenuScope =
+        this.ketcherRootElement?.isConnected && this.ketcherRootElement
+          ? this.ketcherRootElement
+          : this.canvas?.isConnected
+          ? this.canvas
+          : null;
       const isEventInsideEditor =
-        this.ketcherRootElement?.isConnected &&
+        contextMenuScope &&
         eventTarget instanceof Node &&
-        this.ketcherRootElement.contains(eventTarget);
+        contextMenuScope.contains(eventTarget);
 
       if (!isEventInsideEditor) {
         return;

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -612,7 +612,13 @@ export class CoreEditor {
 
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
-      if (!this.ketcherRootElement?.contains(event.currentTarget as Node)) {
+      const eventTarget = event.target;
+      const isEventInsideEditor =
+        this.ketcherRootElement?.isConnected &&
+        eventTarget instanceof Node &&
+        this.ketcherRootElement.contains(eventTarget);
+
+      if (!isEventInsideEditor) {
         return;
       }
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -613,12 +613,14 @@ export class CoreEditor {
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
       const eventTarget = event.target;
-      const contextMenuScope =
-        this.ketcherRootElement?.isConnected && this.ketcherRootElement
-          ? this.ketcherRootElement
-          : this.canvas?.isConnected
-          ? this.canvas
-          : null;
+      let contextMenuScope: HTMLDivElement | SVGSVGElement | null = null;
+
+      if (this.ketcherRootElement?.isConnected) {
+        contextMenuScope = this.ketcherRootElement;
+      } else if (this.canvas?.isConnected) {
+        contextMenuScope = this.canvas;
+      }
+
       const isEventInsideEditor =
         contextMenuScope &&
         eventTarget instanceof Node &&

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -207,6 +207,7 @@ export class CoreEditor {
   private pasteEventHandler: (event: ClipboardEvent) => void = () => {};
   private keydownEventHandler: (event: KeyboardEvent) => void = () => {};
   private contextMenuEventHandler: (event: MouseEvent) => void = () => {};
+  private contextMenuEventTarget: HTMLDivElement | SVGSVGElement | null = null;
   private readonly cleanupsForDomEvents: Array<() => void> = [];
 
   constructor({
@@ -611,25 +612,8 @@ export class CoreEditor {
   }
 
   private setupContextMenuEvents() {
+    this.contextMenuEventTarget = this.ketcherRootElement ?? this.canvas;
     this.contextMenuEventHandler = (event) => {
-      const eventTarget = event.target;
-      let contextMenuScope: HTMLDivElement | SVGSVGElement | null = null;
-
-      if (this.ketcherRootElement?.isConnected) {
-        contextMenuScope = this.ketcherRootElement;
-      } else if (this.canvas?.isConnected) {
-        contextMenuScope = this.canvas;
-      }
-
-      const isEventInsideEditor =
-        contextMenuScope &&
-        eventTarget instanceof Node &&
-        contextMenuScope.contains(eventTarget);
-
-      if (!isEventInsideEditor) {
-        return;
-      }
-
       event.preventDefault();
 
       if (this.libraryItemDragState) {
@@ -714,7 +698,10 @@ export class CoreEditor {
       return false;
     };
 
-    document.addEventListener('contextmenu', this.contextMenuEventHandler);
+    this.contextMenuEventTarget.addEventListener(
+      'contextmenu',
+      this.contextMenuEventHandler,
+    );
   }
 
   private onLayoutCircular() {
@@ -1673,7 +1660,10 @@ export class CoreEditor {
     document.removeEventListener('copy', this.copyEventHandler);
     document.removeEventListener('paste', this.pasteEventHandler);
     document.removeEventListener('keydown', this.keydownEventHandler);
-    document.removeEventListener('contextmenu', this.contextMenuEventHandler);
+    this.contextMenuEventTarget?.removeEventListener(
+      'contextmenu',
+      this.contextMenuEventHandler,
+    );
     this.canvas.removeEventListener('mousedown', blurActiveElement);
     document.removeEventListener(
       'visibilitychange',


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Corrected changes from PR: https://github.com/epam/ketcher/pull/9273

The guard is checking `event.currentTarget`, but this handler is attached to `document`, so `currentTarget` is always the `document` rather than the element that was actually right-clicked.

Because of that, the handler returns early even for right-clicks inside the macromolecules editor, so `preventDefault()` is never called there and the browser context menu is shown instead of the Ketcher menu.

I think the guard should be based on `event.target` (with a `Node` check), for example by verifying that the actual clicked element is contained in `this.ketcherRootElement`. It is also worth guarding against the root being detached from the DOM so the listener does not become a zombie after unmount.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request