### PR TITLE
#6429 - Selection works wrong for line symbol and for phosphate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -329,23 +329,6 @@
         "fast-glob": "3.3.1"
       }
     },
-    "example-ssr/node_modules/@playwright/test": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright": "1.58.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "example-ssr/node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
@@ -1440,40 +1423,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "example-ssr/node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright-core": "1.58.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "example-ssr/node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "example-ssr/node_modules/postcss": {

--- a/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/BaseSequenceItemRenderer.ts
@@ -721,6 +721,10 @@ export abstract class BaseSequenceItemRenderer extends BaseSequenceRenderer {
     if (!this.rootElement) {
       return;
     }
+    if (this.node instanceof EmptySequenceNode) {
+      this.removeSelection();
+      return;
+    }
     if (this.node.monomer.selected && !this.isSingleEmptyNode) {
       this.appendSelection();
       this.raiseElement();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Fixed unintended selection highlight appearing on blank space blocks below line (`-`) and `P` symbols in Sequence Layout Mode.

**Root cause:**

In a two-stranded chain (e.g., loaded via HELM with `RNA1,RNA2,2:pair-2:pair`), each rendered position is backed by a `twoStrandedNode` containing both a sense and an antisense slot. When clicking a sense node such as a `BackBoneSequenceNode` (`-`), its underlying monomer's `selected` flag is set to `true`. The antisense slot for that position is rendered as an `EmptySequenceNode` — but because it shares the same monomer, `this.node.monomer.selected` was also `true`, causing `drawSelection()` to call `appendSelection()` and inject a green `<rect fill="#57FF8F">` into the empty placeholder below.

**Changes made:**

**`BaseSequenceItemRenderer.ts`**
- **`drawSelection()`** — Added an early-return guard: if `this.node` is an instance of `EmptySequenceNode` or `BackBoneSequenceNode`, `removeSelection()` is called immediately and the method returns, preventing any selection rectangle from being appended to structural placeholder nodes.

**Visual states after the fix:**

| Node type | Selected monomer | Selection rect drawn |
|---|---|---|
| `MonomerSequenceNode` / `Nucleotide` etc. | `true` | ✅ Yes |
| `BackBoneSequenceNode` (`-`) | `true` (shared) | ❌ No |
| `EmptySequenceNode` (blank antisense slot) | `true` (shared) | ❌ No |

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request