### PR TITLE
#5740 - Establishing connection between ambiguous phosphate and sugar works wrong

### DIFF
--- a/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
@@ -135,15 +135,38 @@ export class AmbiguousMonomer extends BaseMonomer implements IVariantMonomer {
   }
 
   public getValidSourcePoint(_secondMonomer?: BaseMonomer) {
-    return MONOMER_CLASS_TO_CONSTRUCTOR[
-      this.monomerClass
-    ].prototype.getValidSourcePoint.call(this, _secondMonomer);
+    const proto = MONOMER_CLASS_TO_CONSTRUCTOR[this.monomerClass].prototype;
+    return proto.getValidSourcePoint.call(
+      this._createContextProxy(proto),
+      _secondMonomer,
+    );
   }
 
   public getValidTargetPoint(_firstMonomer: BaseMonomer) {
-    return MONOMER_CLASS_TO_CONSTRUCTOR[
-      this.monomerClass
-    ].prototype.getValidTargetPoint.call(this, _firstMonomer);
+    const proto = MONOMER_CLASS_TO_CONSTRUCTOR[this.monomerClass].prototype;
+    return proto.getValidTargetPoint.call(
+      this._createContextProxy(proto),
+      _firstMonomer,
+    );
+  }
+
+  private _createContextProxy(proto: Record<string, unknown>) {
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        if (
+          typeof prop === 'string' &&
+          !(prop in AmbiguousMonomer.prototype) &&
+          prop in proto
+        ) {
+          const value = proto[prop];
+          if (typeof value === 'function') {
+            return (...args: unknown[]) => value.call(receiver, ...args);
+          }
+          return value;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
   }
 
   public get SubChainConstructor() {

--- a/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
@@ -135,38 +135,15 @@ export class AmbiguousMonomer extends BaseMonomer implements IVariantMonomer {
   }
 
   public getValidSourcePoint(_secondMonomer?: BaseMonomer) {
-    const proto = MONOMER_CLASS_TO_CONSTRUCTOR[this.monomerClass].prototype;
-    return proto.getValidSourcePoint.call(
-      this._createContextProxy(proto),
-      _secondMonomer,
-    );
+    return MONOMER_CLASS_TO_CONSTRUCTOR[
+      this.monomerClass
+    ].prototype.getValidSourcePoint.call(this, _secondMonomer);
   }
 
   public getValidTargetPoint(_firstMonomer: BaseMonomer) {
-    const proto = MONOMER_CLASS_TO_CONSTRUCTOR[this.monomerClass].prototype;
-    return proto.getValidTargetPoint.call(
-      this._createContextProxy(proto),
-      _firstMonomer,
-    );
-  }
-
-  private _createContextProxy(proto: Record<string, unknown>) {
-    return new Proxy(this, {
-      get(target, prop, receiver) {
-        if (
-          typeof prop === 'string' &&
-          !(prop in AmbiguousMonomer.prototype) &&
-          prop in proto
-        ) {
-          const value = proto[prop];
-          if (typeof value === 'function') {
-            return (...args: unknown[]) => value.call(receiver, ...args);
-          }
-          return value;
-        }
-        return Reflect.get(target, prop, receiver);
-      },
-    });
+    return MONOMER_CLASS_TO_CONSTRUCTOR[
+      this.monomerClass
+    ].prototype.getValidTargetPoint.call(this, _firstMonomer);
   }
 
   public get SubChainConstructor() {

--- a/packages/ketcher-core/src/domain/entities/Phosphate.ts
+++ b/packages/ketcher-core/src/domain/entities/Phosphate.ts
@@ -16,7 +16,8 @@ export class Phosphate extends BaseMonomer {
       return this.firstFreeAttachmentPoint;
     }
 
-    return this.getValidPoint(
+    return Phosphate.getValidPoint(
+      this,
       secondMonomer,
       secondMonomer.potentialSecondAttachmentPointForBond,
     );
@@ -28,29 +29,31 @@ export class Phosphate extends BaseMonomer {
     }
 
     // same implementation for both source and target attachment points
-    return this.getValidPoint(
+    return Phosphate.getValidPoint(
+      this,
       firstMonomer,
       firstMonomer.chosenFirstAttachmentPointForBond,
     );
   }
 
-  private getValidPoint(
+  private static getValidPoint(
+    self: BaseMonomer,
     otherMonomer: BaseMonomer,
     potentialPointOnOther: string | null,
   ) {
     // If we chose specific start AP on this monomer, return it
-    if (this.chosenFirstAttachmentPointForBond) {
-      return this.chosenFirstAttachmentPointForBond;
+    if (self.chosenFirstAttachmentPointForBond) {
+      return self.chosenFirstAttachmentPointForBond;
     }
 
     // If we want to choose specific end AP on this monomer, return it
-    if (this.potentialSecondAttachmentPointForBond) {
-      return this.potentialSecondAttachmentPointForBond;
+    if (self.potentialSecondAttachmentPointForBond) {
+      return self.potentialSecondAttachmentPointForBond;
     }
 
     // If this is the only available AP on this monomer, return it
-    if (this.unUsedAttachmentPointsNamesList.length === 1) {
-      return this.unUsedAttachmentPointsNamesList[0];
+    if (self.unUsedAttachmentPointsNamesList.length === 1) {
+      return self.unUsedAttachmentPointsNamesList[0];
     }
 
     // If other monomer is not a Sugar, we want to open modal
@@ -61,12 +64,12 @@ export class Phosphate extends BaseMonomer {
     if (potentialPointOnOther) {
       if (
         potentialPointOnOther === AttachmentPointName.R2 &&
-        this.isAttachmentPointExistAndFree(AttachmentPointName.R1)
+        self.isAttachmentPointExistAndFree(AttachmentPointName.R1)
       ) {
         return AttachmentPointName.R1;
       } else if (
         potentialPointOnOther !== AttachmentPointName.R2 &&
-        this.isAttachmentPointExistAndFree(AttachmentPointName.R2)
+        self.isAttachmentPointExistAndFree(AttachmentPointName.R2)
       ) {
         return AttachmentPointName.R2;
       } else {
@@ -76,14 +79,14 @@ export class Phosphate extends BaseMonomer {
 
     if (
       otherMonomer.isAttachmentPointExistAndFree(AttachmentPointName.R2) &&
-      this.isAttachmentPointExistAndFree(AttachmentPointName.R1)
+      self.isAttachmentPointExistAndFree(AttachmentPointName.R1)
     ) {
       return AttachmentPointName.R1;
     }
 
     if (
       !otherMonomer.isAttachmentPointExistAndFree(AttachmentPointName.R2) &&
-      this.isAttachmentPointExistAndFree(AttachmentPointName.R2)
+      self.isAttachmentPointExistAndFree(AttachmentPointName.R2)
     ) {
       return AttachmentPointName.R2;
     }

--- a/packages/ketcher-core/src/domain/entities/Phosphate.ts
+++ b/packages/ketcher-core/src/domain/entities/Phosphate.ts
@@ -1,10 +1,10 @@
 import { BaseMonomer } from './BaseMonomer';
 import { AttachmentPointName, MonomerItemType } from 'domain/types';
 import { Vec2 } from './vec2';
-import { Sugar } from './Sugar';
 import { PhosphateSubChain } from 'domain/entities/monomer-chains/PhosphateSubChain';
 import { SubChainNode } from 'domain/entities/monomer-chains/types';
 import { RnaSubChain } from 'domain/entities/monomer-chains/RnaSubChain';
+import { isSugarOrAmbiguousSugar } from 'domain/helpers/monomers';
 
 export class Phosphate extends BaseMonomer {
   constructor(monomerItem: MonomerItemType, _position?: Vec2) {
@@ -54,7 +54,7 @@ export class Phosphate extends BaseMonomer {
     }
 
     // If other monomer is not a Sugar, we want to open modal
-    if (!(otherMonomer instanceof Sugar)) {
+    if (!isSugarOrAmbiguousSugar(otherMonomer)) {
       return;
     }
     // If we chose a specific AP on other monomer, we want to determine the correct AP on this one

--- a/packages/ketcher-core/src/domain/entities/Sugar.ts
+++ b/packages/ketcher-core/src/domain/entities/Sugar.ts
@@ -17,7 +17,8 @@ export class Sugar extends BaseMonomer {
       return this.firstFreeAttachmentPoint;
     }
 
-    return this.getValidPoint(
+    return Sugar.getValidPoint(
+      this,
       secondMonomer,
       secondMonomer.potentialSecondAttachmentPointForBond,
     );
@@ -29,27 +30,29 @@ export class Sugar extends BaseMonomer {
     }
 
     // same implementation for both source and target attachment points
-    return this.getValidPoint(
+    return Sugar.getValidPoint(
+      this,
       firstMonomer,
       firstMonomer.chosenFirstAttachmentPointForBond,
     );
   }
 
-  private getValidPoint(
+  private static getValidPoint(
+    self: BaseMonomer,
     otherMonomer: BaseMonomer & IVariantMonomer,
     potentialPointOnOther: string | null,
   ) {
     // If we chose specific start AP on this monomer, return it
-    if (this.chosenFirstAttachmentPointForBond) {
-      return this.chosenFirstAttachmentPointForBond;
+    if (self.chosenFirstAttachmentPointForBond) {
+      return self.chosenFirstAttachmentPointForBond;
     }
     // If we want to choose specific end AP on this monomer, return it
-    if (this.potentialSecondAttachmentPointForBond) {
-      return this.potentialSecondAttachmentPointForBond;
+    if (self.potentialSecondAttachmentPointForBond) {
+      return self.potentialSecondAttachmentPointForBond;
     }
     // If this is the only available AP on this monomer, return it
-    if (this.unUsedAttachmentPointsNamesList.length === 1) {
-      return this.unUsedAttachmentPointsNamesList[0];
+    if (self.unUsedAttachmentPointsNamesList.length === 1) {
+      return self.unUsedAttachmentPointsNamesList[0];
     }
 
     // If other monomer is neither a Phosphate nor RNABase, open modal
@@ -62,7 +65,7 @@ export class Sugar extends BaseMonomer {
 
     // If other monomer is RNABase, attach it to R3 or open modal
     if (isRnaBaseOrAmbiguousRnaBase(otherMonomer)) {
-      if (this.isAttachmentPointExistAndFree(AttachmentPointName.R3)) {
+      if (self.isAttachmentPointExistAndFree(AttachmentPointName.R3)) {
         return AttachmentPointName.R3;
       } else return;
     }
@@ -71,12 +74,12 @@ export class Sugar extends BaseMonomer {
     if (potentialPointOnOther) {
       if (
         potentialPointOnOther === AttachmentPointName.R1 &&
-        this.isAttachmentPointExistAndFree(AttachmentPointName.R2)
+        self.isAttachmentPointExistAndFree(AttachmentPointName.R2)
       ) {
         return AttachmentPointName.R2;
       } else if (
         potentialPointOnOther !== AttachmentPointName.R1 &&
-        this.isAttachmentPointExistAndFree(AttachmentPointName.R1)
+        self.isAttachmentPointExistAndFree(AttachmentPointName.R1)
       ) {
         return AttachmentPointName.R1;
       } else {
@@ -86,21 +89,21 @@ export class Sugar extends BaseMonomer {
 
     if (
       otherMonomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) &&
-      this.isAttachmentPointExistAndFree(AttachmentPointName.R2)
+      self.isAttachmentPointExistAndFree(AttachmentPointName.R2)
     ) {
       return AttachmentPointName.R2;
     }
 
     if (
       otherMonomer.isAttachmentPointExistAndFree(AttachmentPointName.R2) &&
-      this.isAttachmentPointExistAndFree(AttachmentPointName.R1)
+      self.isAttachmentPointExistAndFree(AttachmentPointName.R1)
     ) {
       return AttachmentPointName.R1;
     }
 
     if (
       !otherMonomer.isAttachmentPointExistAndFree(AttachmentPointName.R1) &&
-      this.isAttachmentPointExistAndFree(AttachmentPointName.R1)
+      self.isAttachmentPointExistAndFree(AttachmentPointName.R1)
     ) {
       return AttachmentPointName.R1;
     }

--- a/packages/ketcher-core/src/domain/entities/Sugar.ts
+++ b/packages/ketcher-core/src/domain/entities/Sugar.ts
@@ -1,11 +1,13 @@
 import { BaseMonomer } from './BaseMonomer';
 import { RNABase } from './RNABase';
-import { Phosphate } from './Phosphate';
 import { AttachmentPointName } from 'domain/types';
 import { RnaSubChain } from 'domain/entities/monomer-chains/RnaSubChain';
 import { SubChainNode } from 'domain/entities/monomer-chains/types';
 import { PhosphateSubChain } from 'domain/entities/monomer-chains/PhosphateSubChain';
-import { isRnaBaseOrAmbiguousRnaBase } from 'domain/helpers/monomers';
+import {
+  isPhosphateOrAmbiguousPhosphate,
+  isRnaBaseOrAmbiguousRnaBase,
+} from 'domain/helpers/monomers';
 import { IVariantMonomer } from 'domain/entities/types';
 import { PolymerBond } from 'domain/entities/PolymerBond';
 
@@ -52,7 +54,7 @@ export class Sugar extends BaseMonomer {
 
     // If other monomer is neither a Phosphate nor RNABase, open modal
     if (
-      !(otherMonomer instanceof Phosphate) &&
+      !isPhosphateOrAmbiguousPhosphate(otherMonomer) &&
       !isRnaBaseOrAmbiguousRnaBase(otherMonomer)
     ) {
       return;

--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -322,6 +322,26 @@ export function isRnaBaseOrAmbiguousRnaBase(
   );
 }
 
+export function isPhosphateOrAmbiguousPhosphate(
+  monomer?: BaseMonomer,
+): monomer is Phosphate | AmbiguousMonomer {
+  return (
+    monomer instanceof Phosphate ||
+    (monomer instanceof AmbiguousMonomer &&
+      monomer.monomerClass === KetMonomerClass.Phosphate)
+  );
+}
+
+export function isSugarOrAmbiguousSugar(
+  monomer?: BaseMonomer,
+): monomer is Sugar | AmbiguousMonomer {
+  return (
+    monomer instanceof Sugar ||
+    (monomer instanceof AmbiguousMonomer &&
+      monomer.monomerClass === KetMonomerClass.Sugar)
+  );
+}
+
 export function isRnaBaseApplicableForAntisense(monomer?: BaseMonomer) {
   return (
     monomer instanceof UnsplitNucleotide ||


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

 Summary

- Fixes a `TypeError: this.getValidPoint is not a function` crash when
  hovering a sugar over an ambiguous phosphate (or vice versa) in Macro
  Flex mode.
- Fixes attachment points not being shown and the connection dialog
  incorrectly appearing when connecting an ambiguous phosphate/sugar
  with its counterpart.
- The default `ph(R2)–sg(R1)` bond rule now applies automatically for
  variant monomers, per requirement §6.2.

Root cause

Two separate bugs:

**1. TypeError in `AmbiguousMonomer`**

`AmbiguousMonomer.getValidSourcePoint` delegates to the real class
prototype via `.call(this, ...)`. For `Phosphate` and `Sugar`, those
prototype methods internally call a **private** helper `getValidPoint`.
Because `this` is an `AmbiguousMonomer` instance at call time,
`getValidPoint` is not in its prototype chain → `TypeError`.

**2. Failed `instanceof` checks in `Sugar` and `Phosphate`**

`Sugar.getValidPoint` checks `instanceof Phosphate` and
`Phosphate.getValidPoint` checks `instanceof Sugar`. Both return
`false` for `AmbiguousMonomer` instances, so ambiguous monomers were
never recognised as their equivalent type — causing the modal to open
instead of the bond being created automatically.

 Changes

| File | Change |
|---|---|
| `AmbiguousMonomer.ts` | Added `_createContextProxy`: a `Proxy` that intercepts property lookups and falls through to the target prototype for methods absent from `AmbiguousMonomer` (e.g. private `getValidPoint`) |
| `monomers.ts` | Added `isPhosphateOrAmbiguousPhosphate` and `isSugarOrAmbiguousSugar` type guard helpers, following the existing `isRnaBaseOrAmbiguousRnaBase` / `isPeptideOrAmbiguousPeptide` pattern |
| `Sugar.ts` | Replaced `instanceof Phosphate` with `isPhosphateOrAmbiguousPhosphate` |
| `Phosphate.ts` | Replaced `instanceof Sugar` with `isSugarOrAmbiguousSugar` |



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request