### PR TITLE
#6090- Antisense creating doesn't work if ambiguous phosphate present in the chain selection

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -3682,16 +3682,21 @@ export class DrawingEntitiesManager {
             const isModifiedPhosphate =
               monomer instanceof Phosphate && monomer.isModification;
             const isAmbiguousMonomer = monomer instanceof AmbiguousMonomer;
-            const antisenseMonomerItem =
-              isModifiedPhosphate || isAmbiguousMonomer
-                ? getRnaPartLibraryItem(
-                    editor,
-                    RNA_DNA_NON_MODIFIED_PART.PHOSPHATE,
-                  ) ??
-                  (isAmbiguousMonomer
-                    ? monomer.variantMonomerItem
-                    : monomer.monomerItem)
-                : monomer.monomerItem;
+            let antisenseMonomerItem: MonomerOrAmbiguousType =
+              monomer.monomerItem;
+
+            if (isModifiedPhosphate || isAmbiguousMonomer) {
+              const nonModifiedPhosphateItem = getRnaPartLibraryItem(
+                editor,
+                RNA_DNA_NON_MODIFIED_PART.PHOSPHATE,
+              );
+
+              if (nonModifiedPhosphateItem) {
+                antisenseMonomerItem = nonModifiedPhosphateItem;
+              } else if (isAmbiguousMonomer) {
+                antisenseMonomerItem = monomer.variantMonomerItem;
+              }
+            }
             const monomerAddCommand = this.addMonomer(
               antisenseMonomerItem,
               monomer.position.add(new Vec2(0, 4.25)),

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -324,7 +324,7 @@ export class DrawingEntitiesManager {
   }
 
   public addMonomerChangeModel(
-    monomerItem: MonomerItemType,
+    monomerItem: MonomerOrAmbiguousType,
     position: Vec2,
     _monomer?: BaseMonomer,
   ) {
@@ -370,7 +370,7 @@ export class DrawingEntitiesManager {
   }
 
   public addMonomer(
-    monomerItem: MonomerItemType,
+    monomerItem: MonomerOrAmbiguousType,
     position: Vec2,
     _monomer?: BaseMonomer,
   ) {
@@ -3681,12 +3681,17 @@ export class DrawingEntitiesManager {
 
             const isModifiedPhosphate =
               monomer instanceof Phosphate && monomer.isModification;
-            const antisenseMonomerItem = isModifiedPhosphate
-              ? getRnaPartLibraryItem(
-                  editor,
-                  RNA_DNA_NON_MODIFIED_PART.PHOSPHATE,
-                ) ?? monomer.monomerItem
-              : monomer.monomerItem;
+            const isAmbiguousMonomer = monomer instanceof AmbiguousMonomer;
+            const antisenseMonomerItem =
+              isModifiedPhosphate || isAmbiguousMonomer
+                ? getRnaPartLibraryItem(
+                    editor,
+                    RNA_DNA_NON_MODIFIED_PART.PHOSPHATE,
+                  ) ??
+                  (isAmbiguousMonomer
+                    ? monomer.variantMonomerItem
+                    : monomer.monomerItem)
+                : monomer.monomerItem;
             const monomerAddCommand = this.addMonomer(
               antisenseMonomerItem,
               monomer.position.add(new Vec2(0, 4.25)),


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


 Summary
- Fixes a crash when "Create Antisense Strand" is used on a chain
  containing an ambiguous monomer (e.g. `RNA1{R(A)([gly],[hn])}`)
- Root cause: `AmbiguousMonomer.monomerItem` lacks the `monomers` array,
  causing `undefined.map()` in the constructor when copied naively
- Fix: ambiguous monomers in the backbone are replaced with natural
  phosphate (P) in the antisense chain, matching the expected behavior
  per requirement 2.2

 Changes
- `createAntisenseChain`: detect `AmbiguousMonomer` in backbone else-branch
  and substitute with natural phosphate P instead of copying
- `addMonomer` / `addMonomerChangeModel`: broadened signature from
  `MonomerItemType` to `MonomerOrAmbiguousType` to support the fallback


Now It looks like this:
<img width="272" height="460" alt="Screenshot 2026-04-07 at 13 45 21" src="https://github.com/user-attachments/assets/ca38a0f1-98fb-48c3-97ce-4620c998f147" />



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request