### PR TITLE
#5110-Aromatize the molecules after drawing 

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -632,6 +632,30 @@ export class Ketcher {
     }, this.eventBus);
   }
 
+  async aromatize(): Promise<void> {
+    if (window.isPolymerEditorTurnedOn) {
+      throw new Error('Aromatize is not available in macro mode');
+    }
+
+    await runAsyncAction<void>(async () => {
+      const struct = await this._indigo.aromatize(this.editor.struct());
+      const ketSerializer = new KetSerializer();
+      await this.setMolecule(ketSerializer.serialize(struct));
+    }, this.eventBus);
+  }
+
+  async dearomatize(): Promise<void> {
+    if (window.isPolymerEditorTurnedOn) {
+      throw new Error('Dearomatize is not available in macro mode');
+    }
+
+    await runAsyncAction<void>(async () => {
+      const struct = await this._indigo.dearomatize(this.editor.struct());
+      const ketSerializer = new KetSerializer();
+      await this.setMolecule(ketSerializer.serialize(struct));
+    }, this.eventBus);
+  }
+
   async calculate(options?: CalculateData): Promise<CalculateResult> {
     if (window.isPolymerEditorTurnedOn) {
       throw new Error('Calculate is not available in macro mode');


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Problem
Users calling the Ketcher API programmatically had no way to aromatize molecules after loading them. The setMolecule() method renders structures in their original (Kekulé) form, and options like autoAromatize or dearomatize-on-load did not trigger aromatization on the rendered structure. The only way to aromatize was by manually clicking the "Aromatize" button in the UI toolbar.

Root Cause
The internal aromatization logic already existed — the Indigo class had aromatize() and dearomatize() methods, and the toolbar button worked via serverTransform('aromatize'). However, neither of these was exposed through the public Ketcher API class that users access via window.ketcher.

Solution
Added two new public async methods to the Ketcher class in ketcher.ts:

aromatize(): Promise<void> — aromatizes the current structure on canvas
dearomatize(): Promise<void> — dearomatizes the current structure on canvas
Both methods follow the same pattern as the existing layout() API method:

Get the current structure from the editor
Pass it to Indigo.aromatize() / Indigo.dearomatize() (which calls the struct service)
Serialize the result and reload it onto the canvas via setMolecule()
Wrapped in runAsyncAction() for proper event bus integration
Throw an error if called in macro (polymer) mode, consistent with other API methods

// Load a molecule, then aromatize it
await window.ketcher.setMolecule("C1C=CC=C(Br)C=1");
await window.ketcher.aromatize();

// Revert to Kekulé form
await window.ketcher.dearomatize();