### PR TITLE
#5934 - Error message is wrong if user tries to establish hydrogen bond if it is already has single one

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Polymer-Bond-Tool/hydrogen-bonds-for-monomers.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Polymer-Bond-Tool/hydrogen-bonds-for-monomers.spec.ts
@@ -489,10 +489,8 @@ Object.values(monomers).forEach((leftMonomer) => {
         MacroBondType.Hydrogen,
       );
 
-      // Error message is wrong because of a bug!
-      // it should be "Unable to establish a hydrogen bond between two monomers connected with a single bond"
       expect(await errorTooltip.getErrorText()).toContain(
-        "There can't be more than 1 bond between the first and the second monomer",
+        'Unable to establish a hydrogen bond between two monomers connected with a single bond',
       );
 
       if (await errorTooltip.isVisible()) {

--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -42,6 +42,7 @@ import { AtomRenderer } from 'application/render/renderers/AtomRenderer';
 import { MACROMOLECULES_BOND_TYPES, ToolName } from 'application/editor';
 import { KetMonomerClass } from 'application/formatters';
 import { MonomerToAtomBond } from 'domain/entities/MonomerToAtomBond';
+import { HydrogenBond } from 'domain/entities/HydrogenBond';
 
 type FlexModeOrSnakeModePolymerBondRenderer =
   | FlexModePolymerBondRenderer
@@ -306,9 +307,17 @@ class PolymerBond implements BaseTool {
           (bond.firstMonomer === secondMonomer &&
             bond.secondMonomer === firstMonomer);
         if (alreadyHasBond) {
-          this.editor.events.error.dispatch(
-            "There can't be more than 1 bond between the first and the second monomer",
-          );
+          // Check bond type: if existing is single bond and we're adding hydrogen bond, show specific error
+          const existingBondIsSingleBond = !(bond instanceof HydrogenBond);
+          if (existingBondIsSingleBond && this.isHydrogenBond) {
+            this.editor.events.error.dispatch(
+              'Unable to establish a hydrogen bond between two monomers connected with a single bond',
+            );
+          } else {
+            this.editor.events.error.dispatch(
+              "There can't be more than 1 bond between the first and the second monomer",
+            );
+          }
           return;
         }
       }
@@ -429,9 +438,17 @@ class PolymerBond implements BaseTool {
           (bond.firstMonomer === secondMonomer &&
             bond.secondMonomer === firstMonomer);
         if (alreadyHasBond) {
-          this.editor.events.error.dispatch(
-            "There can't be more than 1 bond between the first and the second monomer",
-          );
+          // Check bond type: if existing is single bond and we're adding hydrogen bond, show specific error
+          const existingBondIsSingleBond = !(bond instanceof HydrogenBond);
+          if (existingBondIsSingleBond && this.isHydrogenBond) {
+            this.editor.events.error.dispatch(
+              'Unable to establish a hydrogen bond between two monomers connected with a single bond',
+            );
+          } else {
+            this.editor.events.error.dispatch(
+              "There can't be more than 1 bond between the first and the second monomer",
+            );
+          }
           return;
         }
       }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request