### PR TITLE
#7909 - Some structure elements disappear when saving as SVG or PNG in expanded or contracted state

### DIFF
--- a/packages/ketcher-core/src/utilities/getSvgFromDrawnStructures.tsx
+++ b/packages/ketcher-core/src/utilities/getSvgFromDrawnStructures.tsx
@@ -1,13 +1,129 @@
 import { KetcherLogger } from 'utilities';
 
 const SVG_NAMESPACE_URI = 'http://www.w3.org/2000/svg';
-const ADDITIONAL_TOP_MARGIN = 54;
-const ADDITIONAL_LEFT_MARGIN = 50;
 const DEFAULT_MARGIN = 10;
+const EXPORT_EXCLUDED_SELECTOR = '#rectangle-selection-area, .dynamic-element';
 
 type Margins = {
   horizontal: number;
   vertical: number;
+};
+
+const getElementBoundingBox = (
+  element: Element,
+  canvas: SVGSVGElement,
+): DOMRect | null => {
+  if (
+    !(element instanceof SVGGraphicsElement) ||
+    element instanceof SVGSVGElement
+  ) {
+    return null;
+  }
+
+  if (
+    element.matches('defs, style, script, title, desc') ||
+    element.closest('defs') ||
+    element.matches(EXPORT_EXCLUDED_SELECTOR) ||
+    element.closest(EXPORT_EXCLUDED_SELECTOR)
+  ) {
+    return null;
+  }
+
+  const computedStyle = window.getComputedStyle(element);
+
+  if (
+    computedStyle.display === 'none' ||
+    computedStyle.visibility === 'hidden' ||
+    computedStyle.opacity === '0' ||
+    (computedStyle.fillOpacity === '0' && computedStyle.strokeOpacity === '0')
+  ) {
+    return null;
+  }
+
+  const box = element.getBBox();
+  const matrix = element.getCTM();
+
+  if ((!box.width && !box.height) || !matrix) {
+    return null;
+  }
+
+  const createPoint = (x: number, y: number) => {
+    const point = canvas.createSVGPoint();
+    point.x = x;
+    point.y = y;
+    return point.matrixTransform(matrix);
+  };
+
+  const points = [
+    createPoint(box.x, box.y),
+    createPoint(box.x + box.width, box.y),
+    createPoint(box.x, box.y + box.height),
+    createPoint(box.x + box.width, box.y + box.height),
+  ];
+
+  const left = Math.min(...points.map((point) => point.x));
+  const top = Math.min(...points.map((point) => point.y));
+  const right = Math.max(...points.map((point) => point.x));
+  const bottom = Math.max(...points.map((point) => point.y));
+
+  return {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+    left,
+    top,
+    right,
+    bottom,
+    toJSON: () => ({
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+      left,
+      top,
+      right,
+      bottom,
+    }),
+  } as DOMRect;
+};
+
+const getDrawnStructuresBoundingClientRect = (canvas: SVGSVGElement) => {
+  const exportableElements = Array.from(canvas.querySelectorAll('*'))
+    .map((element) => getElementBoundingBox(element, canvas))
+    .filter((rect): rect is DOMRect => !!rect);
+
+  if (!exportableElements.length) {
+    return canvas
+      ?.getElementsByClassName('drawn-structures')[0]
+      ?.getBoundingClientRect();
+  }
+
+  const left = Math.min(...exportableElements.map((rect) => rect.left));
+  const top = Math.min(...exportableElements.map((rect) => rect.top));
+  const right = Math.max(...exportableElements.map((rect) => rect.right));
+  const bottom = Math.max(...exportableElements.map((rect) => rect.bottom));
+
+  return {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+    left,
+    top,
+    right,
+    bottom,
+    toJSON: () => ({
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+      left,
+      top,
+      right,
+      bottom,
+    }),
+  } as DOMRect;
 };
 
 export const getSvgFromDrawnStructures = (
@@ -28,53 +144,67 @@ export const getSvgFromDrawnStructures = (
         };
 
   // Copy and clean up svg structures before previewing or saving
-  let svgInnerHTML = canvas?.innerHTML || '';
-  const wrapper = document.createElementNS(SVG_NAMESPACE_URI, 'svg');
-  wrapper.innerHTML = svgInnerHTML;
-  // remove #rectangle-selection-area
-  wrapper.querySelector('#rectangle-selection-area')?.remove();
-  // remove dynamic elements (scrolls, highlighters, attachment points...)
-  wrapper.querySelectorAll('.dynamic-element')?.forEach((el) => el.remove());
-  // set default cursor, mostly for sequence mode
-  wrapper
-    .querySelectorAll('text')
-    ?.forEach((el) => el.setAttribute('cursor', 'default'));
-  wrapper.querySelectorAll('rect')?.forEach((el) => {
-    if (el.getAttribute('cursor') === 'text') el.removeAttribute('cursor');
-  });
-  // remove opacity of structures, mostly for sequence "edit in RNA builder" mode
-  wrapper.querySelectorAll('g')?.forEach((el) => {
-    if (el.hasAttribute('opacity')) el.removeAttribute('opacity');
-  });
-  svgInnerHTML = wrapper.innerHTML;
-  // remove "cursor: pointer" style
-  svgInnerHTML = svgInnerHTML?.replaceAll('cursor: pointer;', '');
+  const exportCanvas = canvas?.cloneNode(true) as SVGSVGElement | undefined;
 
-  const drawStructureClientRect = canvas
-    ?.getElementsByClassName('drawn-structures')[0]
-    .getBoundingClientRect();
-
-  if (!drawStructureClientRect || !svgInnerHTML) {
+  if (!exportCanvas) {
     const errorMessage = 'Cannot get drawn structures!';
     KetcherLogger.error(errorMessage);
     return;
   }
 
-  const viewBoxX =
-    drawStructureClientRect.x -
-    ADDITIONAL_LEFT_MARGIN -
-    marginValues.horizontal;
-  const viewBoxY =
-    drawStructureClientRect.y - ADDITIONAL_TOP_MARGIN - marginValues.vertical;
+  // remove #rectangle-selection-area
+  exportCanvas.querySelector('#rectangle-selection-area')?.remove();
+  // remove dynamic elements (scrolls, highlighters, attachment points...)
+  exportCanvas
+    .querySelectorAll('.dynamic-element')
+    ?.forEach((el) => el.remove());
+  // set default cursor, mostly for sequence mode
+  exportCanvas
+    .querySelectorAll('text')
+    ?.forEach((el) => el.setAttribute('cursor', 'default'));
+  exportCanvas.querySelectorAll('rect')?.forEach((el) => {
+    if (el.getAttribute('cursor') === 'text') el.removeAttribute('cursor');
+  });
+  // remove opacity of structures, mostly for sequence "edit in RNA builder" mode
+  exportCanvas.querySelectorAll('g')?.forEach((el) => {
+    if (el.hasAttribute('opacity')) el.removeAttribute('opacity');
+  });
+
+  const drawStructureClientRect = getDrawnStructuresBoundingClientRect(canvas);
+  if (!drawStructureClientRect || !exportCanvas.childNodes.length) {
+    const errorMessage = 'Cannot get drawn structures!';
+    KetcherLogger.error(errorMessage);
+    return;
+  }
+
+  const viewBoxX = drawStructureClientRect.x - marginValues.horizontal;
+  const viewBoxY = drawStructureClientRect.y - marginValues.vertical;
   const viewBoxWidth =
     drawStructureClientRect.width + marginValues.horizontal * 2;
   const viewBoxHeight =
     drawStructureClientRect.height + marginValues.vertical * 2;
   const viewBox = `${viewBoxX} ${viewBoxY} ${viewBoxWidth} ${viewBoxHeight}`;
 
-  if (type === 'preview')
-    return `<svg width='100%' height='100%' style='position: absolute' viewBox='${viewBox}'>${svgInnerHTML}</svg>`;
-  else if (type === 'file')
-    return `<svg width='${viewBoxWidth}' height='${viewBoxHeight}' viewBox='${viewBox}' xmlns='${SVG_NAMESPACE_URI}'>${svgInnerHTML}</svg>`;
-  else return `<svg xmlns='${SVG_NAMESPACE_URI}' />`;
+  exportCanvas.setAttribute('viewBox', viewBox);
+  exportCanvas.setAttribute('xmlns', SVG_NAMESPACE_URI);
+  exportCanvas.removeAttribute('x');
+  exportCanvas.removeAttribute('y');
+  exportCanvas.removeAttribute('preserveAspectRatio');
+
+  if (type === 'preview') {
+    exportCanvas.setAttribute('width', '100%');
+    exportCanvas.setAttribute('height', '100%');
+    exportCanvas.setAttribute('style', 'position: absolute');
+  } else if (type === 'file') {
+    exportCanvas.setAttribute('width', String(viewBoxWidth));
+    exportCanvas.setAttribute('height', String(viewBoxHeight));
+    exportCanvas.removeAttribute('style');
+  } else {
+    return `<svg xmlns='${SVG_NAMESPACE_URI}' />`;
+  }
+
+  const serializedSvg = new XMLSerializer().serializeToString(exportCanvas);
+  const normalizedSvg = serializedSvg.replaceAll('cursor: pointer;', '');
+
+  return normalizedSvg;
 };

--- a/packages/ketcher-core/src/utilities/getSvgFromDrawnStructures.tsx
+++ b/packages/ketcher-core/src/utilities/getSvgFromDrawnStructures.tsx
@@ -9,6 +9,33 @@ type Margins = {
   vertical: number;
 };
 
+const createDomRect = (
+  left: number,
+  top: number,
+  right: number,
+  bottom: number,
+): DOMRect =>
+  ({
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+    left,
+    top,
+    right,
+    bottom,
+    toJSON: () => ({
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+      left,
+      top,
+      right,
+      bottom,
+    }),
+  } as DOMRect);
+
 const getElementBoundingBox = (
   element: Element,
   canvas: SVGSVGElement,
@@ -40,7 +67,14 @@ const getElementBoundingBox = (
     return null;
   }
 
-  const box = element.getBBox();
+  let box: DOMRect;
+
+  try {
+    box = element.getBBox();
+  } catch {
+    return null;
+  }
+
   const matrix = element.getCTM();
 
   if ((!box.width && !box.height) || !matrix) {
@@ -66,26 +100,7 @@ const getElementBoundingBox = (
   const right = Math.max(...points.map((point) => point.x));
   const bottom = Math.max(...points.map((point) => point.y));
 
-  return {
-    x: left,
-    y: top,
-    width: right - left,
-    height: bottom - top,
-    left,
-    top,
-    right,
-    bottom,
-    toJSON: () => ({
-      x: left,
-      y: top,
-      width: right - left,
-      height: bottom - top,
-      left,
-      top,
-      right,
-      bottom,
-    }),
-  } as DOMRect;
+  return createDomRect(left, top, right, bottom);
 };
 
 const getDrawnStructuresBoundingClientRect = (canvas: SVGSVGElement) => {
@@ -104,26 +119,7 @@ const getDrawnStructuresBoundingClientRect = (canvas: SVGSVGElement) => {
   const right = Math.max(...exportableElements.map((rect) => rect.right));
   const bottom = Math.max(...exportableElements.map((rect) => rect.bottom));
 
-  return {
-    x: left,
-    y: top,
-    width: right - left,
-    height: bottom - top,
-    left,
-    top,
-    right,
-    bottom,
-    toJSON: () => ({
-      x: left,
-      y: top,
-      width: right - left,
-      height: bottom - top,
-      left,
-      top,
-      right,
-      bottom,
-    }),
-  } as DOMRect;
+  return createDomRect(left, top, right, bottom);
 };
 
 export const getSvgFromDrawnStructures = (

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
@@ -31,6 +31,7 @@ import {
   isClipboardAPIAvailable,
   legacyCopy,
   Struct,
+  getSvgFromDrawnStructures,
 } from 'ketcher-core';
 
 import { Dialog } from '../../../../components';
@@ -47,6 +48,7 @@ import { getSelectOptionsFromSchema } from '../../../../../utils';
 import { LoadingCircles } from 'src/script/ui/views/components/Spinner';
 import { IconButton } from 'components';
 import { Dispatch } from 'redux';
+import { saveAs } from 'file-saver';
 
 const saveSchema = {
   title: 'Save',
@@ -82,6 +84,7 @@ interface ImageContentProps {
   classes: typeof classes;
   format: string;
   imageSrc: string;
+  imageMimeType: string;
   isCleanStruct: boolean;
 }
 
@@ -116,7 +119,13 @@ interface Editor {
   selection: () => { atoms?: number[] } | null;
   errorHandler: (message: string) => void;
   struct: () => Struct;
+  canvas?: SVGSVGElement;
+  ketcherRootElementBoundingClientRect?: DOMRect;
   render: {
+    clientArea?: HTMLElement;
+    paper?: {
+      canvas?: SVGSVGElement;
+    };
     options: {
       ignoreChiralFlag: boolean;
     };
@@ -149,6 +158,8 @@ interface SaveDialogState {
   isLoading: boolean;
   structStr?: string;
   imageSrc?: string;
+  imageMimeType?: string;
+  useCanvasImageExport?: boolean;
 }
 
 interface AppState {
@@ -182,12 +193,13 @@ const ImageContent = ({
   classes,
   format,
   imageSrc,
+  imageMimeType,
   isCleanStruct,
 }: ImageContentProps) => (
   <div className={classes.imageContainer}>
     {!isCleanStruct && (
       <img
-        src={`data:image/${format}+xml;base64,${imageSrc}`}
+        src={`data:${imageMimeType};base64,${imageSrc}`}
         alt={`${format} preview`}
         data-testid="preview-area"
       />
@@ -244,6 +256,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
       imageFormat: 'svg',
       tabIndex: 0,
       isLoading: true,
+      useCanvasImageExport: false,
     };
     this.isRxn =
       this.props.struct.hasRxnArrow() || this.props.struct.hasMultitailArrow();
@@ -313,11 +326,173 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
     return format !== 'mol' && Object.keys(errors).length > 0;
   };
 
+  getImageMimeType = (format: string): string => {
+    return format === 'svg' ? 'image/svg+xml' : `image/${format}`;
+  };
+
+  getCanvasExportMargins = () => {
+    return {
+      horizontal: 0,
+      vertical: 0,
+    };
+  };
+
+  getEditorCanvas = (): SVGSVGElement | undefined => {
+    return this.props.editor.canvas || this.props.editor.render.paper?.canvas;
+  };
+
+  encodeBase64 = (value: string): string => {
+    const encodedValue = new TextEncoder().encode(value);
+    let binaryValue = '';
+
+    encodedValue.forEach((byte) => {
+      binaryValue += String.fromCharCode(byte);
+    });
+
+    return window.btoa(binaryValue);
+  };
+
+  getCanvasSvgData = (): string | undefined => {
+    const canvas = this.getEditorCanvas();
+
+    if (!canvas) {
+      return undefined;
+    }
+
+    return getSvgFromDrawnStructures(
+      canvas,
+      'file',
+      this.getCanvasExportMargins(),
+    );
+  };
+
+  rasterizeSvgToPngBase64 = (svgData: string): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const parsedSvg = new DOMParser().parseFromString(
+        svgData,
+        'image/svg+xml',
+      ).documentElement;
+      const width = Math.ceil(
+        Number.parseFloat(parsedSvg.getAttribute('width') || '0'),
+      );
+      const height = Math.ceil(
+        Number.parseFloat(parsedSvg.getAttribute('height') || '0'),
+      );
+
+      if (!width || !height) {
+        reject(new Error('Cannot prepare PNG export preview'));
+        return;
+      }
+
+      const image = new Image();
+      const svgBlob = new Blob([svgData], { type: 'image/svg+xml' });
+      const svgBlobUrl = URL.createObjectURL(svgBlob);
+
+      image.onload = () => {
+        const exportCanvas = document.createElement('canvas');
+        exportCanvas.width = width;
+        exportCanvas.height = height;
+        const context = exportCanvas.getContext('2d');
+
+        if (!context) {
+          URL.revokeObjectURL(svgBlobUrl);
+          reject(new Error('Cannot prepare PNG export preview'));
+          return;
+        }
+
+        context.drawImage(image, 0, 0, width, height);
+        URL.revokeObjectURL(svgBlobUrl);
+        resolve(exportCanvas.toDataURL('image/png').split(',')[1] || '');
+      };
+
+      image.onerror = () => {
+        URL.revokeObjectURL(svgBlobUrl);
+        reject(new Error('Cannot prepare PNG export preview'));
+      };
+
+      image.src = svgBlobUrl;
+    });
+  };
+
+  generateCanvasImagePreview = async (type: 'svg' | 'png'): Promise<void> => {
+    const svgData = this.getCanvasSvgData();
+
+    if (!svgData) {
+      throw new Error('Cannot get image data from canvas');
+    }
+
+    if (type === 'svg') {
+      this.setState({
+        disableControls: false,
+        tabIndex: 0,
+        structStr: svgData,
+        imageSrc: this.encodeBase64(svgData),
+        imageMimeType: this.getImageMimeType(type),
+        isLoading: false,
+        useCanvasImageExport: true,
+      });
+      return;
+    }
+
+    const pngBase64 = await this.rasterizeSvgToPngBase64(svgData);
+
+    this.setState({
+      disableControls: false,
+      tabIndex: 0,
+      structStr: pngBase64,
+      imageSrc: pngBase64,
+      imageMimeType: this.getImageMimeType(type),
+      isLoading: false,
+      useCanvasImageExport: true,
+    });
+  };
+
+  saveCanvasImage = (): void => {
+    const { structStr, imageMimeType } = this.state;
+    const { filename, format } = this.props.formState.result;
+
+    if (!structStr || !imageMimeType) {
+      return;
+    }
+
+    const blob =
+      format === 'png'
+        ? b64toBlob(structStr, imageMimeType)
+        : new Blob([structStr], { type: imageMimeType });
+
+    saveAs(blob, `${filename}.${format}`);
+    this.props.onOk();
+  };
+
   changeType = (type: string): Promise<Error | void> => {
     const { struct, server, options, formState, ignoreChiralFlag } = this.props;
 
     const errorHandler = this.context.errorHandler;
     if (this.isImageFormat(type)) {
+      if (this.getEditorCanvas() && (type === 'svg' || type === 'png')) {
+        this.setState({
+          disableControls: true,
+          tabIndex: 0,
+          imageFormat: type,
+          isLoading: true,
+          useCanvasImageExport: true,
+        });
+
+        return this.generateCanvasImagePreview(type)
+          .then(() => undefined)
+          .catch((e) => {
+            KetcherLogger.error('Save.jsx::SaveDialog::changeType', e);
+            errorHandler(e);
+            this.props.onResetForm(formState);
+            this.setState({
+              disableControls: false,
+              isLoading: false,
+              useCanvasImageExport: false,
+            });
+            return e;
+          });
+      }
+
       const ketSerialize = new KetSerializer();
       const structStr = ketSerialize.serialize(struct);
       this.setState({
@@ -326,6 +501,8 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
         imageFormat: type,
         structStr,
         isLoading: true,
+        imageMimeType: this.getImageMimeType(type),
+        useCanvasImageExport: false,
       });
       const serverOptions = { ...options };
 
@@ -338,6 +515,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
             disableControls: false,
             tabIndex: 0,
             imageSrc: base64,
+            imageMimeType: this.getImageMimeType(type),
             isLoading: false,
           });
         })
@@ -392,6 +570,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
             this.setState({
               tabIndex: 0,
               structStr,
+              useCanvasImageExport: false,
             });
           },
           (e) => {
@@ -543,6 +722,9 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
           classes={classes}
           format={format}
           imageSrc={imageSrc || ''}
+          imageMimeType={
+            this.state.imageMimeType || this.getImageMimeType(format)
+          }
           isCleanStruct={isCleanStruct}
         />
       );
@@ -579,7 +761,13 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
   };
 
   getButtons = (): JSX.Element[] => {
-    const { disableControls, imageFormat, isLoading, structStr } = this.state;
+    const {
+      disableControls,
+      imageFormat,
+      isLoading,
+      structStr,
+      useCanvasImageExport,
+    } = this.state;
     const { options, formState } = this.props;
     const { filename, format } = formState.result;
     const isCleanStruct = this.props.struct.isBlank();
@@ -618,29 +806,44 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
     );
 
     if (this.isImageFormat(format)) {
-      buttons.push(
-        <SaveButton
-          mode="saveImage"
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          options={options as any}
-          data={structStr || ''}
-          filename={filename}
-          key="save-image-button"
-          type={`image/${format}+xml`}
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          onSave={this.props.onOk as any}
-          testId="save-button"
-          disabled={
-            disableControls ||
-            !formState.valid ||
-            isCleanStruct ||
-            !this.props.server
-          }
-          className={classes.ok}
-        >
-          Save
-        </SaveButton>,
-      );
+      if (useCanvasImageExport) {
+        buttons.push(
+          <button
+            key="save-image-button"
+            onClick={this.saveCanvasImage}
+            type="button"
+            data-testid="save-button"
+            disabled={disableControls || !formState.valid || isCleanStruct}
+            className={classes.ok}
+          >
+            Save
+          </button>,
+        );
+      } else {
+        buttons.push(
+          <SaveButton
+            mode="saveImage"
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            options={options as any}
+            data={structStr || ''}
+            filename={filename}
+            key="save-image-button"
+            type={`image/${format}+xml`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onSave={this.props.onOk as any}
+            testId="save-button"
+            disabled={
+              disableControls ||
+              !formState.valid ||
+              isCleanStruct ||
+              !this.props.server
+            }
+            className={classes.ok}
+          >
+            Save
+          </SaveButton>,
+        );
+      }
     } else {
       buttons.push(
         <SaveButton

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
@@ -120,9 +120,7 @@ interface Editor {
   errorHandler: (message: string) => void;
   struct: () => Struct;
   canvas?: SVGSVGElement;
-  ketcherRootElementBoundingClientRect?: DOMRect;
   render: {
-    clientArea?: HTMLElement;
     paper?: {
       canvas?: SVGSVGElement;
     };
@@ -158,8 +156,6 @@ interface SaveDialogState {
   isLoading: boolean;
   structStr?: string;
   imageSrc?: string;
-  imageMimeType?: string;
-  useCanvasImageExport?: boolean;
 }
 
 interface AppState {
@@ -256,7 +252,6 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
       imageFormat: 'svg',
       tabIndex: 0,
       isLoading: true,
-      useCanvasImageExport: false,
     };
     this.isRxn =
       this.props.struct.hasRxnArrow() || this.props.struct.hasMultitailArrow();
@@ -330,15 +325,12 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
     return format === 'svg' ? 'image/svg+xml' : `image/${format}`;
   };
 
-  getCanvasExportMargins = () => {
-    return {
-      horizontal: 0,
-      vertical: 0,
-    };
-  };
-
   getEditorCanvas = (): SVGSVGElement | undefined => {
     return this.props.editor.canvas || this.props.editor.render.paper?.canvas;
+  };
+
+  shouldUseCanvasImageExport = (format: string): format is 'svg' | 'png' => {
+    return !!this.getEditorCanvas() && (format === 'svg' || format === 'png');
   };
 
   encodeBase64 = (value: string): string => {
@@ -359,11 +351,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
       return undefined;
     }
 
-    return getSvgFromDrawnStructures(
-      canvas,
-      'file',
-      this.getCanvasExportMargins(),
-    );
+    return getSvgFromDrawnStructures(canvas, 'file');
   };
 
   rasterizeSvgToPngBase64 = (svgData: string): Promise<string> => {
@@ -427,9 +415,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
         tabIndex: 0,
         structStr: svgData,
         imageSrc: this.encodeBase64(svgData),
-        imageMimeType: this.getImageMimeType(type),
         isLoading: false,
-        useCanvasImageExport: true,
       });
       return;
     }
@@ -441,17 +427,16 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
       tabIndex: 0,
       structStr: pngBase64,
       imageSrc: pngBase64,
-      imageMimeType: this.getImageMimeType(type),
       isLoading: false,
-      useCanvasImageExport: true,
     });
   };
 
   saveCanvasImage = (): void => {
-    const { structStr, imageMimeType } = this.state;
+    const { structStr } = this.state;
     const { filename, format } = this.props.formState.result;
+    const imageMimeType = this.getImageMimeType(format);
 
-    if (!structStr || !imageMimeType) {
+    if (!structStr || !this.shouldUseCanvasImageExport(format)) {
       return;
     }
 
@@ -469,13 +454,12 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
 
     const errorHandler = this.context.errorHandler;
     if (this.isImageFormat(type)) {
-      if (this.getEditorCanvas() && (type === 'svg' || type === 'png')) {
+      if (this.shouldUseCanvasImageExport(type)) {
         this.setState({
           disableControls: true,
           tabIndex: 0,
           imageFormat: type,
           isLoading: true,
-          useCanvasImageExport: true,
         });
 
         return this.generateCanvasImagePreview(type)
@@ -487,7 +471,6 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
             this.setState({
               disableControls: false,
               isLoading: false,
-              useCanvasImageExport: false,
             });
             return e;
           });
@@ -501,8 +484,6 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
         imageFormat: type,
         structStr,
         isLoading: true,
-        imageMimeType: this.getImageMimeType(type),
-        useCanvasImageExport: false,
       });
       const serverOptions = { ...options };
 
@@ -515,7 +496,6 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
             disableControls: false,
             tabIndex: 0,
             imageSrc: base64,
-            imageMimeType: this.getImageMimeType(type),
             isLoading: false,
           });
         })
@@ -570,7 +550,6 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
             this.setState({
               tabIndex: 0,
               structStr,
-              useCanvasImageExport: false,
             });
           },
           (e) => {
@@ -722,9 +701,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
           classes={classes}
           format={format}
           imageSrc={imageSrc || ''}
-          imageMimeType={
-            this.state.imageMimeType || this.getImageMimeType(format)
-          }
+          imageMimeType={this.getImageMimeType(format)}
           isCleanStruct={isCleanStruct}
         />
       );
@@ -761,18 +738,16 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
   };
 
   getButtons = (): JSX.Element[] => {
-    const {
-      disableControls,
-      imageFormat,
-      isLoading,
-      structStr,
-      useCanvasImageExport,
-    } = this.state;
+    const { disableControls, imageFormat, isLoading, structStr } = this.state;
     const { options, formState } = this.props;
     const { filename, format } = formState.result;
     const isCleanStruct = this.props.struct.isBlank();
+    const useCanvasImageExport = this.shouldUseCanvasImageExport(format);
 
-    options.outputFormat = imageFormat;
+    const imageOptions = {
+      ...options,
+      outputFormat: imageFormat,
+    };
 
     const savingStruct =
       this.isBinaryCdxFormat(format) && !isLoading
@@ -824,7 +799,7 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
           <SaveButton
             mode="saveImage"
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            options={options as any}
+            options={imageOptions as any}
             data={structStr || ''}
             filename={filename}
             key="save-image-button"


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

 Summary

This PR fixes missing elements in SVG/PNG export by switching image generation to canvas-based export with more accurate SVG bounds calculation.

What changed

- updated `getSvgFromDrawnStructures` to calculate export bounds from actual exportable SVG elements
- excluded non-exportable and dynamic UI elements from bounds calculation
- replaced static offset-based export area calculation with element-based bounding boxes
- updated the save dialog to generate `svg` and `png` previews directly from the editor canvas when available
- added client-side PNG rasterization from exported SVG data
- added client-side image saving flow for canvas-based export

Why

Previously, exported images could miss visible structure elements because the export area relied on a wrapper/container-based bounding box plus static offsets. This change makes the export area depend on the actual rendered SVG content.

 Impact

- improves SVG export accuracy
- improves PNG export accuracy
- reduces dependency on server-generated image output when canvas data is available

Risks / Notes

- `getSvgFromDrawnStructures` is a shared utility and also affects other image export flows using it
- existing tests around SVG export may need updates if they depend on the previous static margin behavior

Validation

- verified changed files have no editor-reported TypeScript errors
- manual runtime validation of export output is still recommended

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request