### PR TITLE
#9556 - TODO | Remove stale TODO comment about SGroup ID generation

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -734,7 +734,7 @@ export function fromSgroupAddition(
   // eslint-disable-line
   let action = new Action();
 
-  sgid = typeof sgid === 'number' ? sgid : restruct.molecule.sgroups.newId();
+  sgid = isNumber(sgid) ? sgid : restruct.molecule.sgroups.newId();
 
   if (type === 'SUP') {
     action.addOp(

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -734,9 +734,7 @@ export function fromSgroupAddition(
   // eslint-disable-line
   let action = new Action();
 
-  // TODO: shoud the id be generated when OpSGroupCreate is executed?
-  //      if yes, how to pass it to the following operations?
-  sgid = sgid - 0 === sgid ? sgid : restruct.molecule.sgroups.newId();
+  sgid = typeof sgid === 'number' ? sgid : restruct.molecule.sgroups.newId();
 
   if (type === 'SUP') {
     action.addOp(

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2021,6 +2021,7 @@ export class SequenceMode extends BaseMode {
       BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
         monomerItem.attachmentPoints,
       );
+    // Side chains
     const oldMonomerBonds: [string, PolymerBond | MonomerToAtomBond | null][] =
       sideChainConnections
         ? Object.entries(selectedNode.monomer.attachmentPointsToBonds)
@@ -2036,6 +2037,7 @@ export class SequenceMode extends BaseMode {
               selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2!,
             ],
           ];
+    // Backbone
     return oldMonomerBonds.every(([key, bond]) => {
       if (
         !bond ||

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2021,8 +2021,6 @@ export class SequenceMode extends BaseMode {
       BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
         monomerItem.attachmentPoints,
       );
-    // Side chains
-    // selectedNode.monomers.attachmentPoints
     const oldMonomerBonds: [string, PolymerBond | MonomerToAtomBond | null][] =
       sideChainConnections
         ? Object.entries(selectedNode.monomer.attachmentPointsToBonds)
@@ -2038,9 +2036,6 @@ export class SequenceMode extends BaseMode {
               selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2!,
             ],
           ];
-    // Backbone
-    // selectedNode.firstMonomerInNode.attachmentPointsToBonds.R1
-    // selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2
     return oldMonomerBonds.every(([key, bond]) => {
       if (
         !bond ||


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

  Removed leftover commented-out code in checkIfNewMonomerCouldEstablishConnections. The removed lines were:
  - // Side chains / // selectedNode.monomers.attachmentPoints — a section label and a commented-out expression
  - // Backbone / // selectedNode.firstMonomerInNode.attachmentPointsToBonds.R1 / // selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2 — another section label and two commented-out expressions

**IMPORTANT: The same expressions already exist as live code just above (lines 2033 and 2038), used as the actual R1/R2 values in the array. These comments were development leftovers — someone implemented the backbone case using those expressions but forgot to clean up the notes below. They added no information beyond what the live code already shows.**

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request