### PR TITLE
#5849 Expanded monomer inconsistent behaviour compare to functional groups (s-groups) - bonds and atoms

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -121,10 +121,6 @@ class AtomTool implements Tool {
     const ci = editor.findItem(event, eventMaps);
     const struct = editor.struct();
 
-    if (struct.isTargetFromMacromolecule(ci)) {
-      return;
-    }
-
     if (ci?.map === 'atoms') {
       const atomId = ci.id;
 
@@ -137,6 +133,10 @@ class AtomTool implements Tool {
         editor.event.removeFG.dispatch({ fgIds: [fgId] });
         return;
       }
+    }
+
+    if (struct.isTargetFromMacromolecule(ci)) {
+      return;
     }
 
     const ciFunctionalGroupName =

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -58,9 +58,6 @@ class BondTool implements Tool {
 
   mousedown(event) {
     if (this.dragCtx) return;
-    if (isBondingWithMacroMolecule(this.editor, event)) {
-      return;
-    }
     const struct = this.editor.render.ctab;
     const molecule = struct.molecule;
     const functionalGroups = molecule.functionalGroups;
@@ -69,6 +66,33 @@ class BondTool implements Tool {
       'bonds',
       'functionalGroups',
     ]);
+
+    if (ci?.map === 'bonds' && molecule.isBondFromMacromolecule(ci.id)) {
+      const fgId = FunctionalGroup.findFunctionalGroupByBond(
+        molecule,
+        functionalGroups,
+        ci.id,
+      );
+      if (fgId !== null) {
+        this.editor.event.removeFG.dispatch({ fgIds: [fgId] });
+        return;
+      }
+    }
+
+    if (ci?.map === 'atoms' && molecule.isAtomFromMacromolecule(ci.id)) {
+      const fgId = FunctionalGroup.findFunctionalGroupByAtom(
+        functionalGroups,
+        ci.id,
+      );
+      if (fgId !== null) {
+        this.editor.event.removeFG.dispatch({ fgIds: [fgId] });
+        return;
+      }
+    }
+
+    if (isBondingWithMacroMolecule(this.editor, event)) {
+      return;
+    }
     const atomResult: Array<number> = [];
     const bondResult: Array<number> = [];
     const result: Array<number> = [];

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -33,7 +33,6 @@ import {
   Bond,
   BondAttr,
   AtomAttr,
-  MonomerMicromolecule,
   CoordinateTransformation,
 } from 'ketcher-core';
 import Editor from '../Editor';
@@ -197,10 +196,6 @@ class TemplateTool implements Tool {
       return false;
     }
     const functionalGroup = this.functionalGroups.get(targetId);
-
-    if (functionalGroup?.relatedSGroup instanceof MonomerMicromolecule) {
-      return false;
-    }
 
     const isTargetExpanded = functionalGroup?.isExpanded;
     const isTargetAtomOrBond =


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Fixed clicking on an expanded monomer's atoms or bonds (in Micro mode) with the Bond Tool, Atom Tool, or Template Tool having no effect — the "Edit Abbreviation" dialog was never shown.

**Root cause:**

When a macromolecule structure is loaded and expanded in Micro mode, its atoms and bonds are represented internally as a `MonomerMicromolecule` sgroup, which is registered both in `sgroups` and `functionalGroups`. The existing tool handlers had guards that checked `isTargetFromMacromolecule` or `isBondingWithMacroMolecule` **before** attempting to find and dispatch the `removeFG` event. This caused clicks on expanded monomer atoms/bonds to be silently swallowed, with no dialog triggered.

Additionally, `TemplateTool` explicitly returned `false` from `isNeedToShowRemoveAbbreviationPopup` when the target functional group's `relatedSGroup` was a `MonomerMicromolecule`, preventing the dialog from ever appearing in template mode either.

**Changes made:**

**`atom.ts`**
- Moved the `FunctionalGroup.findFunctionalGroupByAtom` check (which dispatches `removeFG`) **before** the `isTargetFromMacromolecule` guard in `mousedown`. This ensures that clicking on an expanded monomer atom with the Atom Tool triggers the "Edit Abbreviation" dialog instead of being blocked.

**`bond.ts`**
- Moved `struct / molecule / functionalGroups / ci` setup before the `isBondingWithMacroMolecule` guard in `mousedown`.
- Added two early-exit checks before the macromolecule guard:
  - If the clicked **bond** belongs to a `MonomerMicromolecule` sgroup → resolve the sgroup via `findFunctionalGroupByBond` and dispatch `removeFG`.
  - If the clicked **atom** belongs to a `MonomerMicromolecule` sgroup → resolve via `findFunctionalGroupByAtom` and dispatch `removeFG`.

**`template.ts`**
- Removed the explicit `instanceof MonomerMicromolecule → return false` short-circuit from `isNeedToShowRemoveAbbreviationPopup`. Expanded monomers already have `isExpanded = true`, so the existing `isTargetExpanded` condition correctly triggers the dialog without the override.
- Removed the now-unused `MonomerMicromolecule` import.

**Behavior after the fix:**

| Scenario | Before | After |
|---|---|---|
| Bond Tool clicked on expanded monomer bond | Nothing happens | "Edit Abbreviation" dialog shown ✅ |
| Bond Tool clicked on expanded monomer atom | Nothing happens | "Edit Abbreviation" dialog shown ✅ |
| Atom Tool clicked on expanded monomer atom | Nothing happens | "Edit Abbreviation" dialog shown ✅ |
| Template Tool used on expanded monomer atom/bond | Nothing happens | "Edit Abbreviation" dialog shown ✅ |
| Regular functional group behavior | Dialog shown | Dialog shown (unchanged) ✅ |

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request