### PR TITLE
#6314 Export to Sequence (3-letter code) and export to IDT doesn't throws an error if user tries to save micromolecule structures

### DIFF
--- a/ketcher-autotests/tests/specs/Chromium-popup/Monomer-creation/monomer-creation.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Monomer-creation/monomer-creation.spec.ts
@@ -3643,7 +3643,7 @@ for (const monomerToCreate of monomersToCreate51) {
       MacromoleculesFileFormatType.IDT,
     );
     const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-    expect(errorMessage).toContain('Convert error! Sequence saver:');
+    expect(errorMessage).toContain('Convert error!');
     await ErrorMessageDialog(page).close();
     await SaveStructureDialog(page).cancel();
   });

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher4.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Macro-Micro-Switcher/macro-micro-switcher4.spec.ts
@@ -373,7 +373,7 @@ test(`Verify that all 16 bond types can't be saved correctly in macromolecules m
    * Case: 1. Load ket file with 16 bonds at Micro
    *       2. Take screenshot to witness initial state
    *       3. Save to IDT
-   *       4. Take screenshot to witness error message occured
+   *       4. Validate error message occured
    *
    */
   await openFileAndAddToCanvasAsNewProject(
@@ -386,13 +386,12 @@ test(`Verify that all 16 bond types can't be saved correctly in macromolecules m
   await SaveStructureDialog(page).chooseFileFormat(
     MacromoleculesFileFormatType.IDT,
   );
-  await takeEditorScreenshot(page);
-  await SaveStructureDialog(page).cancel();
-  test.fixme(
-    true,
-    `Works wrong because of https://github.com/epam/ketcher/issues/6314 issue(s).
-     Test should be updated after fix`,
+  const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
+  expect(errorMessage).toContain(
+    'Convert error! Error during sequence type recognition(RNA, DNA or Peptide)',
   );
+  await ErrorMessageDialog(page).close();
+  await SaveStructureDialog(page).cancel();
 });
 
 test(`Verify that all 16 types of bonds saved in macro mode can be opened in micro mode in MOL v3000`, async () => {

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -2778,6 +2778,13 @@ export class DrawingEntitiesManager {
   }
 
   public validateIfApplicableForFasta() {
+    if (
+      this.monomers.size === 0 &&
+      this.micromoleculesHiddenEntities.atoms.size > 0
+    ) {
+      return false;
+    }
+
     const monomerTypes = new Set();
     let isValid = true;
 

--- a/packages/ketcher-macromolecules/src/components/modal/save/Save.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/save/Save.tsx
@@ -138,7 +138,11 @@ export const Save = ({
 
     try {
       setIsLoading(true);
-      if (fileFormat === 'fasta' || fileFormat === 'sequence') {
+      if (
+        fileFormat === 'fasta' ||
+        fileFormat === 'sequence' ||
+        fileFormat === 'idt'
+      ) {
         const isValid =
           editor.drawingEntitiesManager.validateIfApplicableForFasta();
         if (!isValid) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Fixed saving to IDT format showing an empty export result instead of an error message when the canvas contains incompatible structures (e.g. micromolecules loaded in Macro/Flex mode).

**Root cause:**

Two separate gaps combined to produce the silent empty export:

1. **`Save.tsx`** — The pre-conversion fasta validation check (`validateIfApplicableForFasta`) was only applied to `fasta` and `sequence` formats. IDT was missing from this list, so for IDT the validation was skipped entirely and `indigo.convert()` was called directly, returning an empty string with no error.

2. **`DrawingEntitiesManager.ts`** — Even after adding IDT to the check, `validateIfApplicableForFasta` iterates `this.monomers`. When a file containing only micromolecules (e.g. standard small molecules with bonds) is loaded in Macro mode, those structures are stored in `micromoleculesHiddenEntities`, not in `monomers`. So `monomers` is empty, the loop never executes, `isValid` stays `true`, and validation incorrectly passes — still producing a silent empty result.

**Changes made:**

**`Save.tsx`**
- Added `'idt'` alongside `'fasta'` and `'sequence'` in the format guard that calls `validateIfApplicableForFasta()` before attempting conversion. IDT is a sequence-based format with the same structural constraints (pure RNA/DNA/Peptide chains only), so the same validation applies.

**`DrawingEntitiesManager.ts` — `validateIfApplicableForFasta()`**
- Added an early return of `false` when `monomers` is empty but `micromoleculesHiddenEntities` contains atoms. This correctly identifies a canvas holding only micromolecules as incompatible with sequence-based formats. A truly empty canvas (no monomers, no micromolecules) still returns `true`, preserving the existing behavior where an empty canvas can be exported to an empty FASTA/sequence/IDT file.

**Behavior after the fix:**

| Scenario | Before | After |
|---|---|---|
| Micromolecules on canvas → save as IDT | Empty export (silent) | Error: `Convert error! Error during sequence type recognition(RNA, DNA or Peptide)` ✅ |
| Micromolecules on canvas → save as FASTA/Sequence | Empty export (silent) | Error: `Convert error! Error during sequence type recognition(RNA, DNA or Peptide)` ✅ |
| Valid RNA/DNA chain → save as IDT | Empty export (silent) | Correct IDT output ✅ |
| Empty canvas → save as FASTA/Sequence/IDT | Empty file | Empty file (unchanged) ✅ |

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request