### PR TITLE
Refactor split right click canvas event into seperate events per mode

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -770,13 +770,14 @@ export class CoreEditor {
           selectedMonomers,
         ]);
       } else if (isClickOnCanvas) {
-        // TODO separate by two events for modes
-        this.events.rightClickCanvas.dispatch([
-          event,
-          this.mode instanceof SequenceMode
-            ? sequenceSelections
-            : selectedMonomers,
-        ]);
+        if (this.mode instanceof SequenceMode) {
+          this.events.rightClickCanvasSequence.dispatch([
+            event,
+            sequenceSelections,
+          ]);
+        } else {
+          this.events.rightClickCanvas.dispatch([event, selectedMonomers]);
+        }
       }
 
       return false;

--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -34,6 +34,7 @@ export interface IEditorEvents {
   mouseUpMonomer: Subscription;
   rightClickSequence: Subscription;
   rightClickCanvas: Subscription;
+  rightClickCanvasSequence: Subscription;
   rightClickPolymerBond: Subscription;
   rightClickSelectedMonomers: Subscription;
   keyDown: Subscription;
@@ -109,6 +110,7 @@ export const editorEvents: IEditorEvents = {
   mouseUpMonomer: new Subscription(),
   rightClickSequence: new Subscription(),
   rightClickCanvas: new Subscription(),
+  rightClickCanvasSequence: new Subscription(),
   rightClickPolymerBond: new Subscription(),
   rightClickSelectedMonomers: new Subscription(),
   keyDown: new Subscription(),
@@ -176,6 +178,7 @@ export const renderersEvents: ToolEventHandlerName[] = [
   'mouseUpMonomer',
   'rightClickSequence',
   'rightClickCanvas',
+  'rightClickCanvasSequence',
   'rightClickPolymerBond',
   'rightClickSelectedMonomers',
   'editSequence',

--- a/packages/ketcher-core/src/application/editor/tools/Tool.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Tool.ts
@@ -55,6 +55,8 @@ interface ToolEventHandler {
 
   rightClickCanvas?(event: Event): void;
 
+  rightClickCanvasSequence?(event: Event): void;
+
   rightClickPolymerBond?(event: Event): void;
 
   rightClickSelectedMonomers?(event: Event): void;

--- a/packages/ketcher-macromolecules/src/Editor.tsx
+++ b/packages/ketcher-macromolecules/src/Editor.tsx
@@ -34,7 +34,6 @@ import {
   SetEditorLineLengthAction,
   NodeSelection,
   NodesSelection,
-  SequenceMode,
 } from 'ketcher-core';
 import { store } from 'state';
 import {
@@ -265,25 +264,27 @@ function Editor({
       },
     );
     editor?.events.rightClickCanvas.add(
-      ([event, selections]: [PointerEvent, NodesSelection | BaseMonomer[]]) => {
+      ([event, selections]: [PointerEvent, BaseMonomer[]]) => {
         setContextMenuEvent(event);
         window.dispatchEvent(new Event('hidePreview'));
         dispatch(setContextMenuActive(true));
-
-        // TODO separate by two events
-        if (editor.mode instanceof SequenceMode) {
-          setSelections(selections as NodesSelection);
-          showSequenceContextMenu({
-            event,
-            props: {},
-          });
-        } else {
-          setSelectedMonomers(selections as BaseMonomer[]);
-          showSelectedMonomersContextMenu({
-            event,
-            props: { selectedMonomers: selections },
-          });
-        }
+        setSelectedMonomers(selections);
+        showSelectedMonomersContextMenu({
+          event,
+          props: { selectedMonomers: selections },
+        });
+      },
+    );
+    editor?.events.rightClickCanvasSequence.add(
+      ([event, selections]: [PointerEvent, NodesSelection]) => {
+        setContextMenuEvent(event);
+        window.dispatchEvent(new Event('hidePreview'));
+        dispatch(setContextMenuActive(true));
+        setSelections(selections);
+        showSequenceContextMenu({
+          event,
+          props: {},
+        });
       },
     );
     editor?.events.toggleMacromoleculesPropertiesVisibility.add(() => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Resolved TODO "separate by two events for modes" on the rightClickCanvas event. Added new rightClickCanvasSequence event to the interface, events object, event names array, and tool interface. In Editor.ts, replaced the single dispatch with a ternary into two explicit mode-specific dispatches. In Editor.tsx, split the single listener with an
  internal mode check into two clean focused listeners — rightClickCanvas for non-sequence modes (receives BaseMonomer[]), rightClickCanvasSequence for sequence mode (receives NodesSelection).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request