### PR TITLE
#9635 - Refactor: Variables are missing in props validation (let's rewrite JS to TS) 53

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/tools.test.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.mock('./isHidden', () => jest.fn((_options, name) => name === 'hidden-tool'));
+jest.mock('./flips', () => ({ isFlipDisabled: jest.fn(() => false) }));
+jest.mock('../data/convert/structconv', () => ({
+  toBondType: jest.fn((type: string) => ({ type, stereo: 0 })),
+}));
+jest.mock('../data/schema/struct-schema', () => ({
+  bond: {
+    properties: {
+      type: {
+        enum: ['single', 'double', 'any', 'singledouble'],
+        enumNames: ['Single', 'Double', 'Any', 'Single/Double'],
+      },
+    },
+  },
+}));
+jest.mock('ketcher-core', () => ({
+  RxnArrowMode: {},
+  SimpleObjectMode: {},
+  Struct: class {},
+  findStereoAtoms: jest.fn(() => []),
+  IMAGE_KEY: 'image',
+  MULTITAIL_ARROW_TOOL_NAME: 'multitail-arrow',
+  CREATE_MONOMER_TOOL_NAME: 'create-monomer',
+}));
+
+import tools from './tools';
+import { findStereoAtoms } from 'ketcher-core';
+
+const makeEditor = (overrides: Record<string, unknown> = {}) => ({
+  isMonomerCreationWizardActive: false,
+  struct: () => ({ atoms: new Map([[1, {}]]) }),
+  ...overrides,
+});
+
+describe('tools', () => {
+  describe('enhanced-stereo disabled', () => {
+    const enhancedStereo = tools['enhanced-stereo'];
+
+    it('disables when monomer creation wizard is active', () => {
+      expect(enhancedStereo.disabled?.(makeEditor({ isMonomerCreationWizardActive: true }))).toBe(true);
+    });
+
+    it('disables when no stereo atoms exist', () => {
+      (findStereoAtoms as jest.Mock).mockReturnValueOnce([]);
+      expect(enhancedStereo.disabled?.(makeEditor())).toBe(true);
+    });
+
+    it('enables when wizard inactive and stereo atoms exist', () => {
+      (findStereoAtoms as jest.Mock).mockReturnValueOnce([{ id: 1 }]);
+      expect(enhancedStereo.disabled?.(makeEditor())).toBe(false);
+    });
+  });
+
+  describe('bond actions', () => {
+    it('builds a bond entry per schema enum value', () => {
+      expect(tools['bond-single']).toBeDefined();
+      expect(tools['bond-double']).toBeDefined();
+      expect(tools['bond-any']).toBeDefined();
+      expect(tools['bond-singledouble']).toBeDefined();
+    });
+
+    it('attaches a wizard-aware disabled fn to monomer-wizard-disallowed bonds', () => {
+      expect(tools['bond-any'].disabled).toBeDefined();
+      expect(tools['bond-singledouble'].disabled).toBeDefined();
+      expect(tools['bond-any'].disabled?.(makeEditor({ isMonomerCreationWizardActive: true }))).toBe(true);
+      expect(tools['bond-any'].disabled?.(makeEditor({ isMonomerCreationWizardActive: false }))).toBe(false);
+    });
+
+    it('does not add a disabled fn to allowed bond types', () => {
+      expect(tools['bond-single'].disabled).toBeUndefined();
+      expect(tools['bond-double'].disabled).toBeUndefined();
+    });
+
+    it('hidden defers to isHidden', () => {
+      expect(tools['bond-single'].hidden?.({})).toBe(false);
+    });
+
+    it('builds the action with the bond opts from toBondType', () => {
+      expect(tools['bond-single'].action).toEqual({
+        tool: 'bond',
+        opts: { type: 'single', stereo: 0 },
+      });
+    });
+  });
+});

--- a/packages/ketcher-react/src/script/ui/action/tools.test.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.test.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { findStereoAtoms } from 'ketcher-core';
+import tools from './tools';
+
 jest.mock('./isHidden', () =>
   jest.fn((_options, name) => name === 'hidden-tool'),
 );
@@ -25,9 +28,6 @@ jest.mock('ketcher-core', () => ({
   MULTITAIL_ARROW_TOOL_NAME: 'multitail-arrow',
   CREATE_MONOMER_TOOL_NAME: 'create-monomer',
 }));
-
-import tools from './tools';
-import { findStereoAtoms } from 'ketcher-core';
 
 const makeEditor = (overrides: Record<string, unknown> = {}) => ({
   isMonomerCreationWizardActive: false,

--- a/packages/ketcher-react/src/script/ui/action/tools.test.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-jest.mock('./isHidden', () => jest.fn((_options, name) => name === 'hidden-tool'));
+jest.mock('./isHidden', () =>
+  jest.fn((_options, name) => name === 'hidden-tool'),
+);
 jest.mock('./flips', () => ({ isFlipDisabled: jest.fn(() => false) }));
 jest.mock('../data/convert/structconv', () => ({
   toBondType: jest.fn((type: string) => ({ type, stereo: 0 })),
@@ -38,7 +40,11 @@ describe('tools', () => {
     const enhancedStereo = tools['enhanced-stereo'];
 
     it('disables when monomer creation wizard is active', () => {
-      expect(enhancedStereo.disabled?.(makeEditor({ isMonomerCreationWizardActive: true }))).toBe(true);
+      expect(
+        enhancedStereo.disabled?.(
+          makeEditor({ isMonomerCreationWizardActive: true }),
+        ),
+      ).toBe(true);
     });
 
     it('disables when no stereo atoms exist', () => {
@@ -63,8 +69,16 @@ describe('tools', () => {
     it('attaches a wizard-aware disabled fn to monomer-wizard-disallowed bonds', () => {
       expect(tools['bond-any'].disabled).toBeDefined();
       expect(tools['bond-singledouble'].disabled).toBeDefined();
-      expect(tools['bond-any'].disabled?.(makeEditor({ isMonomerCreationWizardActive: true }))).toBe(true);
-      expect(tools['bond-any'].disabled?.(makeEditor({ isMonomerCreationWizardActive: false }))).toBe(false);
+      expect(
+        tools['bond-any'].disabled?.(
+          makeEditor({ isMonomerCreationWizardActive: true }),
+        ),
+      ).toBe(true);
+      expect(
+        tools['bond-any'].disabled?.(
+          makeEditor({ isMonomerCreationWizardActive: false }),
+        ),
+      ).toBe(false);
     });
 
     it('does not add a disabled fn to allowed bond types', () => {

--- a/packages/ketcher-react/src/script/ui/action/tools.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.ts
@@ -17,6 +17,7 @@
 import {
   RxnArrowMode,
   SimpleObjectMode,
+  Struct,
   findStereoAtoms,
   IMAGE_KEY,
   MULTITAIL_ARROW_TOOL_NAME,
@@ -29,7 +30,19 @@ import { toBondType } from '../data/convert/structconv';
 import { isFlipDisabled } from './flips';
 import { MONOMER_WIZARD_DISALLOWED_BOND_TYPES } from '../views/components/ContextMenu/utils';
 
-const toolActions = {
+export interface ToolAction {
+  title?: string;
+  shortcut?: string | string[];
+  enabledInViewOnly?: boolean;
+  action?: {
+    tool: string;
+    opts?: string | number | Record<string, unknown>;
+  };
+  disabled?: (editor: Record<string, unknown>) => unknown;
+  hidden?: (options: Record<string, unknown>) => boolean;
+}
+
+const toolActions: Record<string, ToolAction> = {
   hand: {
     title: 'Hand tool',
     enabledInViewOnly: true,
@@ -77,12 +90,16 @@ const toolActions = {
     shortcut: 'Alt+e',
     title: 'Stereochemistry',
     action: { tool: 'enhancedStereo' },
-    disabled: (editor) =>
-      editor.isMonomerCreationWizardActive ||
-      findStereoAtoms(
-        editor?.struct(),
-        Array.from(editor?.struct().atoms.keys()),
-      ).length === 0,
+    disabled: (editor) => {
+      const editorStruct = (editor.struct as () => Struct)?.();
+      return (
+        editor.isMonomerCreationWizardActive ||
+        findStereoAtoms(
+          editorStruct,
+          Array.from(editorStruct?.atoms.keys() ?? []),
+        ).length === 0
+      );
+    },
     hidden: (options) => isHidden(options, 'enhanced-stereo'),
   },
   'charge-plus': {
@@ -399,7 +416,7 @@ const toolActions = {
   },
 };
 
-const bondCuts = {
+const bondCuts: Record<string, string> = {
   single: '1',
   double: '2',
   triple: '3',
@@ -411,24 +428,32 @@ const bondCuts = {
   aromatic: '4',
 };
 
-const typeSchema = bondSchema.properties.type;
+const typeSchema = bondSchema.properties.type as {
+  enum: string[];
+  enumNames: string[];
+};
 
-const monomerWizardDisallowedBondTypes = new Set(
+const monomerWizardDisallowedBondTypes = new Set<string>(
   MONOMER_WIZARD_DISALLOWED_BOND_TYPES,
 );
 
-export default typeSchema.enum.reduce((res, type, i) => {
-  res[`bond-${type}`] = {
-    title: `${typeSchema.enumNames[i]} Bond`,
-    shortcut: bondCuts[type],
-    action: {
-      tool: 'bond',
-      opts: toBondType(type),
-    },
-    hidden: (options) => isHidden(options, `bond-${type}`),
-    ...(monomerWizardDisallowedBondTypes.has(type) && {
-      disabled: (editor) => editor.isMonomerCreationWizardActive,
-    }),
-  };
-  return res;
-}, toolActions);
+export default typeSchema.enum.reduce(
+  (res: Record<string, ToolAction>, type: string, i: number) => {
+    res[`bond-${type}`] = {
+      title: `${typeSchema.enumNames[i]} Bond`,
+      shortcut: bondCuts[type],
+      action: {
+        tool: 'bond',
+        opts: toBondType(type),
+      },
+      hidden: (options: Record<string, unknown>) =>
+        isHidden(options, `bond-${type}`),
+      ...(monomerWizardDisallowedBondTypes.has(type) && {
+        disabled: (editor: Record<string, unknown>) =>
+          editor.isMonomerCreationWizardActive,
+      }),
+    };
+    return res;
+  },
+  toolActions,
+);

--- a/packages/ketcher-react/src/script/ui/action/tools.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.ts
@@ -78,7 +78,7 @@ const toolActions: Record<string, ToolAction> = {
   erase: {
     title: 'Erase',
     shortcut: ['Delete', 'Backspace'],
-    action: { tool: 'eraser', opts: 1 }, // TODO last selector mode is better
+    action: { tool: 'eraser', opts: 1 },
     hidden: (options) => isHidden(options, 'erase'),
   },
   chain: {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
@@ -2,6 +2,7 @@ import {
   fromBondsAttrs,
   ketcherProvider,
   bondChangingAction,
+  Bond,
 } from 'ketcher-core';
 import { useCallback } from 'react';
 import { useAppContext } from 'src/hooks';
@@ -11,6 +12,14 @@ import { BondsContextMenuProps, ItemEventParams } from '../contextMenu.types';
 
 type Params = ItemEventParams<BondsContextMenuProps>;
 
+type BondProps = {
+  type?: number;
+  stereo?: number;
+  topology?: number | null;
+  reactingCenterStatus?: number | null;
+  customQuery?: string | null;
+};
+
 const useBondTypeChange = () => {
   const { ketcherId } = useAppContext();
   const handler = useCallback(
@@ -18,8 +27,12 @@ const useBondTypeChange = () => {
       const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
       const molecule = editor.render.ctab;
       const bondIds = props?.bondIds ?? [];
-      // @ts-expect-error tools[id].action.opts is a bond-type object from toBondType()
-      const bondProps = { ...tools[id].action.opts };
+      const opts = id != null ? tools[String(id)]?.action?.opts : undefined;
+      const bondProps: BondProps = {
+        ...(typeof opts === 'object' && opts !== null
+          ? (opts as BondProps)
+          : null),
+      };
       const isCustomQuery = molecule.bonds.get(bondIds[0])?.b.customQuery;
       if (isCustomQuery) {
         bondProps.customQuery = null;
@@ -43,7 +56,9 @@ const useBondTypeChange = () => {
       }
 
       // For multiple bonds, use fromBondsAttrs
-      editor.update(fromBondsAttrs(molecule, bondIds, bondProps));
+      editor.update(
+        fromBondsAttrs(molecule, bondIds, bondProps as Partial<Bond>),
+      );
     },
     [ketcherId],
   );

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
@@ -18,6 +18,7 @@ const useBondTypeChange = () => {
       const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
       const molecule = editor.render.ctab;
       const bondIds = props?.bondIds ?? [];
+      // @ts-expect-error tools[id].action.opts is a bond-type object from toBondType()
       const bondProps = { ...tools[id].action.opts };
       const isCustomQuery = molecule.bonds.get(bondIds[0])?.b.customQuery;
       if (isCustomQuery) {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/utils.ts
@@ -6,8 +6,8 @@ import { difference } from 'lodash';
  * @example
  * formatTitle('Single Bond') === 'Single'
  */
-export const formatTitle = (title: string) => {
-  return title.slice(0, -5);
+export const formatTitle = (title?: string) => {
+  return title?.slice(0, -5) ?? '';
 };
 
 /**


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
- Convert `tools.js` to TypeScript (`.ts`) with full type definitions
- Define and export `ToolAction` interface describing the shape of each tool entry (`title`, `shortcut`, `action`, `disabled`, `hidden`, `enabledInViewOnly`)
- Type `toolActions` as `Record<string, ToolAction>` and `bondCuts` as `Record<string, string>`
- Type `disabled` and `hidden` callback parameters
- Type the `reduce` that builds bond tool entries with explicit parameter types
- Refactor `enhanced-stereo` disabled callback to safely access `editor.struct()` with proper cast to `Struct`
- No runtime logic changes — all conversions are equivalent

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request