### PR TITLE
#7745-Preview tooltip doesn't appear on the canvas if monomer name too long 

### DIFF
--- a/packages/ketcher-macromolecules/src/components/preview/components/MonomerPreview/MonomerPreview.styles.ts
+++ b/packages/ketcher-macromolecules/src/components/preview/components/MonomerPreview/MonomerPreview.styles.ts
@@ -16,32 +16,46 @@
 import styled from '@emotion/styled';
 import { StructRender } from 'ketcher-react';
 
-export const Container = styled.div`
+export const Container = styled.div<{ isLongName?: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: start;
   gap: 8px;
+  overflow: hidden;
+  width: ${(props) => (props.isLongName ? '450px' : '345px')};
+  height: 345px;
   background: ${(props) => props.theme.ketcher.color.background.primary};
   border: ${(props) => props.theme.ketcher.border.regular};
   border-radius: ${(props) => props.theme.ketcher.border.radius.regular};
   box-shadow: ${(props) => props.theme.ketcher.shadow.regular};
 `;
 
-export const MonomerName = styled.p`
+export const MonomerName = styled.p<{ isLongName?: boolean }>`
   width: calc(100% - 16px);
   padding: 8px;
   color: ${(props) => props.theme.ketcher.color.text.primary};
   background-color: #cceaee;
-  font-size: ${(props) => props.theme.ketcher.font.size.regular};
+  font-size: ${(props) =>
+    props.isLongName ? '8px' : props.theme.ketcher.font.size.regular};
   font-weight: 700;
   word-break: break-all;
   text-align: left;
   margin: 0;
   white-space: pre-wrap;
+  ${(props) =>
+    props.isLongName &&
+    `
+    max-height: 200px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 15;
+    -webkit-box-orient: vertical;
+  `}
 `;
 
 export const StyledStructRender = styled(StructRender)`
-  height: 100%;
+  flex: 1 1 auto;
+  min-height: 80px;
   width: 100%;
   padding: 0 8px;
 `;
@@ -49,6 +63,7 @@ export const StyledStructRender = styled(StructRender)`
 export const InfoBlock = styled.div`
   width: 100%;
   display: flex;
+  flex-shrink: 0;
   gap: 8px;
   padding: 0 8px 4px;
 `;

--- a/packages/ketcher-macromolecules/src/components/preview/components/MonomerPreview/MonomerPreview.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/MonomerPreview/MonomerPreview.tsx
@@ -31,7 +31,6 @@ import MonomerPreviewProperties from '../MonomerPreviewProperties/MonomerPreview
 import AttachmentPoints from '../AttachmentPoints/AttachmentPoints';
 import { UsageInMacromolecule } from 'ketcher-core';
 import { MonomerPreviewState } from 'state';
-import { preview } from 'ketcher-react';
 
 interface Props {
   className?: string;
@@ -39,6 +38,7 @@ interface Props {
 
 const MonomerPreview = ({ className }: Props) => {
   const preview = useAppSelector(selectShowPreview) as MonomerPreviewState;
+  const LONG_NAME_THRESHOLD = 100;
 
   const { monomer, attachmentPointsToBonds } = preview;
 
@@ -74,6 +74,7 @@ const MonomerPreview = ({ className }: Props) => {
     (monomer.struct || isUnresolved) && (
       <Container
         className={className}
+        isLongName={!!monomerName && monomerName.length > LONG_NAME_THRESHOLD}
         data-testid="polymer-library-preview"
         data-idtaliases={idtAliasesText ?? undefined}
         data-axolabs={axoLabsAlias ?? undefined}
@@ -81,7 +82,10 @@ const MonomerPreview = ({ className }: Props) => {
         data-modificationtype={getModificationTypeAttribute(modificationTypes)}
       >
         {monomerName && (
-          <MonomerName data-testid="preview-tooltip-title">
+          <MonomerName
+            data-testid="preview-tooltip-title"
+            isLongName={monomerName.length > 100}
+          >
             {monomerName}
           </MonomerName>
         )}
@@ -120,10 +124,7 @@ const MonomerPreview = ({ className }: Props) => {
   );
 };
 
-const StyledPreview = styled(MonomerPreview)`
-  width: ${preview.width + 'px'};
-  height: ${preview.height + 'px'};
-`;
+const StyledPreview = styled(MonomerPreview)``;
 
 export default StyledPreview;
 export { MonomerPreview };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
When a monomer is created with a very long name (e.g., 3000+ characters), the preview tooltip doesn't appear when hovering over the monomer on the macromolecules canvas.

Root cause: The [MonomerName](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) text area had no height constraint and used white-space: pre-wrap with [word-break: break-all](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), causing it to expand to 700+ pixels for very long names. This overflowed the 345px tooltip container (which had no [overflow: hidden](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), covering the monomer SVG element on the canvas. When the tooltip appeared, [mouseLeaveMonomer](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fired immediately (cursor was now over overflowing tooltip content, not the monomer), triggering [handleClosePreview](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — creating an infinite show/hide loop.

Solution
[Container](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added [overflow: hidden](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), explicit [width](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (345px normal, 450px for long names) and [height: 345px](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to constrain the tooltip
[MonomerName](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Reduced font size to 8px for names > 100 characters, with max-height: 200px, [overflow: hidden](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and -webkit-line-clamp: 15 (only for long names). Short names render unchanged
[StyledStructRender](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed from [height: 100%](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to flex: 1 1 auto; min-height: 80px so it fills remaining space properly
[InfoBlock](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added flex-shrink: 0 so attachment points are always visible
[StyledPreview](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Removed fixed width/height (now handled by [Container](vscode-file://vscode-app/c:/Users/GuliaIsaevaCologlu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/ae130017f8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) directly)

https://github.com/user-attachments/assets/a14d88f7-cd70-42a8-9ec9-a9886c7ddc6d

