### PR TITLE
#9709 – It is not correct to have 5' indicator on an antisense chain.

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/FlexMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/FlexMode.ts
@@ -14,6 +14,10 @@ export class FlexMode extends BaseMode {
     const command = super.initialize();
     const editor = CoreEditor.provideEditorInstance();
 
+    const antisenseChanges =
+      editor.drawingEntitiesManager.recalculateAntisenseChains();
+    editor.renderersContainer.update(antisenseChanges);
+
     const modelChanges =
       editor.drawingEntitiesManager.applyFlexLayoutMode(true);
 

--- a/packages/ketcher-core/src/application/editor/modes/FlexMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/FlexMode.ts
@@ -16,13 +16,13 @@ export class FlexMode extends BaseMode {
 
     const antisenseChanges =
       editor.drawingEntitiesManager.recalculateAntisenseChains();
-    editor.renderersContainer.update(antisenseChanges);
 
     const modelChanges =
       editor.drawingEntitiesManager.applyFlexLayoutMode(true);
 
     command.merge(editor.drawingEntitiesManager.recalculateCanvasMatrix());
 
+    modelChanges.merge(antisenseChanges);
     editor.renderersContainer.update(modelChanges);
 
     return command;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
**Why Sequence → Flex works but Snake → Flex doesn't**
When leaving Sequence mode: `SequenceMode.initialize()` explicitly calls: `editor.drawingEntitiesManager.recalculateAntisenseChains(!this.isEditMode)`

When leaving Snake mode:` FlexMode.initialize()` calls ONLY` applyFlexLayoutMode(true)` — no` recalculateAntisenseChains`. It relies entirely on the `isAntisense `flags being either correctly restored by undo, or preserved from the snake initialization.

**Fixed**.
Now when entering Flex mode, `recalculateAntisenseChains()` runs first (before `applyFlexLayoutMode` re-adds monomers to the renderer), ensuring `isAntisense/isSense` flags are correctly set based on actual bond connectivity — not on whatever state they were left in after a Snake mode session.
<img width="692" height="388" alt="Screenshot 2026-04-15 175936" src="https://github.com/user-attachments/assets/88b29953-3cce-460d-9bf3-d78d82eaa90a" />



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
fix #9709 