### PR TITLE
#9736 - TODO | Refactor: Replace recursive DFS with iterative approach in prepareSubStructure

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -312,53 +312,50 @@ export function setExpandMonomerSGroup(
   const atomsToMove = new Map<number, number[]>();
   const sGroupsToMove = new Map<number, number[]>();
 
-  const prepareSubStructure = (atomId: number, subStructureKey: number) => {
-    if (visitedAtoms.has(atomId)) {
-      return;
-    }
-    visitedAtoms.add(atomId);
+  attachmentAtomsFromOutside.forEach((startAtomId, index) => {
+    const queue: number[] = [startAtomId];
 
-    const atomSGroups = restruct.atoms.get(atomId)?.a.sgs;
-    const atomInSGroup = atomSGroups && atomSGroups.size > 0;
-    if (atomInSGroup) {
-      for (const anotherSGroupId of atomSGroups.values()) {
-        if (visitedSGroups.has(anotherSGroupId) || anotherSGroupId === sgid) {
-          continue;
+    while (queue.length > 0) {
+      const currentAtomId = queue.shift() as number;
+
+      if (visitedAtoms.has(currentAtomId)) {
+        continue;
+      }
+      visitedAtoms.add(currentAtomId);
+
+      const atomSGroups = restruct.atoms.get(currentAtomId)?.a.sgs;
+      const atomInSGroup = atomSGroups && atomSGroups.size > 0;
+      if (atomInSGroup) {
+        for (const anotherSGroupId of atomSGroups.values()) {
+          if (visitedSGroups.has(anotherSGroupId) || anotherSGroupId === sgid) {
+            continue;
+          }
+          visitedSGroups.add(anotherSGroupId);
+
+          const anotherSGroup = struct.sgroups.get(anotherSGroupId);
+          if (!anotherSGroup) {
+            continue;
+          }
+
+          const previousArray = sGroupsToMove.get(index) ?? [];
+          sGroupsToMove.set(index, previousArray.concat(anotherSGroupId));
         }
-        visitedSGroups.add(anotherSGroupId);
+      }
 
-        const anotherSGroup = struct.sgroups.get(anotherSGroupId);
-        if (!anotherSGroup) {
-          continue;
-        }
+      const atom = struct.atoms.get(currentAtomId);
+      if (atom) {
+        const previousArray = atomsToMove.get(index) ?? [];
+        atomsToMove.set(index, previousArray.concat(currentAtomId));
 
-        const previousArray = sGroupsToMove.get(subStructureKey) ?? [];
-        sGroupsToMove.set(
-          subStructureKey,
-          previousArray.concat(anotherSGroupId),
-        );
+        atom.neighbors.forEach((halfBondId) => {
+          const neighborAtomId = struct?.halfBonds?.get(halfBondId)?.end;
+          if (neighborAtomId === undefined || sGroupAtoms.has(neighborAtomId)) {
+            return;
+          }
+          queue.push(neighborAtomId);
+        });
       }
     }
-
-    const atom = struct.atoms.get(atomId);
-    if (atom) {
-      const previousArray = atomsToMove.get(subStructureKey) ?? [];
-      atomsToMove.set(subStructureKey, previousArray.concat(atomId));
-
-      atom.neighbors.forEach((halfBondId) => {
-        const neighborAtomId = struct?.halfBonds?.get(halfBondId)?.end;
-        if (neighborAtomId === undefined || sGroupAtoms.has(neighborAtomId)) {
-          return;
-        }
-
-        // TODO: Rewrite recursion to iteration approach as it leads to incorrect movement order for RNA bases
-        prepareSubStructure(neighborAtomId, subStructureKey);
-      });
-    }
-  };
-
-  attachmentAtomsFromOutside.forEach((atomId, index) => {
-    prepareSubStructure(atomId, index);
   });
 
   const sameLine = new Set<number>();


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 - Replace recursive DFS traversal in `prepareSubStructure` with iterative BFS using an explicit queue
  - Fixes incorrect atom movement order for RNA bases during monomer sgroup expand/contract
  - BFS ensures level-by-level traversal from attachment points outward, giving deterministic spatial ordering
  - Removes the `prepareSubStructure` closure — logic inlined into the `forEach` loop
  - Removes the TODO comment at line 354 that flagged this issue
  - No changes to data structures or filtering logic — only traversal order changed

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request