### PR TITLE
#9744 TODO | Bug: Multiple side chain connections in Linkers not handled during monomer replacement 

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1928,14 +1928,17 @@ export class SequenceMode extends BaseMode {
       ),
     );
 
-    // TODO: Check for multiple side chain connections in Linkers
+    const usedAttachmentPoints = new Set<AttachmentPointName>();
+
     sideChainConnections?.forEach((sideConnectionData) => {
       const {
         firstMonomerAttachmentPointName,
         secondMonomer,
         secondMonomerAttachmentPointName,
       } = sideConnectionData;
+
       if (
+        usedAttachmentPoints.has(firstMonomerAttachmentPointName) ||
         !this.isConnectionPossible(
           newMonomer,
           firstMonomerAttachmentPointName,
@@ -1946,6 +1949,7 @@ export class SequenceMode extends BaseMode {
         return;
       }
 
+      usedAttachmentPoints.add(firstMonomerAttachmentPointName);
       modelChanges.merge(
         editor.drawingEntitiesManager.createPolymerBond(
           newMonomer,


### PR DESCRIPTION
…nomer replacement

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Added a usedAttachmentPoints set to track already-queued attachment points during side chain connection restoration in replaceSelectionWithMonomer. Removed the TODO comment. 


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request