### PR TITLE
#9730 - Rotation tool: Rotation-angle label overlaps 0° label in Macro mode

### DIFF
--- a/packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts
@@ -44,8 +44,8 @@ describe('RotationView', () => {
       (text) => text.textContent === '75°',
     );
     expect(angleText).toBeTruthy();
-    expect(Number(angleText?.getAttribute('x'))).toBeCloseTo(100);
-    expect(Number(angleText?.getAttribute('y'))).toBeCloseTo(-10);
+    expect(Number(angleText?.getAttribute('x'))).toBeCloseTo(120);
+    expect(Number(angleText?.getAttribute('y'))).toBeCloseTo(0);
 
     const arcPath = Array.from(svg.querySelectorAll('path')).find((path) =>
       path.getAttribute('d')?.includes('A90,90 0 0,1'),
@@ -83,8 +83,8 @@ describe('RotationView', () => {
       (text) => text.textContent === '-75°',
     );
     expect(angleText).toBeTruthy();
-    expect(Number(angleText?.getAttribute('x'))).toBeCloseTo(100);
-    expect(Number(angleText?.getAttribute('y'))).toBeCloseTo(-10);
+    expect(Number(angleText?.getAttribute('x'))).toBeCloseTo(120);
+    expect(Number(angleText?.getAttribute('y'))).toBeCloseTo(0);
 
     const arcPath = Array.from(svg.querySelectorAll('path')).find((path) =>
       path.getAttribute('d')?.includes('A90,90 0 0,0'),

--- a/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
+++ b/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
@@ -59,6 +59,8 @@ const STYLE = {
   DEGREE_TEXT_MARGIN: 10,
   DEGREE_LINE_LENGTH: 15,
   MIN_RADIUS_FOR_TEXT: 65,
+  CURRENT_ANGLE_X_OFFSET: 20,
+  CURRENT_ANGLE_Y_OFFSET: 10,
 };
 
 const LEFT_ARROW_PATH =
@@ -423,8 +425,14 @@ export class RotationView extends TransientView {
         const angleInDegrees = Math.round((rotationAngle * 180) / Math.PI);
         const textAngle = startAngle;
         const textRadius = radius + 20;
-        const textX = center.x + textRadius * Math.cos(textAngle);
-        const textY = center.y + textRadius * Math.sin(textAngle);
+        const textX =
+          center.x +
+          textRadius * Math.cos(textAngle) +
+          STYLE.CURRENT_ANGLE_X_OFFSET;
+        const textY =
+          center.y +
+          textRadius * Math.sin(textAngle) +
+          STYLE.CURRENT_ANGLE_Y_OFFSET;
 
         transientLayer
           .append('text')


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
<img width="443" height="401" alt="image" src="https://github.com/user-attachments/assets/625b5518-1fb5-4142-9613-42f933e21182" />


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request