### PR TITLE
#9740 - TODO | Refactor: Decompose fromTemplateOnBond into smaller functions

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -269,45 +269,20 @@ function getConnectingBond(
   return null;
 }
 
-function fromTemplateOnBond(restruct, template, bid, flip, isPreview = false) {
-  // TODO: refactor function !!
-  const action = new Action();
-
-  const tmpl = template.molecule;
-  const struct = restruct.molecule;
-
-  const bond = struct.bonds.get(bid);
-  const tmplBond = tmpl.bonds.get(template.bid);
-
-  const tmplBegin = tmpl.atoms.get(flip ? tmplBond.end : tmplBond.begin);
-
-  const atomsMap = new Map([
-    [tmplBond.begin, flip ? bond.end : bond.begin],
-    [tmplBond.end, flip ? bond.begin : bond.end],
-  ]);
-
-  // calc angle
-  const bondAtoms = {
-    begin: flip ? tmplBond.end : tmplBond.begin,
-    end: flip ? tmplBond.begin : tmplBond.end,
-  };
-  const { angle, scale } = utils.mergeBondsParams(
-    struct,
-    bond,
-    tmpl,
-    bondAtoms,
-  );
-
-  const frid = struct.getBondFragment(bid);
-
-  /* For merge */
-  const pasteItems: any = {
-    // only atoms and bonds now
-    atoms: [],
-    bonds: [],
-  };
-  /* ----- */
-
+function placeTemplateAtoms(
+  restruct,
+  tmpl,
+  struct,
+  tmplBond,
+  tmplBegin,
+  bond,
+  atomsMap,
+  frid,
+  angle,
+  scale,
+  action,
+  pasteItems,
+) {
   tmpl.atoms.forEach((atom, id) => {
     const attrs: any = Atom.getAttrHash(atom);
     attrs.fragment = frid;
@@ -335,12 +310,21 @@ function fromTemplateOnBond(restruct, template, bid, flip, isPreview = false) {
     }
   });
   mergeSgroups(action, restruct, pasteItems.atoms, bond.begin);
+}
 
-  // When a template of "Benzene" molecule is attached it
-  // uses specific fusing rules when attaching to a bond
-  // that is connected exactly to one bond on each side.
-  // For more info please refer to: https://github.com/epam/ketcher/issues/1855
-  const fusingBondType = getConnectingBond(tmpl, struct, bid, bond);
+function placeTemplateBonds(
+  restruct,
+  tmpl,
+  struct,
+  tmplBond,
+  bond,
+  bid,
+  atomsMap,
+  fusingBondType,
+  isPreview,
+  action,
+  pasteItems,
+) {
   const isFusingBenzeneBySpecialRules = fusingBondType !== null;
 
   tmpl.bonds.forEach((tBond, tBondIndex) => {
@@ -407,7 +391,9 @@ function fromTemplateOnBond(restruct, template, bid, flip, isPreview = false) {
       new BondAttr(previewBondId, 'isPreview', isPreview).perform(restruct),
     );
   });
+}
 
+function applyTemplatePostProcessing(restruct, bond, pasteItems, action) {
   if (pasteItems.atoms.length) {
     action.addOp(
       new CalcImplicitH([bond.begin, bond.end, ...pasteItems.atoms]).perform(
@@ -424,6 +410,78 @@ function fromTemplateOnBond(restruct, template, bid, flip, isPreview = false) {
       ),
     );
   }
+}
+
+function fromTemplateOnBond(restruct, template, bid, flip, isPreview = false) {
+  const action = new Action();
+
+  const tmpl = template.molecule;
+  const struct = restruct.molecule;
+
+  const bond = struct.bonds.get(bid);
+  const tmplBond = tmpl.bonds.get(template.bid);
+
+  const tmplBegin = tmpl.atoms.get(flip ? tmplBond.end : tmplBond.begin);
+
+  const atomsMap = new Map([
+    [tmplBond.begin, flip ? bond.end : bond.begin],
+    [tmplBond.end, flip ? bond.begin : bond.end],
+  ]);
+
+  const bondAtoms = {
+    begin: flip ? tmplBond.end : tmplBond.begin,
+    end: flip ? tmplBond.begin : tmplBond.end,
+  };
+  const { angle, scale } = utils.mergeBondsParams(
+    struct,
+    bond,
+    tmpl,
+    bondAtoms,
+  );
+
+  const frid = struct.getBondFragment(bid);
+
+  const pasteItems: any = {
+    atoms: [],
+    bonds: [],
+  };
+
+  placeTemplateAtoms(
+    restruct,
+    tmpl,
+    struct,
+    tmplBond,
+    tmplBegin,
+    bond,
+    atomsMap,
+    frid,
+    angle,
+    scale,
+    action,
+    pasteItems,
+  );
+
+  // When a template of "Benzene" molecule is attached it
+  // uses specific fusing rules when attaching to a bond
+  // that is connected exactly to one bond on each side.
+  // For more info please refer to: https://github.com/epam/ketcher/issues/1855
+  const fusingBondType = getConnectingBond(tmpl, struct, bid, bond);
+
+  placeTemplateBonds(
+    restruct,
+    tmpl,
+    struct,
+    tmplBond,
+    bond,
+    bid,
+    atomsMap,
+    fusingBondType,
+    isPreview,
+    action,
+    pasteItems,
+  );
+
+  applyTemplatePostProcessing(restruct, bond, pasteItems, action);
 
   action.operations.reverse();
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
- Extract `placeTemplateAtoms` — handles iterating template atoms, computing transformed positions, placing new atoms or merging with existing, and merging sgroups
- Extract `placeTemplateBonds` — handles iterating template bonds, creating new bonds or merging existing, applying benzene/cyclopentadiene fusing rules, and setting preview flag
- Extract `applyTemplatePostProcessing` — handles calculating implicit hydrogens and updating bond stereo
- `fromTemplateOnBond` becomes a short orchestrator (~40 lines) that sets up shared state and calls the 3 helpers in order
- Addresses the `// TODO: refactor function !!` at line 273
- Pure refactoring — no logic changes, no behavior changes, no type changes
- Execution order preserved: atoms → sgroups → fusing bond type → bonds → post-processing → reverse

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request