### PR TITLE
#9786 – Add Home/End key support in Sequence edit mode

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1475,6 +1475,28 @@ export class SequenceMode extends BaseMode {
           this.unselectAllEntities();
         },
       },
+      'move-caret-to-row-start': {
+        shortcut: ['Home'],
+        handler: () => {
+          if (this.isEditInRNABuilderMode) return;
+          if (!this.isEditMode) return;
+
+          SequenceRenderer.moveCaretToRowStart();
+          SequenceRenderer.resetLastUserDefinedCaretPosition();
+          this.unselectAllEntities();
+        },
+      },
+      'move-caret-to-row-end': {
+        shortcut: ['End'],
+        handler: () => {
+          if (this.isEditInRNABuilderMode) return;
+          if (!this.isEditMode) return;
+
+          SequenceRenderer.moveCaretToRowEnd();
+          SequenceRenderer.resetLastUserDefinedCaretPosition();
+          this.unselectAllEntities();
+        },
+      },
       'add-sequence-item': {
         shortcut: [
           ...naturalAnalogues,

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -723,6 +723,46 @@ export class SequenceRenderer {
     SequenceRenderer.setCaretPosition(newCaretPosition);
   }
 
+  public static moveCaretToRowStart() {
+    const currentEdittingNode = this.currentEdittingNode;
+
+    if (!currentEdittingNode) {
+      return;
+    }
+
+    const currentNodeIndexInRow =
+      this.currentChainRow.indexOf(currentEdittingNode);
+
+    if (currentNodeIndexInRow <= 0) {
+      return;
+    }
+
+    const newCaretPosition = this.caretPosition - currentNodeIndexInRow;
+
+    SequenceRenderer.setCaretPosition(newCaretPosition);
+  }
+
+  public static moveCaretToRowEnd() {
+    const currentEdittingNode = this.currentEdittingNode;
+
+    if (!currentEdittingNode) {
+      return;
+    }
+
+    const currentNodeIndexInRow =
+      this.currentChainRow.indexOf(currentEdittingNode);
+    const rowEndIndex = this.currentChainRow.length - 1;
+
+    if (currentNodeIndexInRow >= rowEndIndex) {
+      return;
+    }
+
+    const newCaretPosition =
+      this.caretPosition + (rowEndIndex - currentNodeIndexInRow);
+
+    SequenceRenderer.setCaretPosition(newCaretPosition);
+  }
+
   public static moveCaretForward() {
     const operation = new RestoreSequenceCaretPositionOperation(
       this.caretPosition,


### PR DESCRIPTION
Adds Home/End key support in Sequence edit mode as requested in #9786.

- SequenceRenderer: added moveCaretToRowStart() / moveCaretToRowEnd() using currentChainRow to compute row-local offsets and delegate to setCaretPosition(). No-op when caret is already at row boundary or there is no editing node.
- SequenceMode.keyboardEventHandlers: added move-caret-to-row-start (Home) and move-caret-to-row-end (End) entries, guarded by edit mode.
- Home/End outside edit mode remain untouched.

Closes #9786