### PR TITLE
#8332 - cursor flickers between grabbing and pointing hand while dragging a monomer across the cards

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/__snapshots__/RnaPresetGroup.test.tsx.snap
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/__snapshots__/RnaPresetGroup.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Test Rna Preset Group component should render 1`] = `
     class="css-1a3tnc1"
   >
     <div
-      class="css-1lgakmz"
+      class="css-1am9vuh"
       data-rna-preset-item-name="U"
       data-testid="U_U_R_P"
     >

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetItem/RnaPresetItem.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetItem/RnaPresetItem.tsx
@@ -28,7 +28,11 @@ import {
   AutochainIcon,
   AutochainIconWrapper,
 } from 'components/monomerLibrary/monomerLibraryItem/styles';
-import { selectEditor, selectIsSequenceMode } from 'state/common';
+import {
+  selectEditor,
+  selectIsSequenceMode,
+  selectIsDragging,
+} from 'state/common';
 import Tooltip from '@mui/material/Tooltip';
 import { cardMouseOverHandler } from 'components/monomerLibrary/monomerLibraryItem/shared';
 import { AUTOCHAIN_ELEMENT_CLASSNAME } from 'components/monomerLibrary/monomerLibraryItem';
@@ -44,6 +48,7 @@ const RnaPresetItem = ({
   const dispatch = useAppDispatch();
   const editor = useAppSelector(selectEditor);
   const isSequenceMode = useAppSelector(selectIsSequenceMode);
+  const isDragging = useAppSelector(selectIsDragging);
   const [autochainErrorMessage, setAutochainErrorMessage] =
     useState<string>('');
 
@@ -106,6 +111,7 @@ const RnaPresetItem = ({
         onAutochainIconMouseOut();
       }}
       selected={isSelected}
+      isDragging={isDragging}
       code={preset.name}
       data-rna-preset-item-name={preset.name}
       ref={cardRef}

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/__snapshots__/MonomerGroup.test.tsx.snap
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/__snapshots__/MonomerGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Monomer Group should apply correct style if selected 1`] = `
 <div
-  class="css-cyguzh"
+  class="css-w61mbe"
   data-monomer-item-id="RRMonomerName___RRName"
   data-testid="RRMonomerName___RRName"
 >
@@ -62,7 +62,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
           class="css-1a3tnc1"
         >
           <div
-            class="css-1vx381w"
+            class="css-mfw0go"
             data-monomer-item-id="RRMonomerName___RRName"
             data-testid="RRMonomerName___RRName"
           >
@@ -104,7 +104,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-o7i94f"
+            class="css-1mkwiyz"
             data-monomer-item-id="mAMonomerName___mAName"
             data-testid="mAMonomerName___mAName"
           >
@@ -146,7 +146,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-1m6zie5"
+            class="css-rt02do"
             data-monomer-item-id="dDMonomerName___dDName"
             data-testid="dDMonomerName___dDName"
           >
@@ -188,7 +188,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-1vx381w"
+            class="css-mfw0go"
             data-monomer-item-id="arRMonomerName___arRName"
             data-testid="arRMonomerName___arRName"
           >
@@ -230,7 +230,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-o7i94f"
+            class="css-1mkwiyz"
             data-monomer-item-id="LdLMonomerName___LdLRName"
             data-testid="LdLMonomerName___LdLRName"
           >
@@ -288,7 +288,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
         class="css-1a3tnc1"
       >
         <div
-          class="css-1vx381w"
+          class="css-mfw0go"
           data-monomer-item-id="RRMonomerName___RRName"
           data-testid="RRMonomerName___RRName"
         >
@@ -330,7 +330,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-o7i94f"
+          class="css-1mkwiyz"
           data-monomer-item-id="mAMonomerName___mAName"
           data-testid="mAMonomerName___mAName"
         >
@@ -372,7 +372,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-1m6zie5"
+          class="css-rt02do"
           data-monomer-item-id="dDMonomerName___dDName"
           data-testid="dDMonomerName___dDName"
         >
@@ -414,7 +414,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-1vx381w"
+          class="css-mfw0go"
           data-monomer-item-id="arRMonomerName___arRName"
           data-testid="arRMonomerName___arRName"
         >
@@ -456,7 +456,7 @@ exports[`Monomer Group should render correct with title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-o7i94f"
+          class="css-1mkwiyz"
           data-monomer-item-id="LdLMonomerName___LdLRName"
           data-testid="LdLMonomerName___LdLRName"
         >
@@ -566,7 +566,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
           class="css-1a3tnc1"
         >
           <div
-            class="css-1vx381w"
+            class="css-mfw0go"
             data-monomer-item-id="RRMonomerName___RRName"
             data-testid="RRMonomerName___RRName"
           >
@@ -608,7 +608,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-o7i94f"
+            class="css-1mkwiyz"
             data-monomer-item-id="mAMonomerName___mAName"
             data-testid="mAMonomerName___mAName"
           >
@@ -650,7 +650,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-1m6zie5"
+            class="css-rt02do"
             data-monomer-item-id="dDMonomerName___dDName"
             data-testid="dDMonomerName___dDName"
           >
@@ -692,7 +692,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-1vx381w"
+            class="css-mfw0go"
             data-monomer-item-id="arRMonomerName___arRName"
             data-testid="arRMonomerName___arRName"
           >
@@ -734,7 +734,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
             </button>
           </div>
           <div
-            class="css-o7i94f"
+            class="css-1mkwiyz"
             data-monomer-item-id="LdLMonomerName___LdLRName"
             data-testid="LdLMonomerName___LdLRName"
           >
@@ -787,7 +787,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
         class="css-1a3tnc1"
       >
         <div
-          class="css-1vx381w"
+          class="css-mfw0go"
           data-monomer-item-id="RRMonomerName___RRName"
           data-testid="RRMonomerName___RRName"
         >
@@ -829,7 +829,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-o7i94f"
+          class="css-1mkwiyz"
           data-monomer-item-id="mAMonomerName___mAName"
           data-testid="mAMonomerName___mAName"
         >
@@ -871,7 +871,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-1m6zie5"
+          class="css-rt02do"
           data-monomer-item-id="dDMonomerName___dDName"
           data-testid="dDMonomerName___dDName"
         >
@@ -913,7 +913,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-1vx381w"
+          class="css-mfw0go"
           data-monomer-item-id="arRMonomerName___arRName"
           data-testid="arRMonomerName___arRName"
         >
@@ -955,7 +955,7 @@ exports[`Monomer Group should render correct without title prop 1`] = `
           </button>
         </div>
         <div
-          class="css-o7i94f"
+          class="css-1mkwiyz"
           data-monomer-item-id="LdLMonomerName___LdLRName"
           data-testid="LdLMonomerName___LdLRName"
         >

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/MonomerItem.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/MonomerItem.tsx
@@ -30,7 +30,11 @@ import { FavoriteStarSymbol, MONOMER_TYPES } from '../../../constants';
 import useDisabledForSequenceMode from 'components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode';
 import { isAmbiguousMonomerLibraryItem, MonomerItemType } from 'ketcher-core';
 import { useLibraryItemDrag } from 'components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag';
-import { selectEditor, selectIsSequenceMode } from 'state/common';
+import {
+  selectEditor,
+  selectIsSequenceMode,
+  selectIsDragging,
+} from 'state/common';
 import Tooltip from '@mui/material/Tooltip';
 import {
   cardMouseOverHandler,
@@ -51,6 +55,7 @@ const MonomerItem = ({
   const dispatch = useAppDispatch();
   const editor = useAppSelector(selectEditor);
   const isSequenceMode = useAppSelector(selectIsSequenceMode);
+  const isDragging = useAppSelector(selectIsDragging);
   const [autochainErrorMessage, setAutochainErrorMessage] =
     useState<string>('');
 
@@ -133,6 +138,7 @@ const MonomerItem = ({
     <Card
       selected={isSelected}
       disabled={isDisabled}
+      isDragging={isDragging}
       data-testid={monomerKey}
       data-monomer-item-id={monomerKey}
       item={monomerItem}

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag.tsx
@@ -1,14 +1,15 @@
 import { RefObject, useEffect } from 'react';
 import { D3DragEvent, drag, select } from 'd3';
-import { selectEditor } from 'state/common';
+import { selectEditor, setIsDragging } from 'state/common';
 import { IRnaPreset, MonomerOrAmbiguousType, ZoomTool } from 'ketcher-core';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 export const useLibraryItemDrag = (
   item: IRnaPreset | MonomerOrAmbiguousType,
   itemRef: RefObject<HTMLElement>,
 ) => {
   const editor = useSelector(selectEditor);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     if (!editor || !itemRef.current) {
@@ -30,6 +31,8 @@ export const useLibraryItemDrag = (
         if (editor.isLibraryItemDragCancelled) {
           return;
         }
+
+        dispatch(setIsDragging(true));
 
         const { clientX: x, clientY: y } = event.sourceEvent;
         editor.events.setLibraryItemDragState.dispatch({
@@ -66,6 +69,7 @@ export const useLibraryItemDrag = (
         editor.events.setLibraryItemDragState.dispatch(null);
         editor.isLibraryItemDragCancelled = false;
         document.body.style.cursor = '';
+        dispatch(setIsDragging(false));
       });
 
     itemElement.call(dragBehavior);
@@ -73,5 +77,5 @@ export const useLibraryItemDrag = (
     return () => {
       itemElement.on('.drag', null);
     };
-  }, [editor, item, itemRef]);
+  }, [editor, item, itemRef, dispatch]);
 };

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/styles.ts
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/styles.ts
@@ -23,11 +23,13 @@ export const Card = styled.div<{
   disabled?: boolean;
   isVariantMonomer?: boolean;
   item?: MonomerOrAmbiguousType;
+  isDragging?: boolean;
 }>`
   background: white;
   height: 48px;
   text-align: center;
-  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  cursor: ${({ disabled, isDragging }) =>
+    disabled ? 'default' : isDragging ? 'grabbing !important' : 'pointer'};
   opacity: ${({ disabled }) => (disabled ? '0.4' : '1')};
   display: flex;
   justify-content: space-between;
@@ -45,6 +47,15 @@ export const Card = styled.div<{
   border-style: solid;
   box-sizing: border-box;
   z-index: ${({ selected }) => (selected ? 2 : undefined)};
+
+  ${({ isDragging }) =>
+    isDragging &&
+    `
+    &, & * {
+      pointer-events: none !important;
+      cursor: grabbing !important;
+    }
+  `}
 
   .hidden & .star {
     visibility: hidden !important;

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryList/__snapshots__/MonomerList.test.tsx.snap
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryList/__snapshots__/MonomerList.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Monomer List should render correct with groups 1`] = `
             class="css-1a3tnc1"
           >
             <div
-              class="css-d1efkn"
+              class="css-em3li2"
               data-monomer-item-id="Phe4SD___(2S)-2-amino-3-{4-[(4S)-2,6-dioxo-1,3-diazinane-4-amido]phenyl}propanoic acid"
               data-testid="Phe4SD___(2S)-2-amino-3-{4-[(4S)-2,6-dioxo-1,3-diazinane-4-amido]phenyl}propanoic acid"
             >
@@ -72,7 +72,7 @@ exports[`Monomer List should render correct with groups 1`] = `
           class="css-1a3tnc1"
         >
           <div
-            class="css-d1efkn"
+            class="css-em3li2"
             data-monomer-item-id="Phe4SD___(2S)-2-amino-3-{4-[(4S)-2,6-dioxo-1,3-diazinane-4-amido]phenyl}propanoic acid"
             data-testid="Phe4SD___(2S)-2-amino-3-{4-[(4S)-2,6-dioxo-1,3-diazinane-4-amido]phenyl}propanoic acid"
           >
@@ -186,7 +186,7 @@ exports[`Monomer List should render correct without groups 1`] = `
             class="css-1a3tnc1"
           >
             <div
-              class="css-o7i94f"
+              class="css-1mkwiyz"
               data-monomer-item-id="PEG2___Diethylene Glycol"
               data-testid="PEG2___Diethylene Glycol"
             >
@@ -243,7 +243,7 @@ exports[`Monomer List should render correct without groups 1`] = `
           class="css-1a3tnc1"
         >
           <div
-            class="css-o7i94f"
+            class="css-1mkwiyz"
             data-monomer-item-id="PEG2___Diethylene Glycol"
             data-testid="PEG2___Diethylene Glycol"
           >

--- a/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
@@ -59,6 +59,7 @@ interface EditorState {
   preview: EditorStatePreview;
   position: PresetPosition | undefined;
   isContextMenuActive: boolean;
+  isDragging: boolean;
   isMacromoleculesPropertiesWindowOpened: boolean;
   macromoleculesProperties: SingleChainMacromoleculeProperties[] | undefined;
   unipositiveIonsMeasurementUnit: MolarMeasurementUnit;
@@ -83,6 +84,7 @@ const initialState: EditorState = {
   },
   position: undefined,
   isContextMenuActive: false,
+  isDragging: false,
   isMacromoleculesPropertiesWindowOpened: false,
   macromoleculesProperties: undefined,
   unipositiveIonsMeasurementUnit: MolarMeasurementUnit.milliMol,
@@ -166,6 +168,9 @@ export const editorSlice: Slice<EditorState> = createSlice({
     setContextMenuActive: (state, action: PayloadAction<boolean>) => {
       state.isContextMenuActive = action.payload;
     },
+    setIsDragging: (state, action: PayloadAction<boolean>) => {
+      state.isDragging = action.payload;
+    },
     setMacromoleculesPropertiesWindowVisibility: (
       state,
       action: PayloadAction<boolean>,
@@ -235,6 +240,7 @@ export const {
   destroyEditor,
   showPreview,
   setContextMenuActive,
+  setIsDragging,
   setMacromoleculesPropertiesWindowVisibility,
   toggleMacromoleculesPropertiesWindowVisibility,
   setMacromoleculesProperties,
@@ -288,6 +294,9 @@ export const hasAntisenseChains = (state: RootState): CoreEditor =>
 
 export const selectIsContextMenuActive = (state: RootState): boolean =>
   state.editor.isContextMenuActive;
+
+export const selectIsDragging = (state: RootState): boolean =>
+  state.editor.isDragging;
 
 export const selectIsMacromoleculesPropertiesWindowOpened = (
   state: RootState,


### PR DESCRIPTION
## Summary
Fixes cursor flickering between `grabbing` and `pointer` while dragging a monomer card across the library.

## Problem
When dragging a monomer from the library, the cursor was flickering because child elements (e.g. the Favorites star, Autochain button) were intercepting mouse events and overriding the cursor style.

## Solution
Used Redux `isDragging` state that tracks when a drag operation is in progress. Components read this state and apply the appropriate cursor and `pointer-events` styles declaratively.

## Changes
- `editorSlice.ts` — added `isDragging` state, `setIsDragging` action and `selectIsDragging` selector
- `useLibraryItemDrag.tsx` — dispatches `setIsDragging(true/false)` on drag start/end
- `MonomerItem.tsx` — reads `isDragging` from Redux and passes it to `Card`
- `RnaPresetItem.tsx` — same as above for RNA preset cards
- `styles.ts` — applies `cursor: grabbing` and `pointer-events: none` on child elements when `isDragging` is true
- Updated snapshots to reflect new Emotion-generated class names


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request