### PR TITLE
fix SGroup circular dependencies

### DIFF
--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Atom } from './atom';
-import { Bond } from './bond';
+import type { Bond } from './bond';
 import { Box2Abs } from './box2Abs';
 import { Pile } from './pile';
 import { Struct } from './struct';
@@ -692,7 +691,7 @@ export class SGroup {
 
     let xAtom1 = -1;
     let xAtom2 = -1;
-    let crossBond = null;
+    let crossBond: Bond | null = null;
     if (xBonds.length === 2) {
       const bond1 = mol.bonds.get(xBonds[0]);
       xAtom1 = sgroup.parentAtomSet.has(bond1.begin) ? bond1.begin : bond1.end;
@@ -709,20 +708,20 @@ export class SGroup {
       const amap = {};
       sgroup.atoms.forEach((aid) => {
         const atom = mol.atoms.get(aid);
-        const aid2 = mol.atoms.add(new Atom(atom));
+        const aid2 = mol.atoms.add(atom.clone());
         newAtoms.push(aid2);
         sgroup.atomSet.add(aid2);
         amap[aid] = aid2;
       });
       inBonds.forEach((bid) => {
         const bond = mol.bonds.get(bid);
-        const newBond = new Bond(bond);
+        const newBond = bond.clone();
         newBond.begin = amap[newBond.begin];
         newBond.end = amap[newBond.end];
         mol.bonds.add(newBond);
       });
       if (crossBond !== null) {
-        const newCrossBond = new Bond(crossBond);
+        const newCrossBond = crossBond.clone();
         newCrossBond.begin = tailAtom;
         newCrossBond.end = amap[xAtom1];
         mol.bonds.add(newCrossBond);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
solving circular dependencies: 
src/domain/entities/atom.ts -> src/domain/entities/sgroup.ts -> src/domain/entities/bond.ts -> src/domain/entities/atom.ts
src/domain/entities/bond.ts -> src/domain/entities/sgroup.ts -> src/domain/entities/bond.ts

* update `Bond` import to `type`
* replace constructor calls with `clone(...)` method

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request