### PR TITLE
#9792 - Todo | Refactor: Separate atom operation classes to fix circular dependency in invert method

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -54,7 +54,7 @@ export function fromAtomAddition(restruct, pos, atom) {
   const aid = (
     action.addOp(new AtomAdd(atom, pos).perform(restruct)) as AtomAdd
   ).data.aid;
-  action.addOp(new CalcImplicitH([aid]).perform(restruct));
+  action.addOp(new CalcImplicitH([aid as number]).perform(restruct));
 
   return action;
 }

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -69,7 +69,7 @@ export function fromBondAddition(
           beginAtomPos,
         ).perform(reStruct),
       ) as AtomAdd
-    ).data.aid;
+    ).data.aid as number;
 
     const newEndAtomId: number = (
       action.addOp(
@@ -78,7 +78,7 @@ export function fromBondAddition(
           endAtomPos,
         ).perform(reStruct),
       ) as AtomAdd
-    ).data.aid;
+    ).data.aid as number;
 
     return [newBeginAtomId, newEndAtomId] as const;
   };
@@ -92,11 +92,11 @@ export function fromBondAddition(
     const newBeginAtomId: number = (
       action.addOp(
         new AtomAdd(
-          { ...beginAtomAttr, fragment: fragmentId },
+          { ...beginAtomAttr, fragment: fragmentId as number },
           beginAtomPos,
         ).perform(reStruct),
       ) as AtomAdd
-    ).data.aid;
+    ).data.aid as number;
 
     const endAtom = struct.atoms.get(endAtomId);
     if (
@@ -123,12 +123,12 @@ export function fromBondAddition(
         new AtomAdd(
           {
             ...endAtomAttr,
-            fragment: fragmentId,
+            fragment: fragmentId as number,
           },
           endAtomPos ?? atomForNewBond(reStruct, begin, bond).pos,
         ).perform(reStruct),
       ) as AtomAdd
-    ).data.aid;
+    ).data.aid as number;
 
     const beginAtom = struct.atoms.get(beginAtomId);
     if (

--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -109,16 +109,16 @@ export function fromPaste(
       Vec2.diff(atom.pp, xy0).rotate(angle).add(point),
     ).perform(restruct) as AtomAdd;
     action.addOp(operation);
-    aidMap.set(aid, operation.data.aid);
+    aidMap.set(aid, operation.data.aid as number);
 
-    pasteItems.atoms.push(operation.data.aid);
-    items.atoms.push(operation.data.aid);
+    pasteItems.atoms.push(operation.data.aid as number);
+    items.atoms.push(operation.data.aid as number);
 
     action.mergeWith(
       fromRGroupAttachmentPointAddition(
         restruct,
         tmpAtom.attachmentPoints,
-        operation.data.aid,
+        operation.data.aid as number,
       ),
     );
   });

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -75,7 +75,7 @@ function extraBondAction(restruct, aid, angle) {
     additionalAtom = actionRes[2];
   } else {
     const operation = new AtomAdd(
-      { label: 'C', fragment: frid },
+      { label: 'C', fragment: frid as number },
       new Vec2(1, 0)
         .rotate(angle)
         .add(restruct.molecule.atoms.get(aid).pp)
@@ -156,8 +156,8 @@ export function fromTemplateOnAtom(
         restruct,
       ) as AtomAdd;
       action.addOp(operation);
-      map.set(id, operation.data.aid);
-      pasteItems.atoms.push(operation.data.aid);
+      map.set(id, operation.data.aid as number);
+      pasteItems.atoms.push(operation.data.aid as number);
     }
   });
 

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
@@ -1,0 +1,88 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { Atom, AtomAttributes, Pile, Point, Vec2 } from 'domain/entities';
+import { ReAtom, ReStruct } from '../../../render';
+
+import { BaseOperation } from '../BaseOperation';
+import { OperationType } from '../OperationType';
+
+type Data = {
+  aid: number | null;
+  atom: Partial<AtomAttributes> | null;
+  pos: Point | null;
+};
+
+class AtomAdd extends BaseOperation {
+  data: Data;
+  static InverseConstructor: new () => BaseOperation;
+
+  constructor(atom?: Partial<AtomAttributes>, pos?: Point) {
+    super(OperationType.ATOM_ADD);
+    this.data = { atom: atom ?? null, pos: pos ?? null, aid: null };
+  }
+
+  execute(restruct: ReStruct) {
+    const { atom, pos } = this.data;
+
+    const struct = restruct.molecule;
+
+    const pp: Partial<AtomAttributes> & { label: string } = {
+      label: '',
+      ...(atom ?? {}),
+    };
+    pp.label = pp.label || 'C';
+
+    let aid: number;
+    if (typeof this.data.aid !== 'number') {
+      aid = struct.atoms.add(new Atom(pp));
+      this.data.aid = aid;
+    } else {
+      aid = this.data.aid;
+      struct.atoms.set(aid, new Atom(pp));
+    }
+
+    // notifyAtomAdded
+    const reAtom = struct.atoms.get(aid);
+    if (!reAtom) return;
+    const atomData = new ReAtom(reAtom);
+
+    atomData.component = restruct.connectedComponents.add(new Pile([aid]));
+    restruct.atoms.set(aid, atomData);
+    restruct.markAtom(aid, 1);
+
+    struct.atomSetPos(aid, new Vec2(pos as Point));
+
+    const arrow = struct.rxnArrows.get(0);
+    if (arrow) {
+      const atomInstance = struct.atoms.get(aid);
+      if (atomInstance) {
+        atomInstance.rxnFragmentType = struct.defineRxnFragmentTypeForAtomset(
+          new Pile([aid]),
+          arrow.pos[0].x,
+        );
+      }
+    }
+  }
+
+  invert() {
+    const inverted = new AtomAdd.InverseConstructor();
+    inverted.data = this.data;
+    return inverted;
+  }
+}
+
+export { AtomAdd };

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { AtomAttributes, Point } from 'domain/entities';
+import { ReStruct } from '../../../render';
+
+import { BaseOperation } from '../BaseOperation';
+import { OperationPriority, OperationType } from '../OperationType';
+
+type Data = {
+  aid: number | null;
+  atom: Partial<AtomAttributes> | null;
+  pos: Point | null;
+};
+
+class AtomDelete extends BaseOperation {
+  data: Data;
+  static InverseConstructor: new () => BaseOperation;
+
+  constructor(atomId?: number) {
+    super(OperationType.ATOM_DELETE, OperationPriority.ATOM_DELETE);
+    this.data = { aid: atomId ?? null, atom: null, pos: null };
+  }
+
+  execute(restruct: ReStruct) {
+    const { aid } = this.data;
+    if (aid === null) return;
+
+    const struct = restruct.molecule;
+    if (!this.data.atom) {
+      const atomFromStruct = struct.atoms.get(aid);
+      if (!atomFromStruct) return;
+      this.data.atom = atomFromStruct;
+      this.data.pos = atomFromStruct.pp;
+    }
+
+    const restructedAtom = restruct.atoms.get(aid);
+    if (!restructedAtom) {
+      return;
+    }
+
+    const set = restruct.connectedComponents.get(restructedAtom.component);
+    set.delete(aid);
+    if (set.size === 0) {
+      restruct.connectedComponents.delete(restructedAtom.component);
+    }
+
+    restruct.clearVisel(restructedAtom.visel);
+    restruct.atoms.delete(aid);
+    restruct.markItemRemoved();
+    struct.atoms.delete(aid);
+  }
+
+  invert() {
+    const inverted = new AtomDelete.InverseConstructor();
+    inverted.data = this.data;
+    return inverted;
+  }
+}
+
+export { AtomDelete };

--- a/packages/ketcher-core/src/application/editor/operations/atom/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/index.ts
@@ -13,119 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { Atom } from 'domain/entities/atom';
-import { Pile } from 'domain/entities/pile';
-import { Vec2 } from 'domain/entities/vec2';
-import { ReAtom, ReStruct } from '../../../render';
+import { AtomAdd } from './AtomAdd';
+import { AtomDelete } from './AtomDelete';
 
-import { BaseOperation } from '../BaseOperation';
-import { OperationPriority, OperationType } from '../OperationType';
-
-// todo: separate classes: now here is circular dependency in `invert` method
-
-type Data = {
-  aid: any;
-  atom: any;
-  pos: any;
-};
-
-class AtomAdd extends BaseOperation {
-  data: Data;
-
-  constructor(atom?: any, pos?: any) {
-    super(OperationType.ATOM_ADD);
-    this.data = { atom, pos, aid: null };
-  }
-
-  execute(restruct: ReStruct) {
-    const { atom, pos } = this.data;
-
-    const struct = restruct.molecule;
-
-    const pp: { label: string } = { label: '' };
-    if (atom) {
-      Object.keys(atom).forEach((p) => {
-        pp[p] = atom[p];
-      });
-    }
-
-    pp.label = pp.label || 'C';
-    if (typeof this.data.aid !== 'number') {
-      this.data.aid = struct.atoms.add(new Atom(pp));
-    } else {
-      struct.atoms.set(this.data.aid, new Atom(pp));
-    }
-
-    const { aid } = this.data;
-
-    // notifyAtomAdded
-    const atomData = new ReAtom(struct.atoms.get(aid)!);
-
-    atomData.component = restruct.connectedComponents.add(new Pile([aid]));
-    restruct.atoms.set(aid, atomData);
-    restruct.markAtom(aid, 1);
-
-    struct.atomSetPos(aid, new Vec2(pos));
-
-    const arrow = struct.rxnArrows.get(0);
-    if (arrow) {
-      const atom = struct.atoms.get(aid)!;
-      atom.rxnFragmentType = struct.defineRxnFragmentTypeForAtomset(
-        new Pile([aid]),
-        arrow.pos[0].x,
-      );
-    }
-  }
-
-  invert() {
-    const inverted = new AtomDelete();
-    inverted.data = this.data;
-    return inverted;
-  }
-}
-
-class AtomDelete extends BaseOperation {
-  data: Data;
-
-  constructor(atomId?: any) {
-    super(OperationType.ATOM_DELETE, OperationPriority.ATOM_DELETE);
-    this.data = { aid: atomId, atom: null, pos: null };
-  }
-
-  execute(restruct: ReStruct) {
-    const { aid } = this.data;
-
-    const struct = restruct.molecule;
-    if (!this.data.atom) {
-      this.data.atom = struct.atoms.get(aid);
-      this.data.pos = this.data.atom.pp;
-    }
-
-    const restructedAtom = restruct.atoms.get(aid);
-    if (!restructedAtom) {
-      return;
-    }
-
-    const set = restruct.connectedComponents.get(restructedAtom.component);
-    set.delete(aid);
-    if (set.size === 0) {
-      restruct.connectedComponents.delete(restructedAtom.component);
-    }
-
-    restruct.clearVisel(restructedAtom.visel);
-    restruct.atoms.delete(aid);
-    restruct.markItemRemoved();
-    struct.atoms.delete(aid);
-  }
-
-  invert() {
-    const inverted = new AtomAdd();
-    inverted.data = this.data;
-    return inverted;
-  }
-}
+AtomAdd.InverseConstructor = AtomDelete;
+AtomDelete.InverseConstructor = AtomAdd;
 
 export { AtomAdd, AtomDelete };
 export * from './AtomAttr';


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

- Extracted AtomAdd into AtomAdd.ts and AtomDelete into AtomDelete.ts                                                                                                                                                                                                                                                                                                          
  - Broke the circular dependency using a static InverseConstructor pattern: neither file imports the other; instead index.ts imports both and wires the inversion after both modules are loaded:                                                                                                                                                                              
  AtomAdd.InverseConstructor = AtomDelete;                                                                                                                                                                                                                                                                                                                                       
  AtomDelete.InverseConstructor = AtomAdd;                                                                                                                                                                                                                                                                                                                                       
  - Removed /* eslint-disable @typescript-eslint/no-use-before-define */ — no longer needed                                                                                                                                                                                                                                                                                      
  - Strengthened the Data type: aid, atom, and pos are now properly typed instead of any                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                 
  Why as number was added in callers (atom.ts, bond.ts, paste.ts, template.ts):
                                                                                                                                                                                                                                                                                                                                                                                 
  The stricter Data type sets aid: number | null because aid starts as null before execute() runs. However, all call sites access operation.data.aid only after calling .perform() (which calls execute()), at which point aid is always assigned a number. TypeScript cannot infer this post-execution guarantee statically, so as number is used to assert the known runtime   
  state. Similarly, atomGetAttr() returns a wide union type including null, but at those call sites the fragment is guaranteed to exist, so as number is used there as well.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request