### PR TITLE
Reduce circular dependencies in monomers.ts

### DIFF
--- a/packages/ketcher-core/src/domain/helpers/monomers.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomers.ts
@@ -2,7 +2,7 @@ import { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { HydrogenBond } from 'domain/entities/HydrogenBond';
 import type { Peptide } from 'domain/entities/Peptide';
 import type { RNABase } from 'domain/entities/RNABase';
-import { Sugar } from 'domain/entities/Sugar';
+import type { Sugar } from 'domain/entities/Sugar';
 import {
   AttachmentPointName,
   MonomerItemType,
@@ -17,8 +17,7 @@ import {
 } from 'application/formatters/types/ket';
 import { MonomerToAtomBond } from 'domain/entities/MonomerToAtomBond';
 import type { IRnaPreset } from 'application/editor/tools/Tool';
-import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
-import { Phosphate } from 'domain/entities/Phosphate';
+import type { Phosphate } from 'domain/entities/Phosphate';
 
 /**
  * Structural equivalent of AmbiguousMonomer used locally to avoid importing the class
@@ -404,20 +403,20 @@ export function isRnaBaseOrAmbiguousRnaBase(
 
 export function isPhosphateOrAmbiguousPhosphate(
   monomer?: BaseMonomer,
-): monomer is Phosphate | AmbiguousMonomer {
+): monomer is Phosphate | AmbiguousMonomerEntity {
   return (
-    monomer instanceof Phosphate ||
-    (monomer instanceof AmbiguousMonomer &&
+    isMonomerOfClass(monomer, KetMonomerClass.Phosphate) ||
+    (isAmbiguousMonomerEntity(monomer) &&
       monomer.monomerClass === KetMonomerClass.Phosphate)
   );
 }
 
 export function isSugarOrAmbiguousSugar(
   monomer?: BaseMonomer,
-): monomer is Sugar | AmbiguousMonomer {
+): monomer is Sugar | AmbiguousMonomerEntity {
   return (
-    monomer instanceof Sugar ||
-    (monomer instanceof AmbiguousMonomer &&
+    isMonomerOfClass(monomer, KetMonomerClass.Sugar) ||
+    (isAmbiguousMonomerEntity(monomer) &&
       monomer.monomerClass === KetMonomerClass.Sugar)
   );
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
fix circular dependencies: 
`src/domain/helpers/monomers.ts -> src/domain/entities/AmbiguousMonomer.ts -> src/domain/entities/Phosphate.ts -> src/domain/helpers/monomers.ts`
`src/domain/helpers/monomers.ts -> src/domain/entities/AmbiguousMonomer.ts -> src/domain/entities/Sugar.ts -> src/domain/helpers/monomers.ts`


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request