### PR TITLE
#9794 - Todo | Refactor: Separate AlignDescriptors operation class to fix circular dependency in invert method

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
+++ b/packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { BaseOperation } from './BaseOperation';
+import { OperationType } from './OperationType';
+import { ReStruct } from '../../render';
+import { SGroup, Vec2 } from 'domain/entities';
+
+class AlignDescriptors extends BaseOperation {
+  readonly history: Record<number, Vec2 | null>;
+  static InverseConstructor: new (
+    history: Record<number, Vec2 | null>,
+  ) => BaseOperation;
+
+  constructor() {
+    super(OperationType.ALIGN_DESCRIPTORS);
+    this.history = {};
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+    const sgroups: SGroup[] = Array.from(struct.sgroups.values()).reverse();
+
+    const structBox = struct.getCoordBoundingBoxObj();
+    if (!structBox) return;
+
+    let alignPoint = new Vec2(structBox.max.x, structBox.min.y).add(
+      new Vec2(2.0, -1.0),
+    );
+
+    sgroups.forEach((sgroup) => {
+      this.history[sgroup.id] = sgroup.pp ? new Vec2(sgroup.pp) : null;
+      alignPoint = alignPoint.add(new Vec2(0.0, 0.5));
+      sgroup.pp = alignPoint;
+      struct.sgroups.set(sgroup.id, sgroup);
+      BaseOperation.invalidateItem(restruct, 'sgroupData', sgroup.id, 1);
+    });
+  }
+
+  invert() {
+    return new AlignDescriptors.InverseConstructor(this.history);
+  }
+}
+
+export { AlignDescriptors };

--- a/packages/ketcher-core/src/application/editor/operations/RestoreDescriptorsPosition.ts
+++ b/packages/ketcher-core/src/application/editor/operations/RestoreDescriptorsPosition.ts
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { BaseOperation } from './BaseOperation';
+import { OperationType } from './OperationType';
+import { ReStruct } from '../../render';
+import { SGroup, Vec2 } from 'domain/entities';
+
+class RestoreDescriptorsPosition extends BaseOperation {
+  readonly history: Record<number, Vec2 | null>;
+  static InverseConstructor: new () => BaseOperation;
+
+  constructor(history: Record<number, Vec2 | null>) {
+    super(OperationType.RESTORE_DESCRIPTORS_POSITION);
+    this.history = history;
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+    const sgroups: SGroup[] = Array.from(struct.sgroups.values());
+
+    sgroups.forEach((sgroup) => {
+      sgroup.pp = this.history[sgroup.id];
+      struct.sgroups.set(sgroup.id, sgroup);
+      BaseOperation.invalidateItem(restruct, 'sgroupData', sgroup.id, 1);
+    });
+  }
+
+  invert() {
+    return new RestoreDescriptorsPosition.InverseConstructor();
+  }
+}
+
+export { RestoreDescriptorsPosition };

--- a/packages/ketcher-core/src/application/editor/operations/descriptors.ts
+++ b/packages/ketcher-core/src/application/editor/operations/descriptors.ts
@@ -13,67 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
-import { BaseOperation } from './BaseOperation';
-import { OperationType } from './OperationType';
-import { ReStruct } from '../../render';
-import { Vec2 } from 'domain/entities/vec2';
 
-// todo: separate classes: now here is circular dependency in `invert` method
+import { AlignDescriptors } from './AlignDescriptors';
+import { RestoreDescriptorsPosition } from './RestoreDescriptorsPosition';
 
-class AlignDescriptors extends BaseOperation {
-  readonly history: any;
-
-  constructor() {
-    super(OperationType.ALIGN_DESCRIPTORS);
-    this.history = {};
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-    const sgroups: any[] = Array.from(struct.sgroups.values()).reverse();
-
-    const structBox: any = struct.getCoordBoundingBoxObj();
-    let alignPoint = new Vec2(structBox.max.x, structBox.min.y).add(
-      new Vec2(2.0, -1.0),
-    );
-
-    sgroups.forEach((sgroup) => {
-      this.history[sgroup.id] = new Vec2(sgroup.pp);
-      alignPoint = alignPoint.add(new Vec2(0.0, 0.5));
-      sgroup.pp = alignPoint;
-      struct.sgroups.set(sgroup.id, sgroup);
-      BaseOperation.invalidateItem(restruct, 'sgroupData', sgroup.id, 1);
-    });
-  }
-
-  invert() {
-    return new RestoreDescriptorsPosition(this.history);
-  }
-}
-
-class RestoreDescriptorsPosition extends BaseOperation {
-  readonly history: any;
-
-  constructor(history: any) {
-    super(OperationType.RESTORE_DESCRIPTORS_POSITION);
-    this.history = history;
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-    const sgroups: any[] = Array.from(struct.sgroups.values());
-
-    sgroups.forEach((sgroup) => {
-      sgroup.pp = this.history[sgroup.id];
-      struct.sgroups.set(sgroup.id, sgroup);
-      BaseOperation.invalidateItem(restruct, 'sgroupData', sgroup.id, 1);
-    });
-  }
-
-  invert() {
-    return new AlignDescriptors();
-  }
-}
+AlignDescriptors.InverseConstructor = RestoreDescriptorsPosition;
+RestoreDescriptorsPosition.InverseConstructor = AlignDescriptors;
 
 export { AlignDescriptors, RestoreDescriptorsPosition };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

- Extracted AlignDescriptors and RestoreDescriptorsPosition from operations/descriptors.ts into separate files (AlignDescriptors.ts, RestoreDescriptorsPosition.ts)                                                                                                                                                                                                            
  - Used the static InverseConstructor pattern to avoid introducing a new circular import: neither class imports the other directly; descriptors.ts wires AlignDescriptors.InverseConstructor = RestoreDescriptorsPosition and RestoreDescriptorsPosition.InverseConstructor = AlignDescriptors after both modules are loaded                                                    
  - descriptors.ts now serves as the entry point that wires and re-exports both classes                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                 
  Note                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                 
  There was no actual circular dependency between modules before this change — both classes lived in the same file, so no module-level cycle existed. This refactor is purely for code organization: each class now has its own file, improving readability and maintainability. The static InverseConstructor pattern is used intentionally to prevent a circular import from   
  being introduced as a side effect of the separation.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request