### PR TITLE
#9795 - Todo | Refactor: Separate fragment operation classes to fix circular dependency in invert method

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { ReEnhancedFlag, ReFrag, ReStruct } from '../../render';
+
+import { BaseOperation } from './BaseOperation';
+import { Fragment, StructProperty } from 'domain/entities';
+import { OperationType } from './OperationType';
+
+class FragmentAdd extends BaseOperation {
+  frid: number | null;
+  readonly properties?: Array<StructProperty>;
+  static InverseConstructor: new (fragmentId: number) => BaseOperation;
+
+  constructor(fragmentId?: number | null, properties?: Array<StructProperty>) {
+    super(OperationType.FRAGMENT_ADD);
+    this.frid = typeof fragmentId === 'undefined' ? null : fragmentId;
+    if (properties) {
+      this.properties = properties;
+    }
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+    const frag = new Fragment([], null, this.properties);
+
+    if (this.frid === null) {
+      this.frid = struct.frags.add(frag);
+    } else {
+      struct.frags.set(this.frid, frag);
+    }
+
+    restruct.frags.set(this.frid, new ReFrag(frag));
+    restruct.markItem('frags', this.frid, 1); // notifyFragmentAdded
+    restruct.enhancedFlags.set(this.frid, new ReEnhancedFlag());
+  }
+
+  invert() {
+    return new FragmentAdd.InverseConstructor(this.frid as number);
+  }
+}
+
+export { FragmentAdd };

--- a/packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { ReStruct } from '../../render';
+
+import { BaseOperation } from './BaseOperation';
+import { StructProperty } from 'domain/entities/struct';
+import { OperationType } from './OperationType';
+
+class FragmentDelete extends BaseOperation {
+  readonly frid: number;
+  static InverseConstructor: new (
+    fragmentId?: number | null,
+    properties?: Array<StructProperty>,
+  ) => BaseOperation;
+
+  constructor(fragmentId: number) {
+    super(OperationType.FRAGMENT_DELETE, 100);
+    this.frid = fragmentId;
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+    if (!struct.frags.get(this.frid)) {
+      return;
+    }
+
+    BaseOperation.invalidateItem(restruct, 'frags', this.frid, 1);
+    restruct.frags.delete(this.frid);
+    restruct.markItemRemoved(); // notifyFragmentRemoved
+    struct.frags.delete(this.frid);
+
+    const enhancedFalg = restruct.enhancedFlags.get(this.frid);
+    if (!enhancedFalg) return;
+    restruct.clearVisel(enhancedFalg.visel);
+    restruct.enhancedFlags.delete(this.frid);
+  }
+
+  invert() {
+    return new FragmentDelete.InverseConstructor(this.frid);
+  }
+}
+
+export { FragmentDelete };

--- a/packages/ketcher-core/src/application/editor/operations/FragmentSetProperties.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentSetProperties.ts
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { ReStruct } from '../../render';
+
+import { BaseOperation } from './BaseOperation';
+import { StructProperty } from 'domain/entities/struct';
+import { OperationType } from './OperationType';
+
+class FragmentSetProperties extends BaseOperation {
+  readonly frid: any;
+  readonly properties?: Array<StructProperty>;
+
+  constructor(fragmentId: any, properties?: Array<StructProperty>) {
+    super(OperationType.FRAGMENT_SET_PROPERTIES);
+    this.frid = fragmentId;
+    this.properties = properties;
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+    const frag = struct.frags.get(this.frid);
+
+    if (frag) {
+      if (this.properties) {
+        frag.properties = this.properties;
+      } else {
+        delete frag?.properties;
+      }
+    }
+  }
+
+  invert() {
+    return new FragmentSetProperties(this.frid, undefined);
+  }
+}
+
+export { FragmentSetProperties };

--- a/packages/ketcher-core/src/application/editor/operations/fragment.ts
+++ b/packages/ketcher-core/src/application/editor/operations/fragment.ts
@@ -13,105 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { ReEnhancedFlag, ReFrag, ReStruct } from '../../render';
+import { FragmentAdd } from './FragmentAdd';
+import { FragmentDelete } from './FragmentDelete';
+import { FragmentSetProperties } from './FragmentSetProperties';
 
-import { BaseOperation } from './BaseOperation';
-import { Fragment } from 'domain/entities/fragment';
-import { StructProperty } from 'domain/entities/struct';
-import { OperationType } from './OperationType';
-
-// todo: separate classes: now here is circular dependency in `invert` method
-
-class FragmentAdd extends BaseOperation {
-  frid: any;
-  readonly properties?: Array<StructProperty>;
-
-  constructor(fragmentId?: any, properties?: Array<StructProperty>) {
-    super(OperationType.FRAGMENT_ADD);
-    this.frid = typeof fragmentId === 'undefined' ? null : fragmentId;
-    if (properties) {
-      this.properties = properties;
-    }
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-    const frag = new Fragment([], null, this.properties);
-
-    if (this.frid === null) {
-      this.frid = struct.frags.add(frag);
-    } else {
-      struct.frags.set(this.frid, frag);
-    }
-
-    restruct.frags.set(this.frid, new ReFrag(frag));
-    restruct.markItem('frags', this.frid, 1); // notifyFragmentAdded
-    restruct.enhancedFlags.set(this.frid, new ReEnhancedFlag());
-  }
-
-  invert() {
-    return new FragmentDelete(this.frid);
-  }
-}
-
-class FragmentSetProperties extends BaseOperation {
-  readonly frid: any;
-  readonly properties?: Array<StructProperty>;
-
-  constructor(fragmentId: any, properties?: Array<StructProperty>) {
-    super(OperationType.FRAGMENT_SET_PROPERTIES);
-    this.frid = fragmentId;
-    this.properties = properties;
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-    const frag = struct.frags.get(this.frid);
-
-    if (frag) {
-      if (this.properties) {
-        frag.properties = this.properties;
-      } else {
-        delete frag?.properties;
-      }
-    }
-  }
-
-  invert() {
-    return new FragmentSetProperties(this.frid, undefined);
-  }
-}
-
-class FragmentDelete extends BaseOperation {
-  readonly frid: any;
-
-  constructor(fragmentId: any) {
-    super(OperationType.FRAGMENT_DELETE, 100);
-    this.frid = fragmentId;
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-    if (!struct.frags.get(this.frid)) {
-      return;
-    }
-
-    BaseOperation.invalidateItem(restruct, 'frags', this.frid, 1);
-    restruct.frags.delete(this.frid);
-    restruct.markItemRemoved(); // notifyFragmentRemoved
-    struct.frags.delete(this.frid);
-
-    const enhancedFalg = restruct.enhancedFlags.get(this.frid);
-    if (!enhancedFalg) return;
-    restruct.clearVisel(enhancedFalg.visel);
-    restruct.enhancedFlags.delete(this.frid);
-  }
-
-  invert() {
-    return new FragmentAdd(this.frid);
-  }
-}
+FragmentAdd.InverseConstructor = FragmentDelete;
+FragmentDelete.InverseConstructor = FragmentAdd;
 
 export { FragmentAdd, FragmentDelete, FragmentSetProperties };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

- Extracted FragmentAdd, FragmentDelete, and FragmentSetProperties from operations/fragment.ts into separate files                                                                                                                                                                                                                                                             
  - Used the static InverseConstructor pattern to avoid introducing a circular import between FragmentAdd.ts and FragmentDelete.ts: neither file imports the other; fragment.ts wires FragmentAdd.InverseConstructor = FragmentDelete and FragmentDelete.InverseConstructor = FragmentAdd after both modules are loaded                                                          
  - FragmentSetProperties has no cross-class dependency in invert() (it returns a new instance of itself), so no InverseConstructor is needed there                                                                                                                                                                                                                              
  - fragment.ts now serves as the entry point that wires and re-exports all three classes                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                 
  Note                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                 
  There was no actual circular dependency between modules before this change — all three classes lived in the same file, so no module-level cycle existed. This refactor is purely for code organization: each class now has its own file, improving readability and maintainability. The static InverseConstructor pattern is used intentionally to prevent a circular import   
  from being introduced as a side effect of the separation.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request