### PR TITLE
#9797 - Todo | Refactor: Separate UpdateIfThen operation class to fix circular dependency in invert method

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { BaseOperation } from './BaseOperation';
+import { OperationType } from './OperationType';
+import { ReStruct } from '../../render';
+
+class RestoreIfThen extends BaseOperation {
+  readonly rgid_new: number;
+  readonly rgid_old: number;
+  readonly ifThenHistory: Map<number, number>;
+  static InverseConstructor: new (
+    rgNew: number,
+    rgOld: number,
+    skipRgids?: Array<number>,
+  ) => BaseOperation;
+
+  constructor(rgNew: number, rgOld: number, history: Map<number, number>) {
+    super(OperationType.RESTORE_IF_THEN);
+    this.rgid_new = rgNew;
+    this.rgid_old = rgOld;
+    this.ifThenHistory = history || new Map();
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+
+    this.ifThenHistory.forEach((rg, rgid) => {
+      const rgValue = struct.rgroups.get(rgid);
+      if (!rgValue) return;
+      rgValue.ifthen = rg;
+      struct.rgroups.set(rgid, rgValue);
+    });
+  }
+
+  invert() {
+    return new RestoreIfThen.InverseConstructor(this.rgid_old, this.rgid_new);
+  }
+}
+
+export { RestoreIfThen };

--- a/packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { BaseOperation } from './BaseOperation';
+import { OperationType } from './OperationType';
+import { ReStruct } from '../../render';
+
+class UpdateIfThen extends BaseOperation {
+  readonly rgid_new: number;
+  readonly rgid_old: number;
+  readonly ifThenHistory: Map<number, number>;
+  readonly skipRgids: Array<number>;
+  static InverseConstructor: new (
+    rgNew: number,
+    rgOld: number,
+    history: Map<number, number>,
+  ) => BaseOperation;
+
+  constructor(rgNew: number, rgOld: number, skipRgids: Array<number> = []) {
+    super(OperationType.UPDATE_IF_THEN);
+    this.rgid_new = rgNew;
+    this.rgid_old = rgOld;
+    this.ifThenHistory = new Map();
+    this.skipRgids = skipRgids || [];
+  }
+
+  execute(restruct: ReStruct) {
+    const struct = restruct.molecule;
+
+    struct.rgroups.forEach((rg, rgid) => {
+      if (rg.ifthen === this.rgid_old && !this.skipRgids.includes(rgid)) {
+        rg.ifthen = this.rgid_new;
+        this.ifThenHistory.set(rgid, this.rgid_old);
+        struct.rgroups.set(rgid, rg);
+      }
+    });
+  }
+
+  invert() {
+    return new UpdateIfThen.InverseConstructor(
+      this.rgid_new,
+      this.rgid_old,
+      this.ifThenHistory,
+    );
+  }
+}
+
+export { UpdateIfThen };

--- a/packages/ketcher-core/src/application/editor/operations/ifThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/ifThen.ts
@@ -13,70 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
-import { BaseOperation } from './BaseOperation';
-import { OperationType } from './OperationType';
-import { ReStruct } from '../../render';
+import { UpdateIfThen } from './UpdateIfThen';
+import { RestoreIfThen } from './RestoreIfThen';
 
-// todo: separate classes: now here is circular dependency in `invert` method
-
-class UpdateIfThen extends BaseOperation {
-  readonly rgid_new: any;
-  readonly rgid_old: any;
-  readonly ifThenHistory: any;
-  readonly skipRgids: any[];
-
-  constructor(rgNew: any, rgOld: any, skipRgids: any = []) {
-    super(OperationType.UPDATE_IF_THEN);
-    this.rgid_new = rgNew;
-    this.rgid_old = rgOld;
-    this.ifThenHistory = new Map();
-    this.skipRgids = skipRgids || [];
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-
-    struct.rgroups.forEach((rg, rgid) => {
-      if (rg.ifthen === this.rgid_old && !this.skipRgids.includes(rgid)) {
-        rg.ifthen = this.rgid_new;
-        this.ifThenHistory.set(rgid, this.rgid_old);
-        struct.rgroups.set(rgid, rg);
-      }
-    });
-  }
-
-  invert() {
-    return new RestoreIfThen(this.rgid_new, this.rgid_old, this.ifThenHistory);
-  }
-}
-
-class RestoreIfThen extends BaseOperation {
-  readonly rgid_new: any;
-  readonly rgid_old: any;
-  readonly ifThenHistory: any;
-
-  constructor(rgNew: any, rgOld: any, history: any) {
-    super(OperationType.RESTORE_IF_THEN);
-    this.rgid_new = rgNew;
-    this.rgid_old = rgOld;
-    this.ifThenHistory = history || new Map();
-  }
-
-  execute(restruct: ReStruct) {
-    const struct = restruct.molecule;
-
-    this.ifThenHistory.forEach((rg, rgid) => {
-      const rgValue = struct.rgroups.get(rgid)!;
-      rgValue.ifthen = rg;
-      struct.rgroups.set(rgid, rgValue);
-    });
-  }
-
-  invert() {
-    return new UpdateIfThen(this.rgid_old, this.rgid_new);
-  }
-}
+UpdateIfThen.InverseConstructor = RestoreIfThen;
+RestoreIfThen.InverseConstructor = UpdateIfThen;
 
 export { UpdateIfThen, RestoreIfThen };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

- Extracted UpdateIfThen and RestoreIfThen from operations/ifThen.ts into separate files                                                                                                                                                                                                                                                                                       
  - Used the static InverseConstructor pattern to avoid introducing a circular import between the two files; ifThen.ts wires UpdateIfThen.InverseConstructor = RestoreIfThen and RestoreIfThen.InverseConstructor = UpdateIfThen after both modules are loaded                                                                                                                   
  - Improved types in the process: replaced any with proper types — number for rgroup IDs, Map<number, number> for ifThenHistory, and Array<number> for skipRgids                                                                                                                                                                                                                
  - ifThen.ts now serves as the entry point that wires and re-exports both classes                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                 
  There was no actual circular dependency between modules before this change — both classes lived in the same file. This refactor is purely for code organization. The static InverseConstructor pattern is used intentionally to prevent a circular import from being introduced as a side effect of the separation

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request