### PR TITLE
#9299 - Fixes on new lexical library

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -626,6 +626,14 @@ export class CoreEditor {
     const keySettings = hotkeysConfiguration;
     const hotKeys = initHotKeys(keySettings);
     const shortcutKey = keyNorm.lookup(hotKeys, event);
+    const isClipArea = event.target?.hasAttribute?.('data-cliparea');
+    if (isClipArea) {
+      if (keySettings[shortcutKey]?.handler) {
+        keySettings[shortcutKey].handler(this);
+        event.preventDefault();
+      }
+      return;
+    }
     const isInput =
       event.target.nodeName === 'INPUT' ||
       event.target.nodeName === 'TEXTAREA' ||

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -627,7 +627,9 @@ export class CoreEditor {
     const hotKeys = initHotKeys(keySettings);
     const shortcutKey = keyNorm.lookup(hotKeys, event);
     const isInput =
-      event.target.nodeName === 'INPUT' || event.target.nodeName === 'TEXTAREA';
+      event.target.nodeName === 'INPUT' ||
+      event.target.nodeName === 'TEXTAREA' ||
+      event.target.isContentEditable;
 
     if (keySettings[shortcutKey]?.handler && !isInput) {
       keySettings[shortcutKey].handler(this);

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -77,6 +77,7 @@ import {
   HELM_ALIAS_FORMAT_ERROR_MESSAGE,
   isValidHelmAlias,
   initHotKeys,
+  isEditableInputTarget,
   KetcherLogger,
   keyNorm,
   SettingsManager,
@@ -626,14 +627,11 @@ export class CoreEditor {
     const keySettings = hotkeysConfiguration;
     const hotKeys = initHotKeys(keySettings);
     const shortcutKey = keyNorm.lookup(hotKeys, event);
-    const isClipAreaTarget = event.target.hasAttribute('data-cliparea');
-    const isInput =
-      !isClipAreaTarget &&
-      (event.target.nodeName === 'INPUT' ||
-        event.target.nodeName === 'TEXTAREA' ||
-        event.target.isContentEditable);
 
-    if (keySettings[shortcutKey]?.handler && !isInput) {
+    if (
+      keySettings[shortcutKey]?.handler &&
+      !isEditableInputTarget(event.target)
+    ) {
       keySettings[shortcutKey].handler(this);
       event.preventDefault();
     }

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -626,18 +626,12 @@ export class CoreEditor {
     const keySettings = hotkeysConfiguration;
     const hotKeys = initHotKeys(keySettings);
     const shortcutKey = keyNorm.lookup(hotKeys, event);
-    const isClipArea = event.target?.hasAttribute?.('data-cliparea');
-    if (isClipArea) {
-      if (keySettings[shortcutKey]?.handler) {
-        keySettings[shortcutKey].handler(this);
-        event.preventDefault();
-      }
-      return;
-    }
+    const isClipAreaTarget = event.target.hasAttribute('data-cliparea');
     const isInput =
-      event.target.nodeName === 'INPUT' ||
-      event.target.nodeName === 'TEXTAREA' ||
-      event.target.isContentEditable;
+      !isClipAreaTarget &&
+      (event.target.nodeName === 'INPUT' ||
+        event.target.nodeName === 'TEXTAREA' ||
+        event.target.isContentEditable);
 
     if (keySettings[shortcutKey]?.handler && !isInput) {
       keySettings[shortcutKey].handler(this);

--- a/packages/ketcher-core/src/utilities/dom.ts
+++ b/packages/ketcher-core/src/utilities/dom.ts
@@ -3,3 +3,15 @@ export function blurActiveElement(): void {
   // @ts-ignore
   document.activeElement?.blur();
 }
+
+export function isEditableInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  // The cliparea is a hidden textarea used to capture copy/paste events,
+  // so hotkeys must still fire when it is focused.
+  if (target.hasAttribute('data-cliparea')) return false;
+  return (
+    target.nodeName === 'INPUT' ||
+    target.nodeName === 'TEXTAREA' ||
+    target.isContentEditable
+  );
+}

--- a/packages/ketcher-core/src/utilities/index.ts
+++ b/packages/ketcher-core/src/utilities/index.ts
@@ -28,3 +28,4 @@ export * from './getSvgFromDrawnStructures';
 export * from './ensureString';
 export * from './normalizeError';
 export * from './monomers';
+export * from './dom';

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -102,6 +102,10 @@ function shouldIgnoreKeyEvent(state, event): boolean {
   // TODO: It is done to intercept hotkeys when editing inputs in monomer creation wizard
   // It targets plain inputs only, ideally it has to be incorporated with ClipArea functionality
   // Ideally x2 – create a common event interception layer for both micro and macro editors
+  const isClipArea = event.target?.hasAttribute?.('data-cliparea');
+  if (isClipArea) {
+    return false;
+  }
   return (
     event.target.nodeName === 'INPUT' ||
     event.target.nodeName === 'TEXTAREA' ||

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -102,7 +102,11 @@ function shouldIgnoreKeyEvent(state, event): boolean {
   // TODO: It is done to intercept hotkeys when editing inputs in monomer creation wizard
   // It targets plain inputs only, ideally it has to be incorporated with ClipArea functionality
   // Ideally x2 – create a common event interception layer for both micro and macro editors
-  return event.target.nodeName === 'INPUT';
+  return (
+    event.target.nodeName === 'INPUT' ||
+    event.target.nodeName === 'TEXTAREA' ||
+    event.target.isContentEditable
+  );
 }
 
 function shouldShowAbbreviationLookup(key: string, state): boolean {

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -25,6 +25,7 @@ import {
   SupportedFormat,
   Editor,
   getStructure,
+  isEditableInputTarget,
   MolSerializer,
   runAsyncAction,
   SettingsManager,
@@ -99,21 +100,10 @@ function shouldIgnoreKeyEvent(state, event): boolean {
   if (state.modal || selectIsAbbreviationLookupOpen(state)) {
     return true;
   }
-  if (!(event.target instanceof HTMLElement)) {
-    return false;
-  }
-
-  const isClipAreaTarget = event.target.hasAttribute('data-cliparea');
-
   // TODO: It is done to intercept hotkeys when editing inputs in monomer creation wizard
   // It targets plain inputs only, ideally it has to be incorporated with ClipArea functionality
   // Ideally x2 – create a common event interception layer for both micro and macro editors
-  return (
-    !isClipAreaTarget &&
-    (event.target.nodeName === 'INPUT' ||
-      event.target.nodeName === 'TEXTAREA' ||
-      event.target.isContentEditable)
-  );
+  return isEditableInputTarget(event.target);
 }
 
 function shouldShowAbbreviationLookup(key: string, state): boolean {

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -99,17 +99,20 @@ function shouldIgnoreKeyEvent(state, event): boolean {
   if (state.modal || selectIsAbbreviationLookupOpen(state)) {
     return true;
   }
+  if (!(event.target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const isClipAreaTarget = event.target.hasAttribute('data-cliparea');
+
   // TODO: It is done to intercept hotkeys when editing inputs in monomer creation wizard
   // It targets plain inputs only, ideally it has to be incorporated with ClipArea functionality
   // Ideally x2 – create a common event interception layer for both micro and macro editors
-  const isClipArea = event.target?.hasAttribute?.('data-cliparea');
-  if (isClipArea) {
-    return false;
-  }
   return (
-    event.target.nodeName === 'INPUT' ||
-    event.target.nodeName === 'TEXTAREA' ||
-    event.target.isContentEditable
+    !isClipAreaTarget &&
+    (event.target.nodeName === 'INPUT' ||
+      event.target.nodeName === 'TEXTAREA' ||
+      event.target.isContentEditable)
   );
 }
 

--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx
@@ -32,6 +32,7 @@ import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin';
+import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 
 import { Dialog } from '../../../components';
 import { DialogParams } from '../../../../../../components/Dialog/Dialog';
@@ -226,6 +227,7 @@ const TextEditorInner = (props: {
         }
         ErrorBoundary={LexicalErrorBoundary}
       />
+      <HistoryPlugin />
       <EnterKeyPlugin />
       <EditorRefPlugin editorRef={editorRef} />
       <AutoFocusPlugin />

--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/TextButton/TextButton.module.less
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/TextButton/TextButton.module.less
@@ -45,7 +45,7 @@
     border-radius: 2px;
 
     & > svg {
-      fill: @color-background-primary;
+      color: @color-background-primary;
       transition: 0.2s;
     }
 
@@ -53,7 +53,7 @@
       background-color: @color-spec-button-primary-hover;
 
       & > svg {
-        fill: @color-background-primary;
+        color: @color-background-primary;
         transition: 0.2s;
       }
     }


### PR DESCRIPTION
## Summary

Fixes hotkeys triggering in the Lexical text editor and adds undo/redo support for text editing.

## Changes

**Hotkey Event Handling Improvements:**

**Problem:**  
The previous logic used `&& !isClipArea` which caused hotkeys to execute in the cliparea, calling `event.preventDefault()` and breaking keyboard event flow across the entire editor.

**Solution:**  
- Fixed hotkey blocking logic in `Editor.ts` and `hotkeys.ts` to correctly handle the cliparea element  
- The cliparea (`<textarea data-cliparea>`) is now explicitly checked first and allowed to trigger hotkeys, preserving normal canvas keyboard interactions  
- Added `isContentEditable` check to block hotkeys when users are editing in the Lexical text editor or other content-editable elements  

**Text Editor Functionality:**

- Added `HistoryPlugin` to the Lexical text editor in `Text.tsx` to enable undo/redo functionality  
- Users can now use `Ctrl+Z/Cmd+Z` and `Ctrl+Y/Cmd+Shift+Z` for undo/redo operations within the text editor  

**Style Fix:**

- Changed icon styling in `TextButton.module.less` from `fill` to `color` property for better compatibility with SVG rendering  

## Files Modified

- `packages/ketcher-core/src/application/editor/Editor.ts`
- `packages/ketcher-react/src/script/ui/state/hotkeys.ts`
- `packages/ketcher-react/src/script/ui/views/modal/components/Text/Text.tsx`
- `packages/ketcher-react/src/script/ui/views/modal/components/Text/TextButton/TextButton.module.less`                                      



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request