### PR TITLE
#9817 - Double call of context menu for symbol on sequence canvas causes different menu to appear

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -693,6 +693,15 @@ export class CoreEditor {
         return;
       }
 
+      // If the right-click happened inside an already-open context menu (the
+      // menu DOM is rendered as a portal sibling of the canvas SVG and overlaps
+      // the symbol underneath), event.target.__data__ is undefined and the
+      // logic below would fall through to rightClickCanvasSequence and replace
+      // the original menu with a reduced one. Skip the dispatch in that case.
+      if ((event.target as HTMLElement | null)?.closest('.contexify')) {
+        return;
+      }
+
       const eventData = event.target?.__data__;
       const canvasBoundingClientRect = this.canvas.getBoundingClientRect();
       const isClickOnCanvas =

--- a/packages/ketcher-macromolecules/src/components/contextMenu/ContextMenu.tsx
+++ b/packages/ketcher-macromolecules/src/components/contextMenu/ContextMenu.tsx
@@ -138,11 +138,6 @@ export const ContextMenu = ({ id, handleMenuChange, menuItems }: MenuProps) => {
         e.stopPropagation();
         return;
       }
-      const canvas = document.getElementById('polymer-editor-canvas');
-      const isClickOnCanvas = canvas?.contains(e.target);
-      if (isClickOnCanvas && e.type === 'contextmenu') {
-        return;
-      }
       dispatch(setContextMenuActive(false));
     };
     document.addEventListener('click', handleContextMenuClose);

--- a/packages/ketcher-macromolecules/src/components/contextMenu/ContextMenu.tsx
+++ b/packages/ketcher-macromolecules/src/components/contextMenu/ContextMenu.tsx
@@ -138,6 +138,11 @@ export const ContextMenu = ({ id, handleMenuChange, menuItems }: MenuProps) => {
         e.stopPropagation();
         return;
       }
+      const canvas = document.getElementById('polymer-editor-canvas');
+      const isClickOnCanvas = canvas?.contains(e.target);
+      if (isClickOnCanvas && e.type === 'contextmenu') {
+        return;
+      }
       dispatch(setContextMenuActive(false));
     };
     document.addEventListener('click', handleContextMenuClose);


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
  - Fix context menu losing selection state on second right-click in Sequence mode
  - Root cause: `handleContextMenuClose` in `ContextMenu.tsx` was dispatching `setContextMenuActive(false)` on
  `contextmenu` events when the nucleotide detection (`e.target.__data__`) failed — which happens when the right-click
  target is the context menu overlay itself rather than the SVG element
  - Fix: skip deactivation for `contextmenu` events when the target is inside the canvas SVG element
  (`polymer-editor-canvas`), letting the editor's event chain handle showing the correct menu
  - Left-click behavior unchanged — still deactivates context menu as before
  - Right-click outside the canvas — still deactivates as before

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request