### PR TITLE
#9820 - Adding bond to atom could ended with wrong bond angle if user slightly moved mouse during click

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -34,6 +34,8 @@ import { Tool } from './Tool';
 import { isBondingWithMacroMolecule } from './helper/isMacroMolecule';
 
 class BondTool implements Tool {
+  private static readonly DRAG_START_THRESHOLD_PX = 10;
+
   private readonly editor: Editor;
   private readonly atomProps: { label: string };
   private readonly bondProps: any;
@@ -129,6 +131,9 @@ class BondTool implements Tool {
     this.editor.selection(null);
     this.dragCtx = {
       xy0: CoordinateTransformation.pageToModel(event, rnd),
+      pageX0: event.clientX,
+      pageY0: event.clientY,
+      hasStartedDragging: false,
       item:
         attachmentAtomId === undefined
           ? ci
@@ -149,6 +154,9 @@ class BondTool implements Tool {
       return true;
     }
     if (this.dragCtx) {
+      if (!this.isDragStartThresholdReached(event, this.dragCtx)) {
+        return true;
+      }
       return this.handleDragMove(event);
     }
     this.editor.hover(
@@ -156,6 +164,22 @@ class BondTool implements Tool {
       null,
       event,
     );
+    return true;
+  }
+
+  private isDragStartThresholdReached(event, dragCtx) {
+    if (dragCtx.hasStartedDragging) {
+      return true;
+    }
+
+    const dx = event.clientX - dragCtx.pageX0;
+    const dy = event.clientY - dragCtx.pageY0;
+    const distance = Math.hypot(dx, dy);
+    if (distance < BondTool.DRAG_START_THRESHOLD_PX) {
+      return false;
+    }
+
+    dragCtx.hasStartedDragging = true;
     return true;
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
**Summary**

Adds a movement threshold to bond tool mouse drag handling so mousemove effects only start after meaningful cursor movement.

**What changed**
- Added drag start threshold check in BondTool mousemove flow.
- Stored initial pointer position on mousedown.
- Ignored drag-related mousemove updates until cursor travel exceeds the threshold (10 px).
- Once threshold is reached, drag behavior continues as before.

**Why**
This prevents tiny cursor jitter from triggering drag effects and improves click vs drag behavior consistency.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request