### PR TITLE
#6092 - Antisense creating doesn't work if ambiguous peptide present in the chain selection

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -3686,10 +3686,21 @@ export class DrawingEntitiesManager {
             const isModifiedPhosphate =
               monomer instanceof Phosphate && monomer.isModification;
             const isAmbiguousMonomer = monomer instanceof AmbiguousMonomer;
+            const isAmbiguousPhosphate =
+              isAmbiguousMonomer &&
+              monomer.monomerClass === KetMonomerClass.Phosphate;
+
+            if (isAmbiguousMonomer && !isAmbiguousPhosphate) {
+              lastAddedMonomer = undefined;
+              lastAddedNode = undefined;
+
+              return;
+            }
+
             let antisenseMonomerItem: MonomerOrAmbiguousType =
               monomer.monomerItem;
 
-            if (isModifiedPhosphate || isAmbiguousMonomer) {
+            if (isModifiedPhosphate || isAmbiguousPhosphate) {
               const nonModifiedPhosphateItem = getRnaPartLibraryItem(
                 editor,
                 RNA_DNA_NON_MODIFIED_PART.PHOSPHATE,
@@ -3697,7 +3708,7 @@ export class DrawingEntitiesManager {
 
               if (nonModifiedPhosphateItem) {
                 antisenseMonomerItem = nonModifiedPhosphateItem;
-              } else if (isAmbiguousMonomer) {
+              } else if (isAmbiguousPhosphate) {
                 antisenseMonomerItem = monomer.variantMonomerItem;
               }
             }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
## Summary
  - Fix antisense strand creation failing when an ambiguous peptide monomer is present in the chain selection
  - Root cause: the existing code treated all ambiguous monomers the same as modified phosphates, incorrectly replacing
  them with a non-modified phosphate item
  - Fix: skip ambiguous non-phosphate monomers (e.g., ambiguous peptides) during antisense creation — they produce no
  monomer in the antisense chain
  - Ambiguous phosphate monomers still correctly get replaced with non-modified phosphate (existing behavior preserved)
  - Regular backbone monomers still get directly copied to antisense (existing behavior preserved)

  ## What changed
  In `DrawingEntitiesManager.ts`, the antisense "else" branch (non-nucleotide monomers):
  - Added check: if monomer is an `AmbiguousMonomer` but NOT a phosphate class → skip it and reset chain connection
  state
  - Narrowed the modified phosphate replacement logic to only apply to actual phosphates (modified or ambiguous
  phosphate class)

  ## Test plan
  - [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
  - [x] All 348 unit tests pass
  - [x] 574 antisense e2e tests pass (Docker)
  - [x] Bug test passes: `ketcher-2.28.0-bugs.spec.ts:444` — "Create Antisense Strand doesn't work in some cases"
  - [x] Test 26.5.1 passes — non R1-R2 connections ignored (RNA)
  - [x] Test 26.8.1 passes — backbone monomers directly copied to antisense (RNA)
  - [x] Test 26.8.2 passes — backbone monomers directly copied to antisense (DNA)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request