### PR TITLE
#9799 Todo | Refactor: Fix types in getEmptyMonomersLibraryJson and remove @ts-ignore

### DIFF
--- a/packages/ketcher-core/src/application/editor/helpers.ts
+++ b/packages/ketcher-core/src/application/editor/helpers.ts
@@ -16,9 +16,6 @@ export const parseMonomersLibrary = (monomersDataRaw: string | JSON) => {
 
 export const getEmptyMonomersLibraryJson =
   function (): IKetMacromoleculesContent {
-    // TODO fix types
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return {
       root: {
         templates: [],

--- a/packages/ketcher-core/src/application/formatters/types/ket.ts
+++ b/packages/ketcher-core/src/application/formatters/types/ket.ts
@@ -220,6 +220,7 @@ export interface IKetMacromoleculesContentRootProperty {
     nodes: IKetNodeRef[];
     connections: IKetConnection[];
     templates: IKetMonomerTemplateRef[];
+    type?: undefined;
   };
 }
 
@@ -228,7 +229,8 @@ export interface IKetMacromoleculesContentOtherProperties {
     | KetNode
     | IKetMonomerTemplate
     | IKetMonomerGroupTemplate
-    | IKetAmbiguousMonomerTemplate;
+    | IKetAmbiguousMonomerTemplate
+    | IKetMacromoleculesContentRootProperty['root'];
 }
 
 export type IKetMacromoleculesContent = IKetMacromoleculesContentRootProperty &


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

getEmptyMonomersLibraryJson was suppressing a type error with @ts-ignore because IKetMacromoleculesContent is a structurally broken intersection: IKetMacromoleculesContentOtherProperties has an index signature requiring every value to be KetNode | IKetMonomerTemplate | ..., but the named root property's value type
  doesn't satisfy that union, making { root: { ... } } unassignable.                                                                                                                                                                                                                                                             
   
  The fix adds type?: undefined to the root value type (truthful — accessing .root.type at runtime is undefined) and adds IKetMacromoleculesContentRootProperty['root'] to the index signature union. This resolves the intersection incompatibility without touching any other files, without type assertion hacks, and without 
  breaking any existing ?.type access patterns elsewhere.  

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request