### PR TITLE
#9745 - TODO | Bug: Side chain restoration picks wrong monomer for Sugar-to-Sugar connections in Nucleotides

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2389,7 +2389,6 @@ export class SequenceMode extends BaseMode {
       ),
     );
 
-    // TODO: This check breaks some side chains (e.g. Sugar-to-Sugar for Nucleotides), need another way of preserving connections
     let monomerForSideConnections = newPresetNode.monomer;
 
     if (newPresetNode instanceof Nucleotide) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

This is an outdated comment. The problem is not actual. It has not been reproduced in the recent past.

In theory we can mirror what `preservedHydrogenBonds` already does:
1. Change `preserveSideChainConnections` to also record `fromMonomer: BaseMonomer` - the exact sub-monomer that owned the bond (not just the node's representative monomer). It should iterate over all `selectedNode.monomers`, not just `selectedNode.monomer`.

2. In `replaceSelectionWithPreset`, resolve the correct target monomer in the new preset by matching `fromMonomer's` type - exactly like the hydrogen bond loop does:
```
// existing hydrogen bond pattern (already correct):
if (fromMonomer instanceof RNABase)      monomerForHydrogenBond = newPresetNode.rnaBase;
else if (fromMonomer instanceof Sugar)   monomerForHydrogenBond = newPresetNode.sugar;
else if (fromMonomer instanceof Phosphate) monomerForHydrogenBond = newPresetNode.phosphate;
```
Apply the same type-based dispatch for side chain connections instead of the hardcoded` monomerForSideConnections`.

This way a Sugar→X side chain bond is re-established on `newPresetNode.sugar`, a Phosphate→X bond on `newPresetNode.phosphate`, etc. — regardless of which monomer is` firstMonomerInNode`.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

close #9745