### PR TITLE
#9800 - Todo | Feature: Add event propagation control from mode handlers to keyboard shortcut handlers

### DIFF
--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -262,11 +262,6 @@ export const hotkeysConfiguration = {
   erase: {
     shortcut: ['Delete', 'Backspace'],
     handler: (editor: CoreEditor) => {
-      // TODO create an ability to stop event propagation from mode event handlers to keyboard shortcuts handlers
-      // Sequence mode handles Delete/Backspace itself (even when not editing),
-      // so skip tool switching here.
-      if (editor.isSequenceMode) return;
-
       const hasSelectedEntities =
         editor.drawingEntitiesManager.selectedEntities.length > 0;
 

--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -72,6 +72,14 @@ export abstract class BaseMode {
   }
 
   async onKeyDown(event: KeyboardEvent) {
+    if (!this.checkIfTargetIsInput(event)) {
+      const hotKeys = initHotKeys(this.keyboardEventHandlers);
+      const shortcutKey = keyNorm.lookup(hotKeys, event);
+
+      if (this.keyboardEventHandlers[shortcutKey]) {
+        event.stopImmediatePropagation();
+      }
+    }
     await new Promise<void>((resolve) => {
       setTimeout(() => {
         const editor = provideEditorInstance();

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1304,7 +1304,12 @@ export class SequenceMode extends BaseMode {
         shortcut: ['Escape'],
         handler: () => {
           if (this.isEditInRNABuilderMode) return;
-          this.turnOffEditMode();
+          if (this.isEditMode) {
+            this.turnOffEditMode();
+          } else {
+            const editor = provideEditorInstance();
+            editor.events.selectSelectionTool.dispatch();
+          }
         },
       },
       'start-new-sequence': {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Previously, when a mode (e.g. SequenceMode) handled a keyboard event like Delete/Backspace, the global hotkey handler would also fire for the same event. This was worked around with a hardcoded if (editor.isSequenceMode) return; guard  in the erase hotkey handler.

  This change replaces that workaround with a general mechanism: BaseMode.onKeyDown now calls event.stopImmediatePropagation() synchronously when it finds a matching handler, preventing the global hotkey listener from firing. The hardcoded guard is removed.
                                                                                                                        
  This works because both listeners are registered on the same document element — stopImmediatePropagation prevents subsequent listeners on that element from being called, unlike stopPropagation which only stops bubbling to parent elements.

  As a side effect, SequenceMode's Escape handler now fully owns the key: the global exit handler that previously also ran (and cleared selection via selectSelectionTool.dispatch()) is no longer called. The SequenceMode Escape handler is updated to explicitly clear selection when not in edit mode, making the behavior intentional rather than an
  accidental side effect of the global handler.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request