### PR TITLE
fix import ReStruct

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -30,7 +30,7 @@ import {
 } from './generalEnumTypes';
 
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import draw from '../draw';

--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -25,7 +25,7 @@ import { LayerMap, StereoColoringType } from './generalEnumTypes';
 import { getColorFromStereoLabel } from './reatom';
 
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import draw from '../draw';

--- a/packages/ketcher-core/src/application/render/restruct/redatasgroupdata.ts
+++ b/packages/ketcher-core/src/application/render/restruct/redatasgroupdata.ts
@@ -16,7 +16,7 @@
 
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import { SGroup } from 'domain/entities/sgroup';

--- a/packages/ketcher-core/src/application/render/restruct/reenhancedFlag.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reenhancedFlag.ts
@@ -19,7 +19,7 @@ import { Fragment, StereoFlag } from 'domain/entities/fragment';
 
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 

--- a/packages/ketcher-core/src/application/render/restruct/refrag.ts
+++ b/packages/ketcher-core/src/application/render/restruct/refrag.ts
@@ -19,7 +19,7 @@ import { Vec2 } from 'domain/entities/vec2';
 import { Fragment } from 'domain/entities/fragment';
 
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 

--- a/packages/ketcher-core/src/application/render/restruct/remultitailArrow.ts
+++ b/packages/ketcher-core/src/application/render/restruct/remultitailArrow.ts
@@ -3,7 +3,7 @@ import { Line, MultitailArrow } from 'domain/entities/multitailArrow';
 import { MULTITAIL_ARROW_KEY } from 'domain/constants/multitailArrow';
 import { LayerMap } from './generalEnumTypes';
 import { Render } from '../raphaelRender';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { RenderOptions } from 'application/render/render.types';
 import { getArrowHeadDimensions } from 'application/render/draw';
 import { PathBuilder } from 'application/render/pathBuilder';

--- a/packages/ketcher-core/src/application/render/restruct/reobject.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reobject.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import { Box2Abs } from 'domain/entities/box2Abs';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import Visel from './visel';

--- a/packages/ketcher-core/src/application/render/restruct/rergroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroup.ts
@@ -19,7 +19,7 @@ import { Vec2 } from 'domain/entities/vec2';
 import { RGroup } from 'domain/entities/rgroup';
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { RenderOptions } from '../render.types';
 import { Scale } from 'domain/helpers';

--- a/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
@@ -10,7 +10,7 @@ import { Vec2 } from 'domain/entities/vec2';
 import { Scale } from 'domain/helpers';
 import ReAtom from './reatom';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import draw from '../draw';
 import { Render } from '../raphaelRender';
 import { RenderOptions, RenderOptionStyles } from '../render.types';

--- a/packages/ketcher-core/src/application/render/restruct/rerxnarrow.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rerxnarrow.ts
@@ -21,7 +21,7 @@ import { Vec2 } from 'domain/entities/vec2';
 import { LayerMap } from './generalEnumTypes';
 import Raphael from '../raphael-ext';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import draw from '../draw';

--- a/packages/ketcher-core/src/application/render/restruct/rerxnplus.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rerxnplus.ts
@@ -22,7 +22,7 @@ import { Scale } from 'domain/helpers';
 import draw from '../draw';
 import util from '../util';
 import { Render } from '../raphaelRender';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { RenderOptions } from '../render.types';
 
 class ReRxnPlus extends ReObject {

--- a/packages/ketcher-core/src/application/render/restruct/resgroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resgroup.ts
@@ -21,7 +21,7 @@ import { Box2Abs } from 'domain/entities/box2Abs';
 import { Vec2 } from 'domain/entities/vec2';
 import { SgContexts } from 'application/editor/shared/constants';
 import ReDataSGroupData from './redatasgroupdata';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';

--- a/packages/ketcher-core/src/application/render/restruct/resimpleObject.ts
+++ b/packages/ketcher-core/src/application/render/restruct/resimpleObject.ts
@@ -20,7 +20,7 @@ import { Vec2 } from 'domain/entities/vec2';
 
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import draw from '../draw';

--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -21,7 +21,7 @@ import { flatten } from 'lodash/fp';
 
 import { LayerMap } from './generalEnumTypes';
 import ReObject from './reobject';
-import ReStruct from './restruct';
+import type ReStruct from './restruct';
 import { Scale } from 'domain/helpers';
 import { RaphaelBaseElement } from 'raphael';
 


### PR DESCRIPTION
fix for circular dependencies:
restruct.ts → reatom.ts → reobject.ts → restruct.ts
restruct.ts → reatom.ts → restruct.ts
restruct.ts → rebond.ts → restruct.ts
restruct.ts → redatasgroupdata.ts → restruct.ts
restruct.ts → reenhancedFlag.ts → restruct.ts
restruct.ts → refrag.ts → restruct.ts
restruct.ts → remultitailArrow.ts → restruct.ts
restruct.ts → rergroup.ts → restruct.ts
restruct.ts → rergroupAttachmentPoint.ts → restruct.ts
restruct.ts → rerxnarrow.ts → restruct.ts
restruct.ts → rerxnplus.ts → restruct.ts
restruct.ts → resgroup.ts → restruct.ts
restruct.ts → resimpleObject.ts → restruct.ts
restruct.ts → retext.ts → restruct.ts

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request