### PR TITLE
#9121 - The Attributes panel should be disabled for a non-continuous selection of the Nucleotide (preset) type

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
@@ -37,6 +37,7 @@ interface IMonomerCreationWizardFieldsProps {
   onFieldChange: (fieldId: StringWizardFormFieldId, value: string) => void;
   showNaturalAnalogue?: boolean;
   attachmentPointsExtra?: ReactNode;
+  disabled?: boolean;
 }
 
 interface ModificationTypeItem {
@@ -56,6 +57,7 @@ const MonomerCreationWizardFields = (
     onChangeModificationTypes,
     onFieldChange,
     attachmentPointsExtra,
+    disabled: fieldsDisabled,
   } = props;
   const { values, errors } = wizardState;
   const { type, symbol, name, naturalAnalogue, aliasHELM } = values;
@@ -150,11 +152,11 @@ const MonomerCreationWizardFields = (
               onChange={(event: ChangeEvent<HTMLInputElement>) =>
                 onFieldChange('symbol', event.target.value)
               }
-              disabled={!type}
+              disabled={!type || fieldsDisabled}
             />
           }
           required
-          disabled={!type}
+          disabled={!type || fieldsDisabled}
         />
         <AttributeField
           title="Name"
@@ -168,10 +170,10 @@ const MonomerCreationWizardFields = (
               onChange={(event: ChangeEvent<HTMLInputElement>) =>
                 onFieldChange('name', event.target.value)
               }
-              disabled={!type}
+              disabled={!type || fieldsDisabled}
             />
           }
-          disabled={!type}
+          disabled={!type || fieldsDisabled}
         />
         {props.showNaturalAnalogue !== false && (
           <AttributeField
@@ -186,7 +188,7 @@ const MonomerCreationWizardFields = (
                 error={errors.naturalAnalogue}
               />
             }
-            disabled={!isNaturalAnalogueRequired(type)}
+            disabled={!isNaturalAnalogueRequired(type) || fieldsDisabled}
             required
           />
         )}

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
@@ -47,6 +47,24 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
   const structureSelection = useSelector(selectionSelector);
   const hasSelectedAtoms = Boolean(structureSelection?.atoms?.length);
   const { wizardState, wizardStateDispatch, editor } = props;
+  const isSelectionContinuous = (() => {
+    if (!hasSelectedAtoms) {
+      return true;
+    }
+    const struct = editor.struct();
+    const selectedAtomIds = new Set(structureSelection?.atoms ?? []);
+    const bondIds = Array.from(struct.bonds.keys()).filter((bondId) => {
+      const bond = struct.bonds.get(bondId);
+      return (
+        bond && selectedAtomIds.has(bond.begin) && selectedAtomIds.has(bond.end)
+      );
+    });
+    return Editor.isStructureContinuous(struct, {
+      atoms: structureSelection?.atoms ?? [],
+      bonds: bondIds,
+    });
+  })();
+  const isFieldsDisabled = hasSelectedAtoms && !isSelectionContinuous;
   const currentTabState = wizardState[RNA_COMPONENT_KEYS[selectedTab - 1]];
   const { phosphatePosition, onPhosphatePositionChange } = props;
 
@@ -256,6 +274,7 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
                   handleFieldChange('name', event.target.value, 'preset')
                 }
+                disabled={isFieldsDisabled}
               />
             }
             required
@@ -273,7 +292,7 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
                       monomerCreationWizardStyles.buttonSubmit,
                       styles.createComponentButton,
                     )}
-                    disabled={!hasSelectedAtoms}
+                    disabled={!hasSelectedAtoms || isFieldsDisabled}
                     onClick={() => handleClickCreateComponent(rnaComponentKey)}
                   >
                     Mark as {rnaComponentKey}
@@ -282,6 +301,7 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
                 <MonomerCreationWizardFields
                   assignedAttachmentPoints={new Map()}
                   showNaturalAnalogue={rnaComponentKey === 'base'}
+                  disabled={isFieldsDisabled}
                   attachmentPointsExtra={
                     rnaComponentKey === 'phosphate' ? (
                       <AttributeField


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

<img width="955" height="474" alt="continuous selection" src="https://github.com/user-attachments/assets/66ee29d9-433f-4f35-a0c6-65a597383642" />
<img width="958" height="472" alt="non-continuous selection" src="https://github.com/user-attachments/assets/75a15626-8d2c-4437-b324-d78f3f3da493" />


 - Disable Attributes panel fields (Code, Name, Natural Analogue) in Monomer Creation Wizard when the Nucleotide
  (preset) type is selected and the atom selection is non-continuous
  - Also disable "Mark as" buttons on Base/Sugar/Phosphate tabs for non-continuous selections
  - Uses existing `Editor.isStructureContinuous()` method with struct bonds between selected atoms to determine
  continuity
  - Added `disabled` prop to `MonomerCreationWizardFields` interface for reuse

  ## Files changed
  - `RnaPresetTabs.tsx` — Added continuity check using struct bonds between selected atoms; pass disabled state to Code
  input, Mark-as buttons, and MonomerCreationWizardFields
  - `MonomerCreationWizardFields.tsx` — Added optional `disabled` prop; applied to Code, Name, and Natural Analogue
  fields

  ## Test plan
  - [x] TypeScript compiles with no errors
  - [x] All 38 MonomerCreationWizard/RnaPresetTabs tests pass
  - [x] All 190 ketcher-react tests pass
  - [x] Manual test: no selection → Code field enabled
  - [x] Manual test: one atom selected → Code field enabled
  - [x] Manual test: continuous selection (adjacent atoms) → Code field enabled
  - [x] Manual test: non-continuous selection (separate atoms) → Code field disabled


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request