### PR TITLE
#8389 – Hanging bonds after sequence edit operation

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -1251,6 +1251,20 @@ export class SequenceRenderer {
       twoStrandedNode.senseNode?.renderer?.remove();
       twoStrandedNode.antisenseNode?.renderer?.remove();
     });
+
+    if (this.chainsCollection) {
+      const handledBonds = new Set();
+      this.chainsCollection.chains.forEach((chain) => {
+        chain.monomers.forEach((monomer) => {
+          monomer.forEachBond((bond) => {
+            if (!handledBonds.has(bond)) {
+              handledBonds.add(bond);
+              bond.renderer?.remove();
+            }
+          });
+        });
+      });
+    }
     this.removeNewSequenceButtons();
     this.removeDelegatedEvents();
   }


### PR DESCRIPTION


## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


- SequenceRenderer.startNewSequence() calls show() a second time right
after initialize() already called it via applyMonomersSequenceLayout().
The clear() inside show() only removed node renderers, leaving bond SVG
elements from the first showBonds() call as unreferenced DOM nodes that
could never be deleted.

- Fix: extend clear() to also remove bond renderers by iterating over all
monomers in chainsCollection and calling bond.renderer?.remove() before
the next showBonds() overwrites the renderer references.



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request