### PR TITLE
9738 Fix missing stereo update after bond direction change in fromBondFlip…

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -260,10 +260,18 @@ export function fromBondFlipping(restruct: ReStruct, id: number): Action {
 
   // TODO: find better way to avoid problem with bond.begin = 0
   if (Number.isInteger(bond?.end) && Number.isInteger(bond?.begin)) {
-    action.addOp(new BondAdd(bond?.end, bond?.begin, bond).perform(restruct));
-  }
+    const bondAddOp = new BondAdd(bond?.end, bond?.begin, bond).perform(
+      restruct,
+    );
+    action.addOp(bondAddOp);
 
-  // todo: swap atoms stereoLabels and stereoAtoms in fragment
+    const newBond = restruct.molecule.bonds.get(
+      (bondAddOp as BondAdd).data.bid,
+    );
+    if (newBond) {
+      action.mergeWith(fromBondStereoUpdate(restruct, newBond));
+    }
+  }
 
   return action;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

fromBondFlipping was only issuing BondDelete + BondAdd with swapped begin/end, but never updating the stereo metadata afterward. This left stereoLabel and stereoParity on atoms and stereoAtoms on the fragment stale after a bond direction change — most visibly triggered via the "Change direction" context menu.

Fixed by calling fromBondStereoUpdate on the newly created bond, which recalculates stereo labels and fragment stereo atoms from scratch — consistent with how all other bond-mutating actions (fromBondAddition, fromBondsAttrs, fromOneBondDeletion) handle stereo updates.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request