### PR TITLE
#9715 No gray arrows appear when hovering on the bond in the direction leading to an already marked component in Monomer Creation Wizard

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -552,6 +552,7 @@ class ReBond extends ReObject {
   public drawFragmentSelectionPreview(
     render: Render,
     atomIdToDrawArrows: number,
+    isGray = false,
   ) {
     this.hovering?.node?.remove();
 
@@ -606,6 +607,9 @@ class ReBond extends ReObject {
     );
     backgroundRect.rotate(this.b.angle, atom1Position.x, atom1Position.y);
 
+    // Use gray color for blocked directions, blue for available directions
+    const strokeColor = isGray ? '#9ab5b8' : '#365CFF';
+
     const contour = render.paper
       .rect(
         atom1Position.x,
@@ -614,7 +618,7 @@ class ReBond extends ReObject {
         contourSize.y,
         contourBorderRadius,
       )
-      .attr({ fill: 'none', stroke: '#365CFF', 'stroke-width': 0.7 });
+      .attr({ fill: 'none', stroke: strokeColor, 'stroke-width': 0.7 });
 
     render.ctab.addReObjectPath(LayerMap.additionalInfo, newVisel, contour);
     // TODO find another way instead of this.visel.paths[0] to move by Z only bond skeleton without selection, hover etc
@@ -660,7 +664,7 @@ class ReBond extends ReObject {
             }`,
         )
         .attr({
-          stroke: '#365CFF',
+          stroke: strokeColor,
           'stroke-width': 2,
         });
 

--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -36,6 +36,10 @@ import { isNumber } from 'lodash';
 import Visel from './visel';
 import { Coordinates } from 'application/editor/shared/coordinates';
 
+type FragmentSelectionPreviewOptions = {
+  disabled?: boolean;
+};
+
 class ReBond extends ReObject {
   b: Bond;
   doubleBondShift: number;
@@ -552,7 +556,7 @@ class ReBond extends ReObject {
   public drawFragmentSelectionPreview(
     render: Render,
     atomIdToDrawArrows: number,
-    isGray = false,
+    options?: FragmentSelectionPreviewOptions,
   ) {
     this.hovering?.node?.remove();
 
@@ -608,7 +612,7 @@ class ReBond extends ReObject {
     backgroundRect.rotate(this.b.angle, atom1Position.x, atom1Position.y);
 
     // Use gray color for blocked directions, blue for available directions
-    const strokeColor = isGray ? '#9ab5b8' : '#365CFF';
+    const strokeColor = options?.disabled ? '#9ab5b8' : '#365CFF';
 
     const contour = render.paper
       .rect(

--- a/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
+++ b/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
@@ -22,6 +22,7 @@ const CYCLE_TOOLTIP =
 const COMPONENT_TOOLTIP =
   'The structure fragment in this direction is already marked as a nucleotide component.';
 const TOOLTIP_DELAY = 200;
+const FORBIDDEN_CURSOR = `url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZGJkYmRiIiBzdHJva2Utd2lkdGg9IjIiLz48bGluZSB4MT0iNSIgeTE9IjUiIHgyPSIxOSIgeTI9IjE5IiBzdHJva2U9IiNkYmRiZGIiIHN0cm9rZS13aWR0aD0iMiIvPjwvc3ZnPg==') 12 12, not-allowed`;
 
 type FragmentPreview = {
   atoms: number[];
@@ -207,11 +208,7 @@ export default class FragmentSelectionTool implements Tool {
         ? reBond.b.begin
         : reBond.b.end;
     const componentData = this.getComponentData(struct);
-
-    if (componentData.componentAtoms.has(startAtomId)) {
-      this.setDisabledState(COMPONENT_TOOLTIP);
-      return;
-    }
+    const isStartAtomComponent = componentData.componentAtoms.has(startAtomId);
 
     if (this.isBondInCycle(struct, bondItem.id)) {
       this.setDisabledState(CYCLE_TOOLTIP);
@@ -222,6 +219,24 @@ export default class FragmentSelectionTool implements Tool {
 
     componentData.connectingBonds.forEach((bondId) => blockedBonds.add(bondId));
     blockedBonds.add(bondItem.id);
+
+    if (isStartAtomComponent) {
+      // Direction leads to marked component - show gray arrows and tooltip
+      this.preview = null;
+      this.disabledMessage = COMPONENT_TOOLTIP;
+      this.setCursor(true);
+      this.queueTooltip(COMPONENT_TOOLTIP);
+      this.editor.hover(null, this);
+
+      // Draw gray arrows to indicate blocked direction
+      this.bondPreview = reBond.drawFragmentSelectionPreview(
+        this.editor.render,
+        startAtomId,
+        true, // isGray parameter
+      );
+      return;
+    }
+
     this.disabledMessage = undefined;
     this.setCursor(false);
     this.clearTooltip();
@@ -251,6 +266,7 @@ export default class FragmentSelectionTool implements Tool {
     this.bondPreview = reBond.drawFragmentSelectionPreview(
       this.editor.render,
       startAtomId,
+      false, // isGray parameter
     );
   }
 
@@ -305,7 +321,7 @@ export default class FragmentSelectionTool implements Tool {
   private setCursor(isForbidden: boolean) {
     const canvas = this.editor.render.paper?.canvas;
     if (!canvas) return;
-    canvas.style.cursor = isForbidden ? 'not-allowed' : '';
+    canvas.style.cursor = isForbidden ? FORBIDDEN_CURSOR : '';
   }
 
   private isBondInCycle(struct: Struct, bondId: number): boolean {

--- a/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
+++ b/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
@@ -229,7 +229,7 @@ export default class FragmentSelectionTool implements Tool {
       this.bondPreview = reBond.drawFragmentSelectionPreview(
         this.editor.render,
         startAtomId,
-        true, // isGray parameter
+        { disabled: true },
       );
       return;
     }
@@ -263,7 +263,6 @@ export default class FragmentSelectionTool implements Tool {
     this.bondPreview = reBond.drawFragmentSelectionPreview(
       this.editor.render,
       startAtomId,
-      false, // isGray parameter
     );
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
+++ b/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
@@ -221,12 +221,9 @@ export default class FragmentSelectionTool implements Tool {
     blockedBonds.add(bondItem.id);
 
     if (isStartAtomComponent) {
-      // Direction leads to marked component - show gray arrows and tooltip
-      this.preview = null;
-      this.disabledMessage = COMPONENT_TOOLTIP;
-      this.setCursor(true);
-      this.queueTooltip(COMPONENT_TOOLTIP);
-      this.editor.hover(null, this);
+      // Direction leads to marked component - apply common disabled state
+      // handling and then show gray arrows for the blocked direction.
+      this.setDisabledState(COMPONENT_TOOLTIP);
 
       // Draw gray arrows to indicate blocked direction
       this.bondPreview = reBond.drawFragmentSelectionPreview(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request