### PR TITLE
#8399-Uncaught ReferenceError: process is not defined on create monomer button press after monomer creation 

### DIFF
--- a/packages/ketcher-standalone/rollup.config.js
+++ b/packages/ketcher-standalone/rollup.config.js
@@ -76,7 +76,9 @@ const baseConfig = {
       comments: 'none',
     }),
     replace({
-      'process.env.SEPARATE_INDIGO_RENDER': process.env.SEPARATE_INDIGO_RENDER,
+      'process.env.SEPARATE_INDIGO_RENDER': JSON.stringify(
+        process.env.SEPARATE_INDIGO_RENDER || '',
+      ),
     }),
     ...(isProduction ? [strip({ include: includePattern })] : []),
   ],


### PR DESCRIPTION
…ime (#8399)

## How the feature works? / How did you fix the issue?
Fix
Wrap the replacement value with JSON.stringify() and a fallback to empty string, ensuring the substitution always produces a valid JavaScript string literal in the output: