### PR TITLE
#9844 - System doesn't save to ket selection flags is molecule was added to canvas via Add to canvas button

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -1072,8 +1072,23 @@ export class KetSerializer implements Serializer<Struct> {
     };
   }
 
-  public static removeLeavingGroupsFromConnectedAtoms(_struct: Struct) {
-    const struct = _struct.clone();
+  public static removeLeavingGroupsFromConnectedAtoms(
+    _struct: Struct,
+    atomIdsMap?: Map<number, number>,
+    bondIdsMap?: Map<number, number>,
+  ) {
+    const struct = _struct.clone(
+      undefined,
+      undefined,
+      undefined,
+      atomIdsMap,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      bondIdsMap,
+    );
 
     struct.atoms.forEach((_atom, atomId) => {
       if (Atom.isHiddenLeavingGroupAtom(struct, atomId, false, true)) {
@@ -1134,11 +1149,32 @@ export class KetSerializer implements Serializer<Struct> {
     isBeautified = true, // TODO make false by default
     needSetSelectionToMacromolecules = false,
   ) {
-    const struct = KetSerializer.removeLeavingGroupsFromConnectedAtoms(_struct);
+    const atomIdsMap = new Map<number, number>();
+    const bondIdsMap = new Map<number, number>();
+    const struct = KetSerializer.removeLeavingGroupsFromConnectedAtoms(
+      _struct,
+      atomIdsMap,
+      bondIdsMap,
+    );
+    const remappedSelection = selection
+      ? {
+          ...selection,
+          ...(selection.atoms && {
+            atoms: selection.atoms
+              .map((atomId) => atomIdsMap.get(atomId))
+              .filter(isNumber),
+          }),
+          ...(selection.bonds && {
+            bonds: selection.bonds
+              .map((bondId) => bondIdsMap.get(bondId))
+              .filter(isNumber),
+          }),
+        }
+      : undefined;
     struct.enableInitiallySelected();
     const populatedStruct = populateStructWithSelection(
       struct,
-      selection,
+      remappedSelection,
       true,
     );
     MacromoleculesConverter.convertStructToDrawingEntities(


### PR DESCRIPTION
 Summary:

This PR fixes a bug where saving a selected structure in KET format could omit  for atoms and bonds.

Problem:

During KET serialization, the source  is cloned and cleaned up before export. The incoming selection still referenced atom/bond IDs from the original struct, while serialization continued with the cloned struct.

Root cause:

After cloning, atom and bond IDs no longer matched the IDs stored in , so  could not mark the intended entities as selected.

 Fix

- capture atom and bond ID mappings while cloning the struct in 
- remap  and  to the cloned struct IDs
- apply the remapped selection before KET serialization

 Result

KET export now correctly includes  for selected atoms and bonds.




## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request