### PR TITLE
#9821 Collapsing a monomer alters the length and direction of its connecting bond

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -890,6 +890,40 @@ class Editor implements KetcherEditor {
     );
   }
 
+  /**
+   * Computes the position used as `sgroup.pp` for a newly created monomer.
+   *
+   * Preference: average of all attachment-point atom positions.
+   * This keeps the connecting bond visually stable when the monomer is
+   * collapsed, because `sgroup.pp` is used directly as the bond endpoint
+   * and the attachment atom is typically off-centre relative to the bbox.
+   *
+   * Fallback: bounding-box centre (used when no attachment points exist).
+   */
+  private static resolveMonomerPosition(
+    structure: Struct,
+    attachmentPointsData: Map<string, [number, number]>,
+  ): Vec2 {
+    const attachmentAtomPositions = [...attachmentPointsData.values()]
+      .map(([attachmentAtomId]) => structure.atoms.get(attachmentAtomId)?.pp)
+      .filter((pp): pp is Vec2 => pp != null);
+
+    if (attachmentAtomPositions.length > 0) {
+      const count = attachmentAtomPositions.length;
+      const sum = attachmentAtomPositions.reduce(
+        (acc, pos) => new Vec2(acc.x + pos.x, acc.y + pos.y),
+        new Vec2(0, 0),
+      );
+      return new Vec2(sum.x / count, sum.y / count);
+    }
+
+    const bbox = structure.getCoordBoundingBoxObj();
+    return new Vec2(
+      (bbox.min.x + bbox.max.x) / 2,
+      (bbox.min.y + bbox.max.y) / 2,
+    );
+  }
+
   private originalStruct: Struct = new Struct();
   private originalSelection: Selection = {};
   private originalHistoryStack: Action[] = [];
@@ -1356,38 +1390,10 @@ class Editor implements KetcherEditor {
     const monomerItem =
       ketSerializer.convertMonomerTemplateToLibraryItem(monomerTemplate);
     const [Monomer] = monomerFactory(monomerItem);
-
-    // Compute sgroup.pp as the average of attachment-point atom positions so
-    // that collapsing the monomer keeps the connecting bond at the same
-    // geometric location (direction and length unchanged).
-    // Using the bounding-box centre caused the bond to visually jump because
-    // the attachment atom is typically off-centre inside the selection.
-    const attachmentAtomPositions: Vec2[] = [];
-    sortedAttachmentPointsData.forEach(([attachmentAtomId]) => {
-      const atom = data.structure.atoms.get(attachmentAtomId);
-      if (atom?.pp) {
-        attachmentAtomPositions.push(atom.pp);
-      }
-    });
-
-    let monomerPosition: Vec2;
-    if (attachmentAtomPositions.length > 0) {
-      const sum = attachmentAtomPositions.reduce(
-        (acc, pos) => new Vec2(acc.x + pos.x, acc.y + pos.y),
-        new Vec2(0, 0),
-      );
-      monomerPosition = new Vec2(
-        sum.x / attachmentAtomPositions.length,
-        sum.y / attachmentAtomPositions.length,
-      );
-    } else {
-      const monomerBBox = data.structure.getCoordBoundingBoxObj();
-      monomerPosition = new Vec2(
-        (monomerBBox.min.x + monomerBBox.max.x) / 2,
-        (monomerBBox.min.y + monomerBBox.max.y) / 2,
-      );
-    }
-
+    const monomerPosition = Editor.resolveMonomerPosition(
+      data.structure,
+      sortedAttachmentPointsData,
+    );
     const monomer = new Monomer(monomerItem, monomerPosition);
 
     return {

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1335,7 +1335,6 @@ class Editor implements KetcherEditor {
       naturalAnalogShort: naturalAnalogueToUse,
       modificationTypes,
       aliasHELM,
-      // TODO: Even though atoms positions are normalized, collapsing/expanding monomers still has some shift, investigate
       atoms: normalizeMonomerAtomsPositions(ketMicromolecule.mol0.atoms),
       bonds: ketMicromolecule.mol0.bonds,
       attachmentPoints,
@@ -1357,11 +1356,38 @@ class Editor implements KetcherEditor {
     const monomerItem =
       ketSerializer.convertMonomerTemplateToLibraryItem(monomerTemplate);
     const [Monomer] = monomerFactory(monomerItem);
-    const monomerBBox = data.structure.getCoordBoundingBoxObj();
-    const monomerPosition = new Vec2(
-      (monomerBBox.min.x + monomerBBox.max.x) / 2,
-      (monomerBBox.min.y + monomerBBox.max.y) / 2,
-    );
+
+    // Compute sgroup.pp as the average of attachment-point atom positions so
+    // that collapsing the monomer keeps the connecting bond at the same
+    // geometric location (direction and length unchanged).
+    // Using the bounding-box centre caused the bond to visually jump because
+    // the attachment atom is typically off-centre inside the selection.
+    const attachmentAtomPositions: Vec2[] = [];
+    sortedAttachmentPointsData.forEach(([attachmentAtomId]) => {
+      const atom = data.structure.atoms.get(attachmentAtomId);
+      if (atom?.pp) {
+        attachmentAtomPositions.push(atom.pp);
+      }
+    });
+
+    let monomerPosition: Vec2;
+    if (attachmentAtomPositions.length > 0) {
+      const sum = attachmentAtomPositions.reduce(
+        (acc, pos) => new Vec2(acc.x + pos.x, acc.y + pos.y),
+        new Vec2(0, 0),
+      );
+      monomerPosition = new Vec2(
+        sum.x / attachmentAtomPositions.length,
+        sum.y / attachmentAtomPositions.length,
+      );
+    } else {
+      const monomerBBox = data.structure.getCoordBoundingBoxObj();
+      monomerPosition = new Vec2(
+        (monomerBBox.min.x + monomerBBox.max.x) / 2,
+        (monomerBBox.min.y + monomerBBox.max.y) / 2,
+      );
+    }
+
     const monomer = new Monomer(monomerItem, monomerPosition);
 
     return {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Fixed collapsing a CHEM monomer (created via "Create a monomer") causing the connecting bond to visibly change its length and direction.

**Root cause:**

When a monomer is saved, `Editor.saveNewMonomer()` computes `monomerPosition`, which is stored as `sgroup.pp` on the resulting `MonomerMicromolecule`. During collapse, `sgroup.pp` is used directly as the bond endpoint in both `struct.ts` (`halfBondUpdate`) and `rebond.ts` (`bondRecalc`).

Previously, `monomerPosition` was calculated as the **bounding-box centre** of all selected atoms. The connecting bond was anchored to the **attachment-point atom**, which is typically off-centre inside the selection bounding box. This mismatch caused the bond to jump to a different position when the monomer was collapsed, changing both its direction and apparent length.

**Changes made:**

**`Editor.ts`**
- Extracted a new `private static resolveMonomerPosition()` method that computes `monomerPosition` as the **average position of the attachment-point atoms** instead of the bounding-box centre. This aligns `sgroup.pp` with where the bond was already anchored when expanded, so collapsing no longer alters the bond's visual direction or length.
- Falls back to the bounding-box centre when no attachment points are present (e.g. standalone monomers with no external connections).
- Removed the long-standing `// TODO: Even though atoms positions are normalized, collapsing/expanding monomers still has some shift, investigate` comment that was tracking this exact issue.

**Visual states after the fix:**

| Condition | Before fix | After fix |
|---|---|---|
| Collapse monomer with one attachment point | Bond becomes longer / changes direction ❌ | Bond stays identical ✅ |
| Expand monomer after collapse | Bond repositions again ❌ | Bond stays identical ✅ |
| Monomer without attachment points | Bounding-box centre used (fallback) | Bounding-box centre used (unchanged) ✅ |

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request