### PR TITLE
#9921 - Refactor: Ends of strings should be checked with "startsWith()" and "endsWith()"

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/v3000.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/v3000.ts
@@ -40,10 +40,10 @@ function parseAtomLineV3000(line: string): Atom {
     aam: split[5].trim(),
   };
   let label = split[1].trim();
-  if (label.charAt(0) === '"' && label.charAt(label.length - 1) === '"') {
+  if (label.startsWith('"') && label.endsWith('"')) {
     label = label.slice(1, -1);
   } // strip qutation marks
-  if (label.charAt(label.length - 1) === ']') {
+  if (label.endsWith(']')) {
     // assume atom list
     label = label.slice(0, -1); // remove ']'
     const atomListParams: Record<string, unknown> = {};
@@ -53,7 +53,7 @@ function parseAtomLineV3000(line: string): Atom {
       atomListParams.notList = true;
       const [matchedSubstr] = matchNotListInfo;
       label = label.slice(matchedSubstr.length); // remove 'NOT [' or 'NOT['
-    } else if (label.charAt(0) !== '[') {
+    } else if (!label.startsWith('[')) {
       throw new Error("Error: atom list expected, found '" + label + "'");
     } else {
       label = label.slice(1); // remove '['
@@ -155,7 +155,7 @@ function v3000parseSGroup(
   while (shift < ctabLines.length) {
     line = stripV30(ctabLines[shift++]).trim();
     if (line.trim() === 'END SGROUP') return shift;
-    while (line.charAt(line.length - 1) === '-') {
+    while (line.endsWith('-')) {
       line = (line.slice(0, -1) + stripV30(ctabLines[shift++])).trim();
     }
     const split = splitSGroupDef(line);
@@ -231,7 +231,7 @@ function parseCTabV3000(
   if (ctabLines[shift++].trim() !== 'M  V30 BEGIN CTAB') {
     throw Error('CTAB V3000 invalid');
   }
-  if (ctabLines[shift].slice(0, 13) !== 'M  V30 COUNTS') {
+  if (!ctabLines[shift].startsWith('M  V30 COUNTS')) {
     throw Error('CTAB V3000 invalid');
   }
   const vals = ctabLines[shift].slice(14).split(' ');
@@ -495,7 +495,7 @@ function spacebarsplit(line: string): string[] {
 
 // utils
 function stripQuotes(str: string): string {
-  if (str[0] === '"' && str[str.length - 1] === '"') {
+  if (str.startsWith('"') && str.endsWith('"')) {
     return str.slice(1, -1);
   }
   return str;
@@ -561,7 +561,7 @@ function parseBracedNumberList(line: string, shift?: number): number[] | null {
 
 function stripV30(line: string): string {
   /* reader */
-  if (line.slice(0, 7) !== 'M  V30 ') throw new Error('Prefix invalid');
+  if (!line.startsWith('M  V30 ')) throw new Error('Prefix invalid');
   return line.slice(7);
 }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
## Summary
  Sonar flagged seven sites in `v3000.ts` that test string ends with `charAt`/`slice`/index expressions instead of the dedicated `String#startsWith` / `String#endsWith` methods. Replaced each at the exact lines flagged. Pure mechanical refactor — no logic change.

  ## Changes
  `packages/ketcher-core/src/domain/serializers/mol/v3000.ts`:

  - L43: `label.charAt(0) === '"' && label.charAt(label.length - 1) === '"'` → `label.startsWith('"') && label.endsWith('"')`
  - L46: `label.charAt(label.length - 1) === ']'` → `label.endsWith(']')`
  - L56: `label.charAt(0) !== '['` → `!label.startsWith('[')`
  - L158: `line.charAt(line.length - 1) === '-'` → `line.endsWith('-')`
  - L234: `ctabLines[shift].slice(0, 13) !== 'M  V30 COUNTS'` → `!ctabLines[shift].startsWith('M  V30 COUNTS')`
  - L498: `str[0] === '"' && str[str.length - 1] === '"'` → `str.startsWith('"') && str.endsWith('"')`
  - L564: `line.slice(0, 7) !== 'M  V30 '` → `!line.startsWith('M  V30 ')`

  ## Behavioral equivalence

  Each conversion was audited against the relevant edge cases (empty string, single-character input matching the test char,
  length-mismatched short input, exact match, longer matching prefix/suffix). For every case both forms produce the same boolean — including the empty-string case where `charAt(-1)` returns `''` and `endsWith` on an empty string returns `false`.

  ## Out of scope (deliberate)

  Three other identical `charAt(line.length - 1) === '-'` occurrences at lines 247 and 260 of the same file were **not** converted because Sonar flagged only line 158 and the task description explicitly limits the change to the listed sites.

## Sonar pre-existing findings (not addressed)

  Sonar reports three Cognitive Complexity warnings inside the file this PR touches. They are **pre-existing** on master and are not introduced or worsened by this PR — Sonar simply re-analyzes any function in a changed file and attributes findings to the touching PR. Each of my edits is an expression-level swap (`charAt(...) === c` → `endsWith(c)`); none add branches, loops, or boolean operators, so the cognitive complexity score is identical before and after.

  - L30 — `parseAtomLineV3000` (Cognitive Complexity 27, allowed 15)
  - L144 — `v3000parseSGroup` (Cognitive Complexity 40, allowed 15)
  - L222 — `parseCTabV3000` (Cognitive Complexity 43, allowed 15)

  Each function would need a dedicated decomposition refactor (extract helpers for atom-list parsing, SGroup line-continuation reader, CTab section dispatcher, etc.), which is out of scope for a `startsWith`/`endsWith` cleanup. Tracking suggested under tech-debt umbrella issue #9518 or as separate issues.

  ## Test plan
  - [x] `prettier --check` clean on the changed file
  - [x] `eslint --quiet` clean on the changed file
  - [x] `tsc --noEmit` clean (only pre-existing `jsonschema` errors on master)
  - [x] All 73 `domain/serializers/mol` + `__tests__/domain/serializers` unit tests pass
  - [x] No snapshot files reference these lines, no snapshot updates required

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request