### PR TITLE
#9923 - Refactor: Mark the props of the component as read-only

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -300,7 +300,7 @@ function Label({
   error: _error,
   children,
   ...props
-}: LabelProps) {
+}: Readonly<LabelProps>) {
   return (
     <label {...props}>
       {labelPos !== 'after' && renderLabelContent(title ?? '', tooltip ?? null)}
@@ -322,7 +322,7 @@ function usePopoverAnchor() {
   return { anchorEl, handleOpen, handleClose };
 }
 
-function Field(props: FieldProps) {
+function Field(props: Readonly<FieldProps>) {
   const {
     name,
     extraName,
@@ -404,7 +404,7 @@ function Field(props: FieldProps) {
   );
 }
 
-function FieldWithModal(props: FieldWithModalProps) {
+function FieldWithModal(props: Readonly<FieldWithModalProps>) {
   const { name, onChange, labelPos, className, onEdit, ...rest } = props;
   // Separate Label/wrapper-only props from Input-compatible props
   const {
@@ -470,7 +470,7 @@ function FieldWithModal(props: FieldWithModalProps) {
   );
 }
 
-function CustomQueryField(props: CustomQueryFieldProps) {
+function CustomQueryField(props: Readonly<CustomQueryFieldProps>) {
   const {
     name,
     onChange,


### PR DESCRIPTION
## Summary
Marks React functional component props as `Readonly` in `form.tsx` to enforce immutability and prevent unintended prop mutation.

## Changes
* Wrapped `LabelProps` with `Readonly<LabelProps>` in `Label` component
* Wrapped `FieldProps` with `Readonly<FieldProps>` in `Field` component
* Wrapped `FieldWithModalProps` with `Readonly<FieldWithModalProps>` in `FieldWithModal` component
* Wrapped `CustomQueryFieldProps` with `Readonly<CustomQueryFieldProps>` in `CustomQueryField` component

## Files Modified
packages/ketcher-react/src/script/ui/component/form/form/form.tsx


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request