### PR TITLE
#9925 - Refactor: Unused React typed props should be removed

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
@@ -135,7 +135,6 @@ interface SaveDialogProps {
   formState: FormState;
   moleculeErrors?: Record<string, string>;
   checkState: CheckState;
-  bondThickness?: number;
   ignoreChiralFlag: boolean;
   editor: Editor;
   onCheck: (checkOptions: unknown) => void;
@@ -733,7 +732,6 @@ const mapStateToProps = (state: AppState) => ({
   formState: state.modal.form,
   moleculeErrors: state.modal.form.moleculeErrors,
   checkState: state.options.check,
-  bondThickness: state.options.settings.bondThickness,
   ignoreChiralFlag: state.editor.render.options.ignoreChiralFlag,
   editor: state.editor,
 });


### PR DESCRIPTION
## Summary
Removed unused `bondThickness` prop from `SaveDialog`. The other props flagged by SonarQube (`onCancel` in both files) are passed to the `Dialog` component via `params={props}` and are required by `DialogParams` - removing them causes TypeScript errors, so they are intentionally kept.

## Changes
* Removed `bondThickness?: number` from `SaveDialogProps` interface
* Removed `bondThickness: state.options.settings.bondThickness` from `mapStateToProps`

## Files Modified
packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request