### PR TITLE
#9919 - Refactor: Public "static" fields should be read-only

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
+++ b/packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
@@ -21,7 +21,7 @@ import { SGroup, Vec2 } from 'domain/entities';
 
 class AlignDescriptors extends BaseOperation {
   readonly history: Record<number, Vec2 | null>;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     history: Record<number, Vec2 | null>,
   ) => BaseOperation;
 

--- a/packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
@@ -23,7 +23,7 @@ import { OperationType } from './OperationType';
 class FragmentAdd extends BaseOperation {
   frid: number | null;
   readonly properties?: Array<StructProperty>;
-  static InverseConstructor: new (fragmentId: number) => BaseOperation;
+  static readonly InverseConstructor: new (fragmentId: number) => BaseOperation;
 
   constructor(fragmentId?: number | null, properties?: Array<StructProperty>) {
     super(OperationType.FRAGMENT_ADD);

--- a/packages/ketcher-core/src/application/editor/operations/FragmentAddStereoAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentAddStereoAtom.ts
@@ -20,7 +20,7 @@ import { ReStruct } from '../../render';
 
 class FragmentAddStereoAtom extends BaseOperation {
   readonly data: { frid: number; aid: number };
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     fragmentId: number,
     atomId: number,
   ) => BaseOperation;

--- a/packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
@@ -22,7 +22,7 @@ import { OperationType } from './OperationType';
 
 class FragmentDelete extends BaseOperation {
   readonly frid: number;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     fragmentId?: number | null,
     properties?: Array<StructProperty>,
   ) => BaseOperation;

--- a/packages/ketcher-core/src/application/editor/operations/FragmentDeleteStereoAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentDeleteStereoAtom.ts
@@ -20,7 +20,7 @@ import { ReStruct } from '../../render';
 
 class FragmentDeleteStereoAtom extends BaseOperation {
   readonly data: { frid: number; aid: number };
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     fragmentId: number,
     atomId: number,
   ) => BaseOperation;

--- a/packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
@@ -22,7 +22,7 @@ class RestoreIfThen extends BaseOperation {
   readonly rgid_new: number;
   readonly rgid_old: number;
   readonly ifThenHistory: Map<number, number>;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     rgNew: number,
     rgOld: number,
     skipRgids?: Array<number>,

--- a/packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
@@ -23,7 +23,7 @@ class UpdateIfThen extends BaseOperation {
   readonly rgid_old: number;
   readonly ifThenHistory: Map<number, number>;
   readonly skipRgids: Array<number>;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     rgNew: number,
     rgOld: number,
     history: Map<number, number>,

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
@@ -28,7 +28,7 @@ type Data = {
 
 class AtomAdd extends BaseOperation {
   data: Data;
-  static InverseConstructor: new () => BaseOperation;
+  static readonly InverseConstructor: new () => BaseOperation;
 
   constructor(atom?: Partial<AtomAttributes>, pos?: Point) {
     super(OperationType.ATOM_ADD);

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
@@ -28,7 +28,7 @@ type Data = {
 
 class AtomDelete extends BaseOperation {
   data: Data;
-  static InverseConstructor: new () => BaseOperation;
+  static readonly InverseConstructor: new () => BaseOperation;
 
   constructor(atomId?: number) {
     super(OperationType.ATOM_DELETE, OperationPriority.ATOM_DELETE);

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
@@ -30,7 +30,7 @@ type Data = {
 
 class BondAdd extends BaseOperation {
   data: Data;
-  static InverseConstructor: new (bondId?: number) => BaseOperation;
+  static readonly InverseConstructor: new (bondId?: number) => BaseOperation;
 
   constructor(
     begin?: number,

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts
@@ -30,7 +30,7 @@ type Data = {
 
 class BondDelete extends BaseOperation {
   data: Data;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     begin?: number,
     end?: number,
     bond?: Partial<BondAttributes>,


### PR DESCRIPTION
## Summary
Added `readonly` qualifier to all public `static` fields flagged by SonarQube. Since these fields are only used with `new` (e.g. `new FragmentAdd.InverseConstructor(...)`) and never reassigned, adding `readonly` has no functional impact and only improves code safety.

## Changes
* Added `readonly` to `static InverseConstructor` in `AlignDescriptors`
* Added `readonly` to `static InverseConstructor` in `FragmentAdd`
* Added `readonly` to `static InverseConstructor` in `FragmentDelete`
* Added `readonly` to `static InverseConstructor` in `FragmentAddStereoAtom`
* Added `readonly` to `static InverseConstructor` in `FragmentDeleteStereoAtom`
* Added `readonly` to `static InverseConstructor` in `RestoreIfThen`
* Added `readonly` to `static InverseConstructor` in `UpdateIfThen`
* Added `readonly` to `static InverseConstructor` in `AtomAdd`
* Added `readonly` to `static InverseConstructor` in `AtomDelete`
* Added `readonly` to `static InverseConstructor` in `BondAdd`
* Added `readonly` to `static InverseConstructor` in `BondDelete`

## Files Modified
packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
packages/ketcher-core/src/application/editor/operations/FragmentAddStereoAtom.ts
packages/ketcher-core/src/application/editor/operations/FragmentDeleteStereoAtom.ts
packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request