### PR TITLE
#9135 Fragment Selction Hover outline should not include the connecting bond

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
+++ b/packages/ketcher-react/src/script/editor/tool/fragmentSelection.ts
@@ -1,6 +1,7 @@
 import {
   Action,
   CoordinateTransformation,
+  SGroup,
   Struct,
   Vec2,
   Visel,
@@ -417,6 +418,23 @@ export default class FragmentSelectionTool implements Tool {
       component.atoms?.forEach((atomId) => componentAtoms.add(atomId));
       component.bonds?.forEach((bondId) => componentBonds.add(bondId));
     });
+
+    if (!rnaComponentAtoms) {
+      struct.sgroups.forEach((sgroup) => {
+        if (SGroup.isSuperAtom(sgroup)) {
+          const sgroupAtomSet = new Set<number>(
+            SGroup.getAtoms(struct, sgroup),
+          );
+          for (const [bondId, bond] of struct.bonds.entries()) {
+            const beginInside = sgroupAtomSet.has(bond.begin);
+            const endInside = sgroupAtomSet.has(bond.end);
+            if (beginInside !== endInside) {
+              connectingBonds.add(bondId);
+            }
+          }
+        }
+      });
+    }
 
     if (componentAtoms.size) {
       for (const [bondId, bond] of struct.bonds.entries()) {


### PR DESCRIPTION
…ecting bond

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request