### PR TITLE
#9924 - Refactor: Ambiguous spacing after previous element span

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/PresetPhosphateFilterPopup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/PresetPhosphateFilterPopup.tsx
@@ -111,8 +111,7 @@ export const PresetPhosphateFilterPopup: React.FC<Props> = ({ onClose }) => {
           onChange={toggle('fivePrime')}
           data-testid="preset-filter-5-phosphate"
         />
-        <span />
-        5&apos;-phosphate
+        <span /> 5&apos;-phosphate
       </FilterPopupOption>
       <FilterPopupOption>
         <StyledCheckboxInput
@@ -121,8 +120,7 @@ export const PresetPhosphateFilterPopup: React.FC<Props> = ({ onClose }) => {
           onChange={toggle('threePrime')}
           data-testid="preset-filter-3-phosphate"
         />
-        <span />
-        3&apos;-phosphate
+        <span /> 3&apos;-phosphate
       </FilterPopupOption>
       <FilterPopupOption>
         <StyledCheckboxInput
@@ -131,8 +129,7 @@ export const PresetPhosphateFilterPopup: React.FC<Props> = ({ onClose }) => {
           onChange={toggle('noPhosphate')}
           data-testid="preset-filter-no-phosphate"
         />
-        <span />
-        No phosphate group
+        <span /> No phosphate group
       </FilterPopupOption>
       <FilterPopupSeparator />
       <FilterPopupActions>


### PR DESCRIPTION
## What's changed
Fix ambiguous spacing between inline JSX elements in `PresetPhosphateFilterPopup` component.

## Problem
In JSX, newline characters between inline elements are removed entirely (unlike HTML which collapses them into a single space). This caused ambiguous spacing after `<span />` elements on lines 114, 124, and 134.

## Solution
Added explicit `{' '}` space expressions after each `<span />` element to make the intended spacing clear and consistent.

## Changes
- `PresetPhosphateFilterPopup.tsx` — added `{' '}` after `<span />` on lines 114, 124, 134


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request