### PR TITLE
#8243: It should be possible to set few same named attachment points while creation monomer

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignAttachmentAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignAttachmentAtomOperation.ts
@@ -8,8 +8,10 @@ import { getNextFreeAttachmentPoint } from 'domain/helpers';
 
 export class AssignAttachmentAtomOperation extends BaseOperation {
   private attachmentPointName: AttachmentPointName | null = null;
-  private assignedAttachmentPoints: Map<AttachmentPointName, [number, number]> =
-    new Map();
+  private assignedAttachmentPoints: Map<
+    number,
+    { name: AttachmentPointName; leavingAtomId: number }
+  > = new Map();
 
   constructor(
     private readonly monomerCreationState: MonomerCreationState,
@@ -17,8 +19,8 @@ export class AssignAttachmentAtomOperation extends BaseOperation {
     private readonly leavingAtomId: number,
     private readonly _attachmentPointName?: AttachmentPointName,
     private readonly _assignedAttachmentPoints?: Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >,
   ) {
     super(OperationType.MONOMER_CREATION_ASSIGN_AA);
@@ -35,13 +37,13 @@ export class AssignAttachmentAtomOperation extends BaseOperation {
     this.attachmentPointName =
       this._attachmentPointName ??
       getNextFreeAttachmentPoint(
-        Array.from(this.assignedAttachmentPoints.keys()),
+        Array.from(this.assignedAttachmentPoints.values()).map((ap) => ap.name),
       );
 
-    this.assignedAttachmentPoints.set(this.attachmentPointName, [
-      this.attachmentAtomId,
-      this.leavingAtomId,
-    ]);
+    this.assignedAttachmentPoints.set(this.attachmentAtomId, {
+      name: this.attachmentPointName,
+      leavingAtomId: this.leavingAtomId,
+    });
     potentialAttachmentPoints.delete(this.attachmentAtomId);
 
     BaseOperation.invalidateAtom(restruct, this.attachmentAtomId);

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
@@ -39,11 +39,14 @@ export class AssignLeavingGroupAtomOperation extends BaseOperation {
     const [attachmentAtomId, leavingAtomId] = atomPairForLeavingGroup;
 
     const attachmentPointName = getNextFreeAttachmentPoint(
-      Array.from(assignedAttachmentPoints.keys()),
+      Array.from(assignedAttachmentPoints.values()).map((ap) => ap.name),
     );
     this.attachmentPointName = attachmentPointName;
 
-    assignedAttachmentPoints.set(attachmentPointName, atomPairForLeavingGroup);
+    assignedAttachmentPoints.set(atomPairForLeavingGroup[0], {
+      name: attachmentPointName,
+      leavingAtomId: atomPairForLeavingGroup[1],
+    });
 
     const potentialAttachmentAtoms =
       potentialAttachmentPoints.get(attachmentAtomId);

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
@@ -40,27 +40,23 @@ export class ReassignAttachmentPointOperation extends BaseOperation {
 
     problematicAttachmentPoints.delete(this.currentName);
 
-    const atomPair = assignedAttachmentPoints.get(this.currentName);
-    assert(atomPair);
+    // Find the entry currently named currentName
+    const entry = Array.from(assignedAttachmentPoints.entries()).find(
+      ([, { name }]) => name === this.currentName,
+    );
+    assert(entry, `Attachment point "${this.currentName}" not found`);
 
-    if (assignedAttachmentPoints.has(this.newName)) {
-      const existingAtomPair = assignedAttachmentPoints.get(this.newName);
-      assert(existingAtomPair);
+    const [attachmentAtomId, { leavingAtomId }] = entry;
 
-      assignedAttachmentPoints.set(this.newName, atomPair);
-      assignedAttachmentPoints.set(this.currentName, existingAtomPair);
+    // Simply rename — duplicate names are allowed transiently and will be
+    // caught by the uniqueness validation before the monomer can be saved.
+    assignedAttachmentPoints.set(attachmentAtomId, {
+      name: this.newName,
+      leavingAtomId,
+    });
 
-      BaseOperation.invalidateAtom(restruct, atomPair[0]);
-      BaseOperation.invalidateAtom(restruct, atomPair[1]);
-      BaseOperation.invalidateAtom(restruct, existingAtomPair[0]);
-      BaseOperation.invalidateAtom(restruct, existingAtomPair[1]);
-    } else {
-      assignedAttachmentPoints.set(this.newName, atomPair);
-      assignedAttachmentPoints.delete(this.currentName);
-
-      BaseOperation.invalidateAtom(restruct, atomPair[0]);
-      BaseOperation.invalidateAtom(restruct, atomPair[1]);
-    }
+    BaseOperation.invalidateAtom(restruct, attachmentAtomId);
+    BaseOperation.invalidateAtom(restruct, leavingAtomId);
   }
 
   invert() {

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
@@ -18,14 +18,9 @@ export class ReassignLeavingAtomOperation extends BaseOperation {
   execute(restruct: ReStruct) {
     assert(this.monomerCreationState);
 
-    const newAtomPair: [number, number] = [
-      this.attachmentAtomId,
-      this.newLeavingAtomId,
-    ];
-
     this.monomerCreationState.assignedAttachmentPoints.set(
-      this.attachmentPointName,
-      newAtomPair,
+      this.attachmentAtomId,
+      { name: this.attachmentPointName, leavingAtomId: this.newLeavingAtomId },
     );
 
     this.monomerCreationState = { ...(this.monomerCreationState || {}) };

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/RemoveAttachmentPointOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/RemoveAttachmentPointOperation.ts
@@ -9,10 +9,11 @@ import { AttachmentPointName } from 'domain/types';
 import Restruct from 'application/render/restruct/restruct';
 
 export class RemoveAttachmentPointOperation extends BaseOperation {
-  private readonly atomPair: [number, number];
+  private readonly attachmentAtomId: number;
+  private readonly leavingAtomId: number;
   private readonly assignedAttachmentPoints: Map<
-    AttachmentPointName,
-    [number, number]
+    number,
+    { name: AttachmentPointName; leavingAtomId: number }
   > = new Map();
 
   constructor(
@@ -20,8 +21,8 @@ export class RemoveAttachmentPointOperation extends BaseOperation {
     private readonly attachmentPointName: AttachmentPointName,
     private readonly potentialLeavingAtoms?: Set<number>,
     private _assignedAttachmentPoints?: Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >,
   ) {
     super(OperationType.MONOMER_CREATION_REMOVE_AP);
@@ -31,13 +32,15 @@ export class RemoveAttachmentPointOperation extends BaseOperation {
     this.assignedAttachmentPoints =
       this._assignedAttachmentPoints ||
       this.monomerCreationState.assignedAttachmentPoints;
-    const atomPair = this.assignedAttachmentPoints.get(
-      this.attachmentPointName,
+
+    const entry = Array.from(this.assignedAttachmentPoints.entries()).find(
+      ([, { name }]) => name === this.attachmentPointName,
     );
+    assert(entry, `Attachment point "${this.attachmentPointName}" not found`);
 
-    assert(atomPair);
-
-    this.atomPair = atomPair;
+    const [attachmentAtomId, { leavingAtomId }] = entry;
+    this.attachmentAtomId = attachmentAtomId;
+    this.leavingAtomId = leavingAtomId;
   }
 
   execute(restruct: Restruct) {
@@ -45,25 +48,22 @@ export class RemoveAttachmentPointOperation extends BaseOperation {
 
     const { potentialAttachmentPoints } = this.monomerCreationState;
 
-    const [attachmentAtomId, leavingAtomId] = this.atomPair;
-    this.assignedAttachmentPoints.delete(this.attachmentPointName);
+    this.assignedAttachmentPoints.delete(this.attachmentAtomId);
 
     if (this.potentialLeavingAtoms)
       potentialAttachmentPoints.set(
-        attachmentAtomId,
+        this.attachmentAtomId,
         this.potentialLeavingAtoms,
       );
 
-    BaseOperation.invalidateAtom(restruct, attachmentAtomId);
-    BaseOperation.invalidateAtom(restruct, leavingAtomId);
+    BaseOperation.invalidateAtom(restruct, this.attachmentAtomId);
+    BaseOperation.invalidateAtom(restruct, this.leavingAtomId);
   }
 
   invert() {
-    const leavingAtomId = this.atomPair[1];
-
     return new AssignLeavingGroupAtomOperation(
       this.monomerCreationState,
-      leavingAtomId,
+      this.leavingAtomId,
     );
   }
 }

--- a/packages/ketcher-core/src/application/editor/shared/customEvents.ts
+++ b/packages/ketcher-core/src/application/editor/shared/customEvents.ts
@@ -8,6 +8,7 @@ export const MonomerCreationComponentStructureUpdateEvent =
   'MonomerCreationComponentStructureUpdate';
 
 export type AttachmentPointClickData = {
+  attachmentAtomId: number;
   attachmentPointName: AttachmentPointName;
   position: Vec2;
 };

--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -38,17 +38,31 @@ export type RnaComponentAtoms = Map<
   { atoms: number[]; bonds: number[] }
 >;
 
+/**
+ * Represents a single assigned attachment point.
+ * The map key is the attachment atom ID (unique), so duplicate names are allowed
+ * transiently during editing and detected at submission time.
+ */
+export type AssignedAttachmentPoint = {
+  name: AttachmentPointName;
+  leavingAtomId: number;
+};
+
+/** Maps attachment atom ID → AssignedAttachmentPoint */
+export type AssignedAttachmentPoints = Map<number, AssignedAttachmentPoint>;
+
 export type MonomerCreationState = {
-  // R-label mapping to [attachment atom id, leaving atom id]
-  assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>;
+  // Maps attachment atom ID to {name, leavingAtomId}. Duplicate names are
+  // allowed during editing and validated (blocked) at submission time.
+  assignedAttachmentPoints: AssignedAttachmentPoints;
   // Subset of assignedAttachmentPoints to show on canvas (used to restrict
   // display to the active RNA component tab). When undefined, all assigned
   // attachment points are displayed.
-  visibleAssignedAttachmentPoints?: Map<AttachmentPointName, [number, number]>;
+  visibleAssignedAttachmentPoints?: AssignedAttachmentPoints;
   // Attachment atom id to a set of connected leaving atom ids
   potentialAttachmentPoints: Map<number, Set<number>>;
   problematicAttachmentPoints: Set<AttachmentPointName>;
-  clickedAttachmentPoint?: AttachmentPointName | null;
+  clickedAttachmentPoint?: number | null;
   selectedMonomerClass?: KetMonomerClass | 'rnaPreset';
   hasDefaultAttachmentPoints?: boolean;
   // RNA preset component atoms and bonds

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -138,32 +138,25 @@ class ReAtom extends ReObject {
 
     const attachmentPointEntry = Array.from(
       assignedAttachmentPoints.entries(),
-    ).find(([, atomsPair]) => {
-      const [attachmentAtomId, leavingAtomId] = atomsPair;
+    ).find(([attachmentAtomId, { leavingAtomId }]) => {
       return attachmentAtomId === atomId || leavingAtomId === atomId;
     });
 
     if (attachmentPointEntry) {
-      const [attachmentPointName] = attachmentPointEntry;
+      const [attachmentAtomId] = attachmentPointEntry;
       hoverElement.hover(
         () => {
           window.dispatchEvent(
-            new CustomEvent<AttachmentPointName>(
-              'highlightAttachmentPointControls',
-              {
-                detail: attachmentPointName,
-              },
-            ),
+            new CustomEvent<number>('highlightAttachmentPointControls', {
+              detail: attachmentAtomId,
+            }),
           );
         },
         () => {
           window.dispatchEvent(
-            new CustomEvent<AttachmentPointName>(
-              'resetHighlightAttachmentPointControls',
-              {
-                detail: attachmentPointName,
-              },
-            ),
+            new CustomEvent<number>('resetHighlightAttachmentPointControls', {
+              detail: attachmentAtomId,
+            }),
           );
         },
       );
@@ -191,9 +184,8 @@ class ReAtom extends ReObject {
     );
 
     const isAtomInAssignedAttachmentPoint = Array.from(
-      assignedAttachmentPoints.values(),
-    ).some((atomsPair) => {
-      const [attachmentAtomId, leavingAtomId] = atomsPair;
+      assignedAttachmentPoints.entries(),
+    ).some(([attachmentAtomId, { leavingAtomId }]) => {
       return attachmentAtomId === atomId || leavingAtomId === atomId;
     });
 
@@ -715,17 +707,15 @@ class ReAtom extends ReObject {
 
       if (aid !== null) {
         const [attachmentAtoms, leavingGroups] = Array.from(
-          assignedAttachmentPoints.values(),
+          assignedAttachmentPoints.entries(),
         ).reduce(
-          (acc, currentPair) => {
+          (acc, [attachmentAtomId, { leavingAtomId }]) => {
             let attachmentAtomsIds = acc[0];
-            const attachmentAtomId = currentPair[0];
             if (!attachmentAtomsIds.includes(attachmentAtomId)) {
               attachmentAtomsIds = attachmentAtomsIds.concat(attachmentAtomId);
             }
 
             let leavingAtomsIds = acc[1];
-            const leavingAtomId = currentPair[1];
             if (!leavingAtomsIds.includes(leavingAtomId)) {
               leavingAtomsIds = leavingAtomsIds.concat(leavingAtomId);
             }
@@ -751,18 +741,15 @@ class ReAtom extends ReObject {
           restruct.addReObjectPath(LayerMap.atom, this.visel, path);
         }
 
-        const attachmentPointName = Array.from(
-          assignedAttachmentPoints.keys(),
-        ).find((key) => {
-          const atomsPair = assignedAttachmentPoints.get(key);
-          assert(atomsPair);
-          return atomsPair[1] === aid;
-        });
+        const attachmentPointEntry = Array.from(
+          assignedAttachmentPoints.entries(),
+        ).find(([, { leavingAtomId }]) => leavingAtomId === aid);
 
-        if (attachmentPointName) {
-          const atomsPair = assignedAttachmentPoints.get(attachmentPointName);
-          assert(atomsPair);
-          const [attachmentAtomId, leavingGroupAtomId] = atomsPair;
+        if (attachmentPointEntry) {
+          const [
+            attachmentAtomId,
+            { name: attachmentPointName, leavingAtomId: leavingGroupAtomId },
+          ] = attachmentPointEntry;
 
           const attachmentAtom = struct.atoms.get(attachmentAtomId);
           const leavingGroupAtom = struct.atoms.get(leavingGroupAtomId);
@@ -839,6 +826,10 @@ class ReAtom extends ReObject {
               attachmentPointName,
             );
             element.node?.setAttribute(
+              'data-attachment-point-atom-id',
+              String(attachmentAtomId),
+            );
+            element.node?.setAttribute(
               'data-testid',
               'monomer-attachment-point',
             );
@@ -852,7 +843,7 @@ class ReAtom extends ReObject {
 
               if (
                 render.monomerCreationState.clickedAttachmentPoint ===
-                  attachmentPointName ||
+                  attachmentAtomId ||
                 isProblematic
               ) {
                 return;
@@ -862,12 +853,9 @@ class ReAtom extends ReObject {
               rLabelElement.attr({ fill: '#ffffff' });
 
               window.dispatchEvent(
-                new CustomEvent<AttachmentPointName>(
-                  'highlightAttachmentPointControls',
-                  {
-                    detail: attachmentPointName,
-                  },
-                ),
+                new CustomEvent<number>('highlightAttachmentPointControls', {
+                  detail: attachmentAtomId,
+                }),
               );
             },
             // Mouse leave
@@ -876,7 +864,7 @@ class ReAtom extends ReObject {
 
               if (
                 render.monomerCreationState.clickedAttachmentPoint ===
-                  attachmentPointName ||
+                  attachmentAtomId ||
                 isProblematic
               ) {
                 return;
@@ -886,10 +874,10 @@ class ReAtom extends ReObject {
               rLabelElement.attr({ fill: '#333333' });
 
               window.dispatchEvent(
-                new CustomEvent<AttachmentPointName>(
+                new CustomEvent<number>(
                   'resetHighlightAttachmentPointControls',
                   {
-                    detail: attachmentPointName,
+                    detail: attachmentAtomId,
                   },
                 ),
               );
@@ -907,7 +895,7 @@ class ReAtom extends ReObject {
             assert(render.monomerCreationState);
 
             render.monomerCreationState.clickedAttachmentPoint =
-              attachmentPointName;
+              attachmentAtomId;
 
             background.attr({ opacity: 1 });
             rLabelElement.attr({ fill: '#ffffff' });

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -641,7 +641,9 @@ class Editor implements KetcherEditor {
    * Pass undefined to show all assigned attachment points (e.g. on Preset tab).
    */
   public setVisibleAssignedAttachmentPoints(
-    points: Map<AttachmentPointName, [number, number]> | undefined,
+    points:
+      | Map<number, { name: AttachmentPointName; leavingAtomId: number }>
+      | undefined,
   ) {
     const currentState = this.render.monomerCreationState;
     if (!currentState) return;
@@ -861,7 +863,7 @@ class Editor implements KetcherEditor {
 
       return Array.from(
         monomerCreationState.assignedAttachmentPoints.values(),
-      ).every((atomPair) => atomPair[1] !== atomId);
+      ).every((ap) => ap.leavingAtomId !== atomId);
     });
 
     if (nonLeavingAtoms.size < 2) {
@@ -982,8 +984,8 @@ class Editor implements KetcherEditor {
       });
 
     const assignedAttachmentPoints = new Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >();
 
     const sideTerminalSGroupAtoms = this.terminalRGroupAtoms.filter(
@@ -1035,9 +1037,9 @@ class Editor implements KetcherEditor {
         const isR1OrR2 =
           attachmentPointLabel === AttachmentPointName.R1 ||
           attachmentPointLabel === AttachmentPointName.R2;
-        const isAlreadyAssigned = assignedAttachmentPoints.has(
-          attachmentPointLabel as AttachmentPointName,
-        );
+        const isAlreadyAssigned = Array.from(
+          assignedAttachmentPoints.values(),
+        ).some((ap) => ap.name === attachmentPointLabel);
 
         if (
           (isR1OrR2 && !isAlreadyAssigned) ||
@@ -1051,8 +1053,8 @@ class Editor implements KetcherEditor {
           // For duplicate R1/R2 or other cases, assign to smallest available Rn (n>2)
           // or fall back to R1/R2 if no side attachment points are available
           const assignedAttachmentPointNames = Array.from(
-            assignedAttachmentPoints.keys(),
-          );
+            assignedAttachmentPoints.values(),
+          ).map((ap) => ap.name);
           // Skip R1/R2 when:
           // 1. Processing a duplicate R1/R2 label (requirement 2.6: prefer R3+)
           // 2. Processing other labels when we haven't assigned all expected side attachments yet
@@ -1076,10 +1078,10 @@ class Editor implements KetcherEditor {
 
         assert(selectedStructAttachmentAtomId !== undefined);
 
-        assignedAttachmentPoints.set(attachmentPointName, [
-          selectedStructAttachmentAtomId,
-          selectedStructLeavingAtomId,
-        ]);
+        assignedAttachmentPoints.set(selectedStructAttachmentAtomId, {
+          name: attachmentPointName,
+          leavingAtomId: selectedStructLeavingAtomId,
+        });
       },
     );
 
@@ -1140,17 +1142,17 @@ class Editor implements KetcherEditor {
       selectedStruct.bonds.add(newBond);
 
       const assignedAttachmentPointNames = Array.from(
-        assignedAttachmentPoints.keys(),
-      );
+        assignedAttachmentPoints.values(),
+      ).map((ap) => ap.name);
       const attachmentPointName = getNextFreeAttachmentPoint(
         assignedAttachmentPointNames,
         assignedAttachmentPointNames.length < sideAttachmentPointsNames.length,
       );
 
-      assignedAttachmentPoints.set(attachmentPointName, [
-        selectedStructAttachmentAtomId,
-        selectedStructLeavingAtomId,
-      ]);
+      assignedAttachmentPoints.set(selectedStructAttachmentAtomId, {
+        name: attachmentPointName,
+        leavingAtomId: selectedStructLeavingAtomId,
+      });
     });
 
     const potentialAttachmentPoints = new Map<number, Set<number>>();
@@ -1235,8 +1237,8 @@ class Editor implements KetcherEditor {
     atomId: number,
     attachmentPointName?: AttachmentPointName,
     assignedAttachmentPointsByMonomer?: Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >,
     monomerStructure?: Selection,
     forceAddNewLeavingGroupAtom = false,
@@ -1349,14 +1351,17 @@ class Editor implements KetcherEditor {
     } = data;
 
     const attachmentPoints: IKetAttachmentPoint[] = [];
-    const sortedAttachmentPointsData = new Map<string, [number, number]>(
-      [...data.attachmentPoints].sort(([leftName], [rightName]) =>
-        leftName.localeCompare(rightName),
+    const sortedAttachmentPointsData = new Map<
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
+    >(
+      [...data.attachmentPoints].sort(([, leftAp], [, rightAp]) =>
+        leftAp.name.localeCompare(rightAp.name),
       ),
     );
 
     sortedAttachmentPointsData.forEach(
-      ([attachmentAtomId, leavingAtomId], attachmentPointName) => {
+      ({ name: attachmentPointName, leavingAtomId }, attachmentAtomId) => {
         let attachmentPointType: 'left' | 'right' | 'side' = 'side';
         if (attachmentPointName === AttachmentPointName.R1) {
           attachmentPointType = 'left';
@@ -1753,11 +1758,12 @@ class Editor implements KetcherEditor {
   ) {
     assert(this.monomerCreationState);
 
-    const atomPair =
-      this.monomerCreationState.assignedAttachmentPoints.get(name);
-    assert(atomPair);
+    const entry = Array.from(
+      this.monomerCreationState.assignedAttachmentPoints.entries(),
+    ).find(([, ap]) => ap.name === name);
+    assert(entry);
 
-    const [attachmentAtomId, currentLeavingAtomId] = atomPair;
+    const [attachmentAtomId, { leavingAtomId: currentLeavingAtomId }] = entry;
 
     let leavingAtomIdToUse = newLeavingAtomId;
     let additionalAction: Action | null = null;
@@ -1791,15 +1797,19 @@ class Editor implements KetcherEditor {
   }
 
   reassignAttachmentPoint(
-    currentName: AttachmentPointName,
+    attachmentAtomId: number,
     newName: AttachmentPointName,
   ) {
     assert(this.monomerCreationState);
 
+    const entry =
+      this.monomerCreationState.assignedAttachmentPoints.get(attachmentAtomId);
+    assert(entry);
+
     const action = new Action([
       new ReassignAttachmentPointOperation(
         this.monomerCreationState,
-        currentName,
+        entry.name,
         newName,
       ),
     ]).perform(this.render.ctab);
@@ -1808,16 +1818,16 @@ class Editor implements KetcherEditor {
   }
 
   changeLeavingAtomLabel(
-    name: AttachmentPointName,
+    attachmentAtomId: number,
     newLeavingAtomLabel: AtomLabel,
   ) {
     assert(this.monomerCreationState);
 
-    const atomPair =
-      this.monomerCreationState.assignedAttachmentPoints.get(name);
-    assert(atomPair);
+    const apEntry =
+      this.monomerCreationState.assignedAttachmentPoints.get(attachmentAtomId);
+    assert(apEntry);
 
-    const [, leavingAtomId] = atomPair;
+    const { leavingAtomId } = apEntry;
     const leavingAtom = this.struct().atoms.get(leavingAtomId);
     assert(leavingAtom);
 
@@ -1837,14 +1847,13 @@ class Editor implements KetcherEditor {
     this.update(action);
   }
 
-  removeAttachmentPoint(name: AttachmentPointName) {
+  removeAttachmentPoint(attachmentAtomId: number) {
     assert(this.monomerCreationState);
 
-    const atomPair =
-      this.monomerCreationState.assignedAttachmentPoints.get(name);
-    assert(atomPair);
-
-    const [attachmentAtomId] = atomPair;
+    const removeEntry =
+      this.monomerCreationState.assignedAttachmentPoints.get(attachmentAtomId);
+    assert(removeEntry);
+    const { name } = removeEntry;
 
     const potentialLeavingAtoms = new Set(
       this.findPotentialLeavingAtoms(attachmentAtomId).map((atom) => {
@@ -1880,23 +1889,23 @@ class Editor implements KetcherEditor {
     this.render.update(true);
   }
 
-  highlightAttachmentPoint(name: AttachmentPointName | null) {
-    if (!name) {
+  highlightAttachmentPoint(attachmentAtomId: number | null) {
+    if (attachmentAtomId === null) {
       this.render.ctab.setSelection(null);
       return;
     }
 
     assert(this.monomerCreationState);
 
-    const atomPair =
-      this.monomerCreationState.assignedAttachmentPoints.get(name);
-    assert(atomPair);
+    const highlightEntry =
+      this.monomerCreationState.assignedAttachmentPoints.get(attachmentAtomId);
+    assert(highlightEntry);
 
+    const { leavingAtomId } = highlightEntry;
     let selection: Selection = {
-      atoms: [...atomPair],
+      atoms: [attachmentAtomId, leavingAtomId],
     };
 
-    const [attachmentAtomId, leavingAtomId] = atomPair;
     const bondId = this.struct().bonds.find((_, bond) => {
       return (
         (bond.begin === attachmentAtomId && bond.end === leavingAtomId) ||
@@ -2325,7 +2334,8 @@ class Editor implements KetcherEditor {
             const attachmentPointsToInvalidate = Array.from(
               this.monomerCreationState.assignedAttachmentPoints.entries(),
             ).filter(
-              ([, atomPair]) => ids.has(atomPair[0]) || ids.has(atomPair[1]),
+              ([attachmentAtomId, { leavingAtomId }]) =>
+                ids.has(attachmentAtomId) || ids.has(leavingAtomId),
             );
 
             if (!attachmentPointsToInvalidate) {
@@ -2333,12 +2343,14 @@ class Editor implements KetcherEditor {
             }
 
             attachmentPointsToInvalidate.forEach(
-              ([attachmentPointName, atomPair]) => {
-                const [attachmentAtomId, leavingAtomId] = atomPair;
+              ([
+                attachmentAtomId,
+                { name: attachmentPointName, leavingAtomId },
+              ]) => {
                 if (ids.has(attachmentAtomId)) {
                   // If attachment atom is deleted, remove the entire entry
                   this.monomerCreationState?.assignedAttachmentPoints.delete(
-                    attachmentPointName,
+                    attachmentAtomId,
                   );
                 } else if (ids.has(leavingAtomId)) {
                   // If leaving atom is deleted, try to find another suitable leaving atom
@@ -2347,7 +2359,7 @@ class Editor implements KetcherEditor {
                   if (potentialLeavingAtoms.length === 0) {
                     // If no suitable leaving atom is found, remove the entire entry
                     this.monomerCreationState?.assignedAttachmentPoints.delete(
-                      attachmentPointName,
+                      attachmentAtomId,
                     );
                   } else {
                     // If a suitable leaving atom is found, update the entry with the new leaving atom
@@ -2356,8 +2368,11 @@ class Editor implements KetcherEditor {
                     );
                     assert(newLeavingAtomId !== null);
                     this.monomerCreationState?.assignedAttachmentPoints.set(
-                      attachmentPointName,
-                      [attachmentAtomId, newLeavingAtomId],
+                      attachmentAtomId,
+                      {
+                        name: attachmentPointName,
+                        leavingAtomId: newLeavingAtomId,
+                      },
                     );
                   }
                 }
@@ -2410,10 +2425,11 @@ class Editor implements KetcherEditor {
             // Handle assigned attachment points
             const attachmentPointWithBond = Array.from(
               this.monomerCreationState.assignedAttachmentPoints.entries(),
-            ).find(([, atomPair]) => {
+            ).find(([attachmentAtomId, { leavingAtomId }]) => {
               return (
-                (bond.begin === atomPair[0] && bond.end === atomPair[1]) ||
-                (bond.begin === atomPair[1] && bond.end === atomPair[0])
+                (bond.begin === attachmentAtomId &&
+                  bond.end === leavingAtomId) ||
+                (bond.begin === leavingAtomId && bond.end === attachmentAtomId)
               );
             });
 
@@ -2421,11 +2437,11 @@ class Editor implements KetcherEditor {
             if (attachmentPointWithBond) {
               if (!Editor.isBondSuitableForAttachmentPoint(bond)) {
                 this.monomerCreationState.problematicAttachmentPoints.add(
-                  attachmentPointWithBond[0],
+                  attachmentPointWithBond[1].name,
                 );
               } else {
                 this.monomerCreationState.problematicAttachmentPoints.delete(
-                  attachmentPointWithBond[0],
+                  attachmentPointWithBond[1].name,
                 );
               }
             }
@@ -2478,7 +2494,7 @@ class Editor implements KetcherEditor {
             // Handle assigned attachment points - existing logic
             const attachmentPointWithBondToLeavingAtom = Array.from(
               this.monomerCreationState.assignedAttachmentPoints.entries(),
-            ).find(([, [attachmentAtomId, leavingAtomId]]) => {
+            ).find(([attachmentAtomId, { leavingAtomId }]) => {
               return (
                 (bond.begin === leavingAtomId &&
                   bond.end !== attachmentAtomId) ||
@@ -2487,10 +2503,9 @@ class Editor implements KetcherEditor {
             });
 
             if (attachmentPointWithBondToLeavingAtom) {
-              const [attachmentPointName] =
-                attachmentPointWithBondToLeavingAtom;
+              const [attachmentAtomId] = attachmentPointWithBondToLeavingAtom;
               this.monomerCreationState.assignedAttachmentPoints.delete(
-                attachmentPointName,
+                attachmentAtomId,
               );
             }
 

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -164,7 +164,7 @@ export function load(struct: Struct, options?) {
         // Find leaving group atoms in new struct
         const leavingGroupAtoms = parsedStruct.atoms.filter((atomId) =>
           Array.from(assignedAttachmentPoints.values()).some(
-            ([, leavingAtomId]) => leavingAtomId === atomId,
+            ({ leavingAtomId }) => leavingAtomId === atomId,
           ),
         );
 

--- a/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
@@ -16,11 +16,11 @@ import assert from 'assert';
 type Props = {
   data: AttachmentPointClickData;
   onNameChange: (
-    currentName: AttachmentPointName,
+    attachmentAtomId: number,
     newName: AttachmentPointName,
   ) => void;
   onLeavingAtomChange: (
-    apName: AttachmentPointName,
+    attachmentAtomId: number,
     newLeavingAtomLabel: AtomLabel,
   ) => void;
   onClose: VoidFunction;
@@ -81,16 +81,13 @@ const AttachmentPointEditPopup = ({
     };
   }, [onClose]);
 
-  const { attachmentPointName, position } = data;
+  const { attachmentAtomId, attachmentPointName, position } = data;
 
   assert(editor.monomerCreationState);
 
   const { assignedAttachmentPoints } = editor.monomerCreationState;
 
-  const selectsData = useAttachmentPointSelectsData(
-    editor,
-    attachmentPointName,
-  );
+  const selectsData = useAttachmentPointSelectsData(editor, attachmentAtomId);
 
   if (!selectsData) {
     return null;
@@ -98,24 +95,24 @@ const AttachmentPointEditPopup = ({
 
   const handleNameChange = (newName: AttachmentPointName) => {
     if (newName !== attachmentPointName) {
-      onNameChange(attachmentPointName, newName);
+      onNameChange(attachmentAtomId, newName);
     }
     onClose();
   };
 
   const handleLeavingAtomChange = (newLeavingAtomLabel: AtomLabel) => {
-    const currentAtomPair = assignedAttachmentPoints.get(attachmentPointName);
+    const apEntry = assignedAttachmentPoints.get(attachmentAtomId);
 
-    assert(currentAtomPair);
+    assert(apEntry);
 
-    const leavingAtomId = currentAtomPair[1];
+    const { leavingAtomId } = apEntry;
     const leavingAtom = editor.struct().atoms.get(leavingAtomId);
     assert(leavingAtom);
 
     const currentLeavingAtomLabel = leavingAtom.label;
 
     if (newLeavingAtomLabel !== currentLeavingAtomLabel) {
-      onLeavingAtomChange(attachmentPointName, newLeavingAtomLabel);
+      onLeavingAtomChange(attachmentAtomId, newLeavingAtomLabel);
     }
     onClose();
   };

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenuTrigger.tsx
@@ -105,11 +105,15 @@ const ContextMenuTrigger: FC<PropsWithChildren> = ({ children }) => {
           const attachmentPointName = rLabelElement.getAttribute(
             'data-attachment-point-alias',
           );
-          if (attachmentPointName) {
+          const attachmentAtomId = Number(
+            rLabelElement.getAttribute('data-attachment-point-atom-id'),
+          );
+          if (attachmentPointName && Number.isInteger(attachmentAtomId)) {
             show({
               id: CONTEXT_MENU_ID.FOR_ATTACHMENT_POINT_LABEL + ketcherId,
               event,
               props: {
+                attachmentAtomId,
                 attachmentPointName,
                 ketcherId,
               },

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/contextMenu.types.ts
@@ -71,6 +71,7 @@ export interface MultitailArrowContextMenuProps {
 export interface AttachmentPointLabelContextMenuProps
   extends BaseContextMenuProps {
   id: string;
+  attachmentAtomId: number;
   attachmentPointName: AttachmentPointName;
 }
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeAttachmentPointMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeAttachmentPointMenuItems.tsx
@@ -30,9 +30,8 @@ const useMakeAttachmentPointMenuItems = ({
     editor.monomerCreationState;
 
   const isAtomInAssignedAttachmentPoint = Array.from(
-    assignedAttachmentPoints.values(),
-  ).some((atomPair) => {
-    const [attachmentAtomId, leavingAtomId] = atomPair;
+    assignedAttachmentPoints.entries(),
+  ).some(([attachmentAtomId, { leavingAtomId }]) => {
     return (
       selectedAtomId === attachmentAtomId || selectedAtomId === leavingAtomId
     );
@@ -40,8 +39,7 @@ const useMakeAttachmentPointMenuItems = ({
 
   const isAtomAlreadyLeavingAtom = Array.from(
     assignedAttachmentPoints.values(),
-  ).some((atomPair) => {
-    const [, leavingAtomId] = atomPair;
+  ).some(({ leavingAtomId }) => {
     return selectedAtomId === leavingAtomId;
   });
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AttachmentPointLabelMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AttachmentPointLabelMenuItems.tsx
@@ -26,21 +26,22 @@ const AttachmentPointLabelMenuItems = ({
     return null;
   }
 
-  const { attachmentPointName } = propsFromTrigger;
+  const { attachmentAtomId, attachmentPointName } = propsFromTrigger;
 
   const handleEditClick = () => {
-    const atomPair =
+    const apEntry =
       editor.monomerCreationState?.assignedAttachmentPoints?.get(
-        attachmentPointName,
+        attachmentAtomId,
       );
 
-    assert(atomPair);
+    assert(apEntry);
 
-    const [, leavingAtomId] = atomPair;
+    const { leavingAtomId } = apEntry;
     const leavingAtom = editor.struct().atoms.get(leavingAtomId);
     assert(leavingAtom);
 
     const attachmentPointEditData: AttachmentPointClickData = {
+      attachmentAtomId,
       attachmentPointName,
       position: Coordinates.modelToView(leavingAtom.pp),
     };
@@ -56,7 +57,7 @@ const AttachmentPointLabelMenuItems = ({
   };
 
   const handleRemoveClick = () => {
-    editor.removeAttachmentPoint(attachmentPointName);
+    editor.removeAttachmentPoint(attachmentAtomId);
   };
 
   return (

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -556,6 +556,21 @@ const validateAttachmentPoints = (attachmentPoints: AttachmentPointName[]) => {
     return { notifications, problematicAttachmentPoints };
   }
 
+  const uniqueNames = new Set(attachmentPoints);
+  if (attachmentPoints.length !== uniqueNames.size) {
+    attachmentPoints.forEach((name) => {
+      if (attachmentPoints.filter((n) => n === name).length > 1) {
+        problematicAttachmentPoints.add(name);
+      }
+    });
+    notifications.set('attachmentPointsNotUnique', {
+      type: 'error',
+      message: NotificationMessages.attachmentPointsNotUnique,
+    });
+
+    return { notifications, problematicAttachmentPoints };
+  }
+
   const sideAttachmentPoints = attachmentPoints.filter(
     (attachmentPointName) => {
       const pointNumber =
@@ -774,9 +789,10 @@ const MonomerCreationWizard = () => {
   useEffect(() => {
     const attachmentPointClickHandler = (event: Event) => {
       const clickData = (event as CustomEvent<AttachmentPointClickData>).detail;
-      const { attachmentPointName, position } = clickData;
+      const { attachmentAtomId, attachmentPointName, position } = clickData;
 
       setAttachmentPointEditPopupData({
+        attachmentAtomId,
         attachmentPointName,
         position,
       });
@@ -935,17 +951,17 @@ const MonomerCreationWizard = () => {
   const selectRectangleAction = tools['select-rectangle'].action;
 
   const handleAttachmentPointNameChange = (
-    currentName: AttachmentPointName,
+    attachmentAtomId: number,
     newName: AttachmentPointName,
   ) => {
-    editor.reassignAttachmentPoint(currentName, newName);
+    editor.reassignAttachmentPoint(attachmentAtomId, newName);
   };
 
   const handleLeavingAtomChange = (
-    apName: AttachmentPointName,
+    attachmentAtomId: number,
     newLeavingAtomLabel: AtomLabel,
   ) => {
-    editor.changeLeavingAtomLabel(apName, newLeavingAtomLabel);
+    editor.changeLeavingAtomLabel(attachmentAtomId, newLeavingAtomLabel);
   };
 
   const handleAttachmentPointEditPopupClose = () => {
@@ -977,25 +993,28 @@ const MonomerCreationWizard = () => {
     }
 
     const sugarAttachmentPoints = new Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >();
     const phosphateAttachmentPoints = new Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >();
 
     monomerCreationState.assignedAttachmentPoints.forEach(
-      ([attachmentAtomId, leavingGroupAtomId], attachmentPointName) => {
+      (
+        { name: attachmentPointName, leavingAtomId: leavingGroupAtomId },
+        attachmentAtomId,
+      ) => {
         if (
           rnaPresetWizardState.sugar.structure?.atoms?.includes(
             attachmentAtomId,
           )
         ) {
-          sugarAttachmentPoints.set(attachmentPointName, [
-            attachmentAtomId,
-            leavingGroupAtomId,
-          ]);
+          sugarAttachmentPoints.set(attachmentAtomId, {
+            name: attachmentPointName,
+            leavingAtomId: leavingGroupAtomId,
+          });
         }
 
         if (
@@ -1003,10 +1022,10 @@ const MonomerCreationWizard = () => {
             attachmentAtomId,
           )
         ) {
-          phosphateAttachmentPoints.set(attachmentPointName, [
-            attachmentAtomId,
-            leavingGroupAtomId,
-          ]);
+          phosphateAttachmentPoints.set(attachmentAtomId, {
+            name: attachmentPointName,
+            leavingAtomId: leavingGroupAtomId,
+          });
         }
       },
     );
@@ -1063,12 +1082,13 @@ const MonomerCreationWizard = () => {
       return;
     }
 
+    const apNames = Array.from(monomerAssignedAttachmentPoints.values()).map(
+      (ap) => ap.name,
+    );
     const {
       notifications: attachmentPointsNotifications,
       problematicAttachmentPoints,
-    } = validateAttachmentPoints(
-      Array.from(monomerAssignedAttachmentPoints.keys()),
-    );
+    } = validateAttachmentPoints(apNames);
     if (attachmentPointsNotifications.size > 0) {
       wizardStateDispatch({
         type: 'SetNotifications',
@@ -1189,10 +1209,14 @@ const MonomerCreationWizard = () => {
     }
 
     if (
-      sugarAttachmentPoints?.get(AttachmentPointName.R3) ||
-      assignedAttachmentPointsByMonomer
-        .get(rnaPresetWizardState.base)
-        ?.get(AttachmentPointName.R1)
+      Array.from(sugarAttachmentPoints?.values() ?? []).some(
+        (ap) => ap.name === AttachmentPointName.R3,
+      ) ||
+      Array.from(
+        assignedAttachmentPointsByMonomer
+          .get(rnaPresetWizardState.base)
+          ?.values() ?? [],
+      ).some((ap) => ap.name === AttachmentPointName.R1)
     ) {
       needSaveMonomers = false;
       presetNotifications.set('invalidRnaPresetStructure', {
@@ -1427,17 +1451,23 @@ const MonomerCreationWizard = () => {
     // separate attachment points by preset components
     if (isRnaPresetType) {
       monomersToSave.forEach((componentWizardState) => {
-        const assignedAttachmentPointsForComponent = new Map();
+        const assignedAttachmentPointsForComponent = new Map<
+          number,
+          { name: AttachmentPointName; leavingAtomId: number }
+        >();
 
         assignedAttachmentPoints.forEach(
-          ([attachmentAtomId, leavingGroupAtomId], attachmentPointName) => {
+          (
+            { name: attachmentPointName, leavingAtomId: leavingGroupAtomId },
+            attachmentAtomId,
+          ) => {
             if (
               componentWizardState.structure?.atoms?.includes(attachmentAtomId)
             ) {
-              assignedAttachmentPointsForComponent.set(attachmentPointName, [
-                attachmentAtomId,
-                leavingGroupAtomId,
-              ]);
+              assignedAttachmentPointsForComponent.set(attachmentAtomId, {
+                name: attachmentPointName,
+                leavingAtomId: leavingGroupAtomId,
+              });
             }
           },
         );
@@ -1626,24 +1656,44 @@ const MonomerCreationWizard = () => {
         const monomerAssignedAttachmentPoints =
           assignedAttachmentPointsByMonomer.get(monomerToSave);
 
-        monomerAssignedAttachmentPoints?.forEach(
-          ([attachmentAtomId, leavingGroupAtomId], attachmentPointKey) => {
-            const mappedAttachmentAtomId = atomIdMap.get(attachmentAtomId);
-            const mappedLeavingGroupAtomId = atomIdMap.get(leavingGroupAtomId);
+        if (monomerAssignedAttachmentPoints) {
+          // Collect remapped entries without mutating during iteration
+          const remappedEntries: Array<
+            [number, { name: AttachmentPointName; leavingAtomId: number }]
+          > = [];
 
-            if (
-              !isNumber(mappedAttachmentAtomId) ||
-              !isNumber(mappedLeavingGroupAtomId)
-            ) {
-              return;
-            }
+          monomerAssignedAttachmentPoints.forEach(
+            (
+              { name: attachmentPointName, leavingAtomId: leavingGroupAtomId },
+              attachmentAtomId,
+            ) => {
+              const mappedAttachmentAtomId = atomIdMap.get(attachmentAtomId);
+              const mappedLeavingGroupAtomId =
+                atomIdMap.get(leavingGroupAtomId);
 
-            monomerAssignedAttachmentPoints.set(attachmentPointKey, [
-              mappedAttachmentAtomId,
-              mappedLeavingGroupAtomId,
-            ]);
-          },
-        );
+              if (
+                !isNumber(mappedAttachmentAtomId) ||
+                !isNumber(mappedLeavingGroupAtomId)
+              ) {
+                return;
+              }
+
+              remappedEntries.push([
+                mappedAttachmentAtomId,
+                {
+                  name: attachmentPointName,
+                  leavingAtomId: mappedLeavingGroupAtomId,
+                },
+              ]);
+            },
+          );
+
+          // Clear and repopulate with remapped entries
+          monomerAssignedAttachmentPoints.clear();
+          remappedEntries.forEach(([key, value]) => {
+            monomerAssignedAttachmentPoints.set(key, value);
+          });
+        }
 
         // Determine if this monomer should be hidden
         const shouldBeHidden = isRnaPresetType;

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.types.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.types.ts
@@ -177,7 +177,7 @@ export type RnaPresetWizardAction =
 
 export type AssignedAttachmentPointsByMonomerType = Map<
   WizardState,
-  Map<AttachmentPointName, [number, number]>
+  Map<number, { name: AttachmentPointName; leavingAtomId: number }>
 >;
 
 export function isDispatchActionForRnaPreset(

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
@@ -33,7 +33,10 @@ import { Autocomplete, TextField } from '@mui/material';
 
 interface IMonomerCreationWizardFieldsProps {
   wizardState: WizardState;
-  assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>;
+  assignedAttachmentPoints: Map<
+    number,
+    { name: AttachmentPointName; leavingAtomId: number }
+  >;
   readonlyAttachmentPoints?: Array<{
     name: AttachmentPointName;
     leavingAtomLabel: AtomLabel;
@@ -111,21 +114,21 @@ const MonomerCreationWizardFields = (
   };
 
   const handleAttachmentPointNameChange = (
-    currentName: AttachmentPointName,
+    attachmentAtomId: number,
     newName: AttachmentPointName,
   ) => {
-    editor.reassignAttachmentPoint(currentName, newName);
+    editor.reassignAttachmentPoint(attachmentAtomId, newName);
   };
 
   const handleLeavingAtomChange = (
-    apName: AttachmentPointName,
+    attachmentAtomId: number,
     newLeavingAtomLabel: AtomLabel,
   ) => {
-    editor.changeLeavingAtomLabel(apName, newLeavingAtomLabel);
+    editor.changeLeavingAtomLabel(attachmentAtomId, newLeavingAtomLabel);
   };
 
-  const handleAttachmentPointRemove = (name: AttachmentPointName) => {
-    editor.removeAttachmentPoint(name);
+  const handleAttachmentPointRemove = (attachmentAtomId: number) => {
+    editor.removeAttachmentPoint(attachmentAtomId);
   };
 
   const monomerCreationState = useSelector(editorMonomerCreationStateSelector);
@@ -227,14 +230,15 @@ const MonomerCreationWizardFields = (
           readonlyAttachmentPoints.length > 0) && (
           <div className={styles.attachmentPoints}>
             {Array.from(assignedAttachmentPoints.entries()).map(
-              ([name, atomPair]) => (
+              ([attachmentAtomId, { name, leavingAtomId }]) => (
                 <AttachmentPoint
+                  attachmentAtomId={attachmentAtomId}
                   name={name}
                   editor={editor}
                   onNameChange={handleAttachmentPointNameChange}
                   onLeavingAtomChange={handleLeavingAtomChange}
                   onRemove={handleAttachmentPointRemove}
-                  key={`${name}-${atomPair[0]}-${atomPair[1]}`}
+                  key={`${name}-${attachmentAtomId}-${leavingAtomId}`}
                 />
               ),
             )}

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerLeavingGroupValidator.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerLeavingGroupValidator.ts
@@ -25,7 +25,10 @@ const getNotificationIdForMonomerType = (
 export const validateMonomerLeavingGroups = (
   editor: Editor,
   monomerType: KetMonomerClass | 'rnaPreset',
-  assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
+  assignedAttachmentPoints: Map<
+    number,
+    { name: AttachmentPointName; leavingAtomId: number }
+  >,
 ): Map<string, WizardNotification> => {
   const notifications = new Map<string, WizardNotification>();
   const validationRule = getValidationRuleForMonomerType(monomerType);
@@ -38,12 +41,12 @@ export const validateMonomerLeavingGroups = (
   let hasWarning = false;
 
   for (const requirement of validationRule.requirements) {
-    const attachmentPoint = assignedAttachmentPoints.get(
-      requirement.attachmentPoint,
+    const apEntry = Array.from(assignedAttachmentPoints.entries()).find(
+      ([, ap]) => ap.name === requirement.attachmentPoint,
     );
 
-    if (attachmentPoint) {
-      const [, leavingAtomId] = attachmentPoint;
+    if (apEntry) {
+      const [, { leavingAtomId }] = apEntry;
       const leavingAtom = struct.atoms.get(leavingAtomId);
 
       if (

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/PhosphatePositionInference.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/PhosphatePositionInference.test.ts
@@ -2,7 +2,10 @@ import { AttachmentPointName, Bond } from 'ketcher-core';
 
 import { inferPhosphatePosition } from './PhosphatePositionInference';
 
-type AttachmentPointMap = Map<AttachmentPointName, [number, number]>;
+type AttachmentPointMap = Map<
+  number,
+  { name: AttachmentPointName; leavingAtomId: number }
+>;
 
 describe('inferPhosphatePosition', () => {
   it.each<{
@@ -15,27 +18,35 @@ describe('inferPhosphatePosition', () => {
     {
       name: "5' when phosphate has an external R1 only",
       sugarAttachmentPoints: new Map(),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R1, [3, 30]]]),
+      phosphateAttachmentPoints: new Map([
+        [3, { name: AttachmentPointName.R1, leavingAtomId: 30 }],
+      ]),
       bonds: [{ begin: 3, end: 100 }],
       expected: '5',
     },
     {
       name: "3' when phosphate has an external R2 only",
       sugarAttachmentPoints: new Map(),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R2, [3, 30]]]),
+      phosphateAttachmentPoints: new Map([
+        [3, { name: AttachmentPointName.R2, leavingAtomId: 30 }],
+      ]),
       bonds: [{ begin: 3, end: 100 }],
       expected: '3',
     },
     {
       name: "3' when sugar has an external R1 only",
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R1, [1, 10]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R1, leavingAtomId: 10 }],
+      ]),
       phosphateAttachmentPoints: new Map(),
       bonds: [{ begin: 1, end: 100 }],
       expected: '3',
     },
     {
       name: "5' when sugar has an external R2 only",
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R2, [1, 10]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R2, leavingAtomId: 10 }],
+      ]),
       phosphateAttachmentPoints: new Map(),
       bonds: [{ begin: 1, end: 100 }],
       expected: '5',
@@ -43,8 +54,8 @@ describe('inferPhosphatePosition', () => {
     {
       name: "3' when sugar exposes both external R1 and R2",
       sugarAttachmentPoints: new Map([
-        [AttachmentPointName.R1, [1, 10]],
-        [AttachmentPointName.R2, [2, 20]],
+        [1, { name: AttachmentPointName.R1, leavingAtomId: 10 }],
+        [2, { name: AttachmentPointName.R2, leavingAtomId: 20 }],
       ]),
       phosphateAttachmentPoints: new Map(),
       bonds: [
@@ -57,8 +68,8 @@ describe('inferPhosphatePosition', () => {
       name: "3' when phosphate exposes both external R1 and R2",
       sugarAttachmentPoints: new Map(),
       phosphateAttachmentPoints: new Map([
-        [AttachmentPointName.R1, [3, 30]],
-        [AttachmentPointName.R2, [4, 40]],
+        [3, { name: AttachmentPointName.R1, leavingAtomId: 30 }],
+        [4, { name: AttachmentPointName.R2, leavingAtomId: 40 }],
       ]),
       bonds: [
         { begin: 3, end: 100 },
@@ -75,8 +86,12 @@ describe('inferPhosphatePosition', () => {
     },
     {
       name: "3' when only non-R1 and non-R2 external attachment points exist",
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R3, [1, 10]]]),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R3, [3, 30]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R3, leavingAtomId: 10 }],
+      ]),
+      phosphateAttachmentPoints: new Map([
+        [3, { name: AttachmentPointName.R3, leavingAtomId: 30 }],
+      ]),
       bonds: [
         { begin: 1, end: 100 },
         { begin: 3, end: 101 },
@@ -85,8 +100,12 @@ describe('inferPhosphatePosition', () => {
     },
     {
       name: "3' when sugar and phosphate infer conflicting positions",
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R2, [1, 10]]]),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R2, [3, 30]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R2, leavingAtomId: 10 }],
+      ]),
+      phosphateAttachmentPoints: new Map([
+        [3, { name: AttachmentPointName.R2, leavingAtomId: 30 }],
+      ]),
       bonds: [
         { begin: 1, end: 100 },
         { begin: 3, end: 101 },

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/PhosphatePositionInference.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/PhosphatePositionInference.ts
@@ -29,15 +29,21 @@ const inferPhosphatePositionFromPhosphate = (
 };
 
 export const inferPhosphatePosition = (
-  sugarAttachmentPoints: Map<AttachmentPointName, [number, number]>,
-  phosphateAttachmentPoints: Map<AttachmentPointName, [number, number]>,
+  sugarAttachmentPoints: Map<
+    number,
+    { name: AttachmentPointName; leavingAtomId: number }
+  >,
+  phosphateAttachmentPoints: Map<
+    number,
+    { name: AttachmentPointName; leavingAtomId: number }
+  >,
 ): PhosphatePosition => {
-  const positionFromSugar = inferPhosphatePositionFromSugar([
-    ...sugarAttachmentPoints.keys(),
-  ]);
-  const positionFromPhosphate = inferPhosphatePositionFromPhosphate([
-    ...phosphateAttachmentPoints.keys(),
-  ]);
+  const positionFromSugar = inferPhosphatePositionFromSugar(
+    Array.from(sugarAttachmentPoints.values()).map((ap) => ap.name),
+  );
+  const positionFromPhosphate = inferPhosphatePositionFromPhosphate(
+    Array.from(phosphateAttachmentPoints.values()).map((ap) => ap.name),
+  );
 
   if (positionFromSugar && positionFromPhosphate) {
     return positionFromSugar === positionFromPhosphate

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointValidation.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointValidation.test.ts
@@ -5,7 +5,10 @@ import {
   hasPhosphatePositionAttachmentPointConflict,
 } from './RnaPresetAttachmentPointValidation';
 
-type AttachmentPointMap = Map<AttachmentPointName, [number, number]>;
+type AttachmentPointMap = Map<
+  number,
+  { name: AttachmentPointName; leavingAtomId: number }
+>;
 
 describe('getRequiredAttachmentPointsForPhosphatePosition', () => {
   it.each<{
@@ -50,7 +53,9 @@ describe('hasPhosphatePositionAttachmentPointConflict', () => {
     {
       name: "3' conflicts when sugar already uses R2",
       phosphatePosition: '3',
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R2, [1, 10]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R2, leavingAtomId: 10 }],
+      ]),
       phosphateAttachmentPoints: new Map(),
       expected: true,
     },
@@ -58,20 +63,28 @@ describe('hasPhosphatePositionAttachmentPointConflict', () => {
       name: "3' conflicts when phosphate already uses R1",
       phosphatePosition: '3',
       sugarAttachmentPoints: new Map(),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R1, [2, 20]]]),
+      phosphateAttachmentPoints: new Map([
+        [2, { name: AttachmentPointName.R1, leavingAtomId: 20 }],
+      ]),
       expected: true,
     },
     {
       name: "3' does not conflict when sugar uses R1 and phosphate uses R2",
       phosphatePosition: '3',
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R1, [1, 10]]]),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R2, [2, 20]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R1, leavingAtomId: 10 }],
+      ]),
+      phosphateAttachmentPoints: new Map([
+        [2, { name: AttachmentPointName.R2, leavingAtomId: 20 }],
+      ]),
       expected: false,
     },
     {
       name: "5' conflicts when sugar already uses R1",
       phosphatePosition: '5',
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R1, [1, 10]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R1, leavingAtomId: 10 }],
+      ]),
       phosphateAttachmentPoints: new Map(),
       expected: true,
     },
@@ -79,14 +92,20 @@ describe('hasPhosphatePositionAttachmentPointConflict', () => {
       name: "5' conflicts when phosphate already uses R2",
       phosphatePosition: '5',
       sugarAttachmentPoints: new Map(),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R2, [2, 20]]]),
+      phosphateAttachmentPoints: new Map([
+        [2, { name: AttachmentPointName.R2, leavingAtomId: 20 }],
+      ]),
       expected: true,
     },
     {
       name: "5' does not conflict when sugar uses R2 and phosphate uses R1",
       phosphatePosition: '5',
-      sugarAttachmentPoints: new Map([[AttachmentPointName.R2, [1, 10]]]),
-      phosphateAttachmentPoints: new Map([[AttachmentPointName.R1, [2, 20]]]),
+      sugarAttachmentPoints: new Map([
+        [1, { name: AttachmentPointName.R2, leavingAtomId: 10 }],
+      ]),
+      phosphateAttachmentPoints: new Map([
+        [2, { name: AttachmentPointName.R1, leavingAtomId: 20 }],
+      ]),
       expected: false,
     },
   ])(

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointValidation.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointValidation.ts
@@ -2,7 +2,10 @@ import { AtomLabel, AttachmentPointName, KetMonomerClass } from 'ketcher-core';
 
 export type PhosphatePosition = '3' | '5';
 
-type AttachmentPointMap = Map<AttachmentPointName, [number, number]>;
+type AttachmentPointMap = Map<
+  number,
+  { name: AttachmentPointName; leavingAtomId: number }
+>;
 
 /**
  * Gets the leaving atom used for RNA preset connection attachment points.
@@ -54,8 +57,16 @@ export const hasPhosphatePositionAttachmentPointConflict = (
   const requiredAttachmentPoints =
     getRequiredAttachmentPointsForPhosphatePosition(phosphatePosition);
 
-  return Boolean(
-    sugarAttachmentPoints?.has(requiredAttachmentPoints.sugar) ||
-      phosphateAttachmentPoints?.has(requiredAttachmentPoints.phosphate),
-  );
+  const sugarHasRequired = sugarAttachmentPoints
+    ? Array.from(sugarAttachmentPoints.values()).some(
+        (ap) => ap.name === requiredAttachmentPoints.sugar,
+      )
+    : false;
+  const phosphateHasRequired = phosphateAttachmentPoints
+    ? Array.from(phosphateAttachmentPoints.values()).some(
+        (ap) => ap.name === requiredAttachmentPoints.phosphate,
+      )
+    : false;
+
+  return sugarHasRequired || phosphateHasRequired;
 };

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.test.ts
@@ -101,12 +101,12 @@ describe('RnaPresetAttachmentPointsVisibility', () => {
     wizardState.base.structure = { atoms: [1, 3], bonds: [] };
     wizardState.sugar.structure = { atoms: [2], bonds: [] };
     const assignedAttachmentPoints = new Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >([
-      [AttachmentPointName.R1, [1, 11]],
-      [AttachmentPointName.R2, [2, 12]],
-      [AttachmentPointName.R3, [3, 13]],
+      [1, { name: AttachmentPointName.R1, leavingAtomId: 11 }],
+      [2, { name: AttachmentPointName.R2, leavingAtomId: 12 }],
+      [3, { name: AttachmentPointName.R3, leavingAtomId: 13 }],
     ]);
 
     expect(
@@ -117,8 +117,8 @@ describe('RnaPresetAttachmentPointsVisibility', () => {
       ),
     ).toEqual(
       new Map([
-        [AttachmentPointName.R1, [1, 11]],
-        [AttachmentPointName.R3, [3, 13]],
+        [1, { name: AttachmentPointName.R1, leavingAtomId: 11 }],
+        [3, { name: AttachmentPointName.R3, leavingAtomId: 13 }],
       ]),
     );
   });
@@ -207,13 +207,13 @@ describe('RnaPresetAttachmentPointsVisibility', () => {
     wizardState.sugar.structure = { atoms: [2, 4], bonds: [] };
     wizardState.phosphate.structure = { atoms: [3], bonds: [] };
     const assignedAttachmentPoints = new Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >([
-      [AttachmentPointName.R1, [1, 11]],
-      [AttachmentPointName.R2, [2, 12]],
-      [AttachmentPointName.R3, [3, 13]],
-      [AttachmentPointName.R4, [4, 14]],
+      [1, { name: AttachmentPointName.R1, leavingAtomId: 11 }],
+      [2, { name: AttachmentPointName.R2, leavingAtomId: 12 }],
+      [3, { name: AttachmentPointName.R3, leavingAtomId: 13 }],
+      [4, { name: AttachmentPointName.R4, leavingAtomId: 14 }],
     ]);
 
     const visibleAttachmentPoints = getVisibleAttachmentPointsForRnaPreset(
@@ -230,8 +230,8 @@ describe('RnaPresetAttachmentPointsVisibility', () => {
 
     expect(visibleAttachmentPoints).toEqual(
       new Map([
-        [AttachmentPointName.R3, [3, 13]],
-        [AttachmentPointName.R4, [4, 14]],
+        [3, { name: AttachmentPointName.R3, leavingAtomId: 13 }],
+        [4, { name: AttachmentPointName.R4, leavingAtomId: 14 }],
       ]),
     );
   });
@@ -241,11 +241,11 @@ describe('RnaPresetAttachmentPointsVisibility', () => {
     wizardState.base.structure = { atoms: [1], bonds: [] };
     wizardState.sugar.structure = { atoms: [2], bonds: [] };
     const assignedAttachmentPoints = new Map<
-      AttachmentPointName,
-      [number, number]
+      number,
+      { name: AttachmentPointName; leavingAtomId: number }
     >([
-      [AttachmentPointName.R1, [1, 11]],
-      [AttachmentPointName.R2, [2, 12]],
+      [1, { name: AttachmentPointName.R1, leavingAtomId: 11 }],
+      [2, { name: AttachmentPointName.R2, leavingAtomId: 12 }],
     ]);
 
     expect(

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.ts
@@ -11,7 +11,10 @@ import {
 } from './RnaPresetAttachmentPointValidation';
 import { findBondBetweenRnaPresetComponents } from './RnaPresetStructureValidation';
 
-type AttachmentPointMap = Map<AttachmentPointName, [number, number]>;
+type AttachmentPointMap = Map<
+  number,
+  { name: AttachmentPointName; leavingAtomId: number }
+>;
 type ComponentAttachmentPointNames = Record<
   RnaPresetComponentKey,
   AttachmentPointName[]
@@ -63,7 +66,7 @@ export const getAttachmentPointsForRnaPresetComponent = (
 
   return new Map(
     Array.from(assignedAttachmentPoints.entries()).filter(
-      ([, [attachmentAtomId]]) => componentAtomIds.has(attachmentAtomId),
+      ([attachmentAtomId]) => componentAtomIds.has(attachmentAtomId),
     ),
   );
 };
@@ -208,7 +211,7 @@ export const getVisibleAttachmentPointsForRnaPreset = (
   const occupiedAttachmentPoints = new Set<AttachmentPointName>();
 
   assignedAttachmentPoints.forEach(
-    ([attachmentAtomId], attachmentPointName) => {
+    ({ name: attachmentPointName }, attachmentAtomId) => {
       const componentKey = atomToComponentMap.get(attachmentAtomId);
 
       if (!componentKey) {
@@ -247,7 +250,7 @@ export const getVisibleAttachmentPointsForRnaPreset = (
 
   return new Map(
     Array.from(assignedAttachmentPoints.entries()).filter(
-      ([attachmentPointName]) =>
+      ([, { name: attachmentPointName }]) =>
         !occupiedAttachmentPoints.has(attachmentPointName),
     ),
   );

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
@@ -231,21 +231,21 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
   };
 
   const handleAttachmentPointNameChange = (
-    currentName: AttachmentPointName,
+    attachmentAtomId: number,
     newName: AttachmentPointName,
   ) => {
-    editor.reassignAttachmentPoint(currentName, newName);
+    editor.reassignAttachmentPoint(attachmentAtomId, newName);
   };
 
   const handleLeavingAtomChange = (
-    apName: AttachmentPointName,
+    attachmentAtomId: number,
     newLeavingAtomLabel: AtomLabel,
   ) => {
-    editor.changeLeavingAtomLabel(apName, newLeavingAtomLabel);
+    editor.changeLeavingAtomLabel(attachmentAtomId, newLeavingAtomLabel);
   };
 
-  const handleAttachmentPointRemove = (name: AttachmentPointName) => {
-    editor.removeAttachmentPoint(name);
+  const handleAttachmentPointRemove = (attachmentAtomId: number) => {
+    editor.removeAttachmentPoint(attachmentAtomId);
   };
 
   const currentTabStructure = currentTabState?.structure;
@@ -442,14 +442,15 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
               {presetAttachmentPoints.size > 0 && (
                 <div className={monomerCreationWizardStyles.attachmentPoints}>
                   {Array.from(presetAttachmentPoints.entries()).map(
-                    ([name, atomPair]) => (
+                    ([attachmentAtomId, { name, leavingAtomId }]) => (
                       <AttachmentPoint
+                        attachmentAtomId={attachmentAtomId}
                         name={name}
                         editor={editor}
                         onNameChange={handleAttachmentPointNameChange}
                         onLeavingAtomChange={handleLeavingAtomChange}
                         onRemove={handleAttachmentPointRemove}
-                        key={`${name}-${atomPair[0]}-${atomPair[1]}`}
+                        key={`${name}-${attachmentAtomId}-${leavingAtomId}`}
                       />
                     ),
                   )}

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPoint/AttachmentPoint.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPoint/AttachmentPoint.tsx
@@ -8,20 +8,22 @@ import { Icon } from '../../../../../../../components';
 import { useEffect, useRef, useState } from 'react';
 
 type Props = {
+  attachmentAtomId: number;
   name: AttachmentPointName;
   editor: Editor;
   onNameChange: (
-    currentName: AttachmentPointName,
+    attachmentAtomId: number,
     newName: AttachmentPointName,
   ) => void;
   onLeavingAtomChange: (
-    apName: AttachmentPointName,
+    attachmentAtomId: number,
     newLeavingAtomLabel: AtomLabel,
   ) => void;
-  onRemove: (name: AttachmentPointName) => void;
+  onRemove: (attachmentAtomId: number) => void;
 };
 
 const AttachmentPoint = ({
+  attachmentAtomId,
   name,
   editor,
   onNameChange,
@@ -37,7 +39,7 @@ const AttachmentPoint = ({
     }
 
     const mouseOverHandler = () => {
-      editor.highlightAttachmentPoint(name);
+      editor.highlightAttachmentPoint(attachmentAtomId);
     };
 
     const mouseLeaveHandler = () => {
@@ -51,20 +53,18 @@ const AttachmentPoint = ({
       element.removeEventListener('mouseover', mouseOverHandler);
       element.removeEventListener('mouseleave', mouseLeaveHandler);
     };
-  }, [editor, name]);
+  }, [attachmentAtomId, editor]);
 
   const [highlight, setHighlight] = useState(false);
 
   useEffect(() => {
     const handleAttachmentPointHighlight = (event: Event) => {
-      const attachmentPointName = (event as CustomEvent<AttachmentPointName>)
-        .detail;
-      setHighlight(attachmentPointName === name);
+      const highlightedAttachmentAtomId = (event as CustomEvent<number>).detail;
+      setHighlight(highlightedAttachmentAtomId === attachmentAtomId);
     };
     const handleResetAttachmentPointHighlight = (event: Event) => {
-      const attachmentPointName = (event as CustomEvent<AttachmentPointName>)
-        .detail;
-      if (attachmentPointName === name) {
+      const highlightedAttachmentAtomId = (event as CustomEvent<number>).detail;
+      if (highlightedAttachmentAtomId === attachmentAtomId) {
         setHighlight(false);
       }
     };
@@ -88,9 +88,9 @@ const AttachmentPoint = ({
         handleResetAttachmentPointHighlight,
       );
     };
-  }, [name]);
+  }, [attachmentAtomId]);
 
-  const selectsData = useAttachmentPointSelectsData(editor, name);
+  const selectsData = useAttachmentPointSelectsData(editor, attachmentAtomId);
 
   if (!selectsData) {
     return null;
@@ -98,16 +98,16 @@ const AttachmentPoint = ({
 
   const handleNameChange = (newName: AttachmentPointName) => {
     if (newName !== name) {
-      onNameChange(name, newName);
+      onNameChange(attachmentAtomId, newName);
     }
   };
 
   const handleLeavingAtomChange = (newLeavingAtomLabel: AtomLabel) => {
-    onLeavingAtomChange(name, newLeavingAtomLabel);
+    onLeavingAtomChange(attachmentAtomId, newLeavingAtomLabel);
   };
 
   const handleRemove = () => {
-    onRemove(name);
+    onRemove(attachmentAtomId);
   };
 
   return (

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
@@ -98,7 +98,7 @@ export const createReadonlyAttachmentPointSelectData = (
 
 export const useAttachmentPointSelectsData = (
   editor: Editor,
-  attachmentPointName: AttachmentPointName,
+  attachmentAtomId: number,
 ): AttachmentPointSelectData | null => {
   if (!editor.monomerCreationState) {
     return null;
@@ -106,12 +106,12 @@ export const useAttachmentPointSelectsData = (
 
   const { assignedAttachmentPoints } = editor.monomerCreationState;
 
-  const atomPair = assignedAttachmentPoints.get(attachmentPointName);
-  if (!atomPair) {
+  const apEntry = assignedAttachmentPoints.get(attachmentAtomId);
+  if (!apEntry) {
     return null;
   }
 
-  const [attachmentAtomId, leavingAtomId] = atomPair;
+  const { name: attachmentPointName, leavingAtomId } = apEntry;
   const attachmentAtom = editor.struct().atoms.get(attachmentAtomId);
   if (!attachmentAtom) {
     return null;
@@ -122,8 +122,8 @@ export const useAttachmentPointSelectsData = (
     return null;
   }
 
-  const usedNumbers = Array.from(assignedAttachmentPoints.keys()).map((name) =>
-    getAttachmentPointNumberFromLabel(name),
+  const usedNumbers = Array.from(assignedAttachmentPoints.values()).map((ap) =>
+    getAttachmentPointNumberFromLabel(ap.name),
   );
   const maxUsedNumber = Math.max(...usedNumbers);
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
### Problem
`assignedAttachmentPoints` used `AttachmentPointName` (e.g. `"R1"`) as the Map key. This made it impossible for two attachment points to temporarily share the same name — renaming R1 to R2 when R2 already existed would silently swap them instead.

Additionally, all UI paths (inline row, edit popup, canvas context menu, hover highlight) resolved an attachment point by looking up its name in the Map, so two APs with the same name always targeted the same entry.

### Changes
- Map key changed from `AttachmentPointName` to attachment atom ID (`number`). The value now stores `{ name: AttachmentPointName; leavingAtomId: number }`. This allows duplicate names to exist transiently during editing.
- Validation added at save time — `validateAttachmentPoints()` checks for duplicate names before submission and surfaces the existing `attachmentPointsNotUnique` error notification.
- UI identity fixed — all editing paths (popup, row handlers, context menu, hover) now identify an AP by `attachmentAtomId` instead of name, so each row edits the correct atom even when names collide.
- Freeze fixed — `handleSubmit` collects Map entries into an array before clearing and repopulating it, avoiding mutation-during-iteration.
- Canvas events now carry attachmentAtomId: number instead of AttachmentPointName.
- New exported types `AssignedAttachmentPoint` and `AssignedAttachmentPoints` added to `raphaelRender.ts`.

<img width="1068" height="523" alt="image" src="https://github.com/user-attachments/assets/79b0a2f9-28fe-4d28-9792-efb91e718183" />


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request