### PR TITLE
Refactor: Fix ketSerializer circular dependencies

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -93,10 +93,8 @@ import { BaseMonomerRenderer } from 'application/render';
 import { getEmptyMonomersLibraryJson, parseMonomersLibrary } from './helpers';
 import { TransientDrawingView } from 'application/render/renderers/TransientView/TransientDrawingView';
 import { SelectLayoutModeOperation } from 'application/editor/operations/polymerBond';
-import {
-  ReinitializeModeOperation,
-  monomerFactory,
-} from 'application/editor/operations';
+import { ReinitializeModeOperation } from 'application/editor/operations';
+import { monomerFactory } from 'application/editor/operations/monomer/monomerFactory';
 import {
   getAminoAcidsToModify,
   getMonomerUniqueKey,

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -93,7 +93,10 @@ import { BaseMonomerRenderer } from 'application/render';
 import { getEmptyMonomersLibraryJson, parseMonomersLibrary } from './helpers';
 import { TransientDrawingView } from 'application/render/renderers/TransientView/TransientDrawingView';
 import { SelectLayoutModeOperation } from 'application/editor/operations/polymerBond';
-import { ReinitializeModeOperation } from 'application/editor/operations';
+import {
+  ReinitializeModeOperation,
+  monomerFactory,
+} from 'application/editor/operations';
 import {
   getAminoAcidsToModify,
   getMonomerUniqueKey,
@@ -115,6 +118,7 @@ import { SelectBase } from 'application/editor/tools/select/SelectBase';
 import {
   getKetRef,
   getMonomerTemplateRefFromMonomerItem,
+  KetSerializer,
 } from 'domain/serializers';
 import type { SequenceMode } from './modes/types/sequenceMode';
 
@@ -235,6 +239,7 @@ export class CoreEditor {
     this.mode = mode ?? new (getModeConstructor(DEFAULT_LAYOUT_MODE))();
     resetEditorEvents();
     this.events = editorEvents;
+    KetSerializer.setMonomerFactory(monomerFactory);
     this.setMonomersLibrary(monomersDataRaw);
     this.events.updateMonomersLibrary.dispatch();
     this.subscribeEvents();

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -545,6 +545,7 @@ export class SequenceMode extends BaseMode {
       const moveCaretOperation = new RestoreSequenceCaretPositionOperation(
         this.selectionStartCaretPosition,
         SequenceRenderer.caretPosition,
+        SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
       );
       modelChanges.addOperation(moveCaretOperation);
       editor.renderersContainer.update(modelChanges);
@@ -778,6 +779,7 @@ export class SequenceMode extends BaseMode {
       isNumber(newCaretPosition)
         ? newCaretPosition
         : SequenceRenderer.caretPosition,
+      SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
     );
     modelChanges.addOperation(new ReinitializeModeOperation());
     editor.renderersContainer.update(modelChanges);
@@ -1820,6 +1822,7 @@ export class SequenceMode extends BaseMode {
       new RestoreSequenceCaretPositionOperation(
         SequenceRenderer.caretPosition,
         nextCaretPosition,
+        SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
       ),
     );
 

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -545,7 +545,6 @@ export class SequenceMode extends BaseMode {
       const moveCaretOperation = new RestoreSequenceCaretPositionOperation(
         this.selectionStartCaretPosition,
         SequenceRenderer.caretPosition,
-        SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
       );
       modelChanges.addOperation(moveCaretOperation);
       editor.renderersContainer.update(modelChanges);
@@ -779,7 +778,6 @@ export class SequenceMode extends BaseMode {
       isNumber(newCaretPosition)
         ? newCaretPosition
         : SequenceRenderer.caretPosition,
-      SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
     );
     modelChanges.addOperation(new ReinitializeModeOperation());
     editor.renderersContainer.update(modelChanges);
@@ -1822,7 +1820,6 @@ export class SequenceMode extends BaseMode {
       new RestoreSequenceCaretPositionOperation(
         SequenceRenderer.caretPosition,
         nextCaretPosition,
-        SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
       ),
     );
 

--- a/packages/ketcher-core/src/application/editor/operations/modes/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/modes/index.ts
@@ -19,7 +19,6 @@ import { provideEditorInstance } from 'application/editor/editorSingleton';
 
 import type { RenderersManager } from 'application/render/renderers/RenderersManager';
 import { Operation } from 'domain/entities/Operation';
-import { SequenceRenderer } from 'application/render/renderers/sequence/SequenceRenderer';
 
 export class ReinitializeModeOperation implements Operation {
   public priority = 2;
@@ -41,15 +40,16 @@ export class RestoreSequenceCaretPositionOperation implements Operation {
   constructor(
     private readonly previousPosition: number,
     private readonly nextPosition: number,
+    private readonly setCaretPosition: (position: number) => void,
   ) {
     this.execute();
   }
 
   public execute() {
-    SequenceRenderer.setCaretPosition(this.nextPosition);
+    this.setCaretPosition(this.nextPosition);
   }
 
   public invert(_renderersManager: RenderersManager) {
-    SequenceRenderer.setCaretPosition(this.previousPosition);
+    this.setCaretPosition(this.previousPosition);
   }
 }

--- a/packages/ketcher-core/src/application/editor/operations/modes/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/modes/index.ts
@@ -19,6 +19,7 @@ import { provideEditorInstance } from 'application/editor/editorSingleton';
 
 import type { RenderersManager } from 'application/render/renderers/RenderersManager';
 import { Operation } from 'domain/entities/Operation';
+import { SequenceRenderer } from 'application/render/renderers/sequence/SequenceRenderer';
 
 export class ReinitializeModeOperation implements Operation {
   public priority = 2;
@@ -40,16 +41,15 @@ export class RestoreSequenceCaretPositionOperation implements Operation {
   constructor(
     private readonly previousPosition: number,
     private readonly nextPosition: number,
-    private readonly setCaretPosition: (position: number) => void,
   ) {
     this.execute();
   }
 
   public execute() {
-    this.setCaretPosition(this.nextPosition);
+    SequenceRenderer.setCaretPosition(this.nextPosition);
   }
 
   public invert(_renderersManager: RenderersManager) {
-    this.setCaretPosition(this.previousPosition);
+    SequenceRenderer.setCaretPosition(this.previousPosition);
   }
 }

--- a/packages/ketcher-core/src/application/render/renderers/AmbiguousMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/AmbiguousMonomerRenderer.ts
@@ -8,7 +8,7 @@ import { AttachmentPointName } from 'domain/types';
 import { PreviewAttachmentPoint } from 'domain/PreviewAttachmentPoint';
 import { UsageInMacromolecule } from 'application/render';
 import { D3SvgElementSelection } from 'application/render/types';
-import { KetMonomerClass } from 'application/formatters';
+import { KetMonomerClass } from 'domain/constants/monomers';
 
 type PreviewAttachmentPointParams = {
   canvas: D3SvgElementSelection<SVGSVGElement, void>;

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -727,7 +727,6 @@ export class SequenceRenderer {
     const operation = new RestoreSequenceCaretPositionOperation(
       this.caretPosition,
       this.nextCaretPosition ?? this.caretPosition,
-      SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
     );
     SequenceRenderer.resetLastUserDefinedCaretPosition();
 
@@ -738,7 +737,6 @@ export class SequenceRenderer {
     const operation = new RestoreSequenceCaretPositionOperation(
       this.caretPosition,
       this.previousCaretPosition ?? this.caretPosition,
-      SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
     );
     SequenceRenderer.resetLastUserDefinedCaretPosition();
 

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -727,6 +727,7 @@ export class SequenceRenderer {
     const operation = new RestoreSequenceCaretPositionOperation(
       this.caretPosition,
       this.nextCaretPosition ?? this.caretPosition,
+      SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
     );
     SequenceRenderer.resetLastUserDefinedCaretPosition();
 
@@ -737,6 +738,7 @@ export class SequenceRenderer {
     const operation = new RestoreSequenceCaretPositionOperation(
       this.caretPosition,
       this.previousCaretPosition ?? this.caretPosition,
+      SequenceRenderer.setCaretPosition.bind(SequenceRenderer),
     );
     SequenceRenderer.resetLastUserDefinedCaretPosition();
 

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerTemplateUtils.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerTemplateUtils.ts
@@ -19,7 +19,7 @@ import {
   MULTITAIL_ARROW_SERIALIZE_KEY,
 } from 'domain/constants';
 
-function parseNode(node: any, struct: any) {
+function parseNode(node, struct) {
   const type = node.type;
   switch (type) {
     case 'arrow':
@@ -34,8 +34,10 @@ function parseNode(node: any, struct: any) {
     case 'molecule': {
       const currentStruct = moleculeToStruct(node);
       if (node.stereoFlagPosition) {
-        const fragment = currentStruct.frags.get(0)!;
-        fragment.stereoFlagPosition = new Vec2(node.stereoFlagPosition);
+        const fragment = currentStruct.frags.get(0);
+        if (fragment) {
+          fragment.stereoFlagPosition = new Vec2(node.stereoFlagPosition);
+        }
       }
       currentStruct.mergeInto(struct);
       break;
@@ -61,7 +63,7 @@ function parseNode(node: any, struct: any) {
   }
 }
 
-export function fillMonomerTemplateStruct(ket: any): Struct {
+export function fillMonomerTemplateStruct(ket): Struct {
   const resultingStruct = new Struct();
   const nodes = ket.root.nodes;
 

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerTemplateUtils.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerTemplateUtils.ts
@@ -1,0 +1,204 @@
+import {
+  IKetAttachmentPoint,
+  IKetMonomerTemplate,
+} from 'application/formatters/types/ket';
+import { Struct, Vec2, BaseMonomer } from 'domain/entities';
+import { MonomerItemType, AttachmentPointName } from 'domain/types';
+import { getAttachmentPointLabelWithBinaryShift } from 'domain/helpers/attachmentPointCalculations';
+import { isNumber } from 'lodash';
+import assert from 'assert';
+import { moleculeToStruct } from './moleculeToStruct';
+import { rxnToStruct } from './rxnToStruct';
+import { simpleObjectToStruct } from './simpleObjectToStruct';
+import { textToStruct } from './textToStruct';
+import { imageToStruct } from './imageToStruct';
+import { multitailArrowToStruct } from './multitailArrowToStruct';
+import { rgroupToStruct } from './rgroupToStruct';
+import {
+  IMAGE_SERIALIZE_KEY,
+  MULTITAIL_ARROW_SERIALIZE_KEY,
+} from 'domain/constants';
+
+function parseNode(node: any, struct: any) {
+  const type = node.type;
+  switch (type) {
+    case 'arrow':
+    case 'plus': {
+      rxnToStruct(node, struct);
+      break;
+    }
+    case 'simpleObject': {
+      simpleObjectToStruct(node, struct);
+      break;
+    }
+    case 'molecule': {
+      const currentStruct = moleculeToStruct(node);
+      if (node.stereoFlagPosition) {
+        const fragment = currentStruct.frags.get(0)!;
+        fragment.stereoFlagPosition = new Vec2(node.stereoFlagPosition);
+      }
+      currentStruct.mergeInto(struct);
+      break;
+    }
+    case 'rgroup': {
+      rgroupToStruct(node).mergeInto(struct);
+      break;
+    }
+    case 'text': {
+      textToStruct(node, struct);
+      break;
+    }
+    case MULTITAIL_ARROW_SERIALIZE_KEY: {
+      multitailArrowToStruct(node, struct);
+      break;
+    }
+    case IMAGE_SERIALIZE_KEY: {
+      imageToStruct(node, struct);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+export function fillMonomerTemplateStruct(ket: any): Struct {
+  const resultingStruct = new Struct();
+  const nodes = ket.root.nodes;
+
+  Object.keys(nodes).forEach((i) => {
+    if (nodes[i].type) parseNode(nodes[i], resultingStruct);
+    else if (nodes[i].$ref) parseNode(ket[nodes[i].$ref], resultingStruct);
+  });
+  resultingStruct.name = ket.header?.moleculeName ?? '';
+
+  return resultingStruct;
+}
+
+export function normalizeTemplateAttachmentPoints(
+  template: IKetMonomerTemplate,
+): IKetAttachmentPoint[] | undefined {
+  const attachmentPointsDict = (
+    template as IKetMonomerTemplate & {
+      attachmentPointsDict?: Record<string, IKetAttachmentPoint>;
+    }
+  ).attachmentPointsDict;
+
+  if (!attachmentPointsDict) {
+    return template.attachmentPoints;
+  }
+
+  return Object.entries(attachmentPointsDict).map(([key, attachmentPoint]) => {
+    let normalizedLabel: AttachmentPointName | undefined;
+    if (attachmentPoint.type === 'left') {
+      normalizedLabel = AttachmentPointName.R1;
+    } else if (attachmentPoint.type === 'right') {
+      normalizedLabel = AttachmentPointName.R2;
+    } else {
+      normalizedLabel = undefined;
+    }
+
+    return {
+      ...attachmentPoint,
+      label: attachmentPoint.label ?? key,
+      ...(normalizedLabel ? { type: attachmentPoint.type } : {}),
+    };
+  });
+}
+
+export function getTemplateAttachmentPoints(
+  template: IKetMonomerTemplate,
+): IKetAttachmentPoint[] {
+  const attachmentPoints = normalizeTemplateAttachmentPoints(template) ?? [];
+
+  return template.unresolved
+    ? attachmentPoints.map((_, index) => {
+        return {
+          attachmentAtom: index,
+          leavingGroup: {
+            atoms: [],
+          },
+        };
+      })
+    : attachmentPoints;
+}
+
+export function convertMonomerTemplateToStruct(
+  template: IKetMonomerTemplate,
+): Struct {
+  const attachmentPoints = getTemplateAttachmentPoints(template) ?? [];
+
+  return fillMonomerTemplateStruct({
+    root: {
+      nodes: [{ $ref: 'mol0' }],
+    },
+    mol0: {
+      ...template,
+      type: 'molecule',
+      atoms: template.unresolved
+        ? attachmentPoints?.map((_, index) => {
+            return {
+              label: 'C',
+              location: [index, index, index],
+            };
+          })
+        : template.atoms,
+      bonds: template.unresolved
+        ? attachmentPoints?.map((_, index) => {
+            if (index === attachmentPoints.length - 1) {
+              return {
+                type: 1,
+                atoms: [0, attachmentPoints.length - 1],
+              };
+            }
+            return {
+              type: 1,
+              atoms: [index, index + 1],
+            };
+          })
+        : template.bonds,
+      attachmentPoints,
+    },
+    header: {
+      moleculeName: template.fullName,
+    },
+  });
+}
+
+export function fillStructRgLabelsByMonomerTemplate(
+  template: IKetMonomerTemplate,
+  monomerItem: MonomerItemType,
+): void {
+  if (monomerItem.props.unresolved) {
+    return;
+  }
+
+  const attachmentPoints = getTemplateAttachmentPoints(template);
+
+  const { attachmentPointsList } =
+    BaseMonomer.getAttachmentPointDictFromMonomerDefinition(attachmentPoints);
+
+  attachmentPoints?.forEach((attachmentPoint, attachmentPointIndex) => {
+    const firstAtomInLeavingGroup = attachmentPoint.leavingGroup?.atoms[0];
+    const leavingGroupAtom = monomerItem.struct.atoms.get(
+      isNumber(firstAtomInLeavingGroup)
+        ? firstAtomInLeavingGroup
+        : attachmentPoint.attachmentAtom,
+    );
+    assert(leavingGroupAtom);
+    leavingGroupAtom.rglabel = (
+      0 |
+      (1 <<
+        (Number(
+          (attachmentPoint.label
+            ? attachmentPoint.label
+            : attachmentPointsList[attachmentPointIndex]
+          ).replace('R', ''),
+        ) -
+          1))
+    ).toString();
+    assert(monomerItem.props.MonomerCaps);
+    monomerItem.props.MonomerCaps[
+      getAttachmentPointLabelWithBinaryShift(Number(leavingGroupAtom.rglabel))
+    ] = leavingGroupAtom.label;
+  });
+}

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerToDrawingEntity.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerToDrawingEntity.ts
@@ -72,10 +72,9 @@ export function monomerToDrawingEntity(
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MonomerFactoryFn = (
   monomerItem: MonomerItemType,
-) => [new (...args: any[]) => BaseMonomer, ...unknown[]];
+) => [new (...args: unknown[]) => BaseMonomer, ...unknown[]];
 
 export function createMonomersForVariantMonomer(
   variantMonomerTemplate: IKetAmbiguousMonomerTemplate,

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerToDrawingEntity.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerToDrawingEntity.ts
@@ -5,15 +5,19 @@ import {
   IKetAmbiguousMonomerNode,
   IKetAmbiguousMonomerTemplate,
 } from 'application/formatters/types/ket';
-import { Struct, Vec2 } from 'domain/entities';
+import { Struct, Vec2, BaseMonomer } from 'domain/entities';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
+import { MonomerItemType } from 'domain/types/monomers';
 import {
   modifyTransformation,
   setMonomerTemplatePrefix,
   switchIntoChemistryCoordSystem,
 } from 'domain/serializers/ket/helpers';
-import { KetSerializer } from 'domain/serializers';
-import { monomerFactory } from 'application/editor/operations/monomer/monomerFactory';
+import {
+  convertMonomerTemplateToStruct,
+  fillStructRgLabelsByMonomerTemplate,
+  getTemplateAttachmentPoints,
+} from './monomerTemplateUtils';
 
 export function templateToMonomerProps(template: IKetMonomerTemplate) {
   return {
@@ -55,7 +59,7 @@ export function monomerToDrawingEntity(
       colorScheme: undefined,
       favorite: false,
       props: templateToMonomerProps(template),
-      attachmentPoints: KetSerializer.getTemplateAttachmentPoints(template),
+      attachmentPoints: getTemplateAttachmentPoints(template),
       seqId: seqid,
       ...(expanded !== undefined && {
         expanded,
@@ -68,9 +72,15 @@ export function monomerToDrawingEntity(
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MonomerFactoryFn = (
+  monomerItem: MonomerItemType,
+) => [new (...args: any[]) => BaseMonomer, ...unknown[]];
+
 export function createMonomersForVariantMonomer(
   variantMonomerTemplate: IKetAmbiguousMonomerTemplate,
   parsedFileContent: IKetMacromoleculesContent,
+  monomerFactory: MonomerFactoryFn,
 ) {
   const monomerTemplates = variantMonomerTemplate.options.map((option) => {
     return parsedFileContent[setMonomerTemplatePrefix(option.templateId)];
@@ -79,16 +89,12 @@ export function createMonomersForVariantMonomer(
     const monomerItem = {
       label: monomerTemplate.alias,
       expanded: false,
-      struct: KetSerializer.convertMonomerTemplateToStruct(monomerTemplate),
+      struct: convertMonomerTemplateToStruct(monomerTemplate),
       props: templateToMonomerProps(monomerTemplate),
-      attachmentPoints:
-        KetSerializer.getTemplateAttachmentPoints(monomerTemplate),
+      attachmentPoints: getTemplateAttachmentPoints(monomerTemplate),
     };
     const [MonomerConstructor] = monomerFactory(monomerItem);
-    KetSerializer.fillStructRgLabelsByMonomerTemplate(
-      monomerTemplate,
-      monomerItem,
-    );
+    fillStructRgLabelsByMonomerTemplate(monomerTemplate, monomerItem);
 
     return new MonomerConstructor(monomerItem, undefined, {
       generateId: false,
@@ -103,12 +109,17 @@ export function variantMonomerToDrawingEntity(
   node: IKetAmbiguousMonomerNode,
   template: IKetAmbiguousMonomerTemplate,
   parsedFileContent: IKetMacromoleculesContent,
+  monomerFactory: MonomerFactoryFn,
 ) {
   const position: Vec2 = switchIntoChemistryCoordSystem(
     new Vec2(node.position.x, node.position.y),
   );
 
-  const monomers = createMonomersForVariantMonomer(template, parsedFileContent);
+  const monomers = createMonomersForVariantMonomer(
+    template,
+    parsedFileContent,
+    monomerFactory,
+  );
 
   return drawingEntitiesManager.addAmbiguousMonomer(
     {

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -40,7 +40,6 @@ import { textToKet } from './toKet/textToKet';
 import { textToStruct } from './fromKet/textToStruct';
 import {
   IKetAmbiguousMonomerTemplate,
-  IKetAttachmentPoint,
   IKetConnection,
   IKetConnectionEndPoint,
   IKetConnectionMoleculeEndPoint,
@@ -65,7 +64,14 @@ import {
 import assert from 'assert';
 import { polymerBondToDrawingEntity } from 'domain/serializers/ket/fromKet/polymerBondToDrawingEntity';
 import { getMonomerUniqueKey } from 'domain/helpers/monomers';
-import { monomerFactory } from 'application/editor/operations/monomer/monomerFactory';
+import {
+  convertMonomerTemplateToStruct as convertMonomerTemplateToStructUtil,
+  fillStructRgLabelsByMonomerTemplate as fillStructRgLabelsByMonomerTemplateUtil,
+  getTemplateAttachmentPoints as getTemplateAttachmentPointsUtil,
+} from 'domain/serializers/ket/fromKet/monomerTemplateUtils';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MonomerFactoryFn = (monomer: any) => [any, any, any];
 import { KetcherLogger } from 'utilities';
 import { Chem } from 'domain/entities/Chem';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
@@ -81,7 +87,6 @@ import {
 import { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { validate } from 'domain/serializers/ket/validate';
 import { MacromoleculesConverter } from 'application/editor/MacromoleculesConverter';
-import { getAttachmentPointLabelWithBinaryShift } from 'domain/helpers/attachmentPointCalculations';
 import { isNumber } from 'lodash';
 import {
   AmbiguousMonomerType,
@@ -146,6 +151,21 @@ function parseNode(node: any, struct: any) {
   }
 }
 export class KetSerializer implements Serializer<Struct> {
+  private static _monomerFactory: MonomerFactoryFn | null = null;
+
+  public static setMonomerFactory(factory: MonomerFactoryFn): void {
+    KetSerializer._monomerFactory = factory;
+  }
+
+  private static getMonomerFactory(): MonomerFactoryFn {
+    if (!KetSerializer._monomerFactory) {
+      throw new Error(
+        'KetSerializer: monomerFactory has not been initialized. Call KetSerializer.setMonomerFactory() before using serializer features that require it.',
+      );
+    }
+    return KetSerializer._monomerFactory;
+  }
+
   deserializeMicromolecules(content: string): Struct {
     const ket = JSON.parse(content);
     if (!validate(ket)) {
@@ -348,53 +368,8 @@ export class KetSerializer implements Serializer<Struct> {
     return fileContentForMicromolecules;
   }
 
-  private static normalizeTemplateAttachmentPoints(
-    template: IKetMonomerTemplate,
-  ) {
-    const attachmentPointsDict = (
-      template as IKetMonomerTemplate & {
-        attachmentPointsDict?: Record<string, IKetAttachmentPoint>;
-      }
-    ).attachmentPointsDict;
-
-    if (!attachmentPointsDict) {
-      return template.attachmentPoints;
-    }
-
-    return Object.entries(attachmentPointsDict).map(
-      ([key, attachmentPoint]) => {
-        let normalizedLabel: AttachmentPointName | undefined;
-        if (attachmentPoint.type === 'left') {
-          normalizedLabel = AttachmentPointName.R1;
-        } else if (attachmentPoint.type === 'right') {
-          normalizedLabel = AttachmentPointName.R2;
-        } else {
-          normalizedLabel = undefined;
-        }
-
-        return {
-          ...attachmentPoint,
-          label: attachmentPoint.label ?? key,
-          ...(normalizedLabel ? { type: attachmentPoint.type } : {}),
-        };
-      },
-    );
-  }
-
   public static getTemplateAttachmentPoints(template: IKetMonomerTemplate) {
-    const attachmentPoints =
-      KetSerializer.normalizeTemplateAttachmentPoints(template) ?? [];
-
-    return template.unresolved
-      ? attachmentPoints.map((_, index) => {
-          return {
-            attachmentAtom: index,
-            leavingGroup: {
-              atoms: [],
-            },
-          };
-        })
-      : attachmentPoints;
+    return getTemplateAttachmentPointsUtil(template);
   }
 
   private static enrichTemplateWithLibraryData(template: IKetMonomerTemplate) {
@@ -418,45 +393,7 @@ export class KetSerializer implements Serializer<Struct> {
   }
 
   public static convertMonomerTemplateToStruct(template: IKetMonomerTemplate) {
-    const attachmentPoints =
-      KetSerializer.getTemplateAttachmentPoints(template) ?? [];
-
-    return KetSerializer.fillStruct({
-      root: {
-        nodes: [{ $ref: 'mol0' }],
-      },
-      mol0: {
-        ...template,
-        type: 'molecule',
-        atoms: template.unresolved
-          ? attachmentPoints?.map((_, index) => {
-              return {
-                label: 'C',
-                location: [index, index, index],
-              };
-            })
-          : template.atoms,
-        bonds: template.unresolved
-          ? attachmentPoints?.map((_, index) => {
-              if (index === attachmentPoints.length - 1) {
-                return {
-                  type: 1,
-                  atoms: [0, attachmentPoints.length - 1],
-                };
-              }
-
-              return {
-                type: 1,
-                atoms: [index, index + 1],
-              };
-            })
-          : template.bonds,
-        attachmentPoints,
-      },
-      header: {
-        moleculeName: template.fullName,
-      },
-    });
+    return convertMonomerTemplateToStructUtil(template);
   }
 
   public convertMonomerTemplateToLibraryItem(
@@ -480,40 +417,7 @@ export class KetSerializer implements Serializer<Struct> {
     template: IKetMonomerTemplate,
     monomerItem: MonomerItemType,
   ) {
-    if (monomerItem.props.unresolved) {
-      return;
-    }
-
-    const attachmentPoints =
-      KetSerializer.getTemplateAttachmentPoints(template);
-
-    const { attachmentPointsList } =
-      BaseMonomer.getAttachmentPointDictFromMonomerDefinition(attachmentPoints);
-
-    attachmentPoints?.forEach((attachmentPoint, attachmentPointIndex) => {
-      const firstAtomInLeavingGroup = attachmentPoint.leavingGroup?.atoms[0];
-      const leavingGroupAtom = monomerItem.struct.atoms.get(
-        isNumber(firstAtomInLeavingGroup)
-          ? firstAtomInLeavingGroup
-          : attachmentPoint.attachmentAtom,
-      );
-      assert(leavingGroupAtom);
-      leavingGroupAtom.rglabel = (
-        0 |
-        (1 <<
-          (Number(
-            (attachmentPoint.label
-              ? attachmentPoint.label
-              : attachmentPointsList[attachmentPointIndex]
-            ).replace('R', ''),
-          ) -
-            1))
-      ).toString();
-      assert(monomerItem.props.MonomerCaps);
-      monomerItem.props.MonomerCaps[
-        getAttachmentPointLabelWithBinaryShift(Number(leavingGroupAtom.rglabel))
-      ] = leavingGroupAtom.label;
-    });
+    return fillStructRgLabelsByMonomerTemplateUtil(template, monomerItem);
   }
 
   deserializeToDrawingEntities(fileContent: string) {
@@ -563,6 +467,7 @@ export class KetSerializer implements Serializer<Struct> {
             nodeDefinition,
             template,
             parsedFileContent,
+            KetSerializer.getMonomerFactory(),
           );
           const monomer = monomerAdditionCommand.operations[0]
             .monomer as BaseMonomer;
@@ -763,7 +668,9 @@ export class KetSerializer implements Serializer<Struct> {
     monomer: BaseMonomer,
     fileContent: IKetMacromoleculesContentRootProperty,
   ) {
-    const [, , monomerClass] = monomerFactory(monomer.monomerItem);
+    const [, , monomerClass] = KetSerializer.getMonomerFactory()(
+      monomer.monomerItem,
+    );
     const templateNameWithPrefix = setMonomerTemplatePrefix(templateId);
 
     if (fileContent[templateNameWithPrefix]) {
@@ -1226,6 +1133,7 @@ export class KetSerializer implements Serializer<Struct> {
             monomers: createMonomersForVariantMonomer(
               variantMonomerTemplate,
               monomersLibrary,
+              KetSerializer.getMonomerFactory(),
             ),
             options: variantMonomerTemplate.options,
             subtype: variantMonomerTemplate.subtype,

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -69,9 +69,6 @@ import {
   fillStructRgLabelsByMonomerTemplate as fillStructRgLabelsByMonomerTemplateUtil,
   getTemplateAttachmentPoints as getTemplateAttachmentPointsUtil,
 } from 'domain/serializers/ket/fromKet/monomerTemplateUtils';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MonomerFactoryFn = (monomer: any) => [any, any, any];
 import { KetcherLogger } from 'utilities';
 import { Chem } from 'domain/entities/Chem';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
@@ -107,6 +104,9 @@ import { isMonomerSgroupWithAttachmentPoints } from '../../../utilities/monomers
 import { HydrogenBond } from 'domain/entities/HydrogenBond';
 
 import { MACROMOLECULES_BOND_TYPES } from 'application/editor/tools/types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MonomerFactoryFn = (monomer: any) => [any, any, any];
 
 function parseNode(node: any, struct: any) {
   const type = node.type;


### PR DESCRIPTION
Contains [PR](https://github.com/epam/ketcher/pull/9950). Review and merge accordingly.

## How the feature works? / How did you fix the issue?
**Cycles shortened:** 
several cycles are 1 hoop shorter now: removed `ketSerializer` -> `monomerFactory` cycle

**Problem 1:** monomerToDrawingEntity.ts imported KetSerializer only to call 3 static utility methods, creating a cycle back through the serializer.

Fix: Extracted `getTemplateAttachmentPoints`, `convertMonomerTemplateToStruct`, and `fillStructRgLabelsByMonomerTemplate` into a new pure-domain file `monomerTemplateUtils.ts`. `monomerToDrawingEntity.ts` now imports them directly - `KetSerializer` import was removed.

**Problem 2:** `ketSerializer.ts` directly imported `monomerFactory` from the application layer, dragging the entire `monomerFactory` -> `renderers` -> `editor` cascade into every path through the serializer.

Fix: Removed the direct import. `monomerFactory` is now injected via a new `KetSerializer.setMonomerFactory()` static setter, to be called once at application boot from the application layer.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request