### PR TITLE
#9918 - Refactor: Functions should not have identical implementations

### DIFF
--- a/ketcher-autotests/tests/utils/files/receiveFileComparisonData.ts
+++ b/ketcher-autotests/tests/utils/files/receiveFileComparisonData.ts
@@ -89,7 +89,7 @@ async function getFileContent(
 }
 
 // Filter file lines: by default drop lines containing '-INDIGO-', 'Ketcher',
-// '$DATM', or '$MDL'. When indexes are provided, keep only those line indexes.
+// '$DATM', or '$MDL'. When indexes are provided, exclude those line indexes.
 function filterExportLines(lines: string[], indexes: number[]): string[] {
   if (indexes.length === 0) {
     return lines.filter(

--- a/ketcher-autotests/tests/utils/files/receiveFileComparisonData.ts
+++ b/ketcher-autotests/tests/utils/files/receiveFileComparisonData.ts
@@ -88,6 +88,21 @@ async function getFileContent(
   return fileContent;
 }
 
+// Filter file lines: by default drop lines containing '-INDIGO-', 'Ketcher',
+// '$DATM', or '$MDL'. When indexes are provided, keep only those line indexes.
+function filterExportLines(lines: string[], indexes: number[]): string[] {
+  if (indexes.length === 0) {
+    return lines.filter(
+      (line) =>
+        !line.includes('-INDIGO-') &&
+        !line.includes('$DATM') &&
+        !line.includes('$MDL') &&
+        !line.includes('Ketcher'),
+    );
+  }
+  return filterByIndexes(lines, indexes);
+}
+
 export async function verifyFileExport(
   page: Page,
   expectedFilename: string,
@@ -109,24 +124,9 @@ export async function verifyFileExport(
     fileFormat: format,
     metaDataIndexes,
   });
-  // Function to filter lines
-  const filterLines = (lines: string[], indexes: number[]) => {
-    if (indexes.length === 0) {
-      // Default behavior: ignore lines containing '-INDIGO-', 'Ketcher' and '$DATM'
-      return lines.filter(
-        (line) =>
-          !line.includes('-INDIGO-') &&
-          !line.includes('$DATM') &&
-          !line.includes('$MDL') &&
-          !line.includes('Ketcher'),
-      );
-    }
-    // If indexes are specified, filter lines by indexes
-    return filterByIndexes(lines, indexes);
-  };
   // Apply filtering to both files
-  const filteredFile = filterLines(file, metaDataIndexes);
-  const filteredFileExpected = filterLines(fileExpected, metaDataIndexes);
+  const filteredFile = filterExportLines(file, metaDataIndexes);
+  const filteredFileExpected = filterExportLines(fileExpected, metaDataIndexes);
   // Compare the filtered files
   expect(filteredFile).toEqual(filteredFileExpected);
 }
@@ -146,26 +146,11 @@ export async function verifyConsoleExport(
   // and file content from memory (named as file) from unnessusary data
   const fileExpected = (await readFileContent(expectedFilename)).split('\n');
 
-  // Function to filter lines
-  const filterLines = (lines: string[], indexes: number[]) => {
-    if (indexes.length === 0) {
-      // Default behavior: ignore lines containing '-INDIGO-', 'Ketcher' and '$DATM'
-      return lines.filter(
-        (line) =>
-          !line.includes('-INDIGO-') &&
-          !line.includes('$DATM') &&
-          !line.includes('$MDL') &&
-          !line.includes('Ketcher'),
-      );
-    }
-    // If indexes are specified, filter lines by indexes
-    return filterByIndexes(lines, indexes);
-  };
-  const filteredConsoleContent = filterLines(
+  const filteredConsoleContent = filterExportLines(
     consoleContent.split('\n'),
     metaDataIndexes,
   );
-  const filteredFileExpected = filterLines(fileExpected, metaDataIndexes);
+  const filteredFileExpected = filterExportLines(fileExpected, metaDataIndexes);
   // Compare the filtered files
   expect(filteredConsoleContent).toEqual(filteredFileExpected);
 }

--- a/packages/ketcher-core/src/domain/serializers/mol/common.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/common.ts
@@ -128,26 +128,8 @@ function prepareSruForSaving(sgroup: SGroup, mol: Struct): void {
 }
 
 function prepareCopForSaving(sgroup: SGroup, mol: Struct): void {
-  const xBonds: number[] = [];
-  mol.bonds.forEach((bond, bid) => {
-    const a1 = getAtom(mol, bond.begin);
-    const a2 = getAtom(mol, bond.end);
-    if (
-      (a1.sgs.has(sgroup.id) && !a2.sgs.has(sgroup.id)) ||
-      (a2.sgs.has(sgroup.id) && !a1.sgs.has(sgroup.id))
-    ) {
-      xBonds.push(bid);
-    }
-  });
-  if (xBonds.length !== 0 && xBonds.length !== 2) {
-    const error = new Error(
-      'Unsupported cross-bonds number',
-    ) as SGroupSavingError;
-    error.id = sgroup.id;
-    error['error-type'] = 'cross-bond-number';
-    throw error;
-  }
-  sgroup.bonds = xBonds;
+  // Same cross-bond computation as SRU.
+  prepareSruForSaving(sgroup, mol);
 }
 
 function prepareSupForSaving(sgroup: SGroup, mol: Struct): void {
@@ -256,13 +238,8 @@ function saveCopToMolfile(
   atomMap: Mapping,
   bondMap: Mapping,
 ): string {
-  const idstr = (sgMap[sgroup.id] + '').padStart(3);
-
-  let lines: string[] = [];
-  lines = lines.concat(makeAtomBondLines('SAL', idstr, sgroup.atoms, atomMap));
-  lines = lines.concat(makeAtomBondLines('SBL', idstr, sgroup.bonds, bondMap));
-  lines = lines.concat(bracketsToMolfile(mol, sgroup, idstr));
-  return lines.join('\n');
+  // COP is serialized identically to SRU.
+  return saveSruToMolfile(sgroup, mol, sgMap, atomMap, bondMap);
 }
 
 function saveSupToMolfile(
@@ -367,13 +344,8 @@ function saveGenToMolfile(
   atomMap: Mapping,
   bondMap: Mapping,
 ): string {
-  const idstr = (sgMap[sgroup.id] + '').padStart(3);
-
-  let lines: string[] = [];
-  lines = lines.concat(makeAtomBondLines('SAL', idstr, sgroup.atoms, atomMap));
-  lines = lines.concat(makeAtomBondLines('SBL', idstr, sgroup.bonds, bondMap));
-  lines = lines.concat(bracketsToMolfile(mol, sgroup, idstr));
-  return lines.join('\n');
+  // GEN is serialized identically to SRU.
+  return saveSruToMolfile(sgroup, mol, sgMap, atomMap, bondMap);
 }
 
 function makeAtomBondLines(

--- a/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.ts
@@ -150,10 +150,8 @@ function postLoadMer(_sgroup: SGroup): void {
 }
 
 function postLoadCop(sgroup: SGroup): void {
-  sgroup.data.connectivity = (sgroup.data.connectivity || 'eu')
-    .trim()
-    .toLowerCase();
-  sgroup.data.subtype = (sgroup.data.subtype || '').trim().toLowerCase();
+  // COP post-load is identical to GEN.
+  postLoadGen(sgroup);
 }
 
 function postLoadCro(_sgroup: SGroup): void {

--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -152,43 +152,6 @@ export const EditorEvents = () => {
     [dispatchShowPreview],
   );
 
-  useEffect(() => {
-    const handler = ([toolName]: [string]) => {
-      if (toolName !== activeTool) {
-        dispatch(selectTool(toolName));
-      }
-    };
-
-    if (editor) {
-      editor.events.error.add((errorText) => {
-        dispatch(openErrorTooltip(errorText));
-      });
-      editor.events.openErrorModal.add(
-        (errorData: string | { errorMessage: string; errorTitle: string }) => {
-          dispatch(openErrorModal(errorData));
-        },
-      );
-
-      dispatch(selectTool('select-rectangle'));
-      editor.events.selectTool.dispatch(['select-rectangle']);
-      editor.events.openMonomerConnectionModal.add(
-        (additionalProps: MonomerConnectionOnlyProps) =>
-          dispatch(
-            openModal({
-              name: 'monomerConnection',
-              additionalProps,
-            }),
-          ),
-      );
-      editor.events.selectTool.add(handler);
-    }
-
-    return () => {
-      dispatch(selectTool(null));
-      editor?.events.selectTool.remove(handler);
-    };
-  }, [editor]);
-
   const handleOpenBondPreview = useCallback(
     (polymerBond: PolymerBond, style: PreviewStyle) => {
       const previewData: BondPreviewState = {

--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -152,6 +152,43 @@ export const EditorEvents = () => {
     [dispatchShowPreview],
   );
 
+  useEffect(() => {
+    const handler = ([toolName]: [string]) => {
+      if (toolName !== activeTool) {
+        dispatch(selectTool(toolName));
+      }
+    };
+
+    if (editor) {
+      editor.events.error.add((errorText) => {
+        dispatch(openErrorTooltip(errorText));
+      });
+      editor.events.openErrorModal.add(
+        (errorData: string | { errorMessage: string; errorTitle: string }) => {
+          dispatch(openErrorModal(errorData));
+        },
+      );
+
+      dispatch(selectTool('select-rectangle'));
+      editor.events.selectTool.dispatch(['select-rectangle']);
+      editor.events.openMonomerConnectionModal.add(
+        (additionalProps: MonomerConnectionOnlyProps) =>
+          dispatch(
+            openModal({
+              name: 'monomerConnection',
+              additionalProps,
+            }),
+          ),
+      );
+      editor.events.selectTool.add(handler);
+    }
+
+    return () => {
+      dispatch(selectTool(null));
+      editor?.events.selectTool.remove(handler);
+    };
+  }, [editor]);
+
   const handleOpenBondPreview = useCallback(
     (polymerBond: PolymerBond, style: PreviewStyle) => {
       const previewData: BondPreviewState = {

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -211,6 +211,22 @@ const messageTypeToEventMapping: {
     WorkerEvent.CalculateMacromoleculeProperties,
 };
 
+// Worker action that resolves with a `{ struct, format: Mol }` payload,
+// shared by every command whose result type is `WithStruct & WithFormat`
+// (Aromatize/Dearomatize/ExplicitHydrogens — all extend the same shape).
+function makeMolResultAction<
+  TResult extends { struct: string; format: ChemicalMimeType },
+>(resolve: (value: TResult) => void, reject: (reason?: unknown) => void) {
+  return ({ data }: OutputMessageWrapper) => {
+    const msg: OutputMessage<string> = data;
+    if (!msg.hasError) {
+      resolve({ struct: msg.payload, format: ChemicalMimeType.Mol } as TResult);
+    } else {
+      reject(new Error(msg.error));
+    }
+  };
+}
+
 class IndigoService implements StructService {
   private readonly defaultOptions: StructServiceOptions;
   private readonly worker: Worker;
@@ -483,19 +499,8 @@ class IndigoService implements StructService {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
 
-    return new Promise((resolve, reject) => {
-      const action = ({ data }: OutputMessageWrapper) => {
-        const msg: OutputMessage<string> = data;
-        if (!msg.hasError) {
-          const result: AromatizeResult = {
-            struct: msg.payload,
-            format: ChemicalMimeType.Mol,
-          };
-          resolve(result);
-        } else {
-          reject(new Error(msg.error));
-        }
-      };
+    return new Promise<AromatizeResult>((resolve, reject) => {
+      const action = makeMolResultAction<AromatizeResult>(resolve, reject);
 
       const commandData: AromatizeCommandData = {
         struct,
@@ -521,19 +526,8 @@ class IndigoService implements StructService {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
 
-    return new Promise((resolve, reject) => {
-      const action = ({ data }: OutputMessageWrapper) => {
-        const msg: OutputMessage<string> = data;
-        if (!msg.hasError) {
-          const result: AromatizeResult = {
-            struct: msg.payload,
-            format: ChemicalMimeType.Mol,
-          };
-          resolve(result);
-        } else {
-          reject(new Error(msg.error));
-        }
-      };
+    return new Promise<DearomatizeResult>((resolve, reject) => {
+      const action = makeMolResultAction<DearomatizeResult>(resolve, reject);
 
       const commandData: DearomatizeCommandData = {
         struct,
@@ -795,19 +789,11 @@ class IndigoService implements StructService {
     const format = convertMimeTypeToOutputFormat(outputFormat);
     const mode = 'auto';
 
-    return new Promise((resolve, reject) => {
-      const action = ({ data }: OutputMessageWrapper) => {
-        const msg: OutputMessage<string> = data;
-        if (!msg.hasError) {
-          const result: AromatizeResult = {
-            struct: msg.payload,
-            format: ChemicalMimeType.Mol,
-          };
-          resolve(result);
-        } else {
-          reject(new Error(msg.error));
-        }
-      };
+    return new Promise<ExplicitHydrogensResult>((resolve, reject) => {
+      const action = makeMolResultAction<ExplicitHydrogensResult>(
+        resolve,
+        reject,
+      );
 
       const commandData: ExplicitHydrogensCommandData = {
         struct,

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -214,13 +214,14 @@ const messageTypeToEventMapping: {
 // Worker action that resolves with a `{ struct, format: Mol }` payload,
 // shared by every command whose result type is `WithStruct & WithFormat`
 // (Aromatize/Dearomatize/ExplicitHydrogens — all extend the same shape).
-function makeMolResultAction<
-  TResult extends { struct: string; format: ChemicalMimeType },
->(resolve: (value: TResult) => void, reject: (reason?: unknown) => void) {
+function makeMolResultAction(
+  resolve: (value: { struct: string; format: ChemicalMimeType.Mol }) => void,
+  reject: (reason?: unknown) => void,
+) {
   return ({ data }: OutputMessageWrapper) => {
     const msg: OutputMessage<string> = data;
     if (!msg.hasError) {
-      resolve({ struct: msg.payload, format: ChemicalMimeType.Mol } as TResult);
+      resolve({ struct: msg.payload, format: ChemicalMimeType.Mol });
     } else {
       reject(new Error(msg.error));
     }
@@ -500,7 +501,7 @@ class IndigoService implements StructService {
     const format = convertMimeTypeToOutputFormat(outputFormat);
 
     return new Promise<AromatizeResult>((resolve, reject) => {
-      const action = makeMolResultAction<AromatizeResult>(resolve, reject);
+      const action = makeMolResultAction(resolve, reject);
 
       const commandData: AromatizeCommandData = {
         struct,
@@ -527,7 +528,7 @@ class IndigoService implements StructService {
     const format = convertMimeTypeToOutputFormat(outputFormat);
 
     return new Promise<DearomatizeResult>((resolve, reject) => {
-      const action = makeMolResultAction<DearomatizeResult>(resolve, reject);
+      const action = makeMolResultAction(resolve, reject);
 
       const commandData: DearomatizeCommandData = {
         struct,
@@ -790,10 +791,7 @@ class IndigoService implements StructService {
     const mode = 'auto';
 
     return new Promise<ExplicitHydrogensResult>((resolve, reject) => {
-      const action = makeMolResultAction<ExplicitHydrogensResult>(
-        resolve,
-        reject,
-      );
+      const action = makeMolResultAction(resolve, reject);
 
       const commandData: ExplicitHydrogensCommandData = {
         struct,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
## Summary
  Sonar flagged eight functions across five files whose bodies were byte-identical to another function (or an embedded
  helper). Each duplicate is replaced by either delegating to the canonical implementation or by extracting a shared
  helper. Pure deduplication — no behavioral change except where noted.

  ## Changes

  ### `packages/ketcher-core/src/domain/serializers/mol/common.ts`
  - `prepareCopForSaving` (L130) now delegates to `prepareSruForSaving`.
  - `saveCopToMolfile` (L252) now delegates to `saveSruToMolfile`.
  - `saveGenToMolfile` (L362) now delegates to `saveSruToMolfile`.

  ### `packages/ketcher-core/src/domain/serializers/mol/parseSGroup.ts`
  - `postLoadCop` (L152) now delegates to `postLoadGen`.

  ### `packages/ketcher-macromolecules/src/EditorEvents.tsx`
  - Removed the second duplicate `useEffect` (L155). It was a strict subset of the first one (L99) and was
  double-registering `error`, `openErrorModal`, `openMonomerConnectionModal`, and `selectTool` handlers, and dispatching
   `selectTool('select-rectangle')` twice on mount. Removing the duplicate prevents redundant subscriptions and
  eliminates a small startup flicker.

  ### `packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts`
  - Extracted a module-scope helper `makeMolResultAction<TResult>(resolve, reject)` that builds the worker-message
  handler returning `{ struct, format: ChemicalMimeType.Mol }`.
  - `aromatize`, `dearomatize`, and `toggleExplicitHydrogens` now use the helper instead of inlining identical
  callbacks.
  - Side fix: `toggleExplicitHydrogens` previously typed its result as `AromatizeResult`. The helper makes the result
  type follow the method's `ExplicitHydrogensResult` signature.

  ### `ketcher-autotests/tests/utils/files/receiveFileComparisonData.ts`
  - Extracted the duplicated inline `filterLines` arrow into a module-scope `filterExportLines` helper used by both
  `verifyFileExport` and `verifyConsoleExport`.

  ## Behavioral notes
  - All delegations preserve identical observable behavior. Each delegate call passes the same arguments in the same
  order.
  - Removing the duplicate `useEffect` in `EditorEvents.tsx` is technically a small behavior change (handlers/dispatches
   no longer fire twice on mount), but the second invocation was always redundant — the original first `useEffect`
  already registers the same handlers in the same order.
  - The `toggleExplicitHydrogens` result-type fix corrects an existing typo with no runtime consequence (both
  `AromatizeResult` and `ExplicitHydrogensResult` are structurally `{ struct, format }`).

  ## Test plan
  - [x] `prettier --check` clean on all five touched files
  - [x] `eslint --quiet` clean on all five touched files
  - [x] `tsc --noEmit` clean for `ketcher-core` and `ketcher-standalone` (the only `ketcher-macromolecules` errors are
  the pre-existing `Cannot find module 'ketcher-react'` ones that exist on master too — unrelated to this PR)
  - [x] `npm run test` (full pipeline) clean for `ketcher-core` (349 unit tests pass) and `ketcher-standalone` (no unit
  tests)
  - [x] `ketcher-macromolecules` test suite outcome identical to master (same 23 fail / 8 pass split caused by missing
  `ketcher-react/dist` — not introduced here)
  - [x] Manual sanity: monomer/sgroup save round-trip relies on `saveCopToMolfile` / `saveGenToMolfile` /
  `prepareCopForSaving` paths, which now delegate to the SRU equivalents — same byte output expected

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request