### PR TITLE
#9920 – Refactor: Redundant casts and non-null assertions should be a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ ketcher-autotests/results.json
 .yarn/*
 output.txt
 .github/agents/*
+
+.cursor
+.cursor/*

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -194,7 +194,7 @@ export function fromBondAddition(
     );
   }
 
-  return [action, beginAtomId, endAtomId, newBondId as number];
+  return [action, beginAtomId, endAtomId, newBondId];
 }
 
 export function fromBondsAttrs(

--- a/packages/ketcher-core/src/application/editor/actions/chain.ts
+++ b/packages/ketcher-core/src/application/editor/actions/chain.ts
@@ -78,8 +78,8 @@ export function fromChain(
       pos,
     );
     action = ret[0].mergeWith(action);
-    id0 = ret[2] as number;
-    chainItems.bonds.push(ret[3] as number);
+    id0 = ret[2];
+    chainItems.bonds.push(ret[3]);
     chainItems.atoms.push(id0);
   }
 

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -32,6 +32,7 @@ import { fromPaste } from './paste';
 import utils from '../shared/utils';
 import { fromSgroupAddition } from './sgroup';
 import type { ReStruct } from 'application/render';
+import { KetcherLogger } from 'utilities';
 
 const benzeneMoleculeName = 'Benzene';
 const cyclopentadieneMoleculeName = 'Cyclopentadiene';
@@ -82,7 +83,10 @@ function extraBondAction(
   } else {
     const pivotAtom = restruct.molecule.atoms.get(aid);
     if (!pivotAtom) {
-      throw new Error(`Atom ${aid} not found`);
+      KetcherLogger.error(
+        `template.ts::extraBondAction: atom ${aid} not found`,
+      );
+      return { action, aid1: aid };
     }
 
     const operation = new AtomAdd(
@@ -93,7 +97,10 @@ function extraBondAction(
     action.addOp(operation);
     const newAid = operation.data.aid;
     if (typeof newAid !== 'number') {
-      throw new Error('Atom id was not assigned after AtomAdd');
+      KetcherLogger.error(
+        'template.ts::extraBondAction: atom id was not assigned after AtomAdd',
+      );
+      return { action, aid1: aid };
     }
 
     action.addOp(new BondAdd(aid, newAid, { type: 1 }).perform(restruct));

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -78,27 +78,30 @@ function extraBondAction(
     );
     action = actionRes[0];
     action.operations.reverse();
-    additionalAtom = actionRes[2] as number;
+    additionalAtom = actionRes[2];
   } else {
+    const pivotAtom = restruct.molecule.atoms.get(aid);
+    if (!pivotAtom) {
+      throw new Error(`Atom ${aid} not found`);
+    }
+
     const operation = new AtomAdd(
       { label: 'C', fragment: frid },
-      new Vec2(1, 0)
-        .rotate(angle)
-        .add((restruct.molecule.atoms.get(aid) as Atom).pp)
-        .get_xy0(),
-    ).perform(restruct) as AtomAdd;
+      new Vec2(1, 0).rotate(angle).add(pivotAtom.pp).get_xy0(),
+    ).perform(restruct);
 
     action.addOp(operation);
-    action.addOp(
-      new BondAdd(aid, operation.data.aid as number, { type: 1 }).perform(
-        restruct,
-      ),
-    );
+    const newAid = operation.data.aid;
+    if (typeof newAid !== 'number') {
+      throw new Error('Atom id was not assigned after AtomAdd');
+    }
 
-    additionalAtom = operation.data.aid as number;
+    action.addOp(new BondAdd(aid, newAid, { type: 1 }).perform(restruct));
+
+    additionalAtom = newAid;
   }
 
-  return { action, aid1: additionalAtom as number };
+  return { action, aid1: additionalAtom };
 }
 
 export function fromTemplateOnAtom(

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -33,6 +33,7 @@ import utils from '../shared/utils';
 import { fromSgroupAddition } from './sgroup';
 import type { ReStruct } from 'application/render';
 import { KetcherLogger } from 'utilities';
+import { isNumber } from 'lodash';
 
 const benzeneMoleculeName = 'Benzene';
 const cyclopentadieneMoleculeName = 'Cyclopentadiene';
@@ -95,17 +96,17 @@ function extraBondAction(
     ).perform(restruct);
 
     action.addOp(operation);
-    const newAid = operation.data.aid;
-    if (typeof newAid !== 'number') {
+    const newAtomId = operation.data.aid;
+    if (!isNumber(newAtomId)) {
       KetcherLogger.error(
         'template.ts::extraBondAction: atom id was not assigned after AtomAdd',
       );
       return { action, aid1: aid };
     }
 
-    action.addOp(new BondAdd(aid, newAid, { type: 1 }).perform(restruct));
+    action.addOp(new BondAdd(aid, newAtomId, { type: 1 }).perform(restruct));
 
-    additionalAtom = newAid;
+    additionalAtom = newAtomId;
   }
 
   return { action, aid1: additionalAtom };

--- a/packages/ketcher-core/src/application/render/restruct/rergroup.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroup.ts
@@ -200,20 +200,17 @@ class ReRGroup extends ReObject {
   }
 
   show(restruct: ReStruct, _id: number, options: RenderOptions): void {
-    const drawing = this.draw(restruct.render, options);
+    const { data } = this.draw(restruct.render, options);
 
-    Object.keys(drawing).forEach((group) => {
-      const items = drawing[group as keyof typeof drawing] as unknown[];
-      while (items.length > 0) {
-        restruct.addReObjectPath(
-          LayerMap.data,
-          this.visel,
-          items.shift(),
-          null,
-          true,
-        );
-      }
-    });
+    while (data.length > 0) {
+      restruct.addReObjectPath(
+        LayerMap.data,
+        this.visel,
+        data.shift(),
+        null,
+        true,
+      );
+    }
   }
 }
 

--- a/packages/ketcher-core/src/application/render/restruct/visel.ts
+++ b/packages/ketcher-core/src/application/render/restruct/visel.ts
@@ -71,7 +71,7 @@ class Visel {
   translate(x: number, y: number): void;
   translate(...args: [Vec2] | [number, number]): void {
     if (args.length === 1) {
-      const vector = args[0] as Vec2;
+      const vector = args[0];
       this.translate(vector.x, vector.y);
     } else {
       const [x, y] = args;

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -522,7 +522,8 @@ export const RnaEditorExpanded = ({
   };
 
   const onSave = () => {
-    if (!newPreset?.name) {
+    const presetName = newPreset?.name;
+    if (!presetName) {
       return;
     }
 
@@ -541,13 +542,13 @@ export const RnaEditorExpanded = ({
     };
 
     const presetWithSameName = presets.find(
-      (preset) => preset.name === presetToSave.name,
+      (preset) => preset.name === presetName,
     );
     if (
       presetWithSameName &&
       activePreset.nameInList !== presetWithSameName.name
     ) {
-      dispatch(setUniqueNameError(presetToSave.name!));
+      dispatch(setUniqueNameError(presetName));
       return;
     }
     dispatch(savePreset(presetToSave));
@@ -556,7 +557,7 @@ export const RnaEditorExpanded = ({
       editor?.events.selectPreset.dispatch(presetToSave);
     }
     setTimeout(() => {
-      scrollToSelectedPreset(presetToSave.name);
+      scrollToSelectedPreset(presetName);
     }, 0);
     resetRnaBuilder(dispatch);
   };

--- a/packages/ketcher-react/src/components/Dialog/Dialog.tsx
+++ b/packages/ketcher-react/src/components/Dialog/Dialog.tsx
@@ -91,14 +91,14 @@ export const Dialog: FC<PropsWithChildren & Props> = (props) => {
     // in popup mode the native <dialog> lives inside a MUI portal appended to
     // document.body — outside the .Ketcher-root subtree — so closest() returns
     // null and clipArea would be undefined.
-    const clipArea = document.querySelector(
+    const clipArea = document.querySelector<HTMLElement>(
       `${KETCHER_ROOT_NODE_CSS_SELECTOR} .${CLIP_AREA_BASE_CLASS}`,
-    ) as HTMLElement | null;
+    );
 
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     if (focusable && dialogElement) {
       timeoutId = setTimeout(() => {
-        (dialogElement as HTMLElement).focus();
+        dialogElement.focus();
       }, 0);
     }
 

--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -148,7 +148,7 @@ class Form extends Component<FormProps> {
 
     if (init) {
       const { valid, errors } = this.schema.serialize(init);
-      const errs = getErrorsObj(errors);
+      const errs = getErrorsObj(errors as FormValidationError[]);
       const initialState = { ...init, init: true };
       onUpdate(initialState, valid, errs);
     }
@@ -173,8 +173,8 @@ class Form extends Component<FormProps> {
   updateState(newState: Record<string, unknown>) {
     const { onUpdate } = this.props;
     const { instance, valid, errors } = this.schema.serialize(newState);
-    const errs = getErrorsObj(errors);
-    onUpdate(instance, valid, errs);
+    const errs = getErrorsObj(errors as FormValidationError[]);
+    onUpdate(instance as Record<string, unknown>, valid, errs);
   }
 
   field(name: string, onChange?: (value: unknown) => void, extraName?: string) {
@@ -644,26 +644,20 @@ function propSchema(
   };
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function serializeRewrite(
   serializeMap: Record<string, string>,
   instance: unknown,
   schema: FormSchema,
-): Record<string, unknown> {
-  if (!isPlainRecord(instance) || !schema.properties) {
-    const fallback = instance !== undefined ? instance : schema.default;
-    if (isPlainRecord(fallback)) {
-      return { ...fallback };
-    }
-    return {};
+): unknown {
+  const res: Record<string, unknown> = {};
+  if (typeof instance !== 'object' || instance === null || !schema.properties) {
+    return instance !== undefined ? instance : schema.default;
   }
 
-  const res: Record<string, unknown> = {};
+  const instanceObj = instance as Record<string, unknown>;
   Object.keys(schema.properties).forEach((p) => {
-    if (p in instance) res[p] = instance[serializeMap[p]] ?? instance[p];
+    if (p in instanceObj)
+      res[p] = instanceObj[serializeMap[p]] ?? instanceObj[p];
   });
 
   return res;

--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -148,7 +148,7 @@ class Form extends Component<FormProps> {
 
     if (init) {
       const { valid, errors } = this.schema.serialize(init);
-      const errs = getErrorsObj(errors as FormValidationError[]);
+      const errs = getErrorsObj(errors);
       const initialState = { ...init, init: true };
       onUpdate(initialState, valid, errs);
     }
@@ -173,8 +173,8 @@ class Form extends Component<FormProps> {
   updateState(newState: Record<string, unknown>) {
     const { onUpdate } = this.props;
     const { instance, valid, errors } = this.schema.serialize(newState);
-    const errs = getErrorsObj(errors as FormValidationError[]);
-    onUpdate(instance as Record<string, unknown>, valid, errs);
+    const errs = getErrorsObj(errors);
+    onUpdate(instance, valid, errs);
   }
 
   field(name: string, onChange?: (value: unknown) => void, extraName?: string) {
@@ -644,20 +644,26 @@ function propSchema(
   };
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function serializeRewrite(
   serializeMap: Record<string, string>,
   instance: unknown,
   schema: FormSchema,
-): unknown {
-  const res: Record<string, unknown> = {};
-  if (typeof instance !== 'object' || instance === null || !schema.properties) {
-    return instance !== undefined ? instance : schema.default;
+): Record<string, unknown> {
+  if (!isPlainRecord(instance) || !schema.properties) {
+    const fallback = instance !== undefined ? instance : schema.default;
+    if (isPlainRecord(fallback)) {
+      return { ...fallback };
+    }
+    return {};
   }
 
-  const instanceObj = instance as Record<string, unknown>;
+  const res: Record<string, unknown> = {};
   Object.keys(schema.properties).forEach((p) => {
-    if (p in instanceObj)
-      res[p] = instanceObj[serializeMap[p]] ?? instanceObj[p];
+    if (p in instance) res[p] = instance[serializeMap[p]] ?? instance[p];
   });
 
   return res;


### PR DESCRIPTION
Address Sonar findings by replacing unsafe casts ```!``` with narrowing and
clearer types.

- ketcher-core: template bond placement, rergroup drawing iteration,
  related editor/render tweaks
- ketcher-react: form state updates without Record casts; Dialog if touched
- ketcher-macromolecules: RNA preset save uses narrowed preset name for
  setUniqueNameError (fixes TS2345 in production build)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request