### PR TITLE
Backmerge: #9887 - Copy paste does not work in Safari

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
+++ b/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
@@ -30,6 +30,13 @@ const ieCb: DataTransfer | undefined =
     ? (window as Window & { clipboardData?: DataTransfer }).clipboardData
     : undefined;
 
+const isSafariBrowser = (): boolean =>
+  typeof navigator !== 'undefined' &&
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+const isAsyncClipboardWriteAvailable = (): boolean =>
+  isClipboardAPIAvailable() && !isSafariBrowser();
+
 export const CLIP_AREA_BASE_CLASS = 'cliparea';
 let needSkipCopyEvent = false;
 
@@ -68,6 +75,7 @@ interface ClipAreaProps {
     data: ClipboardItem[] | ClipboardData,
     isSmarts?: boolean,
   ) => Promise<void>;
+  onLegacyCopy: () => ClipboardData | null | undefined;
   onLegacyCut: () => ClipboardData | null | undefined;
   onLegacyPaste: (data: ClipboardData, isSmarts?: boolean) => void;
   target?: HTMLElement;
@@ -117,7 +125,7 @@ class ClipArea extends Component<ClipAreaProps> {
         if (!this.props.focused() || isUserEditing()) {
           return;
         }
-        if (isClipboardAPIAvailable()) {
+        if (isAsyncClipboardWriteAvailable()) {
           this.props.onCopy().then((data) => {
             if (!data) {
               return;
@@ -128,39 +136,47 @@ class ClipArea extends Component<ClipAreaProps> {
             });
           });
         } else {
-          if (needSkipCopyEvent) {
-            needSkipCopyEvent = false;
-            return;
+          if (isSafariBrowser()) {
+            const data = this.props.onLegacyCopy();
+            if (data && event.clipboardData) {
+              legacyCopy(event.clipboardData, data);
+            }
+            event.preventDefault();
+          } else {
+            if (needSkipCopyEvent) {
+              needSkipCopyEvent = false;
+              return;
+            }
+            needSkipCopyEvent = true;
+
+            this.props.onCopy().then((data) => {
+              // It is possible to have access to clipboard data through evt.clipboardData
+              // only in synchronous code. That's why we dispatch 'copy' event here after server call.
+              // It will not work with long operations which time > 5 sec, because browser will close access
+              // to clipboard data if user did not interact with application.
+              addEventListener(
+                'copy',
+                (evt: Event) => {
+                  const clipboardEvent = evt as ClipboardEvent;
+                  if (clipboardEvent.clipboardData && data) {
+                    legacyCopy(clipboardEvent.clipboardData, data);
+                  }
+                  evt.preventDefault();
+                },
+                { once: true },
+              );
+              document.execCommand('copy');
+            });
+
+            event.preventDefault();
           }
-          needSkipCopyEvent = true;
-
-          this.props.onCopy().then((data) => {
-            // It is possible to have access to clipboard data through evt.clipboardData
-            // only in synchronous code. That's why we dispatch 'copy' event here after server call.
-            // It will not work with long operations which time > 5 sec, because browser will close access
-            // to clipboard data if user did not interact with application.
-            addEventListener(
-              'copy',
-              (evt: Event) => {
-                const clipboardEvent = evt as ClipboardEvent;
-                if (clipboardEvent.clipboardData && data) {
-                  legacyCopy(clipboardEvent.clipboardData, data);
-                }
-                evt.preventDefault();
-              },
-              { once: true },
-            );
-            document.execCommand('copy');
-          });
-
-          event.preventDefault();
         }
       },
       cut: (event: ClipboardEvent) => {
         if (!this.props.focused() || isUserEditing()) {
           return;
         }
-        if (isClipboardAPIAvailable()) {
+        if (isAsyncClipboardWriteAvailable()) {
           (async () => {
             const data = await this.props.onCut();
             if (!data) return;

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -361,6 +361,13 @@ export function initClipboard(dispatch, getState) {
       const state = getState();
       return !state.modal;
     },
+    onLegacyCopy() {
+      const state = getState();
+      const editor = state.editor;
+      const data = legacyClipData(editor);
+      editor.selection(null);
+      return data;
+    },
     onLegacyCut() {
       const state = getState();
       const editor = state.editor;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Fixes Safari copy behavior for selected structures by avoiding async clipboard writes on Safari.

Safari rejects Ketcher’s rich `ClipboardItem` payload with custom chemical MIME types, which caused copy errors. Routing Safari through the existing synchronous legacy clipboard path writes the copied structure directly to the original `ClipboardEvent.clipboardData`, avoiding both the custom MIME write failure and the stuck copy preloader.

### Changes
- Added Safari detection for clipboard write handling.
- Skipped async Clipboard API write paths for Safari copy/cut.
- Added `onLegacyCopy()` to reuse the existing synchronous `legacyClipData(editor)` serialization path.
- Kept non-Safari clipboard behavior unchanged, including rich custom MIME clipboard writes.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request