### PR TITLE
#9751 - RNA Builder: Missing "Switch to right/left" tooltips when hovering over the phosphate position picker options

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -419,34 +419,42 @@ export const RnaEditorExpanded = ({
     );
   };
 
+  const getPhosphatePositionTooltip = (position: RnaPhosphatePosition) =>
+    position === 'left' ? 'Phosphate on the left' : 'Phosphate on the right';
+
   const renderPhosphatePositionOption = (
     position: RnaPhosphatePosition,
     isDisabled: boolean,
-  ) => (
-    <Tooltip
-      key={position}
-      title={isDisabled ? phosphatePositionDisabledTooltip[position] : ''}
-    >
-      <span>
-        <button
-          type="button"
-          className={clsx(
-            styles.phosphatePositionOption,
-            isDisabled && styles.phosphatePositionOptionDisabled,
-          )}
-          disabled={isDisabled}
-          onClick={() => {
-            setPhosphatePosition(position);
-          }}
-        >
-          {renderPhosphateTriggerIcon(position, false, true)}
-        </button>
-      </span>
-    </Tooltip>
-  );
+  ) => {
+    let tooltip: string;
+    if (isDisabled) {
+      tooltip = phosphatePositionDisabledTooltip[position];
+    } else if (selectedPhosphatePosition === position) {
+      tooltip = getPhosphatePositionTooltip(position);
+    } else {
+      tooltip = `Switch to ${position}`;
+    }
 
-  const getPhosphatePositionTooltip = (position: RnaPhosphatePosition) =>
-    position === 'left' ? 'Phosphate on the left' : 'Phosphate on the right';
+    return (
+      <Tooltip key={position} title={tooltip}>
+        <span>
+          <button
+            type="button"
+            className={clsx(
+              styles.phosphatePositionOption,
+              isDisabled && styles.phosphatePositionOptionDisabled,
+            )}
+            disabled={isDisabled}
+            onClick={() => {
+              setPhosphatePosition(position);
+            }}
+          >
+            {renderPhosphateTriggerIcon(position, false, true)}
+          </button>
+        </span>
+      </Tooltip>
+    );
+  };
 
   const renderPhosphatePositionSelector = (position?: RnaPhosphatePosition) => {
     const triggerDisabled = !is5PrimeAvailable && !is3PrimeAvailable;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
<img width="950" height="469" alt="fixed" src="https://github.com/user-attachments/assets/9518c2a5-b81c-43e1-8c9c-0f520e063e9d" />
## Summary
  The RNA Builder phosphate position picker (the two side-by-side icons inside the Phosphate slot) had no tooltips when hovering over its options unless they were disabled. Now hovering shows:

  - The currently selected option → **"Phosphate on the left"** / **"Phosphate on the right"**
  - The other (unselected) option → **"Switch to left"** / **"Switch to right"**

  The disabled-state tooltip ("Sugar must have R1, …" etc.) is preserved.

  ## Changes
  `packages/ketcher macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx` — `renderPhosphatePositionOption` now picks the tooltip from one of three branches:

  - `isDisabled` → existing disabled message
  - enabled and matches `selectedPhosphatePosition` → reuses `getPhosphatePositionTooltip(position)` ("Phosphate on the left/right")
  - enabled and doesn't match → ``Switch to ${position}``

  `getPhosphatePositionTooltip` was moved above its first use site since `renderPhosphatePositionOption` now calls it.

  ## Test plan
  - [x] `prettier --check` clean on the changed file
  - [x] `eslint --quiet` clean
  - [x] `tsc --noEmit` clean for `ketcher-macromolecules` (only pre-existing `Cannot find module 'ketcher-react'` errors that exist on master)
  - [x] All 12 RnaBuilder unit tests pass; 3 snapshots unchanged
  - [x] Manual verification (Macromolecules → RNA tab → RNA Builder, build a preset like `R(A)P`):
    - [x] Hovering the **selected** phosphate-position option → "Phosphate on the right" tooltip
    - [x] Hovering the **other** option → "Switch to left" tooltip
    - [x] Switching positions and re-hovering produces the symmetric tooltips
    - [x] Disabled option still shows the existing "Sugar must have R1…" tooltip
    - [x] Master shows no tooltip on either picker option (confirmed bug)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request