### PR TITLE
#9990 Undo has no effect on bond type changes

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
@@ -42,7 +42,7 @@ export class BondAttr extends BaseOperation {
 
   execute(restruct: ReStruct) {
     if (this.data) {
-      const { attribute, bid, value } = this.data;
+      const { attribute, bid, value, needInvalidateBond } = this.data;
       const bond = restruct.molecule.bonds.get(bid)!;
 
       if (!this.data2) {
@@ -50,6 +50,7 @@ export class BondAttr extends BaseOperation {
           bid,
           attribute,
           value: bond[attribute],
+          needInvalidateBond,
         };
       }
 


### PR DESCRIPTION
When caching the reverse data data2 in BondAttr.execute, the omission of writing needInvalidateBond resulted in the reversed operation obtained through undo having needInvalidateBond = undefined. This caused the skipping of the invalidateBond process. Consequently, although the model was reverted, the restruct was not marked as dirty, and the canvas was not redrawn. This gave the appearance that "undo has no effect on a single bond."

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Before:
<img width="1750" height="1184" alt="img_v3_0211g_966047db-00c8-4bbd-8de1-4d5ea0453c9g" src="https://github.com/user-attachments/assets/7e3b49a7-6345-4499-9f05-00001b496025" />

After:

<img width="1604" height="1088" alt="20260508150533_rec_" src="https://github.com/user-attachments/assets/ceb1836e-979d-4881-837d-a577d8816a18" />


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request