### PR TITLE
#9871 – refactor: prefer nullish coalescing over logical OR

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -377,7 +377,7 @@ function Field(props: Readonly<FieldProps>) {
     <Label
       className={clsx({ [classes.dataError]: dataError }, className)}
       error={dataError}
-      title={rest.title || desc.title}
+      title={rest.title ?? desc.title}
       labelPos={labelPos}
       tooltip={rest?.tooltip}
       data-testid={props['data-testid']}
@@ -434,7 +434,7 @@ function FieldWithModal(props: Readonly<FieldWithModalProps>) {
     <Label
       className={className}
       error={dataError}
-      title={title || desc.title}
+      title={title ?? desc.title}
       labelPos={labelPos}
       tooltip={tooltip}
     >
@@ -620,7 +620,7 @@ function propSchema(
   }
 
   return {
-    key: schema.key || '',
+    key: schema.key ?? '',
     serialize: (inst: Record<string, unknown>) => {
       // Pass an explicit base URI so jsonschema's resolveUrl() always receives
       // a valid absolute URL as `from`.  Without this, it calls

--- a/packages/ketcher-react/src/script/ui/data/convert/structConverter.ts
+++ b/packages/ketcher-react/src/script/ui/data/convert/structConverter.ts
@@ -47,7 +47,7 @@ export function couldBeSaved(
     );
     const bondsHaveUnsupportedProperties = arrayOfBonds.some(
       (bond) =>
-        bond.reactingCenterStatus ||
+        Boolean(bond.reactingCenterStatus) ||
         bond.type === Bond.PATTERN.TYPE.DATIVE ||
         bond.type === Bond.PATTERN.TYPE.HYDROGEN,
     );

--- a/packages/ketcher-react/src/script/ui/data/convert/structconv.ts
+++ b/packages/ketcher-react/src/script/ui/data/convert/structconv.ts
@@ -209,13 +209,13 @@ export function toElement(elem: ElementFormData) {
 
 export function fromAtom(satom?: Atom) {
   if (!satom) return null;
-  const alias = satom.alias || '';
+  const alias = satom.alias ?? '';
   const atomType = getAtomType(satom);
   return {
     alias,
     atomType,
     atomList:
-      satom.atomList?.ids.map((i) => Elements.get(i)!.label).join(',') || '',
+      satom.atomList?.ids.map((i) => Elements.get(i)!.label).join(',') ?? '',
     notList: satom.atomList?.notList || false,
     pseudo: satom.pseudo,
     label: satom.label,
@@ -292,7 +292,8 @@ export function toAtom(atom: ElementFormData): Partial<Atom> {
     // empty charge value by default treated as zero,
     // no need to pass and display zero values(0, -0) explicitly
     charge: restAtom.charge && charge !== 0 ? Number(charge) : null,
-    alias: restAtom.alias || null,
+    // Empty string from cleared form field must become null like undefined (not ?? alone).
+    alias: restAtom.alias === '' ? null : restAtom.alias ?? null,
     exactChangeFlag: +(restAtom.exactChangeFlag ?? false),
     unsaturatedAtom: +(restAtom.unsaturatedAtom ?? false),
     queryProperties: {
@@ -365,10 +366,10 @@ export function toStereoLabel(stereoLabel: {
 }) {
   switch (stereoLabel.type) {
     case StereoLabel.And:
-      return `${StereoLabel.And}${stereoLabel.andNumber || 1}`;
+      return `${StereoLabel.And}${stereoLabel.andNumber ?? 1}`;
 
     case StereoLabel.Or:
-      return `${StereoLabel.Or}${stereoLabel.orNumber || 1}`;
+      return `${StereoLabel.Or}${stereoLabel.orNumber ?? 1}`;
 
     default:
       return stereoLabel.type;
@@ -377,8 +378,8 @@ export function toStereoLabel(stereoLabel: {
 
 function fromApoint(sap: AttachmentPoints | null) {
   return {
-    primary: ((sap || 0) & 1) > 0,
-    secondary: ((sap || 0) & 2) > 0,
+    primary: ((sap ?? 0) & 1) > 0,
+    secondary: ((sap ?? 0) & 2) > 0,
   };
 }
 
@@ -504,7 +505,7 @@ function fromBondType(type: number, stereo: number) {
 }
 
 export function fromSgroup(ssgroup: SGroupInput) {
-  const type = ssgroup.type || 'DAT';
+  const type = ssgroup.type ?? 'DAT';
   const { context, fieldName, fieldValue, absolute, attached } = ssgroup.attrs;
 
   if (absolute === false && attached === false)

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateTable.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateTable.tsx
@@ -58,11 +58,11 @@ function getTemplateTitle(template: Template, index: number): string {
 
 function tmplName(tmpl: Template, i: number): string {
   if (isSaltOrSolventTemplate(tmpl)) {
-    return tmpl.props.abbreviation || '';
+    return tmpl.props.abbreviation ?? '';
   }
   return (
-    tmpl.props.abbreviation ||
-    tmpl.struct.name ||
+    tmpl.props.abbreviation ??
+    tmpl.struct.name ??
     `${tmpl.props.group} template ${i + 1}`
   );
 }


### PR DESCRIPTION
## Summary
- Replaced `||` with `??` in 14 locations across 4 files where the left operand is nullable (`null | undefined`) and falsy-coercion semantics are not required
- Used `Boolean()` wrapper for `bond.reactingCenterStatus ||` in `structConverter.ts` to preserve boolean-OR chain semantics (0 = "no reacting center" is a meaningful falsy value)
- Replaced `restAtom.alias || null` with an explicit check to preserve intentional empty-string-to-null normalization


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request