### PR TITLE
#9383 - Rotation tool: After moving the rotation center the rotation handle is not set to the starting position and rotation circle does not cross the dashed line 

### DIFF
--- a/packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts
@@ -1,10 +1,45 @@
 /** @jest-environment jsdom */
 
-import { RotationView } from 'application/render/renderers/TransientView/RotationView';
+import {
+  RotationView,
+  RotationViewParams,
+} from 'application/render/renderers/TransientView/RotationView';
 import { Coordinates } from 'application/editor';
 import { D3SvgElementSelection } from 'application/render/types';
 import { Vec2 } from 'domain/entities';
 import { select } from 'd3';
+
+const DEFAULT_PARAMS: Omit<RotationViewParams, 'rotationAngle'> = {
+  center: new Vec2(100, 100),
+  boundingBox: { left: 80, top: 80, width: 40, height: 40 },
+  isRotating: true,
+  cursor: new Vec2(200, 100),
+};
+
+const renderRotation = (
+  paramsOverride: Partial<RotationViewParams>,
+): SVGSVGElement => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const transientLayer = select(svg).append('g');
+  RotationView.show(
+    transientLayer as unknown as D3SvgElementSelection<SVGGElement, void>,
+    { ...DEFAULT_PARAMS, ...paramsOverride } as RotationViewParams,
+  );
+  return svg;
+};
+
+const findArcPath = (svg: SVGSVGElement, arcPrefix: string): string =>
+  Array.from(svg.querySelectorAll('path'))
+    .find((path) => path.getAttribute('d')?.includes(arcPrefix))
+    ?.getAttribute('d') ?? '';
+
+const findAngleText = (
+  svg: SVGSVGElement,
+  text: string,
+): SVGTextElement | undefined =>
+  Array.from(svg.querySelectorAll('text')).find(
+    (node) => node.textContent === text,
+  );
 
 describe('RotationView', () => {
   beforeEach(() => {
@@ -21,36 +56,14 @@ describe('RotationView', () => {
   });
 
   it('renders current angle label at the starting position and arc from start to current angle', () => {
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    const transientLayer = select(svg).append('g');
+    const svg = renderRotation({ rotationAngle: (75 * Math.PI) / 180 });
 
-    RotationView.show(
-      transientLayer as unknown as D3SvgElementSelection<SVGGElement, void>,
-      {
-        center: new Vec2(100, 100),
-        boundingBox: {
-          left: 80,
-          top: 80,
-          width: 40,
-          height: 40,
-        },
-        rotationAngle: (75 * Math.PI) / 180,
-        isRotating: true,
-        cursor: new Vec2(200, 100),
-      },
-    );
-
-    const angleText = Array.from(svg.querySelectorAll('text')).find(
-      (text) => text.textContent === '75°',
-    );
+    const angleText = findAngleText(svg, '75°');
     expect(angleText).toBeTruthy();
     expect(Number(angleText?.getAttribute('x'))).toBeCloseTo(120);
     expect(Number(angleText?.getAttribute('y'))).toBeCloseTo(0);
 
-    const arcPath = Array.from(svg.querySelectorAll('path')).find((path) =>
-      path.getAttribute('d')?.includes('A90,90 0 0,1'),
-    );
-    const arcPathValue = arcPath?.getAttribute('d') ?? '';
+    const arcPathValue = findArcPath(svg, 'A90,90 0 0,1');
     expect(arcPathValue).toContain('M100,10A90,90 0 0,1');
 
     const matches =
@@ -60,61 +73,33 @@ describe('RotationView', () => {
   });
 
   it('renders negative rotation with reverse sweep flag and keeps label at starting position', () => {
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    const transientLayer = select(svg).append('g');
+    const svg = renderRotation({ rotationAngle: (-75 * Math.PI) / 180 });
 
-    RotationView.show(
-      transientLayer as unknown as D3SvgElementSelection<SVGGElement, void>,
-      {
-        center: new Vec2(100, 100),
-        boundingBox: {
-          left: 80,
-          top: 80,
-          width: 40,
-          height: 40,
-        },
-        rotationAngle: (-75 * Math.PI) / 180,
-        isRotating: true,
-        cursor: new Vec2(200, 100),
-      },
-    );
-
-    const angleText = Array.from(svg.querySelectorAll('text')).find(
-      (text) => text.textContent === '-75°',
-    );
+    const angleText = findAngleText(svg, '-75°');
     expect(angleText).toBeTruthy();
     expect(Number(angleText?.getAttribute('x'))).toBeCloseTo(120);
     expect(Number(angleText?.getAttribute('y'))).toBeCloseTo(0);
 
-    const arcPath = Array.from(svg.querySelectorAll('path')).find((path) =>
-      path.getAttribute('d')?.includes('A90,90 0 0,0'),
-    );
-    expect(arcPath?.getAttribute('d')).toContain('M100,10A90,90 0 0,0');
+    expect(findArcPath(svg, 'A90,90 0 0,0')).toContain('M100,10A90,90 0 0,0');
+  });
+
+  it('orients the protractor 0° at the provided startAngle (non-default path)', () => {
+    // Provide an explicit startAngle of 0 (rightward in canvas coordinates).
+    // The protractor's 0° tick should anchor on the right of the center
+    // (center.x + radius, center.y), not at the default straight-up position.
+    const svg = renderRotation({
+      rotationAngle: (75 * Math.PI) / 180,
+      startAngle: 0,
+    });
+
+    // With radius 90, startAngle=0 places the 0° point at (190, 100).
+    // The rotation arc starts at that point.
+    expect(findArcPath(svg, 'A90,90 0 0,1')).toContain('M190,100A90,90 0 0,1');
   });
 
   it('uses large-arc-flag for rotation angles above 180 degrees', () => {
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    const transientLayer = select(svg).append('g');
+    const svg = renderRotation({ rotationAngle: (210 * Math.PI) / 180 });
 
-    RotationView.show(
-      transientLayer as unknown as D3SvgElementSelection<SVGGElement, void>,
-      {
-        center: new Vec2(100, 100),
-        boundingBox: {
-          left: 80,
-          top: 80,
-          width: 40,
-          height: 40,
-        },
-        rotationAngle: (210 * Math.PI) / 180,
-        isRotating: true,
-        cursor: new Vec2(200, 100),
-      },
-    );
-
-    const arcPath = Array.from(svg.querySelectorAll('path')).find((path) =>
-      path.getAttribute('d')?.includes('A90,90 0 1,1'),
-    );
-    expect(arcPath?.getAttribute('d')).toContain('M100,10A90,90 0 1,1');
+    expect(findArcPath(svg, 'A90,90 0 1,1')).toContain('M100,10A90,90 0 1,1');
   });
 });

--- a/packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts
+++ b/packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts
@@ -198,11 +198,13 @@ abstract class SelectBase implements BaseTool {
       width: number;
       height: number;
     },
+    startAngle?: number,
   ) {
     return {
       center: Coordinates.modelToCanvas(center),
       boundingBox: this.getCanvasBbox(bbox),
       cursor: this.editor.lastCursorPosition,
+      startAngle,
     };
   }
 
@@ -242,6 +244,7 @@ abstract class SelectBase implements BaseTool {
       const viewParams = this.buildRotationViewParams(
         this.rotationCenter,
         bbox,
+        this.rotationStartAngle,
       );
       this.editor.transientDrawingView.showRotation({
         ...viewParams,
@@ -1301,6 +1304,7 @@ abstract class SelectBase implements BaseTool {
         const viewParams = this.buildRotationViewParams(
           this.rotationCenter,
           bbox,
+          this.rotationStartAngle,
         );
         this.editor.transientDrawingView.showRotation({
           ...viewParams,

--- a/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
+++ b/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
@@ -30,6 +30,11 @@ export type RotationViewParams = {
   rotationAngle?: number;
   isRotating?: boolean;
   cursor?: Vec2;
+  // Direction (in radians, measured the same way as Math.atan2) from the
+  // rotation center to the rotation handle at the moment rotation started.
+  // The protractor uses this as its 0°. Defaults to straight up in canvas
+  // coordinates (-π/2, since +Y is downward in screen space).
+  startAngle?: number;
 };
 
 type RotationHandleEvent = {
@@ -137,6 +142,7 @@ export class RotationView extends TransientView {
       rotationAngle = 0,
       isRotating = false,
       cursor,
+      startAngle: startAngleParam,
     } = params;
 
     if (!isRotating || !RotationView.wasRotating) {
@@ -354,8 +360,11 @@ export class RotationView extends TransientView {
           .attr('stroke-dasharray', '4,4')
           .attr('style', 'pointer-events: none');
 
-        // Draw protractor degree ticks and labels (as in rotate-controller)
-        const startAngle = -Math.PI / 2;
+        // Draw protractor degree ticks and labels (as in rotate-controller).
+        // Use the click direction from the rotation tool so the 0° label,
+        // dashed handle line, and handle stay aligned even after the rotation
+        // center has been moved.
+        const startAngle = startAngleParam ?? -Math.PI / 2;
         const toRadians = (deg: number) => (deg * Math.PI) / 180;
         const predefinedDegrees = [
           0, 30, 45, 60, 90, 120, 135, 150, 180, -150, -135, -120, -90, -60,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
<img width="959" height="467" alt="584752297-af97919f-78aa-4c0c-b006-2507a99b0c77" src="https://github.com/user-attachments/assets/7864d4d3-d32f-4cea-a081-9ead0ff46f37" />
 Summary

  After the user repositions the rotation center, the protractor's 0° anchor now realigns with the rotation handle's actual starting direction. Previously, the protractor's 0° stayed pinned to canvas-up regardless of where the handle started, so the dashed line and arc reading didn't match the visible handle position.

  Changes

  - packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts — Added an optional startAngle parameter to RotationViewParams so the caller can specify where 0° should be anchored. Defaults to canvas-up (-π/2) when omitted.
  - packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts — buildRotationViewParams now forwards the rotation handle's starting angle so the protractor aligns to the handle direction after a center move.
  - packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts — Refactored to extract shared helpers (DEFAULT_PARAMS, renderRotation, findArcPath, findAngleText), reducing duplication flagged by Sonar. Added a test covering the non-default startAngle path.

  Test plan

  - npm run test:types — passes
  - npm run test (Jest) — passes, including new startAngle coverage
  - Full Playwright autotest suite (Docker) — passes
  - Manual verification: move rotation center, confirm protractor 0° aligns with handle, dashed line crosses correctly

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request