### PR TITLE
#9635 - Refactor: Variables are missing in props validation (let's rewrite JS to TS) 53

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/tools.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.ts
@@ -28,8 +28,11 @@ import isHidden from './isHidden';
 import { toBondType } from '../data/convert/structconv';
 import { isFlipDisabled } from './flips';
 import { MONOMER_WIZARD_DISALLOWED_BOND_TYPES } from '../views/components/ContextMenu/utils';
+import { UiAction } from './action.types';
 
-const toolActions = {
+type ToolActionEntry = Partial<UiAction>;
+
+const toolActions: Record<string, ToolActionEntry> = {
   hand: {
     title: 'Hand tool',
     enabledInViewOnly: true,
@@ -399,7 +402,7 @@ const toolActions = {
   },
 };
 
-const bondCuts = {
+const bondCuts: Record<string, string> = {
   single: '1',
   double: '2',
   triple: '3',
@@ -412,23 +415,28 @@ const bondCuts = {
 };
 
 const typeSchema = bondSchema.properties.type;
+const bondTypes = typeSchema.enum as string[];
+const bondTypeNames = typeSchema.enumNames as string[];
 
-const monomerWizardDisallowedBondTypes = new Set(
+const monomerWizardDisallowedBondTypes: Set<string> = new Set(
   MONOMER_WIZARD_DISALLOWED_BOND_TYPES,
 );
 
-export default typeSchema.enum.reduce((res, type, i) => {
-  res[`bond-${type}`] = {
-    title: `${typeSchema.enumNames[i]} Bond`,
-    shortcut: bondCuts[type],
-    action: {
-      tool: 'bond',
-      opts: toBondType(type),
-    },
-    hidden: (options) => isHidden(options, `bond-${type}`),
-    ...(monomerWizardDisallowedBondTypes.has(type) && {
-      disabled: (editor) => editor.isMonomerCreationWizardActive,
-    }),
-  };
-  return res;
-}, toolActions);
+export default bondTypes.reduce<Record<string, ToolActionEntry>>(
+  (res, type, i) => {
+    res[`bond-${type}`] = {
+      title: `${bondTypeNames[i]} Bond`,
+      shortcut: bondCuts[type],
+      action: {
+        tool: 'bond',
+        opts: toBondType(type),
+      },
+      hidden: (options) => isHidden(options, `bond-${type}`),
+      ...(monomerWizardDisallowedBondTypes.has(type) && {
+        disabled: (editor) => editor.isMonomerCreationWizardActive,
+      }),
+    };
+    return res;
+  },
+  toolActions,
+);

--- a/packages/ketcher-react/src/script/ui/action/tools.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.ts
@@ -30,7 +30,9 @@ import { isFlipDisabled } from './flips';
 import { MONOMER_WIZARD_DISALLOWED_BOND_TYPES } from '../views/components/ContextMenu/utils';
 import { UiAction } from './action.types';
 
-type ToolActionEntry = Partial<UiAction>;
+type ToolActionEntry = Omit<UiAction, 'action'> & {
+  action?: UiAction['action'];
+};
 
 const toolActions: Record<string, ToolActionEntry> = {
   hand: {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
@@ -1,4 +1,5 @@
 import {
+  BondAttributes,
   fromBondsAttrs,
   ketcherProvider,
   bondChangingAction,
@@ -15,16 +16,15 @@ const useBondTypeChange = () => {
   const { ketcherId } = useAppContext();
   const handler = useCallback(
     ({ id, props }: Params) => {
+      if (id == null) return;
+      const toolAction = tools[id]?.action;
+      if (!toolAction || typeof toolAction === 'function') return;
+
       const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
       const molecule = editor.render.ctab;
       const bondIds = props?.bondIds ?? [];
-      const toolAction = id != null ? tools[String(id)]?.action : undefined;
-      const toolOpts =
-        toolAction && typeof toolAction !== 'function'
-          ? toolAction.opts
-          : undefined;
-      const bondProps = {
-        ...(toolOpts as Record<string, unknown> | undefined),
+      const bondProps: Partial<BondAttributes> = {
+        ...(toolAction.opts as Partial<BondAttributes>),
       };
       const isCustomQuery = molecule.bonds.get(bondIds[0])?.b.customQuery;
       if (isCustomQuery) {

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
@@ -18,7 +18,14 @@ const useBondTypeChange = () => {
       const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
       const molecule = editor.render.ctab;
       const bondIds = props?.bondIds ?? [];
-      const bondProps = { ...tools[id].action.opts };
+      const toolAction = id != null ? tools[String(id)]?.action : undefined;
+      const toolOpts =
+        toolAction && typeof toolAction !== 'function'
+          ? toolAction.opts
+          : undefined;
+      const bondProps = {
+        ...(toolOpts as Record<string, unknown> | undefined),
+      };
       const isCustomQuery = molecule.bonds.get(bondIds[0])?.b.customQuery;
       if (isCustomQuery) {
         bondProps.customQuery = null;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -123,7 +123,7 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
             disabled={isDisabled}
           >
             {iconName && <Icon name={iconName} className={styles.icon} />}
-            <span>{formatTitle(tools[name].title)}</span>
+            <span>{formatTitle(tools[name].title ?? '')}</span>
           </Item>
         );
       })}
@@ -148,7 +148,7 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
               disabled={isDisabled}
             >
               {iconName && <Icon name={iconName} className={styles.icon} />}
-              <span>{formatTitle(tools[name].title)}</span>
+              <span>{formatTitle(tools[name].title ?? '')}</span>
             </Item>
           );
         })}

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
@@ -147,7 +147,7 @@ const SelectionMenuItems: FC<MenuItemsProps<SelectionContextMenuProps>> = (
               disabled={isDisabledForMonomerWizard}
             >
               {iconName && <Icon name={iconName} className={styles.icon} />}
-              <span>{formatTitle(tools[name].title)}</span>
+              <span>{formatTitle(tools[name].title ?? '')}</span>
             </Item>
           );
         })}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Resolves the `react/prop-types` ESLint rule violations by converting `tools.js` to TypeScript and tightening prop typing in the bond context-menu flow.

### Changes

- **`packages/ketcher-react/src/script/ui/action/tools.js` → `tools.ts`** — converted to TypeScript. Entry shape is `Omit<UiAction, 'action'> & { action?: UiAction['action'] }` so the few group-header entries (`arrows`, `reaction-mapping-tools`, `rgroup`, `shapes`, `bonds`) can omit `action` while typos on `action` in regular entries are still caught.
- **`packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts`** — early-return when the menu item id has no matching tool action, and locally assert the opts to `Partial<BondAttributes>` (the actual shape consumed by `bondChangingAction` / `fromBondsAttrs`) instead of a generic `Record<string, unknown>` cast.
- **`packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/{BondMenuItems,SelectionMenuItems}.tsx`** — add `?? ''` fallback for `tools[name].title`, since `title` is now correctly typed as optional on the entry shape.

### Test plan

- `npm run test:types` — passes (all workspaces)
- `npm run test` — passes (prettier, stylelint, eslint, types, jest across 4 packages)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request