### PR TITLE
#8173 – IDT alias could be longer than 10 symbols without slashes

### DIFF
--- a/packages/ketcher-core/__tests__/utilities/KetcherLogger.test.ts
+++ b/packages/ketcher-core/__tests__/utilities/KetcherLogger.test.ts
@@ -1,0 +1,161 @@
+import { KetcherLogger, LogLevel } from 'utilities';
+
+function setLogging(opts: { enabled?: boolean; level?: LogLevel } | undefined) {
+  (window as unknown as Record<string, unknown>).ketcher =
+    opts != null ? { logging: opts } : {};
+}
+
+describe('KetcherLogger', () => {
+  let errorSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+  let traceSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(window.console, 'error').mockImplementation(() => {});
+    warnSpy = jest.spyOn(window.console, 'warn').mockImplementation(() => {});
+    infoSpy = jest.spyOn(window.console, 'info').mockImplementation(() => {});
+    logSpy = jest.spyOn(window.console, 'log').mockImplementation(() => {});
+    traceSpy = jest.spyOn(window.console, 'trace').mockImplementation(() => {});
+    // Default: no logging configured
+    setLogging(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when logging is not configured (default state)', () => {
+    it('error() outputs to console.error', () => {
+      KetcherLogger.error('something went wrong');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('warn() is suppressed', () => {
+      KetcherLogger.warn('a warning');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('info() is suppressed', () => {
+      KetcherLogger.info('some info');
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it('log() is suppressed', () => {
+      KetcherLogger.log('a log message');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when logging is enabled with level LOG (most verbose)', () => {
+    beforeEach(() => {
+      setLogging({ enabled: true, level: LogLevel.LOG });
+    });
+
+    it('error() outputs to console.error', () => {
+      KetcherLogger.error('err');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('warn() outputs to console.warn', () => {
+      KetcherLogger.warn('warn');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('info() outputs to console.info', () => {
+      KetcherLogger.info('info');
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('log() outputs to console.log', () => {
+      KetcherLogger.log('log');
+      expect(logSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when logging is enabled with level WARN', () => {
+    beforeEach(() => {
+      setLogging({ enabled: true, level: LogLevel.WARN });
+    });
+
+    it('error() outputs to console.error', () => {
+      KetcherLogger.error('err');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('warn() outputs to console.warn', () => {
+      KetcherLogger.warn('warn');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('info() is suppressed', () => {
+      KetcherLogger.info('info');
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it('log() is suppressed', () => {
+      KetcherLogger.log('log');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when logging is enabled with level ERROR only', () => {
+    beforeEach(() => {
+      setLogging({ enabled: true, level: LogLevel.ERROR });
+    });
+
+    it('error() outputs to console.error', () => {
+      KetcherLogger.error('err');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('warn() is suppressed', () => {
+      KetcherLogger.warn('warn');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when logging is explicitly disabled', () => {
+    beforeEach(() => {
+      setLogging({ enabled: false, level: LogLevel.LOG });
+    });
+
+    it('error() still outputs to console.error', () => {
+      KetcherLogger.error('err');
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('warn() is suppressed', () => {
+      KetcherLogger.warn('warn');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('log() is suppressed', () => {
+      KetcherLogger.log('log');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('showTrace option', () => {
+    beforeEach(() => {
+      setLogging({
+        enabled: true,
+        level: LogLevel.LOG,
+        showTrace: true,
+      } as { enabled: boolean; level: LogLevel; showTrace: boolean });
+    });
+
+    it('log() uses console.trace when showTrace is true', () => {
+      KetcherLogger.log('trace me');
+      expect(traceSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('info() uses console.trace when showTrace is true', () => {
+      KetcherLogger.info('trace info');
+      expect(traceSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ketcher-core/__tests__/utilities/monomers.test.ts
+++ b/packages/ketcher-core/__tests__/utilities/monomers.test.ts
@@ -1,0 +1,15 @@
+import { isIdtAliasLengthValid } from 'utilities';
+
+describe('isIdtAliasLengthValid', () => {
+  it.each([
+    ['', true],
+    ['ABCDE12345', true],
+    ['ABCDE123456', false],
+    ['/modif/', true],
+    ['/modif', false],
+    ['modif/', false],
+    ['/ABCDE123456/', true],
+  ])('returns %p as %p', (alias: string, expected: boolean) => {
+    expect(isIdtAliasLengthValid(alias)).toBe(expected);
+  });
+});

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -75,7 +75,7 @@ import { DOMSubscription } from 'subscription';
 import {
   EditorLineLength,
   HELM_ALIAS_FORMAT_ERROR_MESSAGE,
-  IDT_ALIAS_SLASH_ERROR_MESSAGE,
+  IDT_ALIAS_LENGTH_ERROR_MESSAGE,
   isValidHelmAlias,
   isValidIdtAlias,
   initHotKeys,
@@ -119,6 +119,7 @@ import {
   getMonomerTemplateRefFromMonomerItem,
 } from 'domain/serializers';
 import type { SequenceMode } from './modes/types/sequenceMode';
+import { isIdtAliasLengthValid } from '../../../dist';
 
 const SCROLL_SMOOTHNESS_IM_MS = 300;
 
@@ -475,8 +476,17 @@ export class CoreEditor {
           KetcherLogger.error(errorMessage);
           return;
         }
-      }
 
+        const hasInvalidLength = aliasesToValidate.some(
+          (alias) => !isIdtAliasLengthValid(alias),
+        );
+
+        if (hasInvalidLength) {
+          const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed. ${IDT_ALIAS_LENGTH_ERROR_MESSAGE} The monomer was not added to the library.`;
+          KetcherLogger.error(errorMessage);
+          return;
+        }
+      }
       const existingMonomerIndex = this._monomersLibrary.findIndex(
         (monomer) => {
           return (

--- a/packages/ketcher-core/src/utilities/KetcherLogger.ts
+++ b/packages/ketcher-core/src/utilities/KetcherLogger.ts
@@ -80,7 +80,7 @@ export class KetcherLogger {
     const { enabled, level } = this.settings;
 
     if (!enabled || level == null) {
-      return false;
+      return minimumLevel === LogLevel.ERROR;
     }
 
     return level >= minimumLevel;

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -6,6 +6,10 @@ export const HELM_ALIAS_FORMAT_ERROR_MESSAGE =
 export const IDT_ALIAS_SLASH_ERROR_MESSAGE =
   'The slashes (`/`) can only be the first and last character of an IDT alias.';
 
+export const IDT_ALIAS_MAX_LENGTH_WITHOUT_SLASHES = 10;
+
+export const IDT_ALIAS_LENGTH_ERROR_MESSAGE = `The maximum number of characters of an IDT alias without slashes (/) is ${IDT_ALIAS_MAX_LENGTH_WITHOUT_SLASHES}.`;
+
 const HELM_ALIAS_REGEX = /^(?!.*\s)[A-Za-z0-9_*.[\]()-]+$/;
 
 /**
@@ -16,6 +20,20 @@ export function isValidIdtAlias(alias: string): boolean {
   if (!alias) return true;
   const inner = alias.slice(1, -1);
   return !inner.includes('/');
+}
+
+/**
+ * Validates that an IDT alias does not exceed the maximum allowed length,
+ *except for the slash-wrapped modification form (`/alias/`).
+ */
+
+export function isIdtAliasLengthValid(alias: string): boolean {
+  if (!alias) return true;
+  const hasLeadingSlash = alias.startsWith('/');
+  const hasTrailingSlash = alias.endsWith('/');
+  if (hasLeadingSlash && hasTrailingSlash) return true;
+  if (hasLeadingSlash || hasTrailingSlash) return false;
+  return alias.length <= IDT_ALIAS_MAX_LENGTH_WITHOUT_SLASHES;
 }
 
 export function isValidHelmAlias(alias: string) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Added validation in updateMonomersLibrary to enforce the IDT alias length requirement: aliases without leading or trailing slashes (/) must not exceed 10 characters. When a monomer with an oversized alias is loaded, it is skipped and a console error is emitted with the monomer name and the reason for rejection. Aliases that use the slash modification syntax (e.g. /alias/, /alias, alias/) are exempt from the length check. Additionally fixed KetcherLogger.error to always output to the console regardless of logging configuration, so validation errors are visible by default.

<img width="1468" height="680" alt="Screenshot 2026-05-07 at 20 42 44" src="https://github.com/user-attachments/assets/f2270d25-8dba-4794-89a6-8c42d294b2b8" />

[The issue](https://github.com/epam/ketcher/issues/8173)

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request