### PR TITLE
#8198 - It is possible to add monomer with HELM alias is too long

### DIFF
--- a/ketcher-autotests/tests/specs/Chromium-popup/Library/library-update.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Library/library-update.spec.ts
@@ -829,3 +829,32 @@ test.fail(
     expect(await Library(page).isMonomerExist(Preset._A3)).toBeTruthy();
   },
 );
+
+test('Case 29: Update Library item with HELM alias longer than 23 symbols returns an error', async () => {
+  /*
+   * AUTOTEST_REQUEST_URL: N/A
+   * Description: updateMonomersLibrary rejects monomers with HELM aliases longer than 23 symbols.
+   * Scenario:
+   * 1. Go to Macro mode
+   * 2. Execute updateMonomersLibrary with an SDF monomer whose aliasHELM value has 24 symbols
+   * 3. Verify that API returns an error
+   *
+   * Version 3.16
+   */
+  const sdfFile =
+    _Base1Body +
+    _type +
+    'monomerTemplate' +
+    _betweenEntries +
+    _aliasHELM +
+    '123456789012345678901234' +
+    _betweenEntries +
+    _endToken;
+
+  const error = await updateMonomersLibrary(page, sdfFile);
+
+  expect(error).not.toBeNull();
+  expect(error).toContain(
+    'The HELM alias must be no more than 23 symbols long.',
+  );
+});

--- a/ketcher-autotests/tests/specs/Chromium-popup/Library/library-update.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Library/library-update.spec.ts
@@ -830,14 +830,14 @@ test.fail(
   },
 );
 
-test('Case 29: Update Library item with HELM alias longer than 23 symbols returns an error', async () => {
+test('Case 29: Update Library item with HELM alias longer than 23 symbols logs an error', async () => {
   /*
    * AUTOTEST_REQUEST_URL: N/A
    * Description: updateMonomersLibrary rejects monomers with HELM aliases longer than 23 symbols.
    * Scenario:
    * 1. Go to Macro mode
    * 2. Execute updateMonomersLibrary with an SDF monomer whose aliasHELM value has 24 symbols
-   * 3. Verify that API returns an error
+   * 3. Verify that API logs an error
    *
    * Version 3.16
    */
@@ -850,11 +850,32 @@ test('Case 29: Update Library item with HELM alias longer than 23 symbols return
     '123456789012345678901234' +
     _betweenEntries +
     _endToken;
+  type ConsoleCaptureWindow = typeof window & {
+    capturedConsoleErrors: string[];
+    originalConsoleError: typeof console.error;
+  };
+
+  await page.evaluate(() => {
+    const testWindow = window as ConsoleCaptureWindow;
+
+    window.ketcher.logging.enabled = true;
+    testWindow.capturedConsoleErrors = [];
+    testWindow.originalConsoleError = console.error;
+    console.error = (...args) => {
+      testWindow.capturedConsoleErrors.push(args.flat().join(' '));
+    };
+  });
 
   const error = await updateMonomersLibrary(page, sdfFile);
+  const consoleMessages = await page.evaluate(() => {
+    const testWindow = window as ConsoleCaptureWindow;
 
-  expect(error).not.toBeNull();
-  expect(error).toContain(
+    console.error = testWindow.originalConsoleError;
+    return testWindow.capturedConsoleErrors;
+  });
+
+  expect(error).toBeNull();
+  expect(consoleMessages.join('\n')).toContain(
     'The HELM alias must be no more than 23 symbols long.',
   );
 });

--- a/packages/ketcher-core/__tests__/utilities/monomers.test.ts
+++ b/packages/ketcher-core/__tests__/utilities/monomers.test.ts
@@ -1,4 +1,7 @@
-import { HELM_ALIAS_MAX_LENGTH, isValidHelmAliasLength } from '../monomers';
+import {
+  HELM_ALIAS_MAX_LENGTH,
+  isValidHelmAliasLength,
+} from '../../src/utilities/monomers';
 
 describe('monomers utilities', () => {
   describe('isValidHelmAliasLength', () => {

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -76,11 +76,13 @@ import {
   EditorLineLength,
   BILN_ALIAS_FORMAT_ERROR_MESSAGE,
   HELM_ALIAS_FORMAT_ERROR_MESSAGE,
+  HELM_ALIAS_LENGTH_ERROR_MESSAGE,
   IDT_ALIAS_SLASH_ERROR_MESSAGE,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
   isValidBilnAlias,
   isValidHelmAlias,
+  isValidHelmAliasLength,
   isValidIdtAlias,
   initHotKeys,
   KetcherLogger,
@@ -443,6 +445,15 @@ export class CoreEditor {
         const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid BILN alias value. ${BILN_ALIAS_FORMAT_ERROR_MESSAGE} The monomer was not added to the library.`;
         KetcherLogger.error(errorMessage);
         return;
+      }
+
+      if (
+        newMonomer.props?.aliasHELM &&
+        !isValidHelmAliasLength(newMonomer.props.aliasHELM)
+      ) {
+        throw new Error(
+          `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid HELM alias value. ${HELM_ALIAS_LENGTH_ERROR_MESSAGE} The monomer was not added to the library.`,
+        );
       }
 
       const aliasCollisionExists = this._monomersLibrary.some((monomer) => {

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -451,9 +451,9 @@ export class CoreEditor {
         newMonomer.props?.aliasHELM &&
         !isValidHelmAliasLength(newMonomer.props.aliasHELM)
       ) {
-        throw new Error(
-          `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid HELM alias value. ${HELM_ALIAS_LENGTH_ERROR_MESSAGE} The monomer was not added to the library.`,
-        );
+        const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid HELM alias value. ${HELM_ALIAS_LENGTH_ERROR_MESSAGE} The monomer was not added to the library.`;
+        KetcherLogger.error(errorMessage);
+        return;
       }
 
       const aliasCollisionExists = this._monomersLibrary.some((monomer) => {

--- a/packages/ketcher-core/src/utilities/__tests__/monomers.test.ts
+++ b/packages/ketcher-core/src/utilities/__tests__/monomers.test.ts
@@ -1,0 +1,17 @@
+import { HELM_ALIAS_MAX_LENGTH, isValidHelmAliasLength } from '../monomers';
+
+describe('monomers utilities', () => {
+  describe('isValidHelmAliasLength', () => {
+    it('allows HELM aliases up to the maximum length', () => {
+      expect(isValidHelmAliasLength('A'.repeat(HELM_ALIAS_MAX_LENGTH))).toBe(
+        true,
+      );
+    });
+
+    it('rejects HELM aliases longer than the maximum length', () => {
+      expect(
+        isValidHelmAliasLength('A'.repeat(HELM_ALIAS_MAX_LENGTH + 1)),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -6,6 +6,10 @@ export const HELM_ALIAS_FORMAT_ERROR_MESSAGE =
 export const BILN_ALIAS_FORMAT_ERROR_MESSAGE =
   'The BILN alias must consist only of uppercase and lowercase letters, numbers, hyphens (`-`), underscores (`_`), and asterisks (`*`).';
 
+export const HELM_ALIAS_MAX_LENGTH = 23;
+
+export const HELM_ALIAS_LENGTH_ERROR_MESSAGE = `The HELM alias must be no more than ${HELM_ALIAS_MAX_LENGTH} symbols long.`;
+
 export const IDT_ALIAS_SLASH_ERROR_MESSAGE =
   'The slashes (`/`) can only be the first and last character of an IDT alias.';
 
@@ -32,6 +36,10 @@ export function isValidHelmAlias(alias: string) {
 
 export function isValidBilnAlias(alias: string) {
   return BILN_ALIAS_REGEX.test(alias);
+}
+
+export function isValidHelmAliasLength(alias: string) {
+  return alias.length <= HELM_ALIAS_MAX_LENGTH;
 }
 
 export function isMonomerSgroupWithAttachmentPoints(monomer: BaseMonomer) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
This PR adds validation for HELM aliases passed through `ketcher.updateMonomersLibrary`. Monomers with `aliasHELM` values longer than 23 symbols are now rejected with a clear error message and are not added to the library.

It also adds focused unit coverage for the HELM alias length helper and an autotest regression case for importing an SDF monomer with a 24-symbol HELM alias.


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request