### PR TITLE
#8181 - It is possible to define preset (group) name more than 200 symbols

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -7,7 +7,11 @@ import {
 import { SelectBase } from 'application/editor/tools/select';
 import { Vec2 } from 'domain/entities';
 import { peptideMonomerItem, polymerEditorTheme } from '../../mock-data';
-import { KetcherLogger } from 'utilities';
+import {
+  KetcherLogger,
+  MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
+  MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+} from 'utilities';
 
 describe('CoreEditor', () => {
   it('should track dom events and trigger handlers', () => {
@@ -391,6 +395,71 @@ describe('CoreEditor', () => {
       );
       expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
         initialTemplatesCount,
+      );
+    });
+
+    it('should reject monomer group template with name longer than the max length', () => {
+      const longName = 'a'.repeat(
+        MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH + 1,
+      );
+      const presetWithLongName = {
+        root: {
+          templates: [
+            {
+              $ref: `monomerGroupTemplate-${longName}`,
+            },
+          ],
+        },
+        [`monomerGroupTemplate-${longName}`]: {
+          type: 'monomerGroupTemplate',
+          id: '',
+          name: longName,
+          class: 'RNA',
+          templates: [],
+          connections: [],
+        },
+      };
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+      editor.updateMonomersLibrary(JSON.stringify(presetWithLongName));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+        ),
+      );
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
+    });
+
+    it('should accept monomer group template with name at the max length boundary', () => {
+      const boundaryName = 'a'.repeat(MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH);
+      const presetWithBoundaryName = {
+        root: {
+          templates: [
+            {
+              $ref: `monomerGroupTemplate-${boundaryName}`,
+            },
+          ],
+        },
+        [`monomerGroupTemplate-${boundaryName}`]: {
+          type: 'monomerGroupTemplate',
+          id: '',
+          name: boundaryName,
+          class: 'RNA',
+          templates: [],
+          connections: [],
+        },
+      };
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+      editor.updateMonomersLibrary(JSON.stringify(presetWithBoundaryName));
+
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount + 1,
       );
     });
   });

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -76,6 +76,8 @@ import {
   EditorLineLength,
   HELM_ALIAS_FORMAT_ERROR_MESSAGE,
   IDT_ALIAS_SLASH_ERROR_MESSAGE,
+  MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
+  MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
   isValidHelmAlias,
   isValidIdtAlias,
   initHotKeys,
@@ -547,6 +549,19 @@ export class CoreEditor {
       if (!templateDefinition.name?.trim()) {
         KetcherLogger.error(
           `Editor::updateMonomersLibrary: Monomer group template name cannot be empty or whitespace for template ${templateRef.$ref}. The template was not added to the library.`,
+        );
+        return;
+      }
+
+      if (
+        templateDefinition.name.length > MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH
+      ) {
+        const truncatedTemplateName = `${templateDefinition.name.slice(
+          0,
+          MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
+        )}...`;
+        KetcherLogger.error(
+          `Editor::updateMonomersLibrary: Load of monomer group template "${truncatedTemplateName}" (length: ${templateDefinition.name.length}, template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE} The template was not added to the library.`,
         );
         return;
       }

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -6,6 +6,10 @@ export const HELM_ALIAS_FORMAT_ERROR_MESSAGE =
 export const IDT_ALIAS_SLASH_ERROR_MESSAGE =
   'The slashes (`/`) can only be the first and last character of an IDT alias.';
 
+export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH = 200;
+
+export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE = `The monomer group template name must not exceed ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH} characters.`;
+
 const HELM_ALIAS_REGEX = /^(?!.*\s)[A-Za-z0-9_*.[\]()-]+$/;
 
 /**


### PR DESCRIPTION
Summary

  Rejects monomer group templates whose groupName exceeds 200 characters when loading a monomer library via
  ketcher.updateMonomersLibrary(...). Per Ljubica's rule: incorrect property → skip the template, load the rest, log error.

  Changes

  - packages/ketcher-core/src/utilities/monomers.ts — Added MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH = 200 constant and matching error message constant.
  - packages/ketcher-core/src/application/editor/Editor.ts — Added length validation in updateMonomersLibrary after the
  existing empty-name check. Templates with name.length > 200 are skipped and logged via KetcherLogger.error (matching
  the existing validation pattern for HELM alias, IDT slash, empty name).
  - packages/ketcher-core/__tests__/application/editor/Editor.test.ts — Two new unit tests: rejects a template with a
  201-char name, accepts the 200-char boundary case.

  Scope

  This PR addresses length validation only. The companion issue #8182 (invalid symbols in groupName, High severity) is
  tracked separately and not in this PR.

  Test plan

  - npm run test:types — passes
  - npm run test (Jest) — passes, including 2 new tests
  - Full Playwright autotest suite (Docker) — passes
  - Manual repro: ran the issue's SDF snippet via ketcher.updateMonomersLibrary(...) in console → the _MoreThen... (201
  chars) preset is not added to the RNA library; other presets unaffected
  - Boundary: 200-char name still loads correctly

  Note on console visibility

  The error is emitted via KetcherLogger.error for consistency with the 5 sibling validations in the same method. Note
  that KetcherLogger.error is a no-op by default unless window.ketcher.logging = { enabled: true, level: 0 } is set —
  this is a pre-existing behavior shared by all validations in updateMonomersLibrary and is out of scope for this PR.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request