### PR TITLE
#5849 - expanded monomer inconsistent behaviour

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -45,11 +45,38 @@ class BondTool implements Tool {
     this.atomProps = { label: 'C' };
     this.bondProps = bondProps;
     if (editor.selection()?.bonds) {
-      const action = fromBondsAttrs(
-        editor.render.ctab,
-        editor.selection().bonds,
-        bondProps,
-      );
+      const struct = editor.render.ctab;
+      const molecule = struct.molecule;
+      const functionalGroups = molecule.functionalGroups;
+      const selectedBonds = editor.selection().bonds;
+
+      if (functionalGroups.size) {
+        const fgIds: number[] = [];
+        for (const bondId of selectedBonds) {
+          const bondInFG = FunctionalGroup.bondsInFunctionalGroup(
+            molecule,
+            functionalGroups,
+            bondId,
+          );
+          if (bondInFG !== null) {
+            const fgId = FunctionalGroup.findFunctionalGroupByBond(
+              molecule,
+              functionalGroups,
+              bondId,
+            );
+            if (fgId !== null && !fgIds.includes(fgId)) {
+              fgIds.push(fgId);
+            }
+          }
+        }
+        if (fgIds.length) {
+          this.editor.event.removeFG.dispatch({ fgIds });
+          this.isNotActiveTool = true;
+          return;
+        }
+      }
+
+      const action = fromBondsAttrs(struct, selectedBonds, bondProps);
       editor.update(action);
       editor.selection(null);
       this.isNotActiveTool = true;

--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -51,26 +51,19 @@ class BondTool implements Tool {
       const selectedBonds = editor.selection().bonds;
 
       if (functionalGroups.size) {
-        const fgIds: number[] = [];
+        const fgIds = new Set<number>();
         for (const bondId of selectedBonds) {
-          const bondInFG = FunctionalGroup.bondsInFunctionalGroup(
+          const fgId = FunctionalGroup.findFunctionalGroupByBond(
             molecule,
             functionalGroups,
             bondId,
           );
-          if (bondInFG !== null) {
-            const fgId = FunctionalGroup.findFunctionalGroupByBond(
-              molecule,
-              functionalGroups,
-              bondId,
-            );
-            if (fgId !== null && !fgIds.includes(fgId)) {
-              fgIds.push(fgId);
-            }
+          if (fgId !== null) {
+            fgIds.add(fgId);
           }
         }
-        if (fgIds.length) {
-          this.editor.event.removeFG.dispatch({ fgIds });
+        if (fgIds.size) {
+          this.editor.event.removeFG.dispatch({ fgIds: [...fgIds] });
           this.isNotActiveTool = true;
           return;
         }


### PR DESCRIPTION
###   Fix

  Before applying fromBondsAttrs, the fix now:
  1. Checks whether any selected bonds belong to a functional group via FunctionalGroup.bondsInFunctionalGroup.
  2. Collects the IDs of all affected functional groups.
  3. If any are found, dispatches a removeFG event for those groups (collapsing/removing the expanded monomer) and exits early — consistent with how other
  tools handle selection that intersects functional groups.

###   Files Changed

  - packages/ketcher-react/src/script/editor/tool/bond.ts


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request