### PR TITLE
#8356 - System should not load monomer to the library if empty modificationTypes value provided

### DIFF
--- a/packages/ketcher-core/__tests__/domain/serializers/sdf/validateSdfMonomerLibraryData.test.ts
+++ b/packages/ketcher-core/__tests__/domain/serializers/sdf/validateSdfMonomerLibraryData.test.ts
@@ -1,0 +1,147 @@
+import { validateSdfMonomerLibraryData } from 'domain/serializers/sdf/validateSdfMonomerLibraryData';
+
+describe('validateSdfMonomerLibraryData', () => {
+  it('does not throw for valid SDF with non-empty modificationTypes', () => {
+    const sdf = [
+      'header',
+      '> <type>',
+      'monomerTemplate',
+      '> <modificationTypes>',
+      'modified',
+      '> <name>',
+      'TestMonomer',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).not.toThrow();
+  });
+
+  it('does not throw when type is not monomerTemplate', () => {
+    const sdf = [
+      'header',
+      '> <type>',
+      'otherType',
+      '> <modificationTypes>',
+      '',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).not.toThrow();
+  });
+
+  it('does not throw when modificationTypes field is absent', () => {
+    const sdf = [
+      'header',
+      '> <type>',
+      'monomerTemplate',
+      '> <name>',
+      'TestMonomer',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).not.toThrow();
+  });
+
+  it('throws when modificationTypes is empty for a monomerTemplate', () => {
+    const sdf = [
+      'header',
+      '> <type>',
+      'monomerTemplate',
+      '> <modificationTypes>',
+      '',
+      '> <name>',
+      'BadMonomer',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).toThrow(
+      /monomer definition contains invalid modificationTypes value/,
+    );
+  });
+
+  it('includes sanitized monomer name from <name> field in error', () => {
+    const sdf = [
+      'header',
+      '> <type>',
+      'monomerTemplate',
+      '> <name>',
+      'My<Bad>Monomer',
+      '> <modificationTypes>',
+      '',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).toThrow(/My_Bad_Monomer/);
+  });
+
+  it('falls back to V30 TEMPLATE line for name extraction', () => {
+    const sdf = [
+      'M  V30 TEMPLATE 1 RNA/Adenine/',
+      '> <type>',
+      'monomerTemplate',
+      '> <modificationTypes>',
+      '',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).toThrow(/Adenine/);
+  });
+
+  it('reports "unknown" when no name can be extracted', () => {
+    const sdf = [
+      'header',
+      '> <type>',
+      'monomerTemplate',
+      '> <modificationTypes>',
+      '',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).toThrow(
+      /Load of "unknown" monomer has failed/,
+    );
+  });
+
+  it('sanitizes name: truncates to 64 chars and strips special chars', () => {
+    const longName = 'A'.repeat(100);
+    const sdf = [
+      'header',
+      '> <type>',
+      'monomerTemplate',
+      '> <name>',
+      longName,
+      '> <modificationTypes>',
+      '',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).toThrow(
+      new RegExp(`"${'A'.repeat(64)}"`),
+    );
+  });
+
+  it('handles multiple records and only throws on the invalid one', () => {
+    const sdf = [
+      // Valid record
+      '> <type>',
+      'monomerTemplate',
+      '> <modificationTypes>',
+      'validValue',
+      '$$$$',
+      // Invalid record
+      '> <type>',
+      'monomerTemplate',
+      '> <name>',
+      'SecondMonomer',
+      '> <modificationTypes>',
+      '',
+      '$$$$',
+    ].join('\n');
+
+    expect(() => validateSdfMonomerLibraryData(sdf)).toThrow(/SecondMonomer/);
+  });
+
+  it('is a no-op for empty input', () => {
+    expect(() => validateSdfMonomerLibraryData('')).not.toThrow();
+  });
+});

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -64,51 +64,12 @@ import {
 import { isNumber, uniqueId } from 'lodash';
 import { ChemicalMimeType } from 'domain/services/struct/structService.types';
 import { getStructure } from 'application/getStructure';
+import { validateSdfMonomerLibraryData } from 'domain/serializers/sdf/validateSdfMonomerLibraryData';
 
 type SetMoleculeOptions = {
   position?: { x: number; y: number };
   needZoom?: boolean;
 };
-
-function validateSdfMonomerLibraryData(sdfData: string): void {
-  const records = sdfData.split(/\${4}/);
-
-  for (const record of records) {
-    if (!record.trim()) continue;
-
-    const lines = record.split(/\r?\n/);
-
-    const extractFieldValue = (fieldName: string): string | undefined => {
-      let collecting = false;
-      const valueLines: string[] = [];
-      for (const line of lines) {
-        if (collecting) {
-          if (/^\s*>\s*</.test(line)) break;
-          valueLines.push(line);
-        } else if (new RegExp(`^\\s*>\\s*<${fieldName}>\\s*$`).test(line)) {
-          collecting = true;
-        }
-      }
-      return collecting ? valueLines.join('\n').trim() : undefined;
-    };
-
-    const typeValue = extractFieldValue('type');
-    if (typeValue !== 'monomerTemplate') continue;
-
-    const modificationTypesValue = extractFieldValue('modificationTypes');
-    if (modificationTypesValue === undefined) continue;
-
-    if (!modificationTypesValue) {
-      const templateMatch = record.match(
-        /M\s+V30\s+TEMPLATE\s+\d+\s+\S+\/([^/\s]+)\//,
-      );
-      const monomerName = templateMatch ? templateMatch[1] : 'unknown';
-      throw new Error(
-        `Load of "${monomerName}" monomer has failed, monomer definition contains invalid modificationTypes value. The modificationTypes couldn't be empty`,
-      );
-    }
-  }
-}
 
 const allowedApiSettings = {
   'general.dearomatize-on-load': 'dearomatize-on-load',
@@ -794,6 +755,11 @@ export class Ketcher {
     this.eventBus.emit('CUSTOM_BUTTON_PRESSED', name);
   }
 
+  /**
+   * Converts raw monomer library data to KET format.
+   * @throws {Error} If the input is SDF and contains a monomerTemplate record
+   *   with an empty `modificationTypes` field.
+   */
   public async ensureMonomersLibraryDataInKetFormat(
     rawMonomersData: string | JSON,
     params?: UpdateMonomersLibraryParams,
@@ -807,7 +773,12 @@ export class Ketcher {
     if (format === SupportedFormat.ket) {
       dataInKetFormat = rawMonomersDataString;
     } else {
-      validateSdfMonomerLibraryData(rawMonomersDataString);
+      if (
+        format === SupportedFormat.sdf ||
+        format === SupportedFormat.sdfV3000
+      ) {
+        validateSdfMonomerLibraryData(rawMonomersDataString);
+      }
       const convertResult = await this.structService.convert(
         {
           struct: rawMonomersDataString,
@@ -847,6 +818,10 @@ export class Ketcher {
     return convertResult.struct;
   }
 
+  /**
+   * @throws {Error} If SDF input contains a monomerTemplate with an empty
+   *   `modificationTypes` field, or if not in macromolecules mode.
+   */
   public async updateMonomersLibrary(
     rawMonomersData: string | JSON,
     params?: UpdateMonomersLibraryParams,
@@ -881,6 +856,10 @@ export class Ketcher {
     }
   }
 
+  /**
+   * @throws {Error} If SDF input contains a monomerTemplate with an empty
+   *   `modificationTypes` field, or if not in macromolecules mode.
+   */
   public async replaceMonomersLibrary(
     rawMonomersData: string | JSON,
     params?: UpdateMonomersLibraryParams,

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -70,6 +70,46 @@ type SetMoleculeOptions = {
   needZoom?: boolean;
 };
 
+function validateSdfMonomerLibraryData(sdfData: string): void {
+  const records = sdfData.split(/\${4}/);
+
+  for (const record of records) {
+    if (!record.trim()) continue;
+
+    const lines = record.split(/\r?\n/);
+
+    const extractFieldValue = (fieldName: string): string | undefined => {
+      let collecting = false;
+      const valueLines: string[] = [];
+      for (const line of lines) {
+        if (collecting) {
+          if (/^\s*>\s*</.test(line)) break;
+          valueLines.push(line);
+        } else if (new RegExp(`^\\s*>\\s*<${fieldName}>\\s*$`).test(line)) {
+          collecting = true;
+        }
+      }
+      return collecting ? valueLines.join('\n').trim() : undefined;
+    };
+
+    const typeValue = extractFieldValue('type');
+    if (typeValue !== 'monomerTemplate') continue;
+
+    const modificationTypesValue = extractFieldValue('modificationTypes');
+    if (modificationTypesValue === undefined) continue;
+
+    if (!modificationTypesValue) {
+      const templateMatch = record.match(
+        /M\s+V30\s+TEMPLATE\s+\d+\s+\S+\/([^/\s]+)\//,
+      );
+      const monomerName = templateMatch ? templateMatch[1] : 'unknown';
+      throw new Error(
+        `Load of "${monomerName}" monomer has failed, monomer definition contains invalid modificationTypes value. The modificationTypes couldn't be empty`,
+      );
+    }
+  }
+}
+
 const allowedApiSettings = {
   'general.dearomatize-on-load': 'dearomatize-on-load',
   ignoreChiralFlag: 'ignoreChiralFlag',
@@ -767,6 +807,7 @@ export class Ketcher {
     if (format === SupportedFormat.ket) {
       dataInKetFormat = rawMonomersDataString;
     } else {
+      validateSdfMonomerLibraryData(rawMonomersDataString);
       const convertResult = await this.structService.convert(
         {
           struct: rawMonomersDataString,

--- a/packages/ketcher-core/src/domain/serializers/sdf/index.ts
+++ b/packages/ketcher-core/src/domain/serializers/sdf/index.ts
@@ -16,3 +16,4 @@
 
 export * from './sdf.types';
 export * from './sdfSerializer';
+export * from './validateSdfMonomerLibraryData';

--- a/packages/ketcher-core/src/domain/serializers/sdf/validateSdfMonomerLibraryData.ts
+++ b/packages/ketcher-core/src/domain/serializers/sdf/validateSdfMonomerLibraryData.ts
@@ -22,7 +22,7 @@ const NAME_FIELD_RE = /^\s*>\s*<name>\s*$/;
 type CollectingField = 'type' | 'modificationTypes' | 'name';
 
 function sanitizeMonomerName(raw: string): string {
-  return raw.slice(0, 64).replace(/[^\w.\-]/g, '_');
+  return raw.slice(0, 64).replace(/[^\w.-]/g, '_');
 }
 
 /**

--- a/packages/ketcher-core/src/domain/serializers/sdf/validateSdfMonomerLibraryData.ts
+++ b/packages/ketcher-core/src/domain/serializers/sdf/validateSdfMonomerLibraryData.ts
@@ -1,0 +1,131 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+const FIELD_HEADER_RE = /^\s*>\s*</;
+const TYPE_FIELD_RE = /^\s*>\s*<type>\s*$/;
+const MODIFICATION_TYPES_FIELD_RE = /^\s*>\s*<modificationTypes>\s*$/;
+const NAME_FIELD_RE = /^\s*>\s*<name>\s*$/;
+
+type CollectingField = 'type' | 'modificationTypes' | 'name';
+
+function sanitizeMonomerName(raw: string): string {
+  return raw.slice(0, 64).replace(/[^\w.\-]/g, '_');
+}
+
+/**
+ * Validates SDF monomer library data, ensuring that no monomerTemplate record
+ * has an empty `modificationTypes` field.
+ *
+ * @throws {Error} If a monomerTemplate record has a defined but empty
+ *   `modificationTypes` value.
+ */
+export function validateSdfMonomerLibraryData(sdfData: string): void {
+  const records = sdfData.split(/\${4}/);
+
+  for (const record of records) {
+    if (!record.trim()) continue;
+
+    const lines = record.split(/\r?\n/);
+
+    // Single pass: collect 'type', 'modificationTypes', and 'name' field values
+    let typeValue: string | undefined;
+    let modificationTypesValue: string | undefined;
+    let nameValue: string | undefined;
+    let collecting: CollectingField | null = null;
+    let valueLines: string[] = [];
+
+    for (const line of lines) {
+      if (collecting) {
+        if (FIELD_HEADER_RE.test(line)) {
+          const joined = valueLines.join('\n').trim();
+          if (collecting === 'type') {
+            typeValue = joined;
+          } else if (collecting === 'modificationTypes') {
+            modificationTypesValue = joined;
+          } else {
+            nameValue = joined;
+          }
+          // Check if this new header is one we care about
+          if (typeValue === undefined && TYPE_FIELD_RE.test(line)) {
+            collecting = 'type';
+            valueLines = [];
+          } else if (
+            modificationTypesValue === undefined &&
+            MODIFICATION_TYPES_FIELD_RE.test(line)
+          ) {
+            collecting = 'modificationTypes';
+            valueLines = [];
+          } else if (nameValue === undefined && NAME_FIELD_RE.test(line)) {
+            collecting = 'name';
+            valueLines = [];
+          } else {
+            collecting = null;
+            valueLines = [];
+          }
+        } else {
+          valueLines.push(line);
+        }
+      } else if (typeValue === undefined && TYPE_FIELD_RE.test(line)) {
+        collecting = 'type';
+        valueLines = [];
+      } else if (
+        modificationTypesValue === undefined &&
+        MODIFICATION_TYPES_FIELD_RE.test(line)
+      ) {
+        collecting = 'modificationTypes';
+        valueLines = [];
+      } else if (nameValue === undefined && NAME_FIELD_RE.test(line)) {
+        collecting = 'name';
+        valueLines = [];
+      }
+      // Early exit if all fields are found
+      if (
+        typeValue !== undefined &&
+        modificationTypesValue !== undefined &&
+        nameValue !== undefined
+      ) {
+        break;
+      }
+    }
+
+    // Flush any field still being collected at end of record
+    if (collecting) {
+      const joined = valueLines.join('\n').trim();
+      if (collecting === 'type') {
+        typeValue = joined;
+      } else if (collecting === 'modificationTypes') {
+        modificationTypesValue = joined;
+      } else {
+        nameValue = joined;
+      }
+    }
+
+    if (typeValue !== 'monomerTemplate') continue;
+    if (modificationTypesValue === undefined) continue;
+
+    if (!modificationTypesValue) {
+      const templateMatch = record.match(
+        /M\s+V30\s+TEMPLATE\s+\d+\s+\S+\/([^/\s]+)\//,
+      );
+      const rawName =
+        nameValue || (templateMatch ? templateMatch[1] : undefined);
+      const monomerName = rawName ? sanitizeMonomerName(rawName) : 'unknown';
+      throw new Error(
+        `Load of "${monomerName}" monomer has failed, monomer definition contains invalid modificationTypes value. The modificationTypes couldn't be empty`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
### Problem
When loading a custom monomer library in SDF format, Ketcher silently accepted monomer template records where the modificationTypes field was present but contained an empty value. This led to undefined behavior downstream, as an empty modificationTypes is semantically invalid for a monomer template.

### Fix
Added a validateSdfMonomerLibraryData validation step that runs before SDF monomer library data is converted. The validator:

- Splits the SDF input into individual records
- Skips records that are not of type = monomerTemplate
- If a modificationTypes field is present but empty, throws a descriptive error identifying the offending monomer by name (extracted from the M  V30  TEMPLATE line)

Error message:
Load of "<monomerName>" monomer has failed, monomer definition contains invalid modificationTypes value. The modificationTypes couldn't be empty

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request