### PR TITLE
#8184 - No error if preset loaded to the library with wrong <groupClass> defined

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -11,6 +11,7 @@ import {
   KetcherLogger,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+  MONOMER_GROUP_TEMPLATE_CLASS_INVALID_ERROR_MESSAGE,
 } from 'utilities';
 
 describe('CoreEditor', () => {
@@ -592,6 +593,67 @@ describe('CoreEditor', () => {
       const initialTemplatesCount =
         editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
       editor.updateMonomersLibrary(JSON.stringify(presetWithBoundaryName));
+
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount + 1,
+      );
+    });
+
+    it('should reject monomer group template with invalid class', () => {
+      const presetWithInvalidClass = {
+        root: {
+          templates: [
+            {
+              $ref: 'monomerGroupTemplate-invalidClass',
+            },
+          ],
+        },
+        'monomerGroupTemplate-invalidClass': {
+          type: 'monomerGroupTemplate',
+          id: '',
+          name: 'TestPreset',
+          class: 'RNA1111',
+          templates: [],
+          connections: [],
+        },
+      };
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+      editor.updateMonomersLibrary(JSON.stringify(presetWithInvalidClass));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          MONOMER_GROUP_TEMPLATE_CLASS_INVALID_ERROR_MESSAGE,
+        ),
+      );
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
+    });
+
+    it('should accept monomer group template with valid class RNA', () => {
+      const presetWithValidClass = {
+        root: {
+          templates: [
+            {
+              $ref: 'monomerGroupTemplate-validClass',
+            },
+          ],
+        },
+        'monomerGroupTemplate-validClass': {
+          type: 'monomerGroupTemplate',
+          id: '',
+          name: 'TestValidPreset',
+          class: 'RNA',
+          templates: [],
+          connections: [],
+        },
+      };
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+      editor.updateMonomersLibrary(JSON.stringify(presetWithValidClass));
 
       expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
         initialTemplatesCount + 1,

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -80,9 +80,11 @@ import {
   IDT_ALIAS_LENGTH_ERROR_MESSAGE,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+  MONOMER_GROUP_TEMPLATE_CLASS_INVALID_ERROR_MESSAGE,
   isValidBilnAlias,
   isValidHelmAlias,
   isValidIdtAlias,
+  isValidMonomerGroupTemplateClass,
   getTooLongIdtAliasEntries,
   initHotKeys,
   KetcherLogger,
@@ -600,6 +602,16 @@ export class CoreEditor {
         )}...`;
         KetcherLogger.error(
           `Editor::updateMonomersLibrary: Load of monomer group template "${truncatedTemplateName}" (length: ${templateDefinition.name.length}, template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE} The template was not added to the library.`,
+        );
+        return;
+      }
+
+      if (
+        templateDefinition.class &&
+        !isValidMonomerGroupTemplateClass(templateDefinition.class)
+      ) {
+        KetcherLogger.error(
+          `Editor::updateMonomersLibrary: Load of monomer group template "${templateDefinition.name}" (template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_CLASS_INVALID_ERROR_MESSAGE} The template was not added to the library.`,
         );
         return;
       }

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -1,5 +1,8 @@
 import { BaseMonomer } from 'domain/entities/BaseMonomer';
-import { IKetIdtAliases } from 'application/formatters/types/ket';
+import {
+  IKetIdtAliases,
+  KetMonomerGroupTemplateClass,
+} from 'application/formatters/types/ket';
 
 export const HELM_ALIAS_FORMAT_ERROR_MESSAGE =
   'The HELM alias must consist only of uppercase and lowercase letters, numbers, underscores (_), asterisks (*), square brackets ([]), parentheses (()), dots (.), and hyphens (-), spaces prohibited.';
@@ -17,6 +20,27 @@ export const IDT_ALIAS_LENGTH_ERROR_MESSAGE = `IDT alias length must not exceed 
 export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH = 200;
 
 export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE = `The monomer group template name must not exceed ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH} characters.`;
+
+export const MONOMER_GROUP_TEMPLATE_VALID_CLASSES = Object.values(
+  KetMonomerGroupTemplateClass,
+);
+
+export const MONOMER_GROUP_TEMPLATE_CLASS_INVALID_ERROR_MESSAGE = `The monomer group template class must be one of: ${MONOMER_GROUP_TEMPLATE_VALID_CLASSES.join(
+  ', ',
+)}.`;
+
+/**
+ * Returns true when `value` is one of the valid monomer group template
+ * classes. Note: an absent (`undefined`) class is NOT handled here — the
+ * call site decides whether a missing class is acceptable.
+ */
+export function isValidMonomerGroupTemplateClass(
+  value: unknown,
+): value is KetMonomerGroupTemplateClass {
+  return MONOMER_GROUP_TEMPLATE_VALID_CLASSES.includes(
+    value as KetMonomerGroupTemplateClass,
+  );
+}
 
 const HELM_ALIAS_REGEX = /^(?!.*\s)[A-Za-z0-9_*.[\]()-]+$/;
 const BILN_ALIAS_REGEX = /^[A-Za-z0-9_*-]+$/;


### PR DESCRIPTION
  Summary

  Adds validation in Editor.updateMonomersLibrary to reject monomer group templates with a non-empty but invalid class
  value. Previously silently dropped downstream; now logs an error and skips the offending template while continuing to
  load the rest.

  Spec

  - groupClass is mandatory; valid values come from KetMonomerGroupTemplateClass enum ('RNA').
  - Per Ljubica's rule (already documented in epam/ketcher#8181): incorrect property → skip the template, load the rest, throw error.

  Changes

  - packages/ketcher-core/src/utilities/monomers.ts
    - MONOMER_GROUP_TEMPLATE_VALID_CLASSES — derived from Object.values(KetMonomerGroupTemplateClass)
    - MONOMER_GROUP_TEMPLATE_CLASS_INVALID_ERROR_MESSAGE — single source of truth for the error string
    - isValidMonomerGroupTemplateClass(value: unknown): value is KetMonomerGroupTemplateClass — typed predicate
  - packages/ketcher-core/src/application/editor/Editor.ts
    - New validation in the monomer group template loop, after the existing name length check
    - Fires only when class is present and non-empty, so missing class (#8185) and empty class (#8186) fall through to their own dedicated tickets
  - packages/ketcher-core/__tests__/application/editor/Editor.test.ts
    - should reject monomer group template with invalid class — sends class: 'RNA1111'; asserts error logged and template not added
    - should accept monomer group template with valid class RNA — control case
    - Assertions reference the exported error message constant (no hardcoded strings)
   
## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request