### PR TITLE
#8186 - No error if preset loaded to the library with empty <groupClass> provided

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -11,6 +11,7 @@ import {
   KetcherLogger,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+  MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE,
 } from 'utilities';
 
 describe('CoreEditor', () => {
@@ -595,6 +596,72 @@ describe('CoreEditor', () => {
 
       expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
         initialTemplatesCount + 1,
+      );
+    });
+
+    it('should reject monomer group template with empty class', () => {
+      const presetWithEmptyClass = {
+        root: {
+          templates: [
+            {
+              $ref: 'monomerGroupTemplate-emptyClass',
+            },
+          ],
+        },
+        'monomerGroupTemplate-emptyClass': {
+          type: 'monomerGroupTemplate',
+          id: '',
+          name: 'TestPresetEmptyClass',
+          class: '',
+          templates: [],
+          connections: [],
+        },
+      };
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+      editor.updateMonomersLibrary(JSON.stringify(presetWithEmptyClass));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE,
+        ),
+      );
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
+    });
+
+    it('should reject monomer group template with whitespace-only class', () => {
+      const presetWithWhitespaceClass = {
+        root: {
+          templates: [
+            {
+              $ref: 'monomerGroupTemplate-whitespaceClass',
+            },
+          ],
+        },
+        'monomerGroupTemplate-whitespaceClass': {
+          type: 'monomerGroupTemplate',
+          id: '',
+          name: 'TestPresetWhitespaceClass',
+          class: '   ',
+          templates: [],
+          connections: [],
+        },
+      };
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+      editor.updateMonomersLibrary(JSON.stringify(presetWithWhitespaceClass));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE,
+        ),
+      );
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
       );
     });
   });

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -80,6 +80,7 @@ import {
   IDT_ALIAS_LENGTH_ERROR_MESSAGE,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+  MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE,
   isValidBilnAlias,
   isValidHelmAlias,
   isValidIdtAlias,
@@ -600,6 +601,19 @@ export class CoreEditor {
         )}...`;
         KetcherLogger.error(
           `Editor::updateMonomersLibrary: Load of monomer group template "${truncatedTemplateName}" (length: ${templateDefinition.name.length}, template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE} The template was not added to the library.`,
+        );
+        return;
+      }
+
+      // Only a present-but-empty/whitespace class is rejected here. An absent
+      // (`undefined`) class is intentionally left untouched — that case is
+      // out of scope for this validation and handled separately.
+      if (
+        templateDefinition.class !== undefined &&
+        !templateDefinition.class.trim()
+      ) {
+        KetcherLogger.error(
+          `Editor::updateMonomersLibrary: Load of monomer group template "${templateDefinition.name}" (template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE} The template was not added to the library.`,
         );
         return;
       }

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -18,6 +18,9 @@ export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH = 200;
 
 export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE = `The monomer group template name must not exceed ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH} characters.`;
 
+export const MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE =
+  'The monomer group template class cannot be empty or whitespace.';
+
 const HELM_ALIAS_REGEX = /^(?!.*\s)[A-Za-z0-9_*.[\]()-]+$/;
 const BILN_ALIAS_REGEX = /^[A-Za-z0-9_*-]+$/;
 


### PR DESCRIPTION
 Summary

  Adds validation in Editor.updateMonomersLibrary to reject monomer group templates with an empty (or whitespace-only) class.
  Previously silently dropped downstream by the consumer-side filter; now logs an error and skips the offending template while continuing to load the rest.

  Spec

  - groupClass is mandatory; valid values come from KetMonomerGroupTemplateClass enum (currently 'RNA').
  - Per Ljubica's rule: incorrect property → skip the template, load the rest, throw error.

  Changes

  packages/ketcher-core/src/utilities/monomers.ts — new exported constant MONOMER_GROUP_TEMPLATE_CLASS_EMPTY_ERROR_MESSAGE.

  packages/ketcher-core/src/application/editor/Editor.ts — new validation in the monomer group template loop, after the existing name-length check. Imports the new error message constant. Fires only when class is defined and trims to an empty string, so missing class (undefined) falls through to its own dedicated ticket.

  packages/ketcher-core/__tests__/application/editor/Editor.test.ts — two new unit tests:
  - should reject monomer group template with empty class — sends class: '', asserts error logged and template not added
  - should reject monomer group template with whitespace-only class — sends class: '   ', asserts same

  Tests reference the exported error message constant.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request