### PR TITLE
Refactor: Fix serializer circular dependency

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -124,10 +124,8 @@ import {
   MultitailArrowAddOperation,
   MultitailArrowDeleteOperation,
 } from 'application/editor/operations/coreRxn/multitailArrow';
-import {
-  getMonomerTemplateRefFromMonomerItem,
-  KetFileNode,
-} from 'domain/serializers';
+import { getMonomerTemplateRefFromMonomerItem } from 'domain/serializers/ket/helpers';
+import { KetFileNode } from 'domain/serializers/serializers.types';
 import { RxnPlus } from 'domain/entities/CoreRxnPlus';
 import {
   RxnPlusAddOperation,


### PR DESCRIPTION
**Original cycle**: `src/domain/serializers/index.ts` -> `src/domain/serializers/ket/index.ts` -> `src/domain/serializers/ket/ketSerializer.ts` -> `src/domain/entities/DrawingEntitiesManager.ts` -> `src/domain/serializers/index.ts`

**Fix**: replace barrel import with direct imports


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request