### PR TITLE
#4093 – Keep loading indicator visible until paste completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -262,7 +262,7 @@
         "ketcher-macromolecules": "*",
         "ketcher-react": "*",
         "ketcher-standalone": "*",
-        "next": "^16.2.6",
+        "next": "16.2.6",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
       },

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -412,15 +412,14 @@ export function initClipboard(dispatch, getState) {
       const result = await runAsyncAction(async () => {
         const structStr = await getStructStringFromClipboardData(data);
         if (structStr || !rxnTextPlain.test(data['text/plain'])) {
-          if (isSmarts) {
-            loadStruct(structStr, {
-              fragment: true,
-              isPaste: true,
-              'input-format': ChemicalMimeType.DaylightSmarts,
-            });
-          } else {
-            loadStruct(structStr, { fragment: true, isPaste: true });
-          }
+          const opts = isSmarts
+            ? {
+                fragment: true,
+                isPaste: true,
+                'input-format': ChemicalMimeType.DaylightSmarts,
+              }
+            : { fragment: true, isPaste: true };
+          await dispatch(load(structStr, opts));
         }
       }, ketcherInstance.eventBus);
       return result;

--- a/packages/ketcher-react/src/script/ui/state/shared.ts
+++ b/packages/ketcher-react/src/script/ui/state/shared.ts
@@ -99,7 +99,7 @@ export function removeStructAction(): {
   return onAction(savedSelectedTool || tools['select-rectangle'].action);
 }
 
-export function load(struct: Struct, options?) {
+export function load(struct: string | Struct, options?) {
   return async (dispatch, getState) => {
     const state = getState();
     const editor = state.editor as Editor;


### PR DESCRIPTION
## Summary
Fixes #4093.
When pasting a large SMILES (Cmd/Ctrl+V), the three-dots loading indicator disappeared right after reading the clipboard, while `parseStruct` and paste-tool rendering still took several seconds.
- In `onPaste`, replace fire-and-forget `loadStruct` (`debounce(0)`) with `await dispatch(load(structStr, opts))` so `runAsyncAction` emits `SUCCESS` only after the full load/paste pipeline finishes.
- Type `load()` first argument as `string | Struct` (it already accepts strings via `parseStruct`).
`onLegacyPaste` and `loadStruct` are unchanged (legacy path still defers dispatch out of the synchronous paste handler).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request