### PR TITLE
#8138 - System should not add monomer to the library of empty value for type field is provided

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -11,6 +11,7 @@ import {
   KetcherLogger,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+  MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE,
 } from 'utilities';
 
 describe('CoreEditor', () => {
@@ -596,6 +597,62 @@ describe('CoreEditor', () => {
       expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
         initialTemplatesCount + 1,
       );
+    });
+
+    it('should reject monomer template with an empty type', () => {
+      const monomerWithEmptyType = {
+        root: {
+          templates: [
+            {
+              $ref: 'monomerTemplate-_Base2',
+            },
+          ],
+        },
+        'monomerTemplate-_Base2': {
+          type: '',
+          id: '_Base2',
+          name: '_Base2',
+          class: 'Base',
+          classHELM: 'RNA',
+          naturalAnalogShort: 'A',
+        },
+      };
+
+      const initialLibrarySize = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(monomerWithEmptyType));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE),
+      );
+      expect(editor.monomersLibrary.length).toBe(initialLibrarySize);
+    });
+
+    it('should reject monomer template with a whitespace-only type', () => {
+      const monomerWithWhitespaceType = {
+        root: {
+          templates: [
+            {
+              $ref: 'monomerTemplate-_Base2',
+            },
+          ],
+        },
+        'monomerTemplate-_Base2': {
+          type: '   ',
+          id: '_Base2',
+          name: '_Base2',
+          class: 'Base',
+          classHELM: 'RNA',
+          naturalAnalogShort: 'A',
+        },
+      };
+
+      const initialLibrarySize = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(monomerWithWhitespaceType));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE),
+      );
+      expect(editor.monomersLibrary.length).toBe(initialLibrarySize);
     });
   });
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -80,6 +80,7 @@ import {
   IDT_ALIAS_LENGTH_ERROR_MESSAGE,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
+  MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE,
   isValidBilnAlias,
   isValidHelmAlias,
   isValidIdtAlias,
@@ -424,6 +425,32 @@ export class CoreEditor {
       ]
         .filter((value): value is string => Boolean(value))
         .join(', ');
+
+    // Reject templates that declare a present-but-empty `type`. They are
+    // already excluded from loading — `convertMonomersLibrary` only converts
+    // `monomerTemplate`/`ambiguousMonomerTemplate` entries, and the monomer
+    // group template loop below only handles `monomerGroupTemplate` — so this
+    // pass exists to surface the otherwise-silent skip as an explicit error.
+    // An absent (`undefined`) `type` is intentionally left untouched: the
+    // library schema treats it as optional with a `monomerTemplate` default.
+    newMonomersLibraryChunkParsedJson.root.templates.forEach((templateRef) => {
+      const templateDefinition =
+        newMonomersLibraryChunkParsedJson[templateRef.$ref];
+
+      if (
+        templateDefinition?.type !== undefined &&
+        !templateDefinition.type.trim()
+      ) {
+        const monomerName =
+          templateDefinition.name ??
+          templateDefinition.alias ??
+          templateDefinition.id ??
+          templateRef.$ref;
+        KetcherLogger.error(
+          `Editor::updateMonomersLibrary: ${MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE} "${monomerName}" monomer hasn't been added to the library.`,
+        );
+      }
+    });
 
     // handle monomer templates
     newMonomersLibraryChunk.forEach((newMonomer) => {

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -18,6 +18,9 @@ export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH = 200;
 
 export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE = `The monomer group template name must not exceed ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH} characters.`;
 
+export const MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE =
+  'Empty value for "type" is provided.';
+
 const HELM_ALIAS_REGEX = /^(?!.*\s)[A-Za-z0-9_*.[\]()-]+$/;
 const BILN_ALIAS_REGEX = /^[A-Za-z0-9_*-]+$/;
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
### Problem
  Loading a monomer library via `ketcher.updateMonomersLibrary` with a template whose `type` field is present but empty added the monomer silently, with no error.

  ### Fix
  `Editor.updateMonomersLibrary` now runs a validation pass over the incoming templates. A present-but-empty (or whitespace-only) `type` is rejected and logged:

  `Editor::updateMonomersLibrary: Empty value for "type" is provided. "<name>" monomer hasn't been added to the library.`

  An absent (`undefined`) `type` is left untouched — per the library schema it is optional and defaults to `monomerTemplate`. Invalid non-empty `type` values are out of scope here (separate concern). The empty-`type` template was already excluded from loading (`convertMonomersLibrary` only converts `monomerTemplate`/`ambiguousMonomerTemplate` entries, and the monomer-group-template loop only handles `monomerGroupTemplate`); this change surfaces the otherwise-silent skip as an explicit error.

  ### Changes
  - `utilities/monomers.ts` — new `MONOMER_TEMPLATE_TYPE_EMPTY_ERROR_MESSAGE` constant.
  - `application/editor/Editor.ts` — validation pass for empty `type`.
  - `Editor.test.ts` — unit tests for empty and whitespace-only `type`.

  ### Notes
  Paired with Indigo issue epam/Indigo#3161, which preserves the empty `type` through SDF→KET conversion.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request