### PR TITLE
#10102 - Type combobox is empty if S-Group Properties` dialog opened for Copolymer s-group for edit

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.test.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.test.tsx
@@ -60,6 +60,21 @@ describe('Copolymer S-Group type availability', () => {
     renderAndOpenTypeSelect(2);
     expect(screen.getByTestId('Copolymer-option')).toBeInTheDocument();
   });
+
+  it('should show Copolymer option when editing existing Copolymer S-Group', () => {
+    renderWithMockStore(<SGroup type="COP" selectedSruCount={2} />, {
+      modal: {
+        form: {
+          result: {
+            type: 'COP',
+          },
+        },
+      },
+    });
+    const typeSelect = screen.getAllByRole('combobox')[0];
+    fireEvent.mouseDown(typeSelect);
+    expect(screen.getByTestId('Copolymer-option')).toBeInTheDocument();
+  });
 });
 
 describe('S-Group DAT type rendering', () => {

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -42,7 +42,7 @@ import { openInfoModalWithCustomMessage } from '../shared';
 export default function initEditor(dispatch, getState) {
   const updateAction = debounce(100, () => dispatch({ type: 'UPDATE' }));
   const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
-  const getSelectedSruCount = () => {
+  const getSelectedSruCount = (sgroupType) => {
     const editor = getState().editor;
     if (!editor?.structSelected) return 0;
     const selectedStruct = editor.structSelected();
@@ -52,7 +52,7 @@ export default function initEditor(dispatch, getState) {
         count += 1;
       }
     }
-    return count;
+    return sgroupType === 'COP' ? Math.max(2, count) : count;
   };
 
   const resetToSelect =
@@ -187,10 +187,7 @@ export default function initEditor(dispatch, getState) {
         .then(() =>
           openDialog(dispatch, 'sgroup', {
             ...fromSgroup(sgroup),
-            selectedSruCount:
-              sgroup.type === 'COP'
-                ? Math.max(2, getSelectedSruCount())
-                : getSelectedSruCount(),
+            selectedSruCount: getSelectedSruCount(sgroup.type),
           }),
         )
         .then(toSgroup),

--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -187,7 +187,10 @@ export default function initEditor(dispatch, getState) {
         .then(() =>
           openDialog(dispatch, 'sgroup', {
             ...fromSgroup(sgroup),
-            selectedSruCount: getSelectedSruCount(),
+            selectedSruCount:
+              sgroup.type === 'COP'
+                ? Math.max(2, getSelectedSruCount())
+                : getSelectedSruCount(),
           }),
         )
         .then(toSgroup),


### PR DESCRIPTION
## Summary

Fixes the empty Type combobox in the S-Group Properties dialog when opened for editing an existing Copolymer S-Group.

## Changes

### Copolymer S-Group Edit Dialog Fix

**Problem:** Double-clicking a Copolymer (COP) S-Group sets the selection to the sgroup only (no atoms). `getSelectedSruCount()` then returns 0, which causes the dialog to filter COP out of the Type dropdown. The form initializes with `type='COP'` but the option is missing, leaving the combobox empty.

**Solution:** In `onSgroupEdit`, when `sgroup.type === 'COP'`, force `selectedSruCount` to `Math.max(2, getSelectedSruCount())`. A Copolymer can only exist if ≥2 SRUs were present at creation, so the override is always factually correct. Scoped to the COP edit path — all other S-Group types and the create-new flow are unchanged.

### Files Modified

**`ketcher-react`**
- `src/script/ui/state/editor/index.js` — force `selectedSruCount >= 2` in `onSgroupEdit` when editing a COP S-Group
- `src/script/ui/dialog/toolbox/sgroup.test.tsx` — added test verifying the Copolymer option appears when the dialog is rendered with `type='COP'` and `selectedSruCount=2`


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request