### PR TITLE
#9671 - Context menu works wrong for embedded Ketcher

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -1,4 +1,4 @@
-import { CoreEditor, ToolName } from 'application/editor';
+import { CoreEditor, EditorClassName, ToolName } from 'application/editor';
 import { MonomerTool } from 'application/editor/tools/Monomer';
 import {
   createPolymerEditorCanvas,
@@ -642,9 +642,14 @@ describe('CoreEditor', () => {
   describe('context menu handling', () => {
     let canvas: SVGSVGElement;
     let editor: CoreEditor;
+    let rootElement: HTMLDivElement;
 
     beforeEach(() => {
       canvas = createPolymerEditorCanvas();
+      rootElement = document.createElement('div');
+      rootElement.classList.add(EditorClassName);
+      document.body.appendChild(rootElement);
+      rootElement.appendChild(canvas);
       editor = new CoreEditor({
         canvas,
         theme: polymerEditorTheme,
@@ -655,6 +660,7 @@ describe('CoreEditor', () => {
     afterEach(() => {
       editor.destroy();
       canvas.remove();
+      rootElement.remove();
     });
 
     it('should select monomer on right click when it was not selected', () => {
@@ -680,7 +686,7 @@ describe('CoreEditor', () => {
       const monomerDomElement = document.createElement('div');
       (monomerDomElement as unknown as { __data__: unknown }).__data__ =
         monomer.renderer;
-      document.body.appendChild(monomerDomElement);
+      rootElement.appendChild(monomerDomElement);
 
       expect(monomer.selected).toBeFalsy();
       monomerDomElement.dispatchEvent(

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -663,6 +663,37 @@ describe('CoreEditor', () => {
       rootElement.remove();
     });
 
+    it('should ignore right click on element outside ketcherRootElement', () => {
+      const outsideElement = document.createElement('div');
+      document.body.appendChild(outsideElement);
+
+      const preventDefaultSpy = jest.fn();
+      const rightClickSelectedMonomersHandler = jest.fn();
+      const rightClickCanvasHandler = jest.fn();
+      editor.events.rightClickSelectedMonomers.add(
+        rightClickSelectedMonomersHandler,
+      );
+      editor.events.rightClickCanvas.add(rightClickCanvasHandler);
+
+      const event = new MouseEvent('contextmenu', {
+        bubbles: true,
+        clientX: 0,
+        clientY: 0,
+        cancelable: true,
+      });
+      Object.defineProperty(event, 'preventDefault', {
+        value: preventDefaultSpy,
+        writable: true,
+      });
+      outsideElement.dispatchEvent(event);
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(rightClickSelectedMonomersHandler).not.toHaveBeenCalled();
+      expect(rightClickCanvasHandler).not.toHaveBeenCalled();
+
+      outsideElement.remove();
+    });
+
     it('should select monomer on right click when it was not selected', () => {
       const svgElementWithBBox = SVGElement.prototype as SVGElement & {
         getBBox?: () => DOMRect;

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -799,6 +799,7 @@ export class CoreEditor {
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
       const target = event.target as Node | null;
+      // Guard: only handle events whose target is inside this editor's root element
       if (
         !this.ketcherRootElement ||
         !target ||

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -798,6 +798,15 @@ export class CoreEditor {
 
   private setupContextMenuEvents() {
     this.contextMenuEventHandler = (event) => {
+      const target = event.target as Node | null;
+      if (
+        !this.ketcherRootElement ||
+        !target ||
+        !this.ketcherRootElement.contains(target)
+      ) {
+        return;
+      }
+
       event.preventDefault();
 
       if (this.libraryItemDragState) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Added a guard at the top of setupContextMenuEvents that bails out immediately if the event target is not contained within this.ketcherRootElement (the .Ketcher-polymer-editor-root div). preventDefault and all downstream dispatch logic are only reached for clicks inside the editor's own DOM subtree. Clicks anywhere outside — on host-page elements, browser chrome, or other embedded components — are left entirely untouched.
### Tests
Updated the context menu handling test suite to wrap the canvas in a div.Ketcher-polymer-editor-root element, which is required for the guard to pass — this reflects real-world usage and was the root cause of the previously failing test.
Added should ignore right click on element outside ketcherRootElement: dispatches contextmenu on an element appended directly to document.body (outside the root) and asserts that preventDefault is not called and no rightClick* events are dispatched. This pins the guard behavior so a future regression dropping the check would be caught.


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request