### PR TITLE
#10085: add custom isDummy class

### DIFF
--- a/ketcher-autotests/tests/pages/molecules/canvas/createMonomer/selectAtomAndBonds.ts
+++ b/ketcher-autotests/tests/pages/molecules/canvas/createMonomer/selectAtomAndBonds.ts
@@ -53,20 +53,20 @@ export async function selectAtomAndBonds(
   await CommonLeftToolbar(page).handTool();
   await CommonLeftToolbar(page).areaSelectionTool();
   await clickOnCanvas(page, 0, 0);
-  if (options.atomIds) {
-    for (const atomId of options.atomIds) {
-      await clickSelectableCanvasElement(
-        page,
-        getAtomLocator(page, { atomId }),
-        { modifiers: ['Shift'] },
-      );
-    }
-  }
   if (options.bondIds) {
     for (const bondId of options.bondIds) {
       await clickSelectableCanvasElement(
         page,
         getBondLocator(page, { bondId }),
+        { modifiers: ['Shift'] },
+      );
+    }
+  }
+  if (options.atomIds) {
+    for (const atomId of options.atomIds) {
+      await clickSelectableCanvasElement(
+        page,
+        getAtomLocator(page, { atomId }),
         { modifiers: ['Shift'] },
       );
     }

--- a/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.13.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.13.0-bugs.spec.ts
@@ -665,6 +665,13 @@ test.describe('Bugs: ketcher-3.13.0 — Small molecules positioning rule', () =>
       bondIds: [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20],
     });
 
+    // Marking a component recenters the structure under the attributes panel.
+    await CommonLeftToolbar(page).handTool();
+    await page.mouse.move(600, 200);
+    await dragMouseTo(page, 450, 250);
+    await page.mouse.move(600, 200);
+    await dragMouseTo(page, 450, 250);
+
     // --- Sugar ---
     await presetSection.setupSugar({
       atomIds: [0, 1, 2, 3, 4, 5, 6, 7, 23],
@@ -673,8 +680,8 @@ test.describe('Bugs: ketcher-3.13.0 — Small molecules positioning rule', () =>
 
     // --- Phosphate ---
     await presetSection.setupPhosphate({
-      atomIds: [8, 19, 20, 21, 22],
-      bondIds: [21, 22, 23, 24],
+      atomIds: [8, 19, 21, 22],
+      bondIds: [21, 23, 24],
     });
 
     // Select phosphate position (required field; without it the validation dispatches

--- a/packages/ketcher-core/src/application/editor/operations/Text/TextUpdate.ts
+++ b/packages/ketcher-core/src/application/editor/operations/Text/TextUpdate.ts
@@ -50,4 +50,11 @@ export class TextUpdate extends BaseOperation {
     inverted.data.previousContent = this.data.content;
     return inverted;
   }
+
+  isDummy(restruct?: ReStruct) {
+    if (!restruct) return false;
+    const text = restruct.molecule.texts.get(this.data.id);
+    if (!text) return false;
+    return text.content === this.data.content;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/highlight.ts
+++ b/packages/ketcher-core/src/application/editor/operations/highlight.ts
@@ -227,6 +227,21 @@ export class HighlightUpdate extends BaseOperation {
     );
     return inverted;
   }
+
+  isDummy(restruct?: ReStruct) {
+    if (!restruct) return false;
+    const highlight = restruct.molecule.highlights.get(
+      this.newData.highlightId,
+    );
+    if (!highlight) return false;
+    return (
+      highlight.color === this.newData.color &&
+      highlight.atoms.length === this.newData.atoms.length &&
+      highlight.bonds.length === this.newData.bonds.length &&
+      highlight.atoms.every((id, i) => this.newData.atoms[i] === id) &&
+      highlight.bonds.every((id, i) => this.newData.bonds[i] === id)
+    );
+  }
 }
 
 function notifyChanged(

--- a/packages/ketcher-core/src/application/editor/operations/image/imageResize.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageResize.ts
@@ -78,4 +78,16 @@ export class ImageResize extends BaseOperation {
       this.referencePositionName,
     );
   }
+
+  isDummy(restruct?: ReStruct) {
+    if (!restruct) return false;
+    const item = restruct.molecule.images.get(this.id);
+    if (!item) return false;
+    const currentPosition =
+      item.getReferencePositions()[this.referencePositionName];
+    return (
+      this.position.x === currentPosition.x &&
+      this.position.y === currentPosition.y
+    );
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/monomer/RotateMonomerOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/RotateMonomerOperation.ts
@@ -55,4 +55,8 @@ export class RotateMonomerOperation extends BaseOperation {
       value: this.previousValue,
     });
   }
+
+  isDummy() {
+    return this.data.value === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/monomer/ShiftMonomerOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/ShiftMonomerOperation.ts
@@ -63,4 +63,10 @@ export class ShiftMonomerOperation extends BaseOperation {
       value: this.previousValue,
     });
   }
+
+  isDummy() {
+    const { value } = this.data;
+    if (value === null) return false;
+    return (value.x ?? 0) === 0 && (value.y ?? 0) === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
@@ -70,4 +70,8 @@ export class ReassignAttachmentPointOperation extends BaseOperation {
       this.currentName,
     );
   }
+
+  isDummy() {
+    return this.currentName === this.newName;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
@@ -44,4 +44,8 @@ export class ReassignLeavingAtomOperation extends BaseOperation {
       this.newLeavingAtomId,
     );
   }
+
+  isDummy() {
+    return this.newLeavingAtomId === this.previousLeavingAtomId;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowMove.ts
@@ -28,4 +28,8 @@ export class MultitailArrowMove extends BaseOperation {
   invert() {
     return new MultitailArrowMove(this.id, this.offset.negated());
   }
+
+  isDummy() {
+    return this.offset.x === 0 && this.offset.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupFragment.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupFragment.ts
@@ -85,4 +85,13 @@ export class RGroupFragment extends BaseOperation {
   invert() {
     return new RGroupFragment(this.rgid_old, this.frid, this.rg_old);
   }
+
+  isDummy(restruct?: ReStruct) {
+    if (!restruct) return false;
+    const currentRgid = RGroup.findRGroupByFragment(
+      restruct.molecule.rgroups,
+      this.frid,
+    );
+    return currentRgid === this.rgid_new;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowResize.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowResize.ts
@@ -169,6 +169,11 @@ export class RxnArrowResize extends Base {
       this.isSnappingEnabled,
     );
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d.x === 0 && d.y === 0;
+  }
 }
 
 export function getSnappedArrowVector(arrow: Vec2) {

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowRotate.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowRotate.ts
@@ -53,4 +53,8 @@ export class RxnArrowRotate extends Base {
     );
     return move;
   }
+
+  isDummy() {
+    return this.data.angle === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupAttr.ts
@@ -69,4 +69,11 @@ export class SGroupAttr extends BaseOperation {
     inverted.data = this.data;
     return inverted;
   }
+
+  isDummy(restruct?: ReStruct) {
+    if (!restruct) return false;
+    const sgroup = restruct.molecule.sgroups.get(this.data.sgid);
+    if (!sgroup) return false;
+    return sgroup.checkAttr(this.data.attr, this.data.value);
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/simpleObject.ts
+++ b/packages/ketcher-core/src/application/editor/operations/simpleObject.ts
@@ -157,6 +157,11 @@ export class SimpleObjectMove extends Base {
     move.data = this.data;
     return move;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d.x === 0 && d.y === 0;
+  }
 }
 
 interface SimpleObjectResizeData {
@@ -272,6 +277,11 @@ export class SimpleObjectResize extends Base {
       this.data.noinvalidate,
       this.data.toCircle,
     );
+  }
+
+  isDummy() {
+    const { d } = this.data;
+    return d.x === 0 && d.y === 0;
   }
 }
 


### PR DESCRIPTION
## Summary

`Action.isDummy()` is responsible for preventing no-op actions from being added to the undo/redo history. An action should be considered dummy only when all operations inside it produce no effective changes.

The issue was caused by two problems:

### 1. Incorrect action-level dummy aggregation

The previous implementation of `Action.isDummy()` used `find()` with logic that effectively treated any non-empty action as non-dummy.

```ts
// before
this.operations.find((op) => (restruct ? !op.isDummy(restruct) : true)) === undefined
```

As a result, no-op actions were still added to the undo history.

The implementation was replaced with `every()` so an action is considered dummy only if every operation inside it is dummy.

```ts
// after
this.operations.every((op) => op.isDummy(restruct))
```

---

### 2. Missing `isDummy()` implementations in operation classes

Most operation classes relied on `BaseOperation.isDummy()`, which returns `false` by default. This is correct for structural operations (create/delete/etc.), but many update operations can produce effective no-op changes.

Custom `isDummy()` implementations were added to operations capable of producing unchanged updates.

---

## Implemented dummy checks

### Move operations

Operations now return `true` when movement delta equals `(0, 0)`:

* `BondMove`
* `RxnArrowMove`
* `RxnPlusMove`
* `TextMove`
* `LoopMove`
* `SGroupDataMove`
* `EnhancedFlagMove`
* `ImageMove`
* `MultitailArrowMove`
* `SimpleObjectMove`
* `ShiftMonomerOperation`

For `ShiftMonomerOperation`, `null` values still represent meaningful transformation resets and are not treated as dummy.

---

### Scalar move/resize operations

Operations now return `true` when scalar offset equals `0`:

* `MultitailArrowMoveHeadTail`
* `MultitailArrowResizeTailHead`

---

### Rotate operations

Operations now return `true` when rotation angle equals `0`:

* `RxnArrowRotate`
* `RotateMonomerOperation`

---

### Resize operations

Operations now return `true` when resulting geometry remains unchanged:

* `RxnArrowResize`
* `SimpleObjectResize`
* `ImageResize`

`ImageResize` compares resulting geometry against current data from `restruct`.

---

### Value/attribute update operations

Operations now detect unchanged values and return `true` when no effective update occurs:

* `ReassignAttachmentPointOperation`
* `ReassignLeavingAtomOperation`
* `RGroupFragment`
* `HighlightUpdate`

Checks include unchanged names, IDs, fragment assignments, colors, atoms, and bonds.

---

## Operations intentionally left unchanged

Operations representing structural modifications continue using the default `false` implementation because they always produce meaningful changes.

Examples include:

* `CanvasLoad`
* `EnhancedFlagClear`
* `FragmentStereoFlag`
* `TextCreate`
* `TextDelete`
* `HighlightAdd`
* `HighlightDelete`
* `ImageUpsert`
* `ImageDelete`
* `FlipMonomerOperation`
* `AssignAttachmentAtomOperation`
* `AssignLeavingGroupAtomOperation`
* `MarkAsRnaComponentOperation`
* `RemoveAttachmentPointOperation`
* `MultitailArrowAddTail`
* `MultitailArrowRemoveTail`
* `MultitailArrowUpsert`
* `MultitailArrowDelete`
* `SGroupAttachmentPointAdd`
* `SGroupAttachmentPointRemove`
* `SimpleObjectAdd`
* `SimpleObjectDelete`

---

## API adjustment

`BaseOperation.isDummy()` was updated to support an optional `restruct` parameter:

```ts
isDummy(restruct?: ReStruct)
```

This allows lightweight operations (move/rotate/simple resize) to implement local checks without depending on `restruct` when unnecessary.

---

## Result

Undo/redo history no longer records effective no-op actions such as:

* opening dialogs and pressing Apply without changes
* clicking without dragging
* rotating by `0`
* resizing without geometry changes
* updating values with identical data

History now contains only meaningful user modifications.

## Check list

* [ ] unit-tests written
* [ ] e2e-tests written
* [ ] documentation updated
* [ ] PR name follows the pattern `#1234 – issue name`
* [ ] branch name doesn't contain '#'
* [ ] PR is linked with the issue
* [ ] base branch (master or release/xx) is correct
* [ ] task status changed to "Code review"
* [ ] reviewers are notified about the pull request
