### PR TITLE
#7940 -  Export to HELM of monomer with attached micromolecule should cause warning message: The molecule will be exported using inline SMILES, and on load will appear as a CHEM monomer

### DIFF
--- a/packages/ketcher-macromolecules/src/Editor.tsx
+++ b/packages/ketcher-macromolecules/src/Editor.tsx
@@ -63,7 +63,7 @@ import {
   useAppSelector,
   useSequenceEditInRNABuilderMode,
 } from 'hooks';
-import { closeErrorTooltip, selectErrorTooltipText } from 'state/modal';
+import { closeErrorTooltip, selectErrorTooltips } from 'state/modal';
 import { ModalContainer } from 'components/modal/modalContainer';
 import { DeepPartial } from './types';
 import { EditorClassName } from 'ketcher-react';
@@ -71,6 +71,7 @@ import { Snackbar } from '@mui/material';
 import {
   StyledIconButton,
   StyledToast,
+  StyledToastContainer,
   StyledToastContent,
 } from 'components/shared/StyledToast/styles';
 import {
@@ -189,7 +190,7 @@ function Editor({
 }: Readonly<EditorProps>) {
   const dispatch = useAppDispatch();
   const canvasRef = useRef<SVGSVGElement>(null);
-  const errorTooltipText = useAppSelector(selectErrorTooltipText);
+  const errorTooltips = useAppSelector(selectErrorTooltips);
   const editor = useAppSelector(selectEditor);
   const isHandToolSelected = useAppSelector(selectIsHandToolSelected);
   const isLoading = useLoading();
@@ -320,8 +321,8 @@ function Editor({
     };
   }, [dispatch]);
 
-  const handleCloseErrorTooltip = () => {
-    dispatch(closeErrorTooltip());
+  const handleCloseErrorTooltip = (text?: string) => {
+    dispatch(closeErrorTooltip(text));
   };
 
   const toggleLibraryVisibility = useCallback(() => {
@@ -431,20 +432,24 @@ function Editor({
       <ErrorModal />
       <Snackbar
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        open={Boolean(errorTooltipText)}
-        onClose={handleCloseErrorTooltip}
+        open={errorTooltips.length > 0}
+        onClose={() => handleCloseErrorTooltip()}
         autoHideDuration={6000}
       >
-        <StyledToast id="error-tooltip">
-          <StyledToastContent data-testid="error-tooltip">
-            {errorTooltipText}
-          </StyledToastContent>
-          <StyledIconButton
-            testId="error-tooltip-close"
-            iconName="close"
-            onClick={handleCloseErrorTooltip}
-          ></StyledIconButton>
-        </StyledToast>
+        <StyledToastContainer id="error-tooltip">
+          {errorTooltips.map((text) => (
+            <StyledToast key={text}>
+              <StyledToastContent data-testid="error-tooltip">
+                {text}
+              </StyledToastContent>
+              <StyledIconButton
+                testId="error-tooltip-close"
+                iconName="close"
+                onClick={() => handleCloseErrorTooltip(text)}
+              ></StyledIconButton>
+            </StyledToast>
+          ))}
+        </StyledToastContainer>
       </Snackbar>
     </>
   );

--- a/packages/ketcher-macromolecules/src/components/modal/save/Save.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/save/Save.tsx
@@ -126,16 +126,22 @@ export const Save = ({
       setSvgData(svgData);
       return;
     }
-    if (
-      fileFormat === 'helm' &&
-      !isHelmCompatible(
-        Array.from(editor.drawingEntitiesManager.monomers.values()),
-        editor.monomersLibrary,
-      )
-    ) {
-      editor.events.error.dispatch(
-        'Some of the monomers do not have aliases in the HELM Core Library - they are exported using Ketcher aliases.',
-      );
+    if (fileFormat === 'helm') {
+      if (editor.drawingEntitiesManager.molecules.length > 0) {
+        editor.events.error.dispatch(
+          'The molecule will be exported using inline SMILES, and on load will appear as a CHEM monomer',
+        );
+      }
+      if (
+        !isHelmCompatible(
+          Array.from(editor.drawingEntitiesManager.monomers.values()),
+          editor.monomersLibrary,
+        )
+      ) {
+        editor.events.error.dispatch(
+          'Some of the monomers do not have aliases in the HELM Core Library - they are exported using Ketcher aliases.',
+        );
+      }
     }
 
     try {

--- a/packages/ketcher-macromolecules/src/components/shared/StyledToast/styles.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/StyledToast/styles.ts
@@ -1,6 +1,12 @@
 import styled from '@emotion/styled';
 import { IconButton } from 'ketcher-react';
 
+export const StyledToastContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+});
+
 export const StyledToast = styled.div({
   backgroundColor: '#333333',
   maxHeight: '40px',

--- a/packages/ketcher-macromolecules/src/state/modal/modalSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/modal/modalSlice.ts
@@ -21,7 +21,7 @@ interface ModalState {
   name: string | null;
   isOpen: boolean;
   additionalProps: AdditionalModalProps | null;
-  errorTooltipText: string;
+  errorTooltips: string[];
   errorModalText: string;
   errorModalTitle: string;
 }
@@ -30,7 +30,7 @@ const initialState: ModalState = {
   name: null,
   isOpen: false,
   additionalProps: null,
-  errorTooltipText: '',
+  errorTooltips: [],
   errorModalText: '',
   errorModalTitle: '',
 };
@@ -70,10 +70,14 @@ export const modalSlice = createSlice({
       state.additionalProps = null;
     },
     openErrorTooltip: (state, action: PayloadAction<string>) => {
-      state.errorTooltipText = action.payload;
+      if (!state.errorTooltips.includes(action.payload)) {
+        state.errorTooltips.push(action.payload);
+      }
     },
-    closeErrorTooltip: (state) => {
-      state.errorTooltipText = '';
+    closeErrorTooltip: (state, action: PayloadAction<string | undefined>) => {
+      state.errorTooltips = action.payload
+        ? state.errorTooltips.filter((text) => text !== action.payload)
+        : [];
     },
     openErrorModal: (
       state,
@@ -111,8 +115,8 @@ export const selectModalIsOpen = (state: RootState): boolean =>
 export const selectAdditionalProps = (
   state: RootState,
 ): AdditionalModalProps | null => state.modal.additionalProps;
-export const selectErrorTooltipText = (state: RootState): boolean =>
-  state.modal.errorTooltipText;
+export const selectErrorTooltips = (state: RootState): string[] =>
+  state.modal.errorTooltips;
 export const selectErrorModalText = (state: RootState): string => {
   return state.modal.errorModalText;
 };


### PR DESCRIPTION
## Summary

When exporting a structure that contains a micromolecule to HELM, the editor now shows an additional warning telling the user the molecule will be exported as inline SMILES and re-imported as a CHEM monomer. Previously only the generic "no HELM alias" warning appeared.

## Changes

### Inline SMILES / CHEM export warning

**Problem:** Exporting to HELM only showed the "monomers without HELM alias" warning. There was no indication that micromolecules on the canvas are exported as inline SMILES and come back as CHEM monomers on load.

**Solution:** Added a dedicated warning, dispatched on HELM export whenever the canvas contains micromolecules (`drawingEntitiesManager.molecules`).

### Support for multiple stacked warnings

**Problem:** The error tooltip state held a single string, so dispatching a second warning overwrote the first — only one warning could ever be visible at a time.

**Solution:** Changed the state to a list of messages and rendered them as independently-closable stacked toasts, so both warnings appear together.

### Files Modified

**`ketcher-macromolecules`**
- `Save.tsx` — dispatch the inline SMILES / CHEM warning when micromolecules are present during HELM export
- `state/modal/modalSlice.ts` — `errorTooltipText: string` → `errorTooltips: string[]`; push (with de-duplication) on open, remove-by-text on close
- `Editor.tsx` — render the error tooltips as a stack, each toast independently closable
- `components/shared/StyledToast/styles.ts` — add `StyledToastContainer` to stack toasts vertically


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request