### PR TITLE
#9750 - RNA Builder: Phosphate position picker is not visible when modifying preset in Sequence mode

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx
@@ -80,6 +80,11 @@ describe('Test Rna Editor Expanded component', () => {
 
     const rnaEditorExpanded = screen.getByTestId('rna-editor-expanded');
 
+    // In sequence edit mode the phosphate position picker is shown but disabled
+    // (req 5.2 of #9120).
+    expect(
+      screen.getByRole('button', { name: 'Select phosphate position' }),
+    ).toBeDisabled();
     expect(rnaEditorExpanded).toMatchSnapshot();
   });
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -458,12 +458,15 @@ export const RnaEditorExpanded = ({
 
   const renderPhosphatePositionSelector = (position?: RnaPhosphatePosition) => {
     // In "Modify in RNA Builder" (sequence edit) mode the phosphate position is
-    // read-only: the picker must be shown but disabled, indicating the current
-    // position (3'/right for sequence mode) — req 5.2 of #9120.
+    // read-only: the picker is shown but disabled and always indicates 3'/right,
+    // since for the purposes of sequence mode a preset always keeps the
+    // phosphate on the right — req 5.1/5.2 of #9120.
     const isPhosphatePositionReadOnly = isSequenceEditInRNABuilderMode;
     const triggerDisabled =
       isPhosphatePositionReadOnly || (!is5PrimeAvailable && !is3PrimeAvailable);
-    const triggerPosition = position ?? selectedPhosphatePosition ?? 'right';
+    const triggerPosition = isPhosphatePositionReadOnly
+      ? 'right'
+      : position ?? selectedPhosphatePosition ?? 'right';
     const isPhosphateGroupActive =
       !isPhosphatePositionReadOnly &&
       activeMonomerGroup === MonomerGroups.PHOSPHATES;

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -457,9 +457,15 @@ export const RnaEditorExpanded = ({
   };
 
   const renderPhosphatePositionSelector = (position?: RnaPhosphatePosition) => {
-    const triggerDisabled = !is5PrimeAvailable && !is3PrimeAvailable;
+    // In "Modify in RNA Builder" (sequence edit) mode the phosphate position is
+    // read-only: the picker must be shown but disabled, indicating the current
+    // position (3'/right for sequence mode) — req 5.2 of #9120.
+    const isPhosphatePositionReadOnly = isSequenceEditInRNABuilderMode;
+    const triggerDisabled =
+      isPhosphatePositionReadOnly || (!is5PrimeAvailable && !is3PrimeAvailable);
     const triggerPosition = position ?? selectedPhosphatePosition ?? 'right';
     const isPhosphateGroupActive =
+      !isPhosphatePositionReadOnly &&
       activeMonomerGroup === MonomerGroups.PHOSPHATES;
     const showPhosphatePositionTooltip = !isEditMode || !isPhosphateGroupActive;
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/__snapshots__/RnaEditorExpanded.test.tsx.snap
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/__snapshots__/RnaEditorExpanded.test.tsx.snap
@@ -300,6 +300,7 @@ exports[`Test Rna Editor Expanded component should render correctly in edit mode
           <button
             aria-label="Select phosphate position"
             class="phosphatePositionTrigger"
+            disabled=""
             type="button"
           >
             <div


### PR DESCRIPTION
<img width="959" height="501" alt="Screenshot 2026-06-01 142119" src="https://github.com/user-attachments/assets/6cc6d7b6-11df-4897-a3a1-b0e54622d25b" />

What
  In Sequence mode, when modifying a selection via "Modify in RNA Builder…", the phosphate position
  picker is now shown but disabled, indicating 3' (requirement 5.2 of #9120). Previously the picker
  rendered enabled, and selecting the Phosphate slot exposed an interactive left/right switcher that let
  the user change the phosphate position during a sequence modify.

  Note on the original symptom
  The issue was filed as "picker not visible." That symptom was already resolved by #9692, which removed
  the if (!newPreset?.phosphate) return null; guard. On current master the picker renders but is enabled;
  this PR makes it disabled to meet req 5.2.

  Changes
  - RnaEditorExpanded.tsx — in renderPhosphatePositionSelector, the phosphate position is read-only in
  sequence-edit mode: the trigger is disabled and the left/right switcher (both the JSX gate and the CSS
  hover path) is suppressed, while it keeps indicating 3'.
  - Added a unit assertion that the picker is disabled in the sequence-modification test case.
  - Regenerated the corresponding snapshot (only disabled="" added).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request