### PR TITLE
#8249:  prevent hanging hydrogen bond when typing after antisense ove…

### DIFF
--- a/ketcher-autotests/tests/pages/molecules/canvas/createMonomer/NucleotidePresetSection.ts
+++ b/ketcher-autotests/tests/pages/molecules/canvas/createMonomer/NucleotidePresetSection.ts
@@ -154,16 +154,25 @@ export const NucleotidePresetSection = (page: Page) => {
     async markAsBase() {
       await this.openTab(NucleotidePresetTab.Base);
       await locators.baseTab.maskAsBaseButton.click();
+      await page.waitForSelector(
+        '[data-testid="Mark-as-base-button"][disabled]',
+      );
     },
 
     async markAsSugar() {
       await this.openTab(NucleotidePresetTab.Sugar);
       await locators.sugarTab.maskAsSugarButton.click();
+      await page.waitForSelector(
+        '[data-testid="Mark-as-sugar-button"][disabled]',
+      );
     },
 
     async markAsPhosphate() {
       await this.openTab(NucleotidePresetTab.Phosphate);
       await locators.phosphateTab.maskAsPhosphateButton.click();
+      await page.waitForSelector(
+        '[data-testid="Mark-as-phosphate-button"][disabled]',
+      );
     },
 
     async setupBase(options: {

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1544,8 +1544,18 @@ export class SequenceMode extends BaseMode {
           if (
             this.needToEditAntisense &&
             (this.isSyncEditMode
-              ? previousTwoStrandedNodeInSameChain?.antisenseNode ??
-                currentTwoStrandedNode?.antisenseNode
+              ? (previousTwoStrandedNodeInSameChain?.senseNode &&
+                  !(
+                    previousTwoStrandedNodeInSameChain.senseNode instanceof
+                    EmptySequenceNode
+                  ) &&
+                  previousTwoStrandedNodeInSameChain.antisenseNode) ||
+                (currentTwoStrandedNode?.senseNode &&
+                  !(
+                    currentTwoStrandedNode.senseNode instanceof
+                    EmptySequenceNode
+                  ) &&
+                  currentTwoStrandedNode.antisenseNode)
               : !(
                   previousTwoStrandedNodeInSameChain?.antisenseNode instanceof
                   EmptySequenceNode

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1541,32 +1541,34 @@ export class SequenceMode extends BaseMode {
             senseNodeToConnect = insertNewSequenceItemResult.node;
           }
 
+          const prevSense = previousTwoStrandedNodeInSameChain?.senseNode;
+          const prevAntisense =
+            previousTwoStrandedNodeInSameChain?.antisenseNode;
+          const currSense = currentTwoStrandedNode?.senseNode;
+          const currAntisense = currentTwoStrandedNode?.antisenseNode;
+
+          const prevHasRealSenseAndAntisense =
+            !!prevSense &&
+            !(prevSense instanceof EmptySequenceNode) &&
+            !!prevAntisense;
+
+          const currHasAntisenseWithNonEmptyContent =
+            !!currAntisense &&
+            (!(currSense instanceof EmptySequenceNode) ||
+              !(currAntisense instanceof EmptySequenceNode));
+
+          const shouldEditAntisenseInSyncMode =
+            prevHasRealSenseAndAntisense || currHasAntisenseWithNonEmptyContent;
+
+          const shouldEditAntisenseInAsyncMode =
+            !(prevAntisense instanceof EmptySequenceNode) ||
+            !(currAntisense instanceof EmptySequenceNode);
+
           if (
             this.needToEditAntisense &&
             (this.isSyncEditMode
-              ? (previousTwoStrandedNodeInSameChain?.senseNode &&
-                  !(
-                    previousTwoStrandedNodeInSameChain.senseNode instanceof
-                    EmptySequenceNode
-                  ) &&
-                  previousTwoStrandedNodeInSameChain.antisenseNode) ||
-                (currentTwoStrandedNode?.antisenseNode &&
-                  (!(
-                    currentTwoStrandedNode.senseNode instanceof
-                    EmptySequenceNode
-                  ) ||
-                    !(
-                      currentTwoStrandedNode.antisenseNode instanceof
-                      EmptySequenceNode
-                    )))
-              : !(
-                  previousTwoStrandedNodeInSameChain?.antisenseNode instanceof
-                  EmptySequenceNode
-                ) ||
-                !(
-                  currentTwoStrandedNode?.antisenseNode instanceof
-                  EmptySequenceNode
-                ))
+              ? shouldEditAntisenseInSyncMode
+              : shouldEditAntisenseInAsyncMode)
           ) {
             const antisenseNodeCreationResult = this.insertNewSequenceItem(
               editor,

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1550,12 +1550,11 @@ export class SequenceMode extends BaseMode {
                     EmptySequenceNode
                   ) &&
                   previousTwoStrandedNodeInSameChain.antisenseNode) ||
-                (currentTwoStrandedNode?.senseNode &&
+                (currentTwoStrandedNode?.antisenseNode &&
                   !(
-                    currentTwoStrandedNode.senseNode instanceof
+                    currentTwoStrandedNode.antisenseNode instanceof
                     EmptySequenceNode
-                  ) &&
-                  currentTwoStrandedNode.antisenseNode)
+                  ))
               : !(
                   previousTwoStrandedNodeInSameChain?.antisenseNode instanceof
                   EmptySequenceNode

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1551,10 +1551,14 @@ export class SequenceMode extends BaseMode {
                   ) &&
                   previousTwoStrandedNodeInSameChain.antisenseNode) ||
                 (currentTwoStrandedNode?.antisenseNode &&
-                  !(
-                    currentTwoStrandedNode.antisenseNode instanceof
+                  (!(
+                    currentTwoStrandedNode.senseNode instanceof
                     EmptySequenceNode
-                  ))
+                  ) ||
+                    !(
+                      currentTwoStrandedNode.antisenseNode instanceof
+                      EmptySequenceNode
+                    )))
               : !(
                   previousTwoStrandedNodeInSameChain?.antisenseNode instanceof
                   EmptySequenceNode


### PR DESCRIPTION
## Summary

Fixes a bug where an indestructible hanging hydrogen bond appears on the canvas after pressing Enter at the end of an antisense sequence and typing a nucleotide in Sequence mode.

**Steps to reproduce:**
1. Open Macromolecules canvas → Sequence mode (clear canvas)
2. Load from HELM via clipboard:
   `RNA1{r(A)p.r(A)p.r(A)p.r(A)}|RNA2{r(U)p.r(U)p.r(U)p.r(U)}$RNA1,RNA2,11:pair-11:pair$$$V2.0`
3. Switch to edit mode at the end of the antisense sequence
4. Press **Enter**, then press **A**

**Before:** A hanging dashed bond appears — disconnected from any antisense nucleotide, impossible to select or delete.

**After:** The new `A` nucleotide is added as a standalone sense node with no bond.

---

## Root cause

When a HELM structure has a partially-paired antisense chain, the `SequenceViewModel` places unmatched antisense nucleotides into **overflow positions** — `TwoStrandedChainItem` nodes where `senseNode` is `EmptySequenceNode` and `antisenseNode` is a real unmatched nucleotide.

Pressing **Enter** at such a position calls `splitCurrentChain()`, which detaches the last unmatched antisense nucleotide from the backbone. After re-render, the caret lands at the chain's end node, whose `previousNodeInSameChain` is `{EmptySeq, U2}`.

When the user then presses **A** in sync edit mode, the antisense-creation condition:

```ts
// before fix
previousTwoStrandedNodeInSameChain?.antisenseNode ??
currentTwoStrandedNode?.antisenseNode
```

evaluated `U2` as truthy and fired, inserting a new antisense U into U2's existing chain and creating a hydrogen bond between a new sense A (isolated chain) and that antisense U — a bond crossing incompatible chains, making it unremovable.

---

## Fix

The sync-mode branch of the antisense condition in `add-sequence-item` (`SequenceMode.ts`) now also requires that the triggering node's `senseNode` is present **and** not an `EmptySequenceNode`:

```ts
// after fix
(previousTwoStrandedNodeInSameChain?.senseNode &&
  !(previousTwoStrandedNodeInSameChain.senseNode instanceof EmptySequenceNode) &&
  previousTwoStrandedNodeInSameChain.antisenseNode) ||
(currentTwoStrandedNode?.senseNode &&
  !(currentTwoStrandedNode.senseNode instanceof EmptySequenceNode) &&
  currentTwoStrandedNode.antisenseNode)
```

[Issue link](https://github.com/epam/ketcher/issues/8249)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request