### PR TITLE
#10054 - Nucleotide preset: R-group labels disappear when switching component tabs

### DIFF
--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -50,9 +50,9 @@ export type RnaComponentAtoms = Map<
 export type MonomerCreationState = {
   // R-label mapping to [attachment atom id, leaving atom id]
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>;
-  // Subset of assignedAttachmentPoints to show on canvas (used to restrict
-  // display to the active RNA component tab). When undefined, all assigned
-  // attachment points are displayed.
+  // Optional restriction: when set to a subset of assignedAttachmentPoints,
+  // only those are drawn on canvas. When undefined, all assigned attachment
+  // points are displayed.
   visibleAssignedAttachmentPoints?: Map<AttachmentPointName, [number, number]>;
   // Attachment atom id to a set of connected leaving atom ids
   potentialAttachmentPoints: Map<number, Set<number>>;

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -707,7 +707,8 @@ class ReAtom extends ReObject {
         problematicAtoms,
         connectionAttachmentPoints,
       } = render.monomerCreationState;
-      // Use the restricted set when a component tab is active, otherwise show all.
+      // When visibleAssignedAttachmentPoints is set, only that subset is drawn;
+      // otherwise all assigned attachment points are shown.
       const assignedAttachmentPoints =
         visibleAssignedAttachmentPoints ?? allAssignedAttachmentPoints;
       const restruct = render.ctab;

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
@@ -258,23 +258,18 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
   ]);
 
   // Sync connection (readonly) attachment points with the canvas whenever the
-  // active RNA component tab or the wizard state changes.
+  // active RNA component tab or the wizard state changes. All assigned APs
+  // (R-labels) stay visible on every tab so users can see the full attachment-
+  // point picture while editing a single component.
   useEffect(() => {
+    editor.setVisibleAssignedAttachmentPoints(undefined);
+
     const activeComponentKey = RNA_COMPONENT_KEYS[selectedTab - 1];
+
     if (!activeComponentKey) {
-      // Preset tab: show only user-assigned APs (the ones not occupied by
-      // default inter-component connections). Connection APs are not rendered
-      // on the Preset tab, so clear them from the canvas as well.
-      editor.setVisibleAssignedAttachmentPoints(undefined);
       editor.setConnectionAttachmentPoints(new Map());
       return;
     }
-
-    // Component tab: restrict visible assigned APs to those belonging to this
-    // component only, so APs from other components are hidden on the canvas.
-    editor.setVisibleAssignedAttachmentPoints(
-      componentAttachmentPoints[activeComponentKey],
-    );
 
     const connectionAtomIds = getConnectionAttachmentPointAtomIdsForComponent(
       wizardState,
@@ -283,14 +278,7 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
       phosphatePosition as PhosphatePosition | undefined,
     );
     editor.setConnectionAttachmentPoints(connectionAtomIds);
-  }, [
-    editor,
-    selectedTab,
-    struct,
-    wizardState,
-    phosphatePosition,
-    componentAttachmentPoints,
-  ]);
+  }, [editor, selectedTab, struct, wizardState, phosphatePosition]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

Fixes R-group attachment point labels (R1/R2/R3) disappearing from the canvas when switching component tabs in the Create Monomer wizard's Nucleotide (preset) mode.

## Changes

### Nucleotide preset attachment point visibility fix

**Problem:** Switching to a component tab (Base, Sugar, or Phosphate) called `editor.setVisibleAssignedAttachmentPoints(componentAttachmentPoints[activeComponentKey])`, restricting the rendered set to only the active component's attachment points. The renderer uses that restricted set to draw everything AP-related — the atom outline, the leaving-group highlight, and the R-label — so the other components' labels vanished entirely. Only the active component's own AP stayed visible.

**Solution:** Stop filtering the canvas by the active tab. The wizard now always passes `undefined`, so the renderer falls back to showing all assigned attachment points on every tab. The renderer already handled the `undefined` case correctly, so no renderer logic changed. Per-tab UI scoping (the side-panel attachment-point list and the inter-component connection rings) is unaffected — those use separate paths and continue to work as before.

## Files Modified

**ketcher-react**

- `src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx` — always pass `undefined` to `setVisibleAssignedAttachmentPoints`, remove the per-tab restriction, and drop `componentAttachmentPoints` from the effect's dependency array.

**ketcher-core**

- `src/application/render/restruct/reatom.ts` — update the stale comment describing how `visibleAssignedAttachmentPoints` falls back to all assigned points (comment only).
- `src/application/render/raphaelRender.ts` — update the stale comment on the `visibleAssignedAttachmentPoints` field (comment only).


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request