### PR TITLE
#9780 - Save the polymer type switcher (RNA/DNA/PEP) to browser cache

### DIFF
--- a/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
@@ -25,6 +25,10 @@ import styled from '@emotion/styled';
 import { ButtonGroup, Button, Box } from '@mui/material';
 import { setSelectedTabIndex } from 'state/library';
 import { LIBRARY_TAB_INDEX, MONOMER_TYPES } from 'src/constants';
+import {
+  getPersistedSequenceType,
+  persistSequenceType,
+} from 'helpers/sequenceTypeStorage';
 
 const SequenceTypeButton = styled(Button)(({ theme, variant }) => ({
   color:
@@ -97,8 +101,11 @@ export const SequenceTypeGroupButton = () => {
         ),
       );
       setActiveSequenceType(mode);
+      persistSequenceType(mode);
     });
-    editor?.events.changeSequenceTypeEnterMode.dispatch(SequenceType.RNA);
+    editor?.events.changeSequenceTypeEnterMode.dispatch(
+      getPersistedSequenceType(),
+    );
 
     return () => {
       editor?.events.selectMode.remove(onToggleSequenceMode);

--- a/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
@@ -91,8 +91,7 @@ export const SequenceTypeGroupButton = () => {
   };
 
   useEffect(() => {
-    editor?.events.selectMode.add(onToggleSequenceMode);
-    editor?.events.changeSequenceTypeEnterMode.add((mode: SequenceType) => {
+    const onChangeSequenceType = (mode: SequenceType) => {
       dispatch(
         setSelectedTabIndex(
           mode === MONOMER_TYPES.PEPTIDE
@@ -102,13 +101,16 @@ export const SequenceTypeGroupButton = () => {
       );
       setActiveSequenceType(mode);
       persistSequenceType(mode);
-    });
+    };
+    editor?.events.selectMode.add(onToggleSequenceMode);
+    editor?.events.changeSequenceTypeEnterMode.add(onChangeSequenceType);
     editor?.events.changeSequenceTypeEnterMode.dispatch(
       getPersistedSequenceType(),
     );
 
     return () => {
       editor?.events.selectMode.remove(onToggleSequenceMode);
+      editor?.events.changeSequenceTypeEnterMode.remove(onChangeSequenceType);
     };
   }, [editor]);
 

--- a/packages/ketcher-macromolecules/src/constants.ts
+++ b/packages/ketcher-macromolecules/src/constants.ts
@@ -60,6 +60,7 @@ export const FAVORITE_ITEMS_UNIQUE_KEYS = 'favoriteItemsUniqueKeys';
 export const CUSTOM_PRESETS = 'ketcher_custom_presets';
 export const PRESET_PHOSPHATE_FILTER_STORAGE_KEY =
   'ketcher_preset_phosphate_filter';
+export const SEQUENCE_TYPE_STORAGE_KEY = 'ketcher_polymer_sequence_type';
 
 // It's set as Z, so it will always be put in the end when alphabetically sorting groups by code
 export const NoNaturalAnalogueGroupCode = 'Z';

--- a/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.test.ts
+++ b/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.test.ts
@@ -1,0 +1,32 @@
+import { SequenceType } from 'ketcher-core';
+import { SEQUENCE_TYPE_STORAGE_KEY } from 'src/constants';
+import {
+  getPersistedSequenceType,
+  persistSequenceType,
+} from './sequenceTypeStorage';
+
+describe('sequenceTypeStorage', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to RNA when nothing is persisted', () => {
+    expect(getPersistedSequenceType()).toBe(SequenceType.RNA);
+  });
+
+  it('persists and restores the selected polymer type', () => {
+    persistSequenceType(SequenceType.PEPTIDE);
+    expect(getPersistedSequenceType()).toBe(SequenceType.PEPTIDE);
+
+    persistSequenceType(SequenceType.DNA);
+    expect(getPersistedSequenceType()).toBe(SequenceType.DNA);
+  });
+
+  it('falls back to RNA when the stored value is invalid', () => {
+    window.localStorage.setItem(
+      SEQUENCE_TYPE_STORAGE_KEY,
+      JSON.stringify('NOT_A_TYPE'),
+    );
+    expect(getPersistedSequenceType()).toBe(SequenceType.RNA);
+  });
+});

--- a/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.test.ts
+++ b/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.test.ts
@@ -1,4 +1,4 @@
-import { SequenceType } from 'ketcher-core';
+import { KetcherLogger, SequenceType } from 'ketcher-core';
 import { SEQUENCE_TYPE_STORAGE_KEY } from 'src/constants';
 import {
   getPersistedSequenceType,
@@ -28,5 +28,19 @@ describe('sequenceTypeStorage', () => {
       JSON.stringify('NOT_A_TYPE'),
     );
     expect(getPersistedSequenceType()).toBe(SequenceType.RNA);
+  });
+
+  it('falls back to RNA when the stored value is malformed JSON', () => {
+    const loggerSpy = jest
+      .spyOn(KetcherLogger, 'error')
+      .mockImplementation(() => undefined);
+    // Raw, non-JSON string (bypassing JSON.stringify) simulates a corrupted or
+    // manually-edited value that makes JSON.parse throw inside getItem.
+    window.localStorage.setItem(SEQUENCE_TYPE_STORAGE_KEY, 'not-json{');
+
+    expect(getPersistedSequenceType()).toBe(SequenceType.RNA);
+    expect(loggerSpy).toHaveBeenCalled();
+
+    loggerSpy.mockRestore();
   });
 });

--- a/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.ts
+++ b/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.ts
@@ -1,0 +1,21 @@
+import { SequenceType } from 'ketcher-core';
+import { localStorageWrapper } from './localStorage';
+import { SEQUENCE_TYPE_STORAGE_KEY } from '../constants';
+
+const isSequenceType = (value: unknown): value is SequenceType =>
+  value === SequenceType.RNA ||
+  value === SequenceType.DNA ||
+  value === SequenceType.PEPTIDE;
+
+// Read the last polymer type chosen on the sequence-type switcher from the
+// browser cache, falling back to RNA when nothing valid is stored (#9780).
+export const getPersistedSequenceType = (): SequenceType => {
+  const stored: unknown = localStorageWrapper.getItem(
+    SEQUENCE_TYPE_STORAGE_KEY,
+  );
+  return isSequenceType(stored) ? stored : SequenceType.RNA;
+};
+
+export const persistSequenceType = (sequenceType: SequenceType): void => {
+  localStorageWrapper.setItem(SEQUENCE_TYPE_STORAGE_KEY, sequenceType);
+};

--- a/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.ts
+++ b/packages/ketcher-macromolecules/src/helpers/sequenceTypeStorage.ts
@@ -1,4 +1,4 @@
-import { SequenceType } from 'ketcher-core';
+import { KetcherLogger, SequenceType } from 'ketcher-core';
 import { localStorageWrapper } from './localStorage';
 import { SEQUENCE_TYPE_STORAGE_KEY } from '../constants';
 
@@ -7,12 +7,22 @@ const isSequenceType = (value: unknown): value is SequenceType =>
   value === SequenceType.DNA ||
   value === SequenceType.PEPTIDE;
 
-// Read the last polymer type chosen on the sequence-type switcher from the
-// browser cache, falling back to RNA when nothing valid is stored (#9780).
+// Read the last polymer type chosen on the sequence-type switcher from
+// localStorage, falling back to RNA when nothing valid is stored (#9780).
+// `localStorageWrapper.getItem` runs `JSON.parse`, which throws on a malformed
+// value (manual edit / partial write), so the read is guarded to avoid
+// crashing the switcher's mount effect.
 export const getPersistedSequenceType = (): SequenceType => {
-  const stored: unknown = localStorageWrapper.getItem(
-    SEQUENCE_TYPE_STORAGE_KEY,
-  );
+  let stored: unknown;
+  try {
+    stored = localStorageWrapper.getItem(SEQUENCE_TYPE_STORAGE_KEY);
+  } catch (error) {
+    KetcherLogger.error(
+      'sequenceTypeStorage.ts::getPersistedSequenceType',
+      error,
+    );
+    return SequenceType.RNA;
+  }
   return isSequenceType(stored) ? stored : SequenceType.RNA;
 };
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Description

  The Macromolecules polymer-type switcher (RNA / DNA / PEP) now remembers the last-selected type in the browser
  cache (localStorage) and restores it when Macromolecules mode is opened, instead of always resetting to RNA.
  Defaults to RNA when nothing is stored.

  Requirements covered

  - Saves the last switcher option to browser cache, persisted on every change path: clicking the switcher and the
  Ctrl+Alt+R/D/P hotkeys (both funnel through the single changeSequenceTypeEnterMode event).
  - On opening Macromolecules mode, the polymer type is restored from cache.
  - Defaults to RNA when no value is stored, or when the stored value is invalid.
  - The restored type also drives the default monomer-library tab (PEP → Peptides tab), including in snake/flex modes
  where the switcher is not visible — the switcher component is always mounted, so the restore-on-open dispatch
  flows through the existing type→tab mapping.

  Changes

  - constants.ts — added SEQUENCE_TYPE_STORAGE_KEY.
  - helpers/sequenceTypeStorage.ts (new) — getPersistedSequenceType() (reads and validates against SequenceType,
  falls back to RNA) and persistSequenceType(), following the existing localStorageWrapper convention.
  - helpers/sequenceTypeStorage.test.ts (new) — unit tests: default RNA, persist/restore round-trip, invalid value →
  RNA.
  - SequenceTypeGroupButton.tsx — persist the type on change, and restore from cache on mount instead of hardcoding
  RNA.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request