### PR TITLE
#8174-An IDT alias for one of the positions (5', internal, 3') must be unique in the whole library

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -468,6 +468,121 @@ describe('CoreEditor', () => {
       );
     });
 
+    it('should reject monomer when same IDT modification alias is used at multiple positions within the same monomer', () => {
+      const sizeBefore = editor.monomersLibrary.length;
+      const monomerWithIntraDuplicateAliases = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-CHEM_DUP_INTRA' }],
+        },
+        'monomerTemplate-CHEM_DUP_INTRA': {
+          type: 'monomerTemplate',
+          id: 'CHEM_DUP_INTRA',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'Test Chem Intra Dup',
+          name: 'CHEM_DUP_INTRA',
+          naturalAnalogShort: 'X',
+          props: {
+            MonomerName: 'CHEM_DUP_INTRA',
+            MonomerClass: 'CHEM',
+            Name: 'CHEM_DUP_INTRA',
+            MonomerNaturalAnalogCode: 'X',
+          },
+          idtAliases: {
+            base: 'IdtBaseI',
+            modifications: {
+              endpoint5: 'DupTag',
+              internal: 'DupTag',
+              endpoint3: 'DupTag',
+            },
+          },
+        },
+      };
+
+      editor.updateMonomersLibrary(
+        JSON.stringify(monomerWithIntraDuplicateAliases),
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "IDT alias must be unique per position (5', internal, 3')",
+        ),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('CHEM_DUP_INTRA'),
+      );
+      expect(editor.monomersLibrary.length).toBe(sizeBefore);
+    });
+
+    it('should reject monomer when IDT modification alias collides at a different position in another monomer', () => {
+      const monomerA = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-CHEM_CROSS_A' }],
+        },
+        'monomerTemplate-CHEM_CROSS_A': {
+          type: 'monomerTemplate',
+          id: 'CHEM_CROSS_A',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'Test Chem Cross A',
+          name: 'CHEM_CROSS_A',
+          naturalAnalogShort: 'X',
+          props: {
+            MonomerName: 'CHEM_CROSS_A',
+            MonomerClass: 'CHEM',
+            Name: 'CHEM_CROSS_A',
+            MonomerNaturalAnalogCode: 'X',
+          },
+          idtAliases: {
+            base: 'IdtBaseA',
+            modifications: {
+              endpoint3: 'SharedMod',
+            },
+          },
+        },
+      };
+      const monomerB = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-CHEM_CROSS_B' }],
+        },
+        'monomerTemplate-CHEM_CROSS_B': {
+          type: 'monomerTemplate',
+          id: 'CHEM_CROSS_B',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'Test Chem Cross B',
+          name: 'CHEM_CROSS_B',
+          naturalAnalogShort: 'X',
+          props: {
+            MonomerName: 'CHEM_CROSS_B',
+            MonomerClass: 'CHEM',
+            Name: 'CHEM_CROSS_B',
+            MonomerNaturalAnalogCode: 'X',
+          },
+          idtAliases: {
+            base: 'IdtBaseB',
+            modifications: {
+              endpoint5: 'SharedMod',
+            },
+          },
+        },
+      };
+
+      editor.updateMonomersLibrary(JSON.stringify(monomerA));
+      const sizeAfterA = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(monomerB));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "IDT alias must be unique per position (5', internal, 3')",
+        ),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('CHEM_CROSS_B'),
+      );
+      expect(editor.monomersLibrary.length).toBe(sizeAfterA);
+    });
+
     it('should reject monomer with IDT alias exceeding 10 characters without slashes', () => {
       const monomerWithLongIdtAlias = {
         root: {

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -505,11 +505,16 @@ describe('CoreEditor', () => {
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "IDT alias must be unique per position (5', internal, 3')",
+          "IDT modification alias (5'/internal/3') must be unique",
         ),
       );
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining('CHEM_DUP_INTRA'),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The same alias is used at more than one position',
+        ),
       );
       expect(editor.monomersLibrary.length).toBe(sizeBefore);
     });
@@ -574,11 +579,16 @@ describe('CoreEditor', () => {
 
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "IDT alias must be unique per position (5', internal, 3')",
+          "IDT modification alias (5'/internal/3') must be unique",
         ),
       );
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining('CHEM_CROSS_B'),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Conflicting alias "SharedMod" is already used by monomer CHEM_CROSS_A',
+        ),
       );
       expect(editor.monomersLibrary.length).toBe(sizeAfterA);
     });

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -438,6 +438,7 @@ export class CoreEditor {
         !isValidHelmAlias(newMonomer.props.aliasHELM)
       ) {
         const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid HELM alias value. ${HELM_ALIAS_FORMAT_ERROR_MESSAGE} The monomer was not added to the library.`;
+        console.error(errorMessage);
         KetcherLogger.error(errorMessage);
         return;
       }
@@ -446,6 +447,7 @@ export class CoreEditor {
         !isValidBilnAlias(newMonomer.props.aliasBILN)
       ) {
         const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid BILN alias value. ${BILN_ALIAS_FORMAT_ERROR_MESSAGE} The monomer was not added to the library.`;
+        console.error(errorMessage);
         KetcherLogger.error(errorMessage);
         return;
       }
@@ -455,6 +457,7 @@ export class CoreEditor {
         !isValidHelmAliasLength(newMonomer.props.aliasHELM)
       ) {
         const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed, monomer definition contains invalid HELM alias value. ${HELM_ALIAS_LENGTH_ERROR_MESSAGE} The monomer was not added to the library.`;
+        console.error(errorMessage);
         KetcherLogger.error(errorMessage);
         return;
       }
@@ -493,6 +496,47 @@ export class CoreEditor {
         }${
           aliasDetails ? ` (${aliasDetails})` : ''
         }. The monomer was not added to the library.`;
+        console.error(errorMessage);
+        KetcherLogger.error(errorMessage);
+        return;
+      }
+
+      // Per Indigo#3161: an IDT modification alias (5'/internal/3') must be
+      // unique across the whole library — including across positions and
+      // within a single monomer. Base alias collisions are handled above.
+      const getModificationIdtAliases = (monomer: MonomerItemType) => {
+        const modifications = monomer.props?.idtAliases?.modifications;
+        return [
+          modifications?.endpoint5,
+          modifications?.internal,
+          modifications?.endpoint3,
+        ].filter((alias): alias is string => Boolean(alias));
+      };
+      const newModificationAliases = getModificationIdtAliases(newMonomer);
+      const newModificationAliasesSet = new Set(newModificationAliases);
+      const hasIntraMonomerModificationCollision =
+        newModificationAliasesSet.size !== newModificationAliases.length;
+      const hasCrossMonomerModificationCollision =
+        newModificationAliasesSet.size > 0 &&
+        this._monomersLibrary.some((monomer) => {
+          if (areSameMonomers(monomer, newMonomer)) {
+            return false;
+          }
+          return getModificationIdtAliases(monomer).some((alias) =>
+            newModificationAliasesSet.has(alias),
+          );
+        });
+      if (
+        hasIntraMonomerModificationCollision ||
+        hasCrossMonomerModificationCollision
+      ) {
+        const aliasDetails = formatAliasDetails(newMonomer);
+        const errorMessage = `Editor::updateMonomersLibrary: IDT alias must be unique per position (5', internal, 3') across the whole library for monomer ${
+          newMonomer.props.MonomerName
+        }${
+          aliasDetails ? ` (${aliasDetails})` : ''
+        }. The monomer was not added to the library.`;
+        console.error(errorMessage);
         KetcherLogger.error(errorMessage);
         return;
       }
@@ -500,6 +544,7 @@ export class CoreEditor {
       // Validate base IDT alias is present when idtAliases is defined
       if (newMonomer.props?.idtAliases && !newMonomer.props.idtAliases.base) {
         const errorMessage = `Editor::updateMonomersLibrary: Base IDT alias is required when idtAliases is defined for monomer ${newMonomer.props.MonomerName}. The monomer was not added to the library.`;
+        console.error(errorMessage);
         KetcherLogger.error(errorMessage);
         return;
       }
@@ -520,6 +565,7 @@ export class CoreEditor {
 
         if (hasInvalidSlash) {
           const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed. ${IDT_ALIAS_SLASH_ERROR_MESSAGE} The monomer was not added to the library.`;
+          console.error(errorMessage);
           KetcherLogger.error(errorMessage);
           return;
         }
@@ -533,6 +579,7 @@ export class CoreEditor {
             .map(({ alias: field, value }) => `${field}="${value}"`)
             .join(', ');
           const errorMessage = `Editor::updateMonomersLibrary: Load of "${newMonomer.props.MonomerName}" monomer has failed. ${IDT_ALIAS_LENGTH_ERROR_MESSAGE} Offending field(s): ${offenders}. The monomer was not added to the library.`;
+          console.error(errorMessage);
           KetcherLogger.error(errorMessage);
           return;
         }

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -516,26 +516,36 @@ export class CoreEditor {
       const newModificationAliasesSet = new Set(newModificationAliases);
       const hasIntraMonomerModificationCollision =
         newModificationAliasesSet.size !== newModificationAliases.length;
-      const hasCrossMonomerModificationCollision =
-        newModificationAliasesSet.size > 0 &&
-        this._monomersLibrary.some((monomer) => {
+      let crossMonomerCollision:
+        | { alias: string; otherMonomerName: string }
+        | undefined;
+      if (newModificationAliasesSet.size > 0) {
+        for (const monomer of this._monomersLibrary) {
           if (areSameMonomers(monomer, newMonomer)) {
-            return false;
+            continue;
           }
-          return getModificationIdtAliases(monomer).some((alias) =>
-            newModificationAliasesSet.has(alias),
+          const collidingAlias = getModificationIdtAliases(monomer).find(
+            (alias) => newModificationAliasesSet.has(alias),
           );
-        });
-      if (
-        hasIntraMonomerModificationCollision ||
-        hasCrossMonomerModificationCollision
-      ) {
+          if (collidingAlias) {
+            crossMonomerCollision = {
+              alias: collidingAlias,
+              otherMonomerName: monomer.props.MonomerName,
+            };
+            break;
+          }
+        }
+      }
+      if (hasIntraMonomerModificationCollision || crossMonomerCollision) {
         const aliasDetails = formatAliasDetails(newMonomer);
-        const errorMessage = `Editor::updateMonomersLibrary: IDT alias must be unique per position (5', internal, 3') across the whole library for monomer ${
+        const conflictDetail = crossMonomerCollision
+          ? ` Conflicting alias "${crossMonomerCollision.alias}" is already used by monomer ${crossMonomerCollision.otherMonomerName}.`
+          : ` The same alias is used at more than one position (5'/internal/3') within this monomer.`;
+        const errorMessage = `Editor::updateMonomersLibrary: IDT modification alias (5'/internal/3') must be unique across all positions and all monomers in the library for monomer ${
           newMonomer.props.MonomerName
         }${
           aliasDetails ? ` (${aliasDetails})` : ''
-        }. The monomer was not added to the library.`;
+        }.${conflictDetail} The monomer was not added to the library.`;
         console.error(errorMessage);
         KetcherLogger.error(errorMessage);
         return;


### PR DESCRIPTION
Per the Indigo spec, an IDT alias for each position (5′, internal, 3′) must be unique across the whole monomer library. Previously, monomers/presets with colliding IDT modification aliases were silently loaded, leading to ambiguous IDT serialization. This PR validates IDT modification aliases during library load and user uploads, skips the offending monomer, and surfaces a clear error — while still loading the rest of the library.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Changes
packages/ketcher-core/src/application/editor/Editor.ts

In CoreEditor.updateMonomersLibrary, added a validator that:
Collects endpoint5, internal, endpoint3 IDT aliases for each incoming monomer.
Rejects the monomer if the same alias is reused at multiple positions within itself (intra-monomer collision).
Rejects the monomer if any of its position aliases collides with a different position on an already-loaded monomer (cross-monomer, cross-position collision).
Error message includes the monomer name and the offending alias details, e.g.:
Editor::updateMonomersLibrary: IDT alias must be unique per position (5', internal, 3') across the whole library for monomer CHEM_CROSS_B (IDT base alias "IdtBaseB", IDT 5' alias "SharedMod"). The monomer was not added to the library.

Paired every existing KetcherLogger.error(...) in updateMonomersLibrary with a console.error(...) so validation failures are visible by default (without requiring window.ketcher.logging opt-in).