### PR TITLE
#10064 - Refactor: Update TypeScript to latest (TS 6) in ketcher-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11681,7 +11681,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -11697,7 +11696,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
       "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.20"
@@ -14602,7 +14600,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dpdm/-/dpdm-4.2.0.tgz",
       "integrity": "sha512-Vq862fZ9UE66rlr2VcMhU8ZstTH3ItqmniLSCtAeg6T2AYeB2oD3Z6lGjiFDjyUvxLbfLyBBNWagCLMehpmo5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -14621,7 +14618,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14634,7 +14630,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14647,7 +14642,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -14660,7 +14654,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^7.2.0",
@@ -14675,14 +14668,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dpdm/node_modules/fs-extra": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
       "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -14697,7 +14688,6 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -14715,7 +14705,6 @@
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
       "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -14725,7 +14714,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -14742,7 +14730,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -14760,7 +14747,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -14776,14 +14762,12 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/dpdm/node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14797,7 +14781,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -14815,7 +14798,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -14825,7 +14807,6 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
@@ -14843,7 +14824,6 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -17781,7 +17761,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19083,7 +19062,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -19318,7 +19296,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -23012,7 +22989,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
       "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0",
@@ -23720,7 +23696,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -24597,7 +24572,6 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
       "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -24620,7 +24594,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -24633,7 +24606,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -24646,7 +24618,6 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -24663,7 +24634,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -28840,7 +28810,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -28857,7 +28826,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -28873,7 +28841,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -29927,7 +29894,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -30970,7 +30939,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
       "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -34573,7 +34541,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -34616,6 +34583,7 @@
         "@babel/runtime": "^7.26.10",
         "assert": "^2.0.0",
         "d3": "^7.8.5",
+        "dpdm": "^4.2.0",
         "file-saver": "^2.0.5",
         "lodash": "^4.18.1",
         "paper": "^0.12.18",
@@ -39755,6 +39723,7 @@
         "@mui/material": "^5.18.0",
         "cfb": "^1.2.2",
         "clsx": "^1.1.1",
+        "dpdm": "^4.2.0",
         "element-closest-polyfill": "^1.0.2",
         "file-saver": "^2.0.2",
         "font-face-observer": "^1.0.0",
@@ -39810,7 +39779,6 @@
         "autoprefixer": "^10.2.5",
         "babel-jest": "^30.3.0",
         "cross-env": "^7.0.3",
-        "dpdm": "^4.2.0",
         "eslint": "^8.49.0",
         "eslint-plugin-jest": "^25.3.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
@@ -39831,8 +39799,8 @@
         "rollup-plugin-string": "^3.0.0",
         "rollup-plugin-typescript2": "^0.31.1",
         "rollup-plugin-visualizer": "^5.5.2",
-        "ts-jest": "^29.4.6",
-        "typescript": "^4.5.2"
+        "ts-jest": "^29.4.11",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=24.14.1"
@@ -42963,19 +42931,19 @@
       }
     },
     "packages/ketcher-react/node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -42992,7 +42960,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -43026,6 +42994,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ketcher-react/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ketcher-react/node_modules/v8-to-istanbul": {

--- a/packages/ketcher-core/src/domain/entities/pile.ts
+++ b/packages/ketcher-core/src/domain/entities/pile.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  ***************************************************************************/
 
+interface PileSetLike<T> {
+  readonly size: number;
+  has(value: T): boolean;
+  keys(): IterableIterator<T>;
+}
+
 export class Pile<TValue = any> extends Set<TValue> {
   // TODO: it's used only in dfs.js in one place in some strange way.
   // Should be removed after dfs.js refactoring
@@ -25,13 +31,13 @@ export class Pile<TValue = any> extends Set<TValue> {
     return null;
   }
 
-  equals(setB: Pile): boolean {
-    return this.isSuperset(setB) && setB.isSuperset(this);
+  equals(setB: PileSetLike<unknown>): boolean {
+    return this.size === setB.size && this.isSuperset(setB);
   }
 
-  isSuperset(subset: Pile): boolean {
-    for (const item of subset) {
-      if (!this.has(item)) return false;
+  isSuperset(subset: PileSetLike<unknown>): boolean {
+    for (const item of subset.keys()) {
+      if (!this.has(item as TValue)) return false;
     }
 
     return true;
@@ -41,17 +47,26 @@ export class Pile<TValue = any> extends Set<TValue> {
     return new Pile(Array.from(this).filter(expression));
   }
 
-  union(setB: Pile): Pile<TValue> {
-    const union = new Pile(this);
+  union<U>(setB: PileSetLike<U>): Pile<TValue | U> {
+    const union = new Pile<TValue | U>(this);
 
-    for (const item of setB) union.add(item);
+    for (const item of setB.keys()) {
+      union.add(item as U);
+    }
 
     return union;
   }
 
-  intersection(setB: Pile): Pile<TValue> {
-    const thisSet = new Pile(this);
-    return new Pile([...thisSet].filter((item) => setB.has(item)));
+  intersection<U>(setB: PileSetLike<U>): Pile<TValue & U> {
+    const intersection = new Pile<TValue & U>();
+
+    for (const item of this) {
+      if ((setB as PileSetLike<unknown>).has(item as unknown)) {
+        intersection.add(item as TValue & U);
+      }
+    }
+
+    return intersection;
   }
 
   /**

--- a/packages/ketcher-core/src/utilities/b64toBlob.ts
+++ b/packages/ketcher-core/src/utilities/b64toBlob.ts
@@ -4,7 +4,7 @@ export function b64toBlob(
   sliceSize = 512,
 ): Blob {
   const byteCharacters: string = window.atob(b64Data);
-  const byteArrays: Array<Uint8Array> = [];
+  const byteArrays: Array<BlobPart> = [];
 
   for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
     const slice: string = byteCharacters.slice(offset, offset + sliceSize);
@@ -15,7 +15,7 @@ export function b64toBlob(
     }
 
     const byteArray: Uint8Array = new Uint8Array(byteNumbers);
-    byteArrays.push(byteArray);
+    byteArrays.push(byteArray as unknown as BlobPart);
   }
 
   const blob: Blob = new Blob(byteArrays, { type: contentType });

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -132,8 +132,8 @@
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-typescript2": "^0.31.1",
     "rollup-plugin-visualizer": "^5.5.2",
-    "ts-jest": "^29.4.6",
-    "typescript": "^4.5.2"
+    "ts-jest": "^29.4.11",
+    "typescript": "^6.0.3"
   },
   "files": [
     "dist"

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -407,6 +407,10 @@ const onModalClose = (props, dispatch) => {
   props.onCancel();
 };
 
+// Workaround: @types/react version conflict with connect()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TemplateDialogAny = TemplateDialog as any;
+
 export default connect(
   (store: any) => ({
     ...omit(['attach'], store.templates),
@@ -425,4 +429,4 @@ export default connect(
     onCancel: () => onModalClose(props, dispatch),
     onDelete: (tmpl) => dispatch(deleteTmpl(tmpl)),
   }),
-)(TemplateDialog);
+)(TemplateDialogAny);

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/ModificationTypeDropdown/ModificationTypeDropdown.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/ModificationTypeDropdown/ModificationTypeDropdown.tsx
@@ -1,26 +1,11 @@
 import { Autocomplete, createFilterOptions, TextField } from '@mui/material';
 import clsx from 'clsx';
-import { type HTMLAttributes, forwardRef } from 'react';
 import styles from './ModificationTypeDropdown.module.less';
 import monomerWizardStyles from '../../MonomerCreationWizard.module.less';
 import {
   compareByTitleWithNaturalFirst,
   provideEditorInstance,
 } from 'ketcher-core';
-
-const OptionsListbox = forwardRef<HTMLDivElement, HTMLAttributes<HTMLElement>>(
-  (props, ref) => {
-    return (
-      <div
-        {...props}
-        ref={ref}
-        className={clsx(props.className, styles.optionsList)}
-      />
-    );
-  },
-);
-
-OptionsListbox.displayName = 'OptionsListbox';
 
 interface IOptionType {
   title: string;
@@ -128,7 +113,7 @@ export default function ModificationTypeDropdown(
           </li>
         );
       }}
-      ListboxComponent={OptionsListbox}
+      ListboxProps={{ className: styles.optionsList }}
       sx={{ width: '100%' }}
       freeSolo
       forcePopupIcon

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -195,4 +195,8 @@ export default connect((store: any) => ({
   groupStruct: functionGroupInfoSelector(store)?.groupStruct || null,
   sGroup: functionGroupInfoSelector(store)?.sGroup || null,
   render: store.editor?.render?.ctab?.render,
-}))(InfoPanel);
+}))(
+  // Workaround: @types/react version conflict with connect()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  InfoPanel as any,
+);

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoTooltip.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoTooltip.tsx
@@ -151,4 +151,8 @@ const InfoTooltip: FC<InfoPanelProps> = (props) => {
 
 export default connect((store: any) => ({
   render: store.editor?.render?.ctab?.render,
-}))(InfoTooltip);
+}))(
+  // Workaround: @types/react version conflict with connect()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  InfoTooltip as any,
+);

--- a/packages/ketcher-react/src/script/ui/views/modal/components/InfoModal/InfoModal.test.utils.js
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/InfoModal/InfoModal.test.utils.js
@@ -12,10 +12,12 @@ export function renderWithMockStore(
       },
     },
   },
-  store = createStore(modalReducer, initialState),
+  store,
 ) {
+  const createdStore = store || createStore(modalReducer, initialState);
+
   return {
-    ...rtlRender(<Provider store={store}>{component}</Provider>),
-    store,
+    ...rtlRender(<Provider store={createdStore}>{component}</Provider>),
+    store: createdStore,
   };
 }

--- a/packages/ketcher-react/src/script/ui/views/modal/components/PeriodTable/PeriodTable.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/PeriodTable/PeriodTable.tsx
@@ -265,6 +265,10 @@ const mapDispatchToProps = (
 const PeriodTable = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(PeriodTableWrapper);
+)(
+  // Workaround: @types/react version conflict with connect()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PeriodTableWrapper as any,
+);
 
 export default PeriodTable;

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/Open.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/Open.container.ts
@@ -55,5 +55,8 @@ const mapDispatchToProps = (dispatch): DispatchProps => ({
   },
 });
 
-const OpenContainer = connect(mapStateToProps, mapDispatchToProps)(Open);
+// Workaround: @types/react version conflict with connect()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const OpenAny = Open as any;
+const OpenContainer = connect(mapStateToProps, mapDispatchToProps)(OpenAny);
 export default OpenContainer;

--- a/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/Atom/Atom.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/Atom/Atom.container.ts
@@ -27,5 +27,8 @@ const mapStateToProps = (state: any): StateProps => ({
   isMonomerCreationWizardActive: state.editor.isMonomerCreationWizardActive,
 });
 
-const AtomContainer = connect(mapStateToProps)(Atom);
+// Workaround: @types/react version conflict with connect()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AtomAny = Atom as any;
+const AtomContainer = connect(mapStateToProps)(AtomAny);
 export default AtomContainer;

--- a/packages/ketcher-react/src/script/ui/views/toolbars/FloatingTools/FloatingTools.container.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/FloatingTools/FloatingTools.container.ts
@@ -27,6 +27,10 @@ const mapDispatchToProps = (dispatch: Dispatch): FloatingToolsCallProps => ({
 const FloatingToolContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(FloatingTools);
+)(
+  // Workaround: @types/react version conflict with connect()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FloatingTools as any,
+);
 
 export { FloatingToolContainer };

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.test.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ModeControl/ModeControl.test.tsx
@@ -32,7 +32,9 @@ describe('ModeControl', () => {
 
     await user.click(screen.getByTestId('polymer-toggler'));
 
-    expect(screen.getByTestId('molecules_mode')).toBeInTheDocument();
-    expect(screen.getByTestId('macromolecules_mode')).toBeInTheDocument();
-  });
+    expect(await screen.findByTestId('molecules_mode')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('macromolecules_mode'),
+    ).toBeInTheDocument();
+  }, 15000);
 });

--- a/packages/ketcher-react/src/typings.d.ts
+++ b/packages/ketcher-react/src/typings.d.ts
@@ -3,6 +3,11 @@ declare module '*.less' {
   export default classes;
 }
 
+declare module '*.css' {
+  const classes: { [className: string]: string };
+  export default classes;
+}
+
 declare module '*.sdf' {
   const content: string;
   export default content;

--- a/packages/ketcher-react/tsconfig.build.json
+++ b/packages/ketcher-react/tsconfig.build.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "esnext",
+    "module": "ESNext",
     "lib": ["dom", "esnext"],
-    "moduleResolution": "node16",
+    "moduleResolution": "node",
     "jsx": "react-jsx",
     "sourceMap": true,
     "declaration": true,

--- a/packages/ketcher-react/tsconfig.json
+++ b/packages/ketcher-react/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "paths": {
       "components": ["./src/components"],
       "src/*": ["./src/*"],


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Upgrade ketcher-react to TypeScript 6 and apply the minimal compatibility fixes needed for type-checking and tests.

What changed
- Bumped TypeScript to major 6 in ketcher-react.
- Updated Jest TypeScript compatibility by moving to a ts-jest version that supports TypeScript 6.
- Aligned TypeScript config with Node16 module resolution requirements.
- Fixed TS6 type issues in shared/core utilities and React/Redux typing edges.
- Kept declaration output enabled and fixed TS9006 by adjusting test utility typing/inference.
- Removed a lint violation introduced during migration (no explicit any).
Result
- ketcher-react type-check now passes with TypeScript 6.
- Changes were kept targeted to compatibility only, with no intentional functional behavior changes.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request