### PR TITLE
#10157 - Refactor: Every stacked toast renders with the same data-testid="error-tooltip" and testId="error-tooltip-close".

### DIFF
--- a/ketcher-autotests/tests/pages/macromolecules/canvas/NotificationBanner.ts
+++ b/ketcher-autotests/tests/pages/macromolecules/canvas/NotificationBanner.ts
@@ -8,8 +8,11 @@ type NotificationBannerLocators = {
 
 export const NotificationBanner = (page: Page) => {
   const locators: NotificationBannerLocators = {
-    message: page.getByTestId('error-tooltip').first(),
-    closeButton: page.locator('#error-tooltip').getByRole('button').first(),
+    message: page.getByTestId('error-tooltip-0'),
+    closeButton: page
+      .locator('#error-tooltip-list')
+      .getByRole('button')
+      .first(),
   };
 
   return {

--- a/packages/ketcher-macromolecules/src/Editor.tsx
+++ b/packages/ketcher-macromolecules/src/Editor.tsx
@@ -436,14 +436,17 @@ function Editor({
         onClose={() => handleCloseErrorTooltip()}
         autoHideDuration={6000}
       >
-        <StyledToastContainer id="error-tooltip">
-          {errorTooltips.map((text) => (
+        <StyledToastContainer
+          id="error-tooltip-list"
+          data-testid="error-tooltip-list"
+        >
+          {errorTooltips.map((text, index) => (
             <StyledToast key={text}>
-              <StyledToastContent data-testid="error-tooltip">
+              <StyledToastContent data-testid={`error-tooltip-${index}`}>
                 {text}
               </StyledToastContent>
               <StyledIconButton
-                testId="error-tooltip-close"
+                testId={`error-tooltip-close-${index}`}
                 iconName="close"
                 onClick={() => handleCloseErrorTooltip(text)}
               ></StyledIconButton>


### PR DESCRIPTION
## Summary

Fixes test ambiguity introduced by the stacked-toast refactor (#10157).

Previously every toast in the list rendered with the same `data-testid="error-tooltip"` and `testId="error-tooltip-close"`. Once multiple toasts can be visible simultaneously, `getByTestId` queries matched all of them non-deterministically, breaking existing e2e tests.

**Changes:**
- Each toast now receives a unique, index-based id: `error-tooltip-${index}` / `error-tooltip-close-${index}`
- The container gets a single stable id: `id="error-tooltip-list"` / `data-testid="error-tooltip-list"`
- `NotificationBanner` test helper updated to target `error-tooltip-0` and scope the close button to `#error-tooltip-list`

---

## Root cause

```tsx
// before — every toast in the list got the same id
{errorTooltips.map((text) => (
  <StyledToastContent data-testid="error-tooltip">      {/* ← same for all */}
  <StyledIconButton testId="error-tooltip-close" ... />  {/* ← same for all */}
))}
```

```tsx
// after — unique per toast, stable id on the container
<StyledToastContainer id="error-tooltip-list" data-testid="error-tooltip-list">
  {errorTooltips.map((text, index) => (
    <StyledToastContent data-testid={`error-tooltip-${index}`}>
    <StyledIconButton testId={`error-tooltip-close-${index}`} ... />
  ))}
```

[Issue link](https://github.com/epam/ketcher/issues/10157)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request