### PR TITLE
#8133 - Impossible to restrict adding invalid monomer types (e.g. Unknown base, Micromolecule) through API

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -982,6 +982,169 @@ describe('CoreEditor', () => {
         initialTemplatesCount + 1,
       );
     });
+
+    // In the KET format, modificationTypes is defined at the template level.
+    // During parsing (via templateToMonomerProps) it gets moved to
+    // props.modificationTypes, which the validation checks (#8133).
+    it('should reject monomer with a disallowed modificationType (Unknown base)', () => {
+      const monomerWithDisallowedType = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-XUB' }],
+        },
+        'monomerTemplate-XUB': {
+          type: 'monomerTemplate',
+          id: 'XUB',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'XUB',
+          name: 'XUB',
+          naturalAnalogShort: 'X',
+          modificationTypes: ['Unknown base'],
+          props: {
+            MonomerName: 'XUB',
+            MonomerClass: 'CHEM',
+            Name: 'XUB',
+            MonomerNaturalAnalogCode: 'X',
+          },
+        },
+      };
+
+      const initialLibrarySize = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(monomerWithDisallowedType));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Monomers with an unknown, ambiguous, or molecule modification type cannot be added to the library.',
+        ),
+      );
+      expect(editor.monomersLibrary.length).toBe(initialLibrarySize);
+    });
+
+    it('should reject monomer with a disallowed modificationType (Micromolecule)', () => {
+      const monomerWithDisallowedType = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-MCM88' }],
+        },
+        'monomerTemplate-MCM88': {
+          type: 'monomerTemplate',
+          id: 'MCM88',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'MCM88',
+          name: 'MCM88',
+          naturalAnalogShort: 'X',
+          modificationTypes: ['Micromolecule'],
+          props: {
+            MonomerName: 'MCM88',
+            MonomerClass: 'CHEM',
+            Name: 'MCM88',
+            MonomerNaturalAnalogCode: 'X',
+          },
+        },
+      };
+
+      const initialLibrarySize = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(monomerWithDisallowedType));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Offending modification type(s): Micromolecule',
+        ),
+      );
+      expect(editor.monomersLibrary.length).toBe(initialLibrarySize);
+    });
+
+    it('should skip a disallowed monomer but still load a valid one from the same chunk', () => {
+      const mixedMonomers = {
+        root: {
+          templates: [
+            { $ref: 'monomerTemplate-BAD' },
+            { $ref: 'monomerTemplate-GOOD' },
+          ],
+        },
+        'monomerTemplate-BAD': {
+          type: 'monomerTemplate',
+          id: 'BAD',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'BAD',
+          name: 'BAD',
+          naturalAnalogShort: 'X',
+          modificationTypes: ['Unknown monomer'],
+          props: {
+            MonomerName: 'BAD',
+            MonomerClass: 'CHEM',
+            Name: 'BAD',
+            MonomerNaturalAnalogCode: 'X',
+          },
+        },
+        'monomerTemplate-GOOD': {
+          type: 'monomerTemplate',
+          id: 'GOOD',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'GOOD',
+          name: 'GOOD',
+          naturalAnalogShort: 'X',
+          modificationTypes: ['Natural amino acid'],
+          props: {
+            MonomerName: 'GOOD',
+            MonomerClass: 'CHEM',
+            Name: 'GOOD',
+            MonomerNaturalAnalogCode: 'X',
+          },
+        },
+      };
+
+      const initialLibrarySize = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(mixedMonomers));
+
+      expect(editor.monomersLibrary.length).toBe(initialLibrarySize + 1);
+      expect(
+        editor.monomersLibrary.some(
+          (monomer) => monomer.props?.MonomerName === 'GOOD',
+        ),
+      ).toBe(true);
+      expect(
+        editor.monomersLibrary.some(
+          (monomer) => monomer.props?.MonomerName === 'BAD',
+        ),
+      ).toBe(false);
+    });
+
+    it('should accept a monomer with an allowed modificationType', () => {
+      const monomerWithAllowedType = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-OK' }],
+        },
+        'monomerTemplate-OK': {
+          type: 'monomerTemplate',
+          id: 'OK',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'OK',
+          name: 'OK',
+          naturalAnalogShort: 'X',
+          modificationTypes: ['Natural amino acid'],
+          props: {
+            MonomerName: 'OK',
+            MonomerClass: 'CHEM',
+            Name: 'OK',
+            MonomerNaturalAnalogCode: 'X',
+          },
+        },
+      };
+
+      const initialLibrarySize = editor.monomersLibrary.length;
+      editor.updateMonomersLibrary(JSON.stringify(monomerWithAllowedType));
+
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          'modification type cannot be added to the library',
+        ),
+      );
+      expect(editor.monomersLibrary.length).toBe(initialLibrarySize + 1);
+    });
   });
 
   describe('window blur handling', () => {

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -5,6 +5,7 @@ import {
   MonomerLibraryUpdateError,
   ToolName,
 } from 'application/editor';
+import { ketcherProvider } from 'application/ketcherProvider';
 import { provideEditorSettings } from 'application/editor/editorSettings';
 import { MonomerTool } from 'application/editor/tools/Monomer';
 import {
@@ -1010,6 +1011,8 @@ describe('CoreEditor', () => {
       };
 
       const initialLibrarySize = editor.monomersLibrary.length;
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
       editor.updateMonomersLibrary(JSON.stringify(monomerWithDisallowedType));
 
       expect(errorSpy).toHaveBeenCalledWith(
@@ -1018,6 +1021,11 @@ describe('CoreEditor', () => {
         ),
       );
       expect(editor.monomersLibrary.length).toBe(initialLibrarySize);
+      // The reject branch must not leak the rejected template into the parsed
+      // JSON side-table either.
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
     });
 
     it('should reject monomer with a disallowed modificationType (Micromolecule)', () => {
@@ -1044,6 +1052,8 @@ describe('CoreEditor', () => {
       };
 
       const initialLibrarySize = editor.monomersLibrary.length;
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
       editor.updateMonomersLibrary(JSON.stringify(monomerWithDisallowedType));
 
       expect(errorSpy).toHaveBeenCalledWith(
@@ -1052,6 +1062,11 @@ describe('CoreEditor', () => {
         ),
       );
       expect(editor.monomersLibrary.length).toBe(initialLibrarySize);
+      // The reject branch must not leak the rejected template into the parsed
+      // JSON side-table either.
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
     });
 
     it('should skip a disallowed monomer but still load a valid one from the same chunk', () => {
@@ -1144,6 +1159,65 @@ describe('CoreEditor', () => {
         ),
       );
       expect(editor.monomersLibrary.length).toBe(initialLibrarySize + 1);
+    });
+
+    it('enforces the modificationType validation through the replace path (initializeMonomersLibraryFromKetcher)', async () => {
+      // There is no standalone `replaceMonomersLibrary` method: the replace
+      // entry point is the second argument of initializeMonomersLibraryFromKetcher,
+      // which clears the library and then delegates to updateMonomersLibrary
+      // (where the validation lives). This locks in that the replace path
+      // enforces the same modificationType validation as the update path.
+      const monomerWithDisallowedType = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-XUB' }],
+        },
+        'monomerTemplate-XUB': {
+          type: 'monomerTemplate',
+          id: 'XUB',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'XUB',
+          name: 'XUB',
+          naturalAnalogShort: 'X',
+          modificationTypes: ['Unknown base'],
+          props: {
+            MonomerName: 'XUB',
+            MonomerClass: 'CHEM',
+            Name: 'XUB',
+            MonomerNaturalAnalogCode: 'X',
+          },
+        },
+      };
+
+      // The replace path passes the data through
+      // ketcher.ensureMonomersLibraryDataInKetFormat; stub it to return the
+      // already-KET-format data unchanged.
+      const getKetcherSpy = jest
+        .spyOn(ketcherProvider, 'getKetcher')
+        .mockReturnValue({
+          ensureMonomersLibraryDataInKetFormat: async (data: string | JSON) =>
+            data,
+        } as unknown as ReturnType<typeof ketcherProvider.getKetcher>);
+
+      try {
+        await editor.initializeMonomersLibraryFromKetcher(
+          undefined,
+          JSON.stringify(monomerWithDisallowedType),
+        );
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Monomers with an unknown, ambiguous, or molecule modification type cannot be added to the library.',
+          ),
+        );
+        expect(
+          editor.monomersLibrary.some(
+            (monomer) => monomer.props?.MonomerName === 'XUB',
+          ),
+        ).toBe(false);
+      } finally {
+        getKetcherSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/ketcher-core/__tests__/utilities/monomers.test.ts
+++ b/packages/ketcher-core/__tests__/utilities/monomers.test.ts
@@ -1,4 +1,6 @@
 import {
+  DISALLOWED_MONOMER_MODIFICATION_TYPES,
+  getDisallowedModificationTypes,
   HELM_ALIAS_MAX_LENGTH,
   isValidHelmAliasLength,
 } from '../../src/utilities/monomers';
@@ -15,6 +17,37 @@ describe('monomers utilities', () => {
       expect(
         isValidHelmAliasLength('A'.repeat(HELM_ALIAS_MAX_LENGTH + 1)),
       ).toBe(false);
+    });
+  });
+
+  describe('getDisallowedModificationTypes', () => {
+    it.each(DISALLOWED_MONOMER_MODIFICATION_TYPES)(
+      'flags the disallowed modification type "%s"',
+      (modificationType) => {
+        expect(getDisallowedModificationTypes([modificationType])).toEqual([
+          modificationType,
+        ]);
+      },
+    );
+
+    it('returns an empty array for allowed modification types', () => {
+      expect(
+        getDisallowedModificationTypes([
+          'Natural amino acid',
+          'Phosphorylation',
+        ]),
+      ).toEqual([]);
+    });
+
+    it('returns only the disallowed types from a mixed list', () => {
+      expect(
+        getDisallowedModificationTypes(['Natural amino acid', 'Unknown base']),
+      ).toEqual(['Unknown base']);
+    });
+
+    it('returns an empty array when modification types are missing or empty', () => {
+      expect(getDisallowedModificationTypes(undefined)).toEqual([]);
+      expect(getDisallowedModificationTypes([])).toEqual([]);
     });
   });
 });

--- a/packages/ketcher-core/__tests__/utilities/monomers.test.ts
+++ b/packages/ketcher-core/__tests__/utilities/monomers.test.ts
@@ -49,5 +49,17 @@ describe('monomers utilities', () => {
       expect(getDisallowedModificationTypes(undefined)).toEqual([]);
       expect(getDisallowedModificationTypes([])).toEqual([]);
     });
+
+    it('returns an empty array for malformed (non-array) modification types', () => {
+      // The value comes from parsed, untrusted library JSON, so it may not be an
+      // array at runtime (e.g. a bare string). The guard must return an empty
+      // result rather than throwing a TypeError.
+      expect(
+        getDisallowedModificationTypes('Unknown base' as unknown as string[]),
+      ).toEqual([]);
+      expect(
+        getDisallowedModificationTypes(null as unknown as string[]),
+      ).toEqual([]);
+    });
   });
 });

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -87,6 +87,8 @@ import {
   isValidHelmAliasLength,
   isValidIdtAlias,
   getTooLongIdtAliasEntries,
+  getDisallowedModificationTypes,
+  DISALLOWED_MODIFICATION_TYPE_ERROR_MESSAGE,
   initHotKeys,
   isEditableInputTarget,
   KetcherLogger,
@@ -526,6 +528,19 @@ export class CoreEditor {
 
     // handle monomer templates
     newMonomersLibraryChunk.forEach((newMonomer) => {
+      const disallowedModificationTypes = getDisallowedModificationTypes(
+        newMonomer.props?.modificationTypes,
+      );
+      if (disallowedModificationTypes.length > 0) {
+        const errorMessage = `Editor::updateMonomersLibrary: Load of "${
+          newMonomer.props.MonomerName
+        }" monomer has failed. ${DISALLOWED_MODIFICATION_TYPE_ERROR_MESSAGE} Offending modification type(s): ${disallowedModificationTypes.join(
+          ', ',
+        )}. The monomer was not added to the library.`;
+        KetcherLogger.error(errorMessage);
+        return;
+      }
+
       const newMonomerHasBilnAliasUniquenessScope = hasBilnAliasUniquenessScope(
         newMonomer.props?.MonomerClass,
       );

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -57,14 +57,22 @@ const disallowedModificationTypesSet = new Set<string>(
  * Returns the modification types of a monomer that are not allowed in the
  * library (unknown / ambiguous / molecule markers). Returns an empty array when
  * the monomer has no modification types or all of them are allowed.
+ *
+ * `modificationTypes` originates from parsed, untrusted library JSON, so it may
+ * not actually be an array at runtime (e.g. a caller passing a bare string).
+ * The `Array.isArray` guard turns such malformed input into an empty result
+ * instead of a `TypeError`, which would otherwise escape the per-monomer loop
+ * in `Editor.updateMonomersLibrary` and abort the whole chunk.
  */
 export function getDisallowedModificationTypes(
   modificationTypes?: string[],
 ): string[] {
-  return (
-    modificationTypes?.filter((type) =>
-      disallowedModificationTypesSet.has(type),
-    ) ?? []
+  if (!Array.isArray(modificationTypes)) {
+    return [];
+  }
+
+  return modificationTypes.filter((type) =>
+    disallowedModificationTypesSet.has(type),
   );
 }
 

--- a/packages/ketcher-core/src/utilities/monomers.ts
+++ b/packages/ketcher-core/src/utilities/monomers.ts
@@ -22,6 +22,52 @@ export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH = 200;
 
 export const MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE = `The monomer group template name must not exceed ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH} characters.`;
 
+// Modification types that mark a monomer as unknown, ambiguous, or a plain
+// molecule. Such monomers must not be added to or shown in the library (#8133).
+export const DISALLOWED_MONOMER_MODIFICATION_TYPES = [
+  'Ambiguous mixed peptide',
+  'Unknown peptide',
+  'Ambiguous alternative sugar',
+  'Ambiguous mixed sugar',
+  'Unknown sugar',
+  'Ambiguous mixed DNA base',
+  'Ambiguous mixed RNA base',
+  'Ambiguous mixed base',
+  'Unknown base',
+  'Ambiguous alternative phosphate',
+  'Ambiguous mixed phosphate',
+  'Unknown phosphate',
+  'Unknown unsplit nucleotide',
+  'Ambiguous alternative CHEM',
+  'Ambiguous mixed CHEM',
+  'Unknown CHEM',
+  'Unknown monomer',
+  'Molecule',
+  'Micromolecule',
+] as const;
+
+export const DISALLOWED_MODIFICATION_TYPE_ERROR_MESSAGE =
+  'Monomers with an unknown, ambiguous, or molecule modification type cannot be added to the library.';
+
+const disallowedModificationTypesSet = new Set<string>(
+  DISALLOWED_MONOMER_MODIFICATION_TYPES,
+);
+
+/**
+ * Returns the modification types of a monomer that are not allowed in the
+ * library (unknown / ambiguous / molecule markers). Returns an empty array when
+ * the monomer has no modification types or all of them are allowed.
+ */
+export function getDisallowedModificationTypes(
+  modificationTypes?: string[],
+): string[] {
+  return (
+    modificationTypes?.filter((type) =>
+      disallowedModificationTypesSet.has(type),
+    ) ?? []
+  );
+}
+
 const HELM_ALIAS_REGEX = /^(?!.*\s)[A-Za-z0-9_*.[\]()-]+$/;
 const BILN_ALIAS_REGEX = /^[A-Za-z0-9_*-]+$/;
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
 Description

  Monomers imported via updateMonomersLibrary / replaceMonomersLibrary whose modification type is an unknown, ambiguous, or molecule marker (Unknown base, Micromolecule, Ambiguous mixed base, … — the 19 values listed in the issue) are now rejected: they are skipped on load, logged via KetcherLogger, and not added to or shown in the library. Valid monomers in the same import still load (consistent with epam/Indigo#3755).

  Changes

  - ketcher-core/src/utilities/monomers.ts: added DISALLOWED_MONOMER_MODIFICATION_TYPES (the 19 values, as const), DISALLOWED_MODIFICATION_TYPE_ERROR_MESSAGE, and getDisallowedModificationTypes() (returns the offending types).
  - ketcher-core/src/application/editor/Editor.ts: added a check at the start of the updateMonomersLibrary per-monomer loop — if a monomer's props.modificationTypes contains a disallowed value, it is skipped and logged. This gates both updateMonomersLibrary and replaceMonomersLibrary.
  - Tests: getDisallowedModificationTypes unit-tested against all 19 values plus mixed/empty inputs; Editor integration tests for reject (Unknown base, Micromolecule), skip-disallowed-but-load-valid, and accept-allowed-type.

  Testing

  - npm run test --workspace=ketcher-core (prettier, eslint, types, circular-deps, jest — 393 tests incl. the new ones): green.
  - npm run test:types (all workspaces): green.
  - Indigo round-trip verified directly (indigo-ketcher v1.44 in Node): an SDF <modificationTypes> field carrying a disallowed value converts to KET props.modificationTypes, which the validation then rejects — confirming the full SDF → conversion → validation chain.

  Notes for reviewers / QA

  - The validation targets the canonical props.modificationTypes field (the value Indigo produces from a monomer's modification-type data field), so it applies regardless of import path.
  - Current Indigo (v1.44) reads/writes this as the plural data field <modificationTypes>. The issue's example SDF predates the current Indigo: it uses the singular <modificationType> field (which current Indigo ignores) and that exact SDF also no longer parses on the current Indigo. To reproduce on the current build, use an SDF with the plural <modificationTypes> field (or the KET format) carrying a disallowed value — not the issue's literal example.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request