### PR TITLE
#10039 - Nucleotide preset: External AP of a phosphate is not always displayed in the preset tab

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.test.ts
@@ -266,4 +266,27 @@ describe('RnaPresetAttachmentPointsVisibility', () => {
       ),
     ).toEqual(assignedAttachmentPoints);
   });
+
+  it('keeps an external attachment point visible when it shares the connection atom but keeps its leaving group inside the component', () => {
+    const wizardState = createWizardState();
+    wizardState.sugar.structure = { atoms: [2], bonds: [] };
+    // Atom 3 is the phosphate atom that connects to the sugar; atom 5 is an
+    // external leaving group the user added to that same phosphate atom.
+    wizardState.phosphate.structure = { atoms: [3, 5], bonds: [] };
+    const assignedAttachmentPoints = new Map<
+      AttachmentPointName,
+      [number, number]
+    >([[AttachmentPointName.R1, [3, 5]]]);
+
+    const visibleAttachmentPoints = getVisibleAttachmentPointsForRnaPreset(
+      assignedAttachmentPoints,
+      wizardState,
+      createStruct([
+        [2, 3],
+        [3, 5],
+      ]),
+    );
+
+    expect(visibleAttachmentPoints).toEqual(assignedAttachmentPoints);
+  });
 });

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetAttachmentPointsVisibility.ts
@@ -208,10 +208,22 @@ export const getVisibleAttachmentPointsForRnaPreset = (
   const occupiedAttachmentPoints = new Set<AttachmentPointName>();
 
   assignedAttachmentPoints.forEach(
-    ([attachmentAtomId], attachmentPointName) => {
+    ([attachmentAtomId, leavingAtomId], attachmentPointName) => {
       const componentKey = atomToComponentMap.get(attachmentAtomId);
 
       if (!componentKey) {
+        return;
+      }
+
+      // A genuine external attachment point keeps its leaving group within the
+      // same component. Such an AP must stay visible on the preset tab even when
+      // its attachment atom also forms an inter-component connection bond (e.g. a
+      // phosphate atom that both connects to the sugar and carries its own
+      // external leaving group). Only APs whose leaving atom is not part of the
+      // component represent the internal connection and should be hidden.
+      const leavingAtomComponentKey = atomToComponentMap.get(leavingAtomId);
+
+      if (leavingAtomComponentKey === componentKey) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes the phosphate's external attachment point not showing in the Preset tab when its attachment atom is also used for the sugar–phosphate connection.

## Changes

### Preset Tab Attachment Point Visibility Fix

**Problem:** `getVisibleAttachmentPointsForRnaPreset` hid any AP whose attachment atom formed an inter-component connection — including a phosphate's own external AP when that atom both connected to the sugar and carried a separate leaving group.

**Solution:** Keep an AP visible when its leaving atom is in the same component as its attachment atom (a genuine external AP); only hide APs whose leaving atom points to another component (the internal connection).

### Files Modified

**`ketcher-react`**
- `RnaPresetAttachmentPointsVisibility.ts` — added a guard that keeps same-component-leaving-atom APs visible, before the inter-component occupancy check
- `RnaPresetAttachmentPointsVisibility.test.ts` — added a test for an external AP that shares the connection atom


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request