### PR TITLE
#7822 -  Already taken connection points are not marked

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.module.less
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.module.less
@@ -71,6 +71,11 @@
     margin: 4px 8px;
   }
 }
+.usedOption {
+  &:global(.MuiMenuItem-root) {
+    color: rgba(51, 51, 51, 0.6);
+  }
+}
 
 .selectContainer {
   width: 100%;
@@ -117,7 +122,7 @@
   }
 
   :global(.Mui-error .MuiSelect-select) {
-    background-color: #FDE0DF;
+    background-color: #fde0df;
     border: 1px solid @color-secondary-red;
   }
 

--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
@@ -28,6 +28,7 @@ export interface Option {
   label: string;
   children?: ReactNode;
   disabled?: boolean;
+  markedAsUsed?: boolean;
 }
 
 interface Props {
@@ -112,8 +113,10 @@ const Select = ({
             key={option.value}
             disableRipple={true}
             disabled={option.disabled}
+            title={option.markedAsUsed ? 'Already in use' : undefined}
             className={clsx({
               [`dropdown-${formName}_${name}`]: formName,
+              [styles.usedOption]: option.markedAsUsed,
             })}
             data-testid={`${option.label}-option`}
           >

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
@@ -126,12 +126,22 @@ export const useAttachmentPointSelectsData = (
   const attachmentPointNameOptionsLength =
     maxUsedNumber <= 3 ? 3 : Math.min(maxUsedNumber, 8);
 
+  const usedNames = new Set(
+    Array.from(assignedAttachmentPoints.keys()).filter(
+      (name) => name !== attachmentPointName,
+    ),
+  );
+
   const nameOptions: Option[] = Array.from({
     length: attachmentPointNameOptionsLength,
-  }).map((_, i) => ({
-    value: `R${i + 1}`,
-    label: `R${i + 1}`,
-  }));
+  }).map((_, i) => {
+    const name = `R${i + 1}`;
+    return {
+      value: name,
+      label: name,
+      markedAsUsed: usedNames.has(name as AttachmentPointName),
+    };
+  });
 
   // Build atom type options for leaving group
   const currentLeavingAtomLabel = leavingAtom.label;


### PR DESCRIPTION
## Summary

Already taken R-numbers were not indicated in the "Edit connection point" dropdown — every option looked the same, so it wasn't obvious which numbers were already assigned:

## Before
<img width="564" height="333" alt="Screenshot 2026-06-08 at 13 58 18" src="https://github.com/user-attachments/assets/8c95f70f-ed83-434d-83b3-2d84a8987f1d" /> 

## After
<img width="471" height="382" alt="Screenshot 2026-06-08 at 13 58 48" src="https://github.com/user-attachments/assets/9e7fcbdd-ac5c-468d-a9f4-a4579ea565b4" />

This PR greys out the R-numbers already in use (with an "Already in use" tooltip), while keeping them selectable per requirement 3.1.1.1:

## Changes

### Mark already-used R-numbers in the connection point dropdown

**Problem:** The R-number dropdown listed all options identically, giving no hint which numbers were already assigned to other attachment points.

**Solution:** Already-used R-numbers are now greyed out with an "Already in use" tooltip. They stay selectable, since picking a taken number performs a valid swap.

### Files Modified

**`ketcher-react`**
- `Select.tsx` — added optional `markedAsUsed` flag to `Option`; marked items are greyed out (not disabled)
- `Select.module.less` — added `.usedOption` muted style
- `useAttachmentPointSelectsData.tsx` — flag R-numbers already taken by other attachment points

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request