### PR TITLE
#5760 - The type file of module 'ketcher-standalone' cannot be resolved.

### DIFF
--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -80,9 +80,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/main.js",
-      "require": "./dist/cjs/main.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/cjs/main.js"
     },
     "./dist/binaryWasm": {
       "import": "./dist/binaryWasm/main.js",


### PR DESCRIPTION
## Summary

Fixes the TypeScript error "Could not find a declaration file for module 'ketcher-standalone'" by ordering the `types` condition first in `package.json` `exports`.

## Changes

### Type Declaration Resolution Fix

**Problem:** Conditional `exports` are matched top-to-bottom, but `types` was listed last — after `import` and `require`. TypeScript matched the JS condition first and never reached the declaration file, so the package resolved as `any` under `node16`/`nodenext`/`bundler` resolution.

The error was originally reported on **v2.25.0**, where `exports` had **no `types` condition at all** (hence "There are types at ... but could not be resolved respecting exports", pointing at `index.modern.js`). On current **`master`** a `types` condition was already present but in the **wrong position**, which silently relied on a TypeScript fallback bug ([microsoft/TypeScript#50762](https://github.com/microsoft/TypeScript/issues/50762)) and still failed under stricter resolvers — so both cases produce the same error.

**Solution:** Move `types` to the first position in `exports["."]`, as the TypeScript docs require. Verified with `@arethetypeswrong/cli` (🐛 → 🟢) and a consumer project running `tsc --noEmit` (error → no error).

### Files Modified

**`ketcher-standalone`**
- `package.json` — moved `types` ahead of `import`/`require` in `exports["."]` so the declaration file resolves first


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request