### PR TITLE
#6056 - Ambiguous monomers (not from our library) are not marked as modified

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/AmbiguousMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/AmbiguousMonomerRenderer.ts
@@ -166,6 +166,17 @@ export class AmbiguousMonomerRenderer extends BaseMonomerRenderer {
   }
 
   protected get modificationConfig() {
-    return undefined;
+    switch (this.monomer.monomerClass) {
+      case KetMonomerClass.AminoAcid:
+        return { backgroundId: '#modified-background', requiresFill: true };
+      case KetMonomerClass.Base:
+        return { backgroundId: '#rna-base-modified-background' };
+      case KetMonomerClass.Sugar:
+        return { backgroundId: '#sugar-modified-background' };
+      case KetMonomerClass.Phosphate:
+        return { backgroundId: '#phosphate-modified-background' };
+      default:
+        return undefined;
+    }
   }
 }

--- a/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/AmbiguousMonomer.ts
@@ -18,6 +18,8 @@ import { Phosphate } from 'domain/entities/Phosphate';
 import { Sugar } from 'domain/entities/Sugar';
 import { RNABase } from 'domain/entities/RNABase';
 import { UnsplitNucleotide } from 'domain/entities/UnsplitNucleotide';
+import { provideEditorInstance } from 'application/editor/editorSingleton';
+import { isAmbiguousMonomerLibraryItem } from 'domain/helpers/monomers';
 
 export const DEFAULT_VARIANT_MONOMER_LABEL = '%';
 
@@ -132,6 +134,34 @@ export class AmbiguousMonomer extends BaseMonomer implements IVariantMonomer {
     });
 
     return monomerCaps;
+  }
+
+  public get isModification() {
+    const ownTemplateIds = this.variantMonomerItem.options
+      .map((option) => option.templateId)
+      .sort();
+
+    const monomersLibrary = provideEditorInstance()?.monomersLibrary ?? [];
+
+    const existsInLibrary = monomersLibrary.some((libraryItem) => {
+      if (
+        !isAmbiguousMonomerLibraryItem(libraryItem) ||
+        libraryItem.subtype !== this.subtype
+      ) {
+        return false;
+      }
+
+      const libraryTemplateIds = libraryItem.options
+        .map((option) => option.templateId)
+        .sort();
+
+      return (
+        libraryTemplateIds.length === ownTemplateIds.length &&
+        libraryTemplateIds.every((id, index) => id === ownTemplateIds[index])
+      );
+    });
+
+    return !existsInLibrary;
   }
 
   public getValidSourcePoint(_secondMonomer?: BaseMonomer) {


### PR DESCRIPTION
## Summary

Ambiguous monomers that are **not** in our library were not marked as modified — they looked identical to library ones (e.g. `N`, `X`), with no hint that a monomer was a custom combination:

| Before | After |
|--------|-------|
| <img width="583" height="362" alt="Before" src="https://github.com/user-attachments/assets/a5cb4802-bd0a-4a22-83d4-6a2f4a2f599c" /> | <img width="559" height="332" alt="After" src="https://github.com/user-attachments/assets/14692bcc-0032-45fc-863e-ffcd6b535aa1" /> |

Per requirement: *library ambiguous monomers (amino acids/bases) are non-modified; all others are modified.*

## Changes

`AmbiguousMonomer.isModification` now compares the monomer's `subtype` and constituent `templateId`s against the library (order-independent). Match → non-modified; otherwise → modified (mixtures are never in the library, so always modified). `AmbiguousMonomerRenderer.modificationConfig` wires up the per-class background so the mark is actually drawn.

## Files Modified

**ketcher-core**

- `AmbiguousMonomer.ts` — added `isModification` getter (library-membership check).
- `AmbiguousMonomerRenderer.ts` — added `modificationConfig` with class-specific backgrounds (`undefined` for CHEM, like the other renderers).


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request