### PR TITLE
#10180 - If the user is editing the R-number of one attachment point, only that that R-number should be changed

### DIFF
--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -67,10 +67,15 @@ export type MonomerCreationState = {
   // Connection APs: inter-component links (readonly). Maps AP name to [component atom id, other-component atom id]
   connectionAttachmentPoints?: Map<AttachmentPointName, [number, number]>;
   editInstanceInitialValues?: MonomerCreationInitialValues;
-  // Display-only overrides for AP labels during editing.
+  // Display-only overrides for AP labels shown on the canvas during editing.
   // Maps attachment atom id → temporary display name.
-  // Never affects assignedAttachmentPoints; resolved into the map only on save.
+  // Never mutates assignedAttachmentPoints; on save, a new resolved map is
+  // produced from assignedAttachmentPoints + these overrides and persisted.
   attachmentPointNameOverrides?: Map<number, AttachmentPointName>;
+  // Attachment atom ids whose AP failed wizard validation (uniqueness/order).
+  // Used to red-highlight AP labels on canvas, mirroring the side-panel invalid
+  // style. Keyed by atom id because validation tracks duplicates/order by atom.
+  problematicAttachmentPointAtomIds?: Set<number>;
 } | null;
 
 export class Render {

--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -67,6 +67,10 @@ export type MonomerCreationState = {
   // Connection APs: inter-component links (readonly). Maps AP name to [component atom id, other-component atom id]
   connectionAttachmentPoints?: Map<AttachmentPointName, [number, number]>;
   editInstanceInitialValues?: MonomerCreationInitialValues;
+  // Display-only overrides for AP labels during editing.
+  // Maps attachment atom id → temporary display name.
+  // Never affects assignedAttachmentPoints; resolved into the map only on save.
+  attachmentPointNameOverrides?: Map<number, AttachmentPointName>;
 } | null;
 
 export class Render {

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -855,7 +855,7 @@ class ReAtom extends ReObject {
           labelGroup.forEach((element) => {
             element.node?.setAttribute(
               'data-attachment-point-alias',
-              attachmentPointName,
+              displayLabel,
             );
             element.node?.setAttribute(
               'data-testid',

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -707,6 +707,7 @@ class ReAtom extends ReObject {
         problematicAtoms,
         connectionAttachmentPoints,
         attachmentPointNameOverrides,
+        problematicAttachmentPointAtomIds,
       } = render.monomerCreationState;
       // When visibleAssignedAttachmentPoints is set, only that subset is drawn;
       // otherwise all assigned attachment points are shown.
@@ -801,8 +802,12 @@ class ReAtom extends ReObject {
           const displayLabel =
             attachmentPointNameOverrides?.get(atomsPair[0]) ??
             attachmentPointName;
+          // An AP is problematic when its bond became unsuitable (tracked by
+          // AP name) or it failed wizard validation (tracked by attachment
+          // atom id). Both sources must be honored to red-highlight the label.
           const isProblematic =
-            problematicAttachmentPoints.has(attachmentPointName);
+            problematicAttachmentPoints.has(attachmentPointName) ||
+            (problematicAttachmentPointAtomIds?.has(atomsPair[0]) ?? false);
 
           const rLabelElement = render.paper
             .text(labelPos.x, labelPos.y, displayLabel)

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -706,6 +706,7 @@ class ReAtom extends ReObject {
         problematicAttachmentPoints,
         problematicAtoms,
         connectionAttachmentPoints,
+        attachmentPointNameOverrides,
       } = render.monomerCreationState;
       // When visibleAssignedAttachmentPoints is set, only that subset is drawn;
       // otherwise all assigned attachment points are shown.
@@ -797,11 +798,14 @@ class ReAtom extends ReObject {
           );
           const labelPos = shiftedPos.addScaled(direction, 8);
 
+          const displayLabel =
+            attachmentPointNameOverrides?.get(atomsPair[0]) ??
+            attachmentPointName;
           const isProblematic =
             problematicAttachmentPoints.has(attachmentPointName);
 
           const rLabelElement = render.paper
-            .text(labelPos.x, labelPos.y, attachmentPointName)
+            .text(labelPos.x, labelPos.y, displayLabel)
             .attr({
               font: options.font,
               'font-size': options.fontszsubInPx,

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1278,6 +1278,7 @@ class Editor implements KetcherEditor {
       assignedAttachmentPoints,
       potentialAttachmentPoints,
       problematicAttachmentPoints: new Set(),
+      problematicAttachmentPointAtomIds: new Set(),
       hasDefaultAttachmentPoints,
       ...(editInstanceInitialValues ? { editInstanceInitialValues } : {}),
     };
@@ -1989,6 +1990,17 @@ class Editor implements KetcherEditor {
     assert(this.monomerCreationState);
 
     this.monomerCreationState.problematicAttachmentPoints = problematicPoints;
+    this.monomerCreationState = { ...(this.monomerCreationState ?? {}) };
+    this.render.update(true);
+  }
+
+  setProblematicAttachmentPointAtomIds(problematicAtomIds: Set<number>) {
+    if (!this.monomerCreationState) {
+      return;
+    }
+
+    this.monomerCreationState.problematicAttachmentPointAtomIds =
+      problematicAtomIds;
     this.monomerCreationState = { ...(this.monomerCreationState ?? {}) };
     this.render.update(true);
   }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1993,6 +1993,16 @@ class Editor implements KetcherEditor {
     this.render.update(true);
   }
 
+  setAttachmentPointNameOverrides(overrides: Map<number, AttachmentPointName>) {
+    if (!this.monomerCreationState) {
+      return;
+    }
+
+    this.monomerCreationState.attachmentPointNameOverrides = overrides;
+    this.monomerCreationState = { ...(this.monomerCreationState ?? {}) };
+    this.render.update(true);
+  }
+
   setProblematicAtoms(problematicAtoms: Set<number>) {
     if (!this.monomerCreationState) {
       KetcherLogger.error(

--- a/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
@@ -18,6 +18,7 @@ type Props = {
   onNameChange: (
     currentName: AttachmentPointName,
     newName: AttachmentPointName,
+    attachmentAtomId: number,
   ) => void;
   onLeavingAtomChange: (
     apName: AttachmentPointName,
@@ -25,6 +26,7 @@ type Props = {
   ) => void;
   onClose: VoidFunction;
   editor: Editor;
+  attachmentPointDisplayNames?: Map<number, AttachmentPointName>;
 };
 
 const AttachmentPointEditPopup = ({
@@ -33,6 +35,7 @@ const AttachmentPointEditPopup = ({
   onLeavingAtomChange,
   onClose,
   editor,
+  attachmentPointDisplayNames,
 }: Props) => {
   const popupRef = useRef<HTMLDivElement>(null);
 
@@ -86,10 +89,23 @@ const AttachmentPointEditPopup = ({
   assert(editor.monomerCreationState);
 
   const { assignedAttachmentPoints } = editor.monomerCreationState;
+  const atomPair = assignedAttachmentPoints.get(attachmentPointName);
+  const displayName = atomPair
+    ? attachmentPointDisplayNames?.get(atomPair[0]) ?? attachmentPointName
+    : attachmentPointName;
+  const usedAttachmentPointNames = Array.from(
+    assignedAttachmentPoints.entries() as Iterable<
+      [AttachmentPointName, [number, number]]
+    >,
+  ).map(([name, [attachmentAtomId]]) => {
+    return attachmentPointDisplayNames?.get(attachmentAtomId) ?? name;
+  });
 
   const selectsData = useAttachmentPointSelectsData(
     editor,
     attachmentPointName,
+    displayName,
+    usedAttachmentPointNames,
   );
 
   if (!selectsData) {
@@ -97,8 +113,8 @@ const AttachmentPointEditPopup = ({
   }
 
   const handleNameChange = (newName: AttachmentPointName) => {
-    if (newName !== attachmentPointName) {
-      onNameChange(attachmentPointName, newName);
+    if (newName !== displayName) {
+      onNameChange(attachmentPointName, newName, selectsData.attachmentAtomId);
     }
     onClose();
   };

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -128,6 +128,17 @@ const getResolvedAttachmentPoints = (
   }, new Map<AttachmentPointName, [number, number]>());
 };
 
+const getAttachmentPointsToValidate = (
+  assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
+  overrides: AttachmentPointNameOverrides,
+) =>
+  getEffectiveAttachmentPointEntries(assignedAttachmentPoints, overrides).map(
+    ({ displayName, atomPair }) => ({
+      name: displayName,
+      attachmentAtomId: atomPair[0],
+    }),
+  );
+
 /**
  * Builds initial wizard state seeded with values from an existing monomer
  * being edited. When `initialValues` is undefined returns the default empty
@@ -1284,13 +1295,10 @@ const MonomerCreationWizardInternal = ({
       notifications: attachmentPointsNotifications,
       problematicAttachmentPointAtomIds,
     } = validateAttachmentPoints(
-      getEffectiveAttachmentPointEntries(
+      getAttachmentPointsToValidate(
         monomerAssignedAttachmentPoints,
         attachmentPointNameOverrides,
-      ).map(({ displayName, atomPair }) => ({
-        name: displayName,
-        attachmentAtomId: atomPair[0],
-      })),
+      ),
     );
     if (attachmentPointsNotifications.size > 0) {
       wizardStateDispatch({
@@ -1615,13 +1623,10 @@ const MonomerCreationWizardInternal = ({
           notifications: attachmentPointsNotifications,
           problematicAttachmentPointAtomIds,
         } = validateAttachmentPoints(
-          getEffectiveAttachmentPointEntries(
+          getAttachmentPointsToValidate(
             monomerAssignedAttachmentPoints,
             attachmentPointNameOverrides,
-          ).map(({ displayName, atomPair }) => ({
-            name: displayName,
-            attachmentAtomId: atomPair[0],
-          })),
+          ),
         );
         if (attachmentPointsNotifications.size > 0) {
           needSaveMonomers = false;

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -13,7 +13,6 @@ import {
   type Struct,
   AttachmentPointName,
   CREATE_MONOMER_TOOL_NAME,
-  getAttachmentPointLabel,
   getAttachmentPointNumberFromLabel,
   isValidBilnAlias,
   isValidHelmAlias,
@@ -94,6 +93,40 @@ const getInitialWizardState = (
 });
 
 const initialWizardState: WizardState = getInitialWizardState();
+
+type AttachmentPointNameOverrides = Map<number, AttachmentPointName>;
+
+type EffectiveAttachmentPoint = {
+  internalName: AttachmentPointName;
+  displayName: AttachmentPointName;
+  atomPair: [number, number];
+};
+
+const getEffectiveAttachmentPointEntries = (
+  assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
+  overrides: AttachmentPointNameOverrides,
+): EffectiveAttachmentPoint[] => {
+  return Array.from(assignedAttachmentPoints.entries()).map(
+    ([internalName, atomPair]) => ({
+      internalName,
+      displayName: overrides.get(atomPair[0]) ?? internalName,
+      atomPair,
+    }),
+  );
+};
+
+const getResolvedAttachmentPoints = (
+  assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
+  overrides: AttachmentPointNameOverrides,
+) => {
+  return getEffectiveAttachmentPointEntries(
+    assignedAttachmentPoints,
+    overrides,
+  ).reduce((result, { displayName, atomPair }) => {
+    result.set(displayName, atomPair);
+    return result;
+  }, new Map<AttachmentPointName, [number, number]>());
+};
 
 /**
  * Builds initial wizard state seeded with values from an existing monomer
@@ -601,9 +634,14 @@ const validateInputs = (
   return { errors, notifications };
 };
 
-const validateAttachmentPoints = (attachmentPoints: AttachmentPointName[]) => {
+const validateAttachmentPoints = (
+  attachmentPoints: Array<{
+    name: AttachmentPointName;
+    attachmentAtomId: number;
+  }>,
+) => {
   const notifications = new Map<WizardNotificationId, WizardNotification>();
-  const problematicAttachmentPoints = new Set<AttachmentPointName>();
+  const problematicAttachmentPointAtomIds = new Set<number>();
 
   if (attachmentPoints.length === 0) {
     notifications.set('noAttachmentPoints', {
@@ -611,11 +649,30 @@ const validateAttachmentPoints = (attachmentPoints: AttachmentPointName[]) => {
       message: NotificationMessages.noAttachmentPoints,
     });
 
-    return { notifications, problematicAttachmentPoints };
+    return { notifications, problematicAttachmentPointAtomIds };
+  }
+
+  const attachmentPointCounts = attachmentPoints.reduce((result, { name }) => {
+    result.set(name, (result.get(name) ?? 0) + 1);
+    return result;
+  }, new Map<AttachmentPointName, number>());
+
+  attachmentPoints.forEach(({ name, attachmentAtomId }) => {
+    if ((attachmentPointCounts.get(name) ?? 0) > 1) {
+      problematicAttachmentPointAtomIds.add(attachmentAtomId);
+    }
+  });
+
+  if (problematicAttachmentPointAtomIds.size > 0) {
+    notifications.set('attachmentPointsNotUnique', {
+      type: 'error',
+      message: NotificationMessages.attachmentPointsNotUnique,
+    });
+    return { notifications, problematicAttachmentPointAtomIds };
   }
 
   const sideAttachmentPoints = attachmentPoints.filter(
-    (attachmentPointName) => {
+    ({ name: attachmentPointName }) => {
       const pointNumber =
         getAttachmentPointNumberFromLabel(attachmentPointName);
       return pointNumber > 2;
@@ -623,33 +680,32 @@ const validateAttachmentPoints = (attachmentPoints: AttachmentPointName[]) => {
   );
 
   if (sideAttachmentPoints.length === 0) {
-    return { notifications, problematicAttachmentPoints };
+    return { notifications, problematicAttachmentPointAtomIds };
   }
 
   const expectedSequence: number[] = [];
-  for (let i = 3; i < 3 + sideAttachmentPoints.length; i++) {
+  const actualNumbers = sideAttachmentPoints
+    .map(({ name }) => getAttachmentPointNumberFromLabel(name))
+    .sort((a, b) => a - b);
+
+  for (let i = 3; i < 3 + actualNumbers.length; i++) {
     expectedSequence.push(i);
   }
 
-  const actualNumbers = sideAttachmentPoints
-    .map(getAttachmentPointNumberFromLabel)
-    .sort((a, b) => a - b);
-
-  actualNumbers.forEach((actualNumber) => {
-    if (!expectedSequence.includes(actualNumber)) {
-      const problematicPointName = getAttachmentPointLabel(actualNumber);
-      problematicAttachmentPoints.add(problematicPointName);
+  sideAttachmentPoints.forEach(({ name, attachmentAtomId }) => {
+    if (!expectedSequence.includes(getAttachmentPointNumberFromLabel(name))) {
+      problematicAttachmentPointAtomIds.add(attachmentAtomId);
     }
   });
 
-  if (problematicAttachmentPoints.size > 0) {
+  if (problematicAttachmentPointAtomIds.size > 0) {
     notifications.set('incorrectAttachmentPointsOrder', {
       type: 'error',
       message: NotificationMessages.incorrectAttachmentPointsOrder,
     });
   }
 
-  return { notifications, problematicAttachmentPoints };
+  return { notifications, problematicAttachmentPointAtomIds };
 };
 
 const validateStructure = (structure: Struct, editor: Editor) => {
@@ -769,6 +825,10 @@ const MonomerCreationWizardInternal = ({
 
   const [attachmentPointEditPopupData, setAttachmentPointEditPopupData] =
     useState<AttachmentPointClickData | null>(null);
+  const [attachmentPointNameOverrides, setAttachmentPointNameOverrides] =
+    useState<AttachmentPointNameOverrides>(new Map());
+  const [invalidAttachmentPointAtomIds, setInvalidAttachmentPointAtomIds] =
+    useState<Set<number>>(new Set());
 
   const {
     values,
@@ -832,6 +892,8 @@ const MonomerCreationWizardInternal = ({
       rnaPresetWizardState.sugar.structure,
     ],
   );
+  const { assignedAttachmentPoints } = monomerCreationState;
+
   const notifications = isRnaPresetType
     ? new Map([
         ...(rnaPresetWizardState.preset.notifications || []),
@@ -1005,6 +1067,9 @@ const MonomerCreationWizardInternal = ({
     rnaPresetWizardStateDispatch({ type: 'ResetWizard' });
     setPhosphatePosition(undefined);
     setAttachmentPointEditPopupData(null);
+    setAttachmentPointNameOverrides(new Map());
+    setInvalidAttachmentPointAtomIds(new Set());
+    editor.setAttachmentPointNameOverrides(new Map());
   };
 
   const handlePhosphatePositionChange = useCallback(
@@ -1034,8 +1099,17 @@ const MonomerCreationWizardInternal = ({
   const handleAttachmentPointNameChange = (
     currentName: AttachmentPointName,
     newName: AttachmentPointName,
+    attachmentAtomId: number,
   ) => {
-    editor.reassignAttachmentPoint(currentName, newName);
+    setInvalidAttachmentPointAtomIds(new Set());
+    const nextOverrides = new Map(attachmentPointNameOverrides);
+    if (currentName === newName) {
+      nextOverrides.delete(attachmentAtomId);
+    } else {
+      nextOverrides.set(attachmentAtomId, newName);
+    }
+    setAttachmentPointNameOverrides(nextOverrides);
+    editor.setAttachmentPointNameOverrides(nextOverrides);
   };
 
   const handleLeavingAtomChange = (
@@ -1044,6 +1118,33 @@ const MonomerCreationWizardInternal = ({
   ) => {
     editor.changeLeavingAtomLabel(apName, newLeavingAtomLabel);
   };
+
+  useEffect(() => {
+    const activeAttachmentAtomIds = new Set(
+      Array.from(assignedAttachmentPoints.values()).map(
+        ([attachmentAtomId]) => attachmentAtomId,
+      ),
+    );
+
+    setAttachmentPointNameOverrides((prev) => {
+      const next = new Map(
+        Array.from(prev.entries()).filter(([attachmentAtomId]) =>
+          activeAttachmentAtomIds.has(attachmentAtomId),
+        ),
+      );
+
+      return next.size === prev.size ? prev : next;
+    });
+    setInvalidAttachmentPointAtomIds((prev) => {
+      const next = new Set(
+        Array.from(prev).filter((attachmentAtomId) =>
+          activeAttachmentAtomIds.has(attachmentAtomId),
+        ),
+      );
+
+      return next.size === prev.size ? prev : next;
+    });
+  }, [assignedAttachmentPoints]);
 
   const handleAttachmentPointEditPopupClose = () => {
     setAttachmentPointEditPopupData(null);
@@ -1146,8 +1247,6 @@ const MonomerCreationWizardInternal = ({
     handlePhosphatePositionChange,
   ]);
 
-  const { assignedAttachmentPoints } = monomerCreationState;
-
   const validateMonomerWizard = (
     assignedAttachmentPointsByMonomer: AssignedAttachmentPointsByMonomerType,
   ) => {
@@ -1183,18 +1282,30 @@ const MonomerCreationWizardInternal = ({
 
     const {
       notifications: attachmentPointsNotifications,
-      problematicAttachmentPoints,
+      problematicAttachmentPointAtomIds,
     } = validateAttachmentPoints(
-      Array.from(monomerAssignedAttachmentPoints.keys()),
+      getEffectiveAttachmentPointEntries(
+        monomerAssignedAttachmentPoints,
+        attachmentPointNameOverrides,
+      ).map(({ displayName, atomPair }) => ({
+        name: displayName,
+        attachmentAtomId: atomPair[0],
+      })),
     );
     if (attachmentPointsNotifications.size > 0) {
       wizardStateDispatch({
         type: 'SetNotifications',
         notifications: attachmentPointsNotifications,
       });
-      editor.setProblematicAttachmentPoints(problematicAttachmentPoints);
+      setInvalidAttachmentPointAtomIds(problematicAttachmentPointAtomIds);
+      editor.setProblematicAttachmentPoints(new Set());
       return;
     }
+
+    const resolvedAttachmentPoints = getResolvedAttachmentPoints(
+      monomerAssignedAttachmentPoints,
+      attachmentPointNameOverrides,
+    );
 
     const {
       errors: modificationTypesErrors,
@@ -1225,7 +1336,7 @@ const MonomerCreationWizardInternal = ({
       const leavingGroupNotifications = validateMonomerLeavingGroups(
         editor,
         type,
-        monomerAssignedAttachmentPoints,
+        resolvedAttachmentPoints,
       );
       if (leavingGroupNotifications.size > 0) {
         needSaveMonomers = false;
@@ -1242,6 +1353,7 @@ const MonomerCreationWizardInternal = ({
     assignedAttachmentPointsByMonomer: AssignedAttachmentPointsByMonomerType,
   ) => {
     let needSaveMonomers = true;
+    const problematicAttachmentPointAtomIdsForSubmit = new Set<number>();
     const componentsToValidate: Array<{
       name: Exclude<RnaPresetWizardStateFieldId, 'preset'>;
       wizardState: WizardState;
@@ -1495,6 +1607,32 @@ const MonomerCreationWizardInternal = ({
         return;
       }
 
+      const {
+        notifications: attachmentPointsNotifications,
+        problematicAttachmentPointAtomIds,
+      } = validateAttachmentPoints(
+        getEffectiveAttachmentPointEntries(
+          monomerAssignedAttachmentPoints,
+          attachmentPointNameOverrides,
+        ).map(({ displayName, atomPair }) => ({
+          name: displayName,
+          attachmentAtomId: atomPair[0],
+        })),
+      );
+      if (attachmentPointsNotifications.size > 0) {
+        needSaveMonomers = false;
+        problematicAttachmentPointAtomIds.forEach((attachmentAtomId) => {
+          problematicAttachmentPointAtomIdsForSubmit.add(attachmentAtomId);
+        });
+        rnaPresetWizardStateDispatch({
+          type: 'SetNotifications',
+          notifications: attachmentPointsNotifications,
+          rnaComponentKey,
+          editor,
+        });
+        return;
+      }
+
       const structure = editor.structSelected(wizardState.structure);
       const { values: valuesToSave } = wizardState;
 
@@ -1536,6 +1674,13 @@ const MonomerCreationWizardInternal = ({
       }
     });
 
+    if (problematicAttachmentPointAtomIdsForSubmit.size > 0) {
+      setInvalidAttachmentPointAtomIds(
+        new Set(problematicAttachmentPointAtomIdsForSubmit),
+      );
+      editor.setProblematicAttachmentPoints(new Set());
+    }
+
     return needSaveMonomers;
   };
 
@@ -1555,6 +1700,7 @@ const MonomerCreationWizardInternal = ({
     editor.setProblematicAttachmentPoints(new Set());
     editor.setProblematicAtoms(new Set());
     setHasActiveRnaPresetAtomValidationErrors(false);
+    setInvalidAttachmentPointAtomIds(new Set());
 
     const monomersToSave = isRnaPresetType
       ? getRnaPresetComponentKeysToSave(rnaPresetWizardState).map(
@@ -1611,6 +1757,20 @@ const MonomerCreationWizardInternal = ({
     // validation
     const needSaveMonomers = validateOnSubmit(
       assignedAttachmentPointsByMonomer,
+    );
+
+    const resolvedAssignedAttachmentPointsByMonomer: AssignedAttachmentPointsByMonomerType =
+      new Map();
+    assignedAttachmentPointsByMonomer.forEach(
+      (monomerAssignedAttachmentPoints, monomerWizardState) => {
+        resolvedAssignedAttachmentPointsByMonomer.set(
+          monomerWizardState,
+          getResolvedAttachmentPoints(
+            monomerAssignedAttachmentPoints,
+            attachmentPointNameOverrides,
+          ),
+        );
+      },
     );
 
     // save
@@ -1693,7 +1853,9 @@ const MonomerCreationWizardInternal = ({
           editor.assignConnectionPointAtom(
             baseR1AttachmentPointAtomId,
             AttachmentPointName.R1,
-            assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.base),
+            resolvedAssignedAttachmentPointsByMonomer.get(
+              rnaPresetWizardState.base,
+            ),
             rnaPresetWizardState.base.structure,
             true,
             getConnectionLeavingAtom(
@@ -1705,7 +1867,9 @@ const MonomerCreationWizardInternal = ({
           editor.assignConnectionPointAtom(
             sugarR3AttachmentPointAtomId,
             AttachmentPointName.R3,
-            assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.sugar),
+            resolvedAssignedAttachmentPointsByMonomer.get(
+              rnaPresetWizardState.sugar,
+            ),
             rnaPresetWizardState.sugar.structure,
             true,
             getConnectionLeavingAtom(
@@ -1743,7 +1907,9 @@ const MonomerCreationWizardInternal = ({
           editor.assignConnectionPointAtom(
             sugarPhosphateAttachmentPointAtomId,
             sugarPhosphateAttachmentPointName,
-            assignedAttachmentPointsByMonomer.get(rnaPresetWizardState.sugar),
+            resolvedAssignedAttachmentPointsByMonomer.get(
+              rnaPresetWizardState.sugar,
+            ),
             rnaPresetWizardState.sugar.structure,
             true,
             getConnectionLeavingAtom(
@@ -1755,7 +1921,7 @@ const MonomerCreationWizardInternal = ({
           editor.assignConnectionPointAtom(
             phosphateSugarAttachmentPointAtomId,
             phosphateSugarAttachmentPointName,
-            assignedAttachmentPointsByMonomer.get(
+            resolvedAssignedAttachmentPointsByMonomer.get(
               rnaPresetWizardState.phosphate,
             ),
             rnaPresetWizardState.phosphate.structure,
@@ -1778,7 +1944,7 @@ const MonomerCreationWizardInternal = ({
           bondIdMap,
         );
         const monomerAssignedAttachmentPoints =
-          assignedAttachmentPointsByMonomer.get(monomerToSave);
+          resolvedAssignedAttachmentPointsByMonomer.get(monomerToSave);
 
         monomerAssignedAttachmentPoints?.forEach(
           ([attachmentAtomId, leavingGroupAtomId], attachmentPointKey) => {
@@ -1919,6 +2085,9 @@ const MonomerCreationWizardInternal = ({
                 editor={editor}
                 phosphatePosition={phosphatePosition}
                 onPhosphatePositionChange={handlePhosphatePositionChange}
+                attachmentPointDisplayNames={attachmentPointNameOverrides}
+                invalidAttachmentPointAtomIds={invalidAttachmentPointAtomIds}
+                onAttachmentPointNameChange={handleAttachmentPointNameChange}
                 connectionLeavingAtoms={connectionLeavingAtoms}
                 onConnectionLeavingAtomChange={
                   handleConnectionLeavingAtomChange
@@ -1928,12 +2097,15 @@ const MonomerCreationWizardInternal = ({
               <MonomerCreationWizardFields
                 wizardState={wizardState}
                 assignedAttachmentPoints={assignedAttachmentPoints}
+                attachmentPointDisplayNames={attachmentPointNameOverrides}
+                invalidAttachmentPointAtomIds={invalidAttachmentPointAtomIds}
                 onFieldChange={(fieldId: WizardFormFieldId, value: string) => {
                   handleFieldChange(fieldId, value);
                 }}
                 onChangeModificationTypes={(modificationTypes: string[]) => {
                   setModificationTypes(modificationTypes);
                 }}
+                onAttachmentPointNameChange={handleAttachmentPointNameChange}
               />
             )}
           </div>
@@ -1947,6 +2119,7 @@ const MonomerCreationWizardInternal = ({
               onLeavingAtomChange={handleLeavingAtomChange}
               onClose={handleAttachmentPointEditPopupClose}
               editor={editor}
+              attachmentPointDisplayNames={attachmentPointNameOverrides}
             />,
             ketcherEditorRootElement,
           )}

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -96,12 +96,37 @@ const initialWizardState: WizardState = getInitialWizardState();
 
 type AttachmentPointNameOverrides = Map<number, AttachmentPointName>;
 
+/**
+ * Key-based equality for override maps: equal when they have the same atom ids
+ * mapped to the same display names. Used to skip no-op state/editor updates
+ * even when entries are simultaneously added and removed in the same tick.
+ */
+const areOverrideMapsEqual = (
+  a: AttachmentPointNameOverrides,
+  b: AttachmentPointNameOverrides,
+): boolean => {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const [atomId, name] of a) {
+    if (b.get(atomId) !== name) {
+      return false;
+    }
+  }
+  return true;
+};
+
 type EffectiveAttachmentPoint = {
   internalName: AttachmentPointName;
   displayName: AttachmentPointName;
   atomPair: [number, number];
 };
 
+/**
+ * Maps each assigned AP to its effective entry, combining the stable internal
+ * R-label, the display name (override if present, else internal), and the
+ * [attachment atom id, leaving atom id] pair. Base for the two helpers below.
+ */
 const getEffectiveAttachmentPointEntries = (
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
   overrides: AttachmentPointNameOverrides,
@@ -115,6 +140,10 @@ const getEffectiveAttachmentPointEntries = (
   );
 };
 
+/**
+ * Builds the map persisted on save: keyed by display name (internal name +
+ * overrides applied), dropping the internal name. Used by the save pipeline.
+ */
 const getResolvedAttachmentPoints = (
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
   overrides: AttachmentPointNameOverrides,
@@ -128,6 +157,10 @@ const getResolvedAttachmentPoints = (
   }, new Map<AttachmentPointName, [number, number]>());
 };
 
+/**
+ * Builds the list fed to AP validation: each entry is the display name plus its
+ * attachment atom id, so validation can report problems back by atom id.
+ */
 const getAttachmentPointsToValidate = (
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>,
   overrides: AttachmentPointNameOverrides,
@@ -1081,6 +1114,7 @@ const MonomerCreationWizardInternal = ({
     setAttachmentPointNameOverrides(new Map());
     setInvalidAttachmentPointAtomIds(new Set());
     editor.setAttachmentPointNameOverrides(new Map());
+    editor.setProblematicAttachmentPointAtomIds(new Set());
   };
 
   const handlePhosphatePositionChange = useCallback(
@@ -1112,7 +1146,17 @@ const MonomerCreationWizardInternal = ({
     newName: AttachmentPointName,
     attachmentAtomId: number,
   ) => {
-    setInvalidAttachmentPointAtomIds(new Set());
+    // Clear only the renamed atom's invalid flag. A rename may not resolve the
+    // violation (e.g. R1/R1 → R1/R5 still breaks the side-AP order rule), so
+    // wholesale-clearing would give a false "fixed" signal until resubmit.
+    setInvalidAttachmentPointAtomIds((prev) => {
+      if (!prev.has(attachmentAtomId)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(attachmentAtomId);
+      return next;
+    });
     const nextOverrides = new Map(attachmentPointNameOverrides);
     if (currentName === newName) {
       nextOverrides.delete(attachmentAtomId);
@@ -1137,15 +1181,18 @@ const MonomerCreationWizardInternal = ({
       ),
     );
 
-    setAttachmentPointNameOverrides((prev) => {
-      const next = new Map(
-        Array.from(prev.entries()).filter(([attachmentAtomId]) =>
-          activeAttachmentAtomIds.has(attachmentAtomId),
-        ),
-      );
+    const prunedOverrides = new Map(
+      Array.from(attachmentPointNameOverrides.entries()).filter(
+        ([attachmentAtomId]) => activeAttachmentAtomIds.has(attachmentAtomId),
+      ),
+    );
+    if (!areOverrideMapsEqual(attachmentPointNameOverrides, prunedOverrides)) {
+      setAttachmentPointNameOverrides(prunedOverrides);
+      // Keep the editor's mirror in sync so its monomerCreationState does not
+      // retain overrides for atoms whose AP was removed.
+      editor.setAttachmentPointNameOverrides(prunedOverrides);
+    }
 
-      return next.size === prev.size ? prev : next;
-    });
     setInvalidAttachmentPointAtomIds((prev) => {
       const next = new Set(
         Array.from(prev).filter((attachmentAtomId) =>
@@ -1155,7 +1202,7 @@ const MonomerCreationWizardInternal = ({
 
       return next.size === prev.size ? prev : next;
     });
-  }, [assignedAttachmentPoints]);
+  }, [assignedAttachmentPoints, attachmentPointNameOverrides, editor]);
 
   const handleAttachmentPointEditPopupClose = () => {
     setAttachmentPointEditPopupData(null);
@@ -1306,7 +1353,9 @@ const MonomerCreationWizardInternal = ({
         notifications: attachmentPointsNotifications,
       });
       setInvalidAttachmentPointAtomIds(problematicAttachmentPointAtomIds);
-      editor.setProblematicAttachmentPoints(new Set());
+      editor.setProblematicAttachmentPointAtomIds(
+        problematicAttachmentPointAtomIds,
+      );
       return;
     }
 
@@ -1688,7 +1737,9 @@ const MonomerCreationWizardInternal = ({
       setInvalidAttachmentPointAtomIds(
         new Set(problematicAttachmentPointAtomIdsForSubmit),
       );
-      editor.setProblematicAttachmentPoints(new Set());
+      editor.setProblematicAttachmentPointAtomIds(
+        new Set(problematicAttachmentPointAtomIdsForSubmit),
+      );
     }
 
     return needSaveMonomers;
@@ -1707,7 +1758,20 @@ const MonomerCreationWizardInternal = ({
   const handleSubmit = () => {
     wizardStateDispatch({ type: 'ResetErrors' });
     rnaPresetWizardStateDispatch({ type: 'ResetErrors' });
+    // Clear AP validation notifications from any previous submit so that a rule
+    // no longer violated (e.g. duplicate AP names) does not linger alongside a
+    // newly failing rule (e.g. incorrect order) after the user fixes the first.
+    const attachmentPointNotificationIds: WizardNotificationId[] = [
+      'noAttachmentPoints',
+      'attachmentPointsNotUnique',
+      'incorrectAttachmentPointsOrder',
+    ];
+    attachmentPointNotificationIds.forEach((id) => {
+      wizardStateDispatch({ type: 'RemoveNotification', id });
+      rnaPresetWizardStateDispatch({ type: 'RemoveNotification', id });
+    });
     editor.setProblematicAttachmentPoints(new Set());
+    editor.setProblematicAttachmentPointAtomIds(new Set());
     editor.setProblematicAtoms(new Set());
     setHasActiveRnaPresetAtomValidationErrors(false);
     setInvalidAttachmentPointAtomIds(new Set());

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -1607,30 +1607,35 @@ const MonomerCreationWizardInternal = ({
         return;
       }
 
-      const {
-        notifications: attachmentPointsNotifications,
-        problematicAttachmentPointAtomIds,
-      } = validateAttachmentPoints(
-        getEffectiveAttachmentPointEntries(
-          monomerAssignedAttachmentPoints,
-          attachmentPointNameOverrides,
-        ).map(({ displayName, atomPair }) => ({
-          name: displayName,
-          attachmentAtomId: atomPair[0],
-        })),
-      );
-      if (attachmentPointsNotifications.size > 0) {
-        needSaveMonomers = false;
-        problematicAttachmentPointAtomIds.forEach((attachmentAtomId) => {
-          problematicAttachmentPointAtomIdsForSubmit.add(attachmentAtomId);
-        });
-        rnaPresetWizardStateDispatch({
-          type: 'SetNotifications',
+      // Only validate attachment point names when the component has explicit
+      // user-assigned R-groups. RNA preset components without attachment points
+      // are valid — their connection points are auto-generated on submit.
+      if (monomerAssignedAttachmentPoints.size > 0) {
+        const {
           notifications: attachmentPointsNotifications,
-          rnaComponentKey,
-          editor,
-        });
-        return;
+          problematicAttachmentPointAtomIds,
+        } = validateAttachmentPoints(
+          getEffectiveAttachmentPointEntries(
+            monomerAssignedAttachmentPoints,
+            attachmentPointNameOverrides,
+          ).map(({ displayName, atomPair }) => ({
+            name: displayName,
+            attachmentAtomId: atomPair[0],
+          })),
+        );
+        if (attachmentPointsNotifications.size > 0) {
+          needSaveMonomers = false;
+          problematicAttachmentPointAtomIds.forEach((attachmentAtomId) => {
+            problematicAttachmentPointAtomIdsForSubmit.add(attachmentAtomId);
+          });
+          rnaPresetWizardStateDispatch({
+            type: 'SetNotifications',
+            notifications: attachmentPointsNotifications,
+            rnaComponentKey,
+            editor,
+          });
+          return;
+        }
       }
 
       const structure = editor.structSelected(wizardState.structure);

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizardFields.tsx
@@ -40,12 +40,19 @@ import { getMonomerPropertyVisibility } from './MonomerCreationWizardFields.util
 interface IMonomerCreationWizardFieldsProps {
   wizardState: WizardState;
   assignedAttachmentPoints: Map<AttachmentPointName, [number, number]>;
+  attachmentPointDisplayNames?: Map<number, AttachmentPointName>;
+  invalidAttachmentPointAtomIds?: Set<number>;
   readonlyAttachmentPoints?: Array<{
     name: AttachmentPointName;
     leavingAtomLabel: AtomLabel;
   }>;
   onChangeModificationTypes?: (modificationTypes: string[]) => void;
   onFieldChange: (fieldId: StringWizardFormFieldId, value: string) => void;
+  onAttachmentPointNameChange?: (
+    currentName: AttachmentPointName,
+    newName: AttachmentPointName,
+    attachmentAtomId: number,
+  ) => void;
   onReadonlyLeavingAtomChange?: (
     apName: AttachmentPointName,
     newLeavingAtomLabel: AtomLabel,
@@ -68,9 +75,12 @@ const MonomerCreationWizardFields = (
   const {
     wizardState,
     assignedAttachmentPoints,
+    attachmentPointDisplayNames,
+    invalidAttachmentPointAtomIds,
     readonlyAttachmentPoints = [],
     onChangeModificationTypes,
     onFieldChange,
+    onAttachmentPointNameChange,
     onReadonlyLeavingAtomChange,
     attachmentPointsExtra,
   } = props;
@@ -119,8 +129,9 @@ const MonomerCreationWizardFields = (
   const handleAttachmentPointNameChange = (
     currentName: AttachmentPointName,
     newName: AttachmentPointName,
+    attachmentAtomId: number,
   ) => {
-    editor.reassignAttachmentPoint(currentName, newName);
+    onAttachmentPointNameChange?.(currentName, newName, attachmentAtomId);
   };
 
   const handleLeavingAtomChange = (
@@ -147,6 +158,11 @@ const MonomerCreationWizardFields = (
     displayHelmAlias,
     displayBilnAlias,
   } = getMonomerPropertyVisibility(type);
+  const attachmentPointNames = Array.from(
+    assignedAttachmentPoints.entries(),
+  ).map(([name, [attachmentAtomId]]) => {
+    return attachmentPointDisplayNames?.get(attachmentAtomId) ?? name;
+  });
 
   return (
     <div>
@@ -234,10 +250,15 @@ const MonomerCreationWizardFields = (
               ([name, atomPair]) => (
                 <AttachmentPoint
                   name={name}
+                  displayName={
+                    attachmentPointDisplayNames?.get(atomPair[0]) ?? name
+                  }
                   editor={editor}
                   onNameChange={handleAttachmentPointNameChange}
                   onLeavingAtomChange={handleLeavingAtomChange}
                   onRemove={handleAttachmentPointRemove}
+                  usedAttachmentPointNames={attachmentPointNames}
+                  invalid={invalidAttachmentPointAtomIds?.has(atomPair[0])}
                   key={`${name}-${atomPair[0]}-${atomPair[1]}`}
                 />
               ),

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
@@ -56,6 +56,13 @@ interface IRnaPresetTabsProps {
   wizardStateDispatch: (action: RnaPresetWizardAction) => void;
   phosphatePosition: '3' | '5' | undefined;
   onPhosphatePositionChange: (position: '3' | '5') => void;
+  attachmentPointDisplayNames?: Map<number, AttachmentPointName>;
+  invalidAttachmentPointAtomIds?: Set<number>;
+  onAttachmentPointNameChange?: (
+    currentName: AttachmentPointName,
+    newName: AttachmentPointName,
+    attachmentAtomId: number,
+  ) => void;
   /** User-overridden leaving atom labels for connection APs, keyed by
    * "<componentKey>:<apName>". Persists across tab switches. */
   connectionLeavingAtoms?: Map<string, AtomLabel>;
@@ -84,6 +91,9 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
   const currentTabState = wizardState[RNA_COMPONENT_KEYS[selectedTab - 1]];
   const {
     phosphatePosition,
+    attachmentPointDisplayNames,
+    invalidAttachmentPointAtomIds,
+    onAttachmentPointNameChange,
     onPhosphatePositionChange,
     onConnectionLeavingAtomChange,
     connectionLeavingAtoms,
@@ -216,13 +226,6 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
     onPhosphatePositionChange(position);
   };
 
-  const handleAttachmentPointNameChange = (
-    currentName: AttachmentPointName,
-    newName: AttachmentPointName,
-  ) => {
-    editor.reassignAttachmentPoint(currentName, newName);
-  };
-
   const handleLeavingAtomChange = (
     apName: AttachmentPointName,
     newLeavingAtomLabel: AtomLabel,
@@ -235,6 +238,12 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
   };
 
   const currentTabStructure = currentTabState?.structure;
+  const presetAttachmentPointNames = Array.from(
+    presetAttachmentPoints.entries(),
+  ).map(
+    ([name, [attachmentAtomId]]) =>
+      attachmentPointDisplayNames?.get(attachmentAtomId) ?? name,
+  );
 
   useEffect(() => {
     if (!currentTabStructure) {
@@ -415,10 +424,19 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
                     ([name, atomPair]) => (
                       <AttachmentPoint
                         name={name}
+                        displayName={
+                          attachmentPointDisplayNames?.get(atomPair[0]) ?? name
+                        }
                         editor={editor}
-                        onNameChange={handleAttachmentPointNameChange}
+                        onNameChange={
+                          onAttachmentPointNameChange ?? (() => null)
+                        }
                         onLeavingAtomChange={handleLeavingAtomChange}
                         onRemove={handleAttachmentPointRemove}
+                        usedAttachmentPointNames={presetAttachmentPointNames}
+                        invalid={invalidAttachmentPointAtomIds?.has(
+                          atomPair[0],
+                        )}
                         key={`${name}-${atomPair[0]}-${atomPair[1]}`}
                       />
                     ),
@@ -450,9 +468,12 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
                   assignedAttachmentPoints={
                     componentAttachmentPoints[rnaComponentKey]
                   }
+                  attachmentPointDisplayNames={attachmentPointDisplayNames}
+                  invalidAttachmentPointAtomIds={invalidAttachmentPointAtomIds}
                   readonlyAttachmentPoints={
                     readonlyComponentAttachmentPoints[rnaComponentKey]
                   }
+                  onAttachmentPointNameChange={onAttachmentPointNameChange}
                   showNaturalAnalogue={rnaComponentKey === 'base'}
                   attachmentPointsExtra={
                     rnaComponentKey === 'phosphate' ? (

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPoint/AttachmentPoint.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPoint/AttachmentPoint.tsx
@@ -9,24 +9,31 @@ import { useEffect, useRef, useState } from 'react';
 
 type Props = {
   name: AttachmentPointName;
+  displayName?: AttachmentPointName;
   editor: Editor;
   onNameChange: (
     currentName: AttachmentPointName,
     newName: AttachmentPointName,
+    attachmentAtomId: number,
   ) => void;
   onLeavingAtomChange: (
     apName: AttachmentPointName,
     newLeavingAtomLabel: AtomLabel,
   ) => void;
   onRemove: (name: AttachmentPointName) => void;
+  usedAttachmentPointNames?: AttachmentPointName[];
+  invalid?: boolean;
 };
 
 const AttachmentPoint = ({
   name,
+  displayName,
   editor,
   onNameChange,
   onLeavingAtomChange,
   onRemove,
+  usedAttachmentPointNames,
+  invalid,
 }: Props) => {
   const attachmentPointsContainerRef = useRef<HTMLDivElement>(null);
 
@@ -90,15 +97,20 @@ const AttachmentPoint = ({
     };
   }, [name]);
 
-  const selectsData = useAttachmentPointSelectsData(editor, name);
+  const selectsData = useAttachmentPointSelectsData(
+    editor,
+    name,
+    displayName ?? name,
+    usedAttachmentPointNames,
+  );
 
   if (!selectsData) {
     return null;
   }
 
   const handleNameChange = (newName: AttachmentPointName) => {
-    if (newName !== name) {
-      onNameChange(name, newName);
+    if (newName !== (displayName ?? name)) {
+      onNameChange(name, newName, selectsData.attachmentAtomId);
     }
   };
 
@@ -117,6 +129,7 @@ const AttachmentPoint = ({
       onLeavingAtomChange={handleLeavingAtomChange}
       className={styles.selects}
       highlight={highlight}
+      invalid={invalid}
       additionalControls={
         <button
           className={styles.removeButton}

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPointControls/AttachmentPointControls.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/AttachmentPointControls/AttachmentPointControls.tsx
@@ -12,6 +12,7 @@ type Props = {
   className?: string;
   additionalControls?: ReactNode;
   highlight?: boolean;
+  invalid?: boolean;
   isPopup?: boolean;
   disabled?: boolean;
   /** Disable only the name select, leaving the leaving-atom select editable */
@@ -29,6 +30,7 @@ const AttachmentPointControls = forwardRef<HTMLDivElement, Props>(
       className,
       additionalControls,
       highlight,
+      invalid,
       isPopup,
       disabled,
       disabledName,
@@ -68,6 +70,7 @@ const AttachmentPointControls = forwardRef<HTMLDivElement, Props>(
           onChange={handleNameChange}
           disabled={disabled || disabledName}
           title={disabledName ? nameTooltip : undefined}
+          error={invalid}
           data-testid={
             isPopup
               ? `attachment-point-name-select`

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/hooks/useAttachmentPointSelectsData.tsx
@@ -7,6 +7,7 @@ import type { Editor } from '../../../../../editor';
 import type { Option } from '../../../../component/form/Select';
 
 export type AttachmentPointSelectData = {
+  attachmentAtomId: number;
   nameOptions: Array<Option>;
   leavingAtomOptions: Array<Option>;
   currentNameOption?: Option;
@@ -85,6 +86,7 @@ export const createReadonlyAttachmentPointSelectData = (
   } = buildLeavingAtomOptions(leavingAtomLabel);
 
   return {
+    attachmentAtomId: -1,
     nameOptions: [currentNameOption],
     leavingAtomOptions,
     currentNameOption,
@@ -95,6 +97,8 @@ export const createReadonlyAttachmentPointSelectData = (
 export const useAttachmentPointSelectsData = (
   editor: Editor,
   attachmentPointName: AttachmentPointName,
+  currentDisplayName: AttachmentPointName = attachmentPointName,
+  usedAttachmentPointNames?: AttachmentPointName[],
 ): AttachmentPointSelectData | null => {
   if (!editor.monomerCreationState) {
     return null;
@@ -118,7 +122,9 @@ export const useAttachmentPointSelectsData = (
     return null;
   }
 
-  const usedNumbers = Array.from(assignedAttachmentPoints.keys()).map((name) =>
+  const namesForOptions =
+    usedAttachmentPointNames ?? Array.from(assignedAttachmentPoints.keys());
+  const usedNumbers = namesForOptions.map((name) =>
     getAttachmentPointNumberFromLabel(name),
   );
   const maxUsedNumber = Math.max(...usedNumbers);
@@ -146,10 +152,14 @@ export const useAttachmentPointSelectsData = (
   );
 
   const currentNameOption = nameOptions.find(
-    (option) => option.value === attachmentPointName,
-  );
+    (option) => option.value === currentDisplayName,
+  ) ?? {
+    value: currentDisplayName,
+    label: currentDisplayName,
+  };
 
   return {
+    attachmentAtomId,
     nameOptions,
     leavingAtomOptions,
     currentNameOption,


### PR DESCRIPTION
## Problem

R-group (attachment point) labels could not be correctly renamed in the Monomer Creation Wizard. AP names served as both stable internal keys and mutable display values, causing validation, canvas highlighting, and save logic to break on rename. Duplicate AP names had no validation.

## Solution

Renames are now stored as display-only overrides (`atomId → newName`) without touching the internal AP map. The canvas renders overrides; validation runs against display names + atom IDs; on save, overrides are folded into the final persisted map.

## Changes

**`ketcher-core`**
- Added `attachmentPointNameOverrides` and `problematicAttachmentPointAtomIds` to `MonomerCreationState`
- Canvas AP labels now render the display name (override if set, else internal R-label)
- Red-highlighting checks both AP-name set and atom-id set to cover all violation sources

**`ketcher-react` — Editor**
- Added `setAttachmentPointNameOverrides(overrides: Map<number, AttachmentPointName>)`
- Added `setProblematicAttachmentPointAtomIds(ids: Set<number>)`

**`ketcher-react` — Monomer Creation Wizard**
- `attachmentPointNameOverrides` state tracks pending renames by atom ID
- `validateAttachmentPoints` refactored to accept `{ name, attachmentAtomId }` objects; reports problems by atom ID for per-atom canvas highlighting
- Added duplicate AP name detection (`attachmentPointsNotUnique` notification)
- `useEffect` prunes overrides and invalid flags when APs are removed
- AP validation notifications cleared at submit start to prevent stale errors
- Overrides resolved into a final map before saving; internal state never mutated during editing

**`ketcher-react` — `AttachmentPointEditPopup`**
- Accepts `attachmentPointDisplayNames`; returns `attachmentAtomId` via `onNameChange`
- Shows current display name (override or internal) as the selected value

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request