### PR TITLE
#10156: give each error toast an independent 6-second auto-dismiss timer

### DIFF
--- a/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.1.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.1.0-bugs.spec.ts
@@ -627,39 +627,35 @@ test.describe('Ketcher bugs in 3.1.0', () => {
     });
   });
 
-  test.fail(
-    'Case 21: Changing of ambiguous base via RNA Builder on Sequence mode not causes sequence corruption',
-
-    async () => {
-      // Fails due to bug: https://github.com/epam/ketcher/issues/7512
-      /*
-       * Test case: https://github.com/epam/ketcher/issues/6602
-       * Bug: https://github.com/epam/ketcher/issues/6085
-       * Description: Changing of ambiguous base via RNA Builder on Sequence mode not causes sequence corruption.
-       * Scenario:
-       * 1. Go to Macro - Sequence mode <--- Important
-       * 2. Load from HELM
-       * 3. Select any N nucleotide and select Modify in RNA Builder
-       * 4. Select 4ime6A base from the library and press Update button
-       * 5. Take a screenshot
-       */
-      await pasteFromClipboardAndAddToMacromoleculesCanvas(
-        page,
-        MacroFileType.HELM,
-        'RNA1{R(A)P.R(A,C,G,T)P.R(A)}$$$$V2.0',
-      );
-      const symbolN = getSymbolLocator(page, { symbolAlias: 'N' }).first();
-      await symbolN.click();
-      await modifyInRnaBuilder(page, symbolN);
-      await Library(page).rnaBuilder.selectBaseSlot();
-      await Library(page).selectMonomer(Base._4ime6A);
-      await Library(page).rnaBuilder.save();
-      await takeEditorScreenshot(page, {
-        hideMonomerPreview: true,
-        hideMacromoleculeEditorScrollBars: true,
-      });
-    },
-  );
+  test('Case 21: Changing of ambiguous base via RNA Builder on Sequence mode not causes sequence corruption', async () => {
+    // Bug fixed: https://github.com/epam/ketcher/issues/7512
+    /*
+     * Test case: https://github.com/epam/ketcher/issues/6602
+     * Bug: https://github.com/epam/ketcher/issues/6085
+     * Description: Changing of ambiguous base via RNA Builder on Sequence mode not causes sequence corruption.
+     * Scenario:
+     * 1. Go to Macro - Sequence mode <--- Important
+     * 2. Load from HELM
+     * 3. Select any N nucleotide and select Modify in RNA Builder
+     * 4. Select 4ime6A base from the library and press Update button
+     * 5. Take a screenshot
+     */
+    await pasteFromClipboardAndAddToMacromoleculesCanvas(
+      page,
+      MacroFileType.HELM,
+      'RNA1{R(A)P.R(A,C,G,T)P.R(A)}$$$$V2.0',
+    );
+    const symbolN = getSymbolLocator(page, { symbolAlias: 'N' }).first();
+    await symbolN.click();
+    await modifyInRnaBuilder(page, symbolN);
+    await Library(page).rnaBuilder.selectBaseSlot();
+    await Library(page).selectMonomer(Base._4ime6A);
+    await Library(page).rnaBuilder.save();
+    await takeEditorScreenshot(page, {
+      hideMonomerPreview: true,
+      hideMacromoleculeEditorScrollBars: true,
+    });
+  });
 
   test('Case 22: Undo of deleted bond on sequence mode not causes "ghost" monomer appearence on the canvas', async () => {
     /*

--- a/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.13.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.13.0-bugs.spec.ts
@@ -708,8 +708,6 @@ test.describe('Bugs: ketcher-3.13.0 — Small molecules positioning rule', () =>
       'Minimal monomer structure is two atoms connected via a single bond.',
     );
 
-    await invalidPhosphatePositionMessage.ok();
-    await notMinimalViableStructureMessage.ok();
     await dialog.discard();
   });
 });

--- a/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.3.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.3.0-bugs.spec.ts
@@ -652,42 +652,36 @@ test.describe('Ketcher bugs in 3.3.0', () => {
     });
   });
 
-  test.fail(
-    'Case 21: Antisense complement is skipped when terminal monomer lacks an attachment point (R1/R2), not causing incorrect structure on canvas',
-
-    async () => {
-      // Fails due to the bug: https://github.com/epam/ketcher/issues/7516
-      /*
-       * Test case: https://github.com/epam/ketcher/issues/6937
-       * Bug: https://github.com/epam/ketcher/issues/6705
-       * Description: Antisense complement is skipped when terminal monomer lacks an attachment point (R1/R2), not causing incorrect structure on canvas.
-       * Scenario:
-       * 1. Go to Macro - Flex mode (clean canvas)
-       * 2. Load from HELM
-       * 3. Generate the antisense sequence.
-       * 4. Observe the canvas
-       */
-      await MacromoleculesTopToolbar(page).selectLayoutModeTool(
-        LayoutMode.Flex,
-      );
-      await pasteFromClipboardAndAddToMacromoleculesCanvas(
-        page,
-        MacroFileType.HELM,
-        'RNA1{R(A)P.R(A)P.R(A)}|PEPTIDE1{[Ala-ol]}$RNA1,PEPTIDE1,7:R2-1:R1$$$V2.0',
-      );
-      await takeEditorScreenshot(page, {
-        hideMonomerPreview: true,
-        hideMacromoleculeEditorScrollBars: true,
-      });
-      await selectAllStructuresOnCanvas(page);
-      const sugarR = getMonomerLocator(page, Sugar.R).nth(0);
-      await createRNAAntisenseChain(page, sugarR);
-      await takeEditorScreenshot(page, {
-        hideMonomerPreview: true,
-        hideMacromoleculeEditorScrollBars: true,
-      });
-    },
-  );
+  test('Case 21: Antisense complement is skipped when terminal monomer lacks an attachment point (R1/R2), not causing incorrect structure on canvas', async () => {
+    // Bug fixed: https://github.com/epam/ketcher/issues/7516
+    /*
+     * Test case: https://github.com/epam/ketcher/issues/6937
+     * Bug: https://github.com/epam/ketcher/issues/6705
+     * Description: Antisense complement is skipped when terminal monomer lacks an attachment point (R1/R2), not causing incorrect structure on canvas.
+     * Scenario:
+     * 1. Go to Macro - Flex mode (clean canvas)
+     * 2. Load from HELM
+     * 3. Generate the antisense sequence.
+     * 4. Observe the canvas
+     */
+    await MacromoleculesTopToolbar(page).selectLayoutModeTool(LayoutMode.Flex);
+    await pasteFromClipboardAndAddToMacromoleculesCanvas(
+      page,
+      MacroFileType.HELM,
+      'RNA1{R(A)P.R(A)P.R(A)}|PEPTIDE1{[Ala-ol]}$RNA1,PEPTIDE1,7:R2-1:R1$$$V2.0',
+    );
+    await takeEditorScreenshot(page, {
+      hideMonomerPreview: true,
+      hideMacromoleculeEditorScrollBars: true,
+    });
+    await selectAllStructuresOnCanvas(page);
+    const sugarR = getMonomerLocator(page, Sugar.R).nth(0);
+    await createRNAAntisenseChain(page, sugarR);
+    await takeEditorScreenshot(page, {
+      hideMonomerPreview: true,
+      hideMacromoleculeEditorScrollBars: true,
+    });
+  });
 
   test('Case 22: Removing dash should turn aligned nucleotide to nucleoside', async ({
     SequenceCanvas: _,

--- a/ketcher-autotests/tests/specs/Chromium-popup/Features/8464-Preset-Creation-Success-Messages.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Features/8464-Preset-Creation-Success-Messages.spec.ts
@@ -295,8 +295,6 @@ test.describe('Exiting the wizard - presets in the monomer creation wizard: ', (
     // No success message should appear
     await expect(NotificationBanner(page).message).not.toBeVisible();
 
-    await errorNotification.ok();
-
     // Fix the validation error
     await presetSection.openTab(NucleotidePresetTab.Preset);
     await presetSection.setName('ValidatedPreset');

--- a/ketcher-autotests/tests/specs/Chromium-popup/Features/8857-monomer-preset-saving-hidden-components.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Features/8857-monomer-preset-saving-hidden-components.spec.ts
@@ -567,7 +567,6 @@ test.describe('Monomer saving - presets in the monomer creation wizard: ', () =>
       ErrorMessage.symbolExists,
     );
     expect(await symbolExistsMessageBanner.isVisible()).toBeTruthy();
-    await symbolExistsMessageBanner.ok();
     await dialog.discard();
 
     // Now create preset with hidden monomer using same code - should succeed

--- a/ketcher-autotests/tests/specs/Chromium-popup/New-monomers/new-monomers.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/New-monomers/new-monomers.spec.ts
@@ -478,7 +478,6 @@ test(`13. Verify that creating a duplicate of a new item is not allowed for CHEM
   await createMonomerDialog.setCode(Chem.SCY5.alias);
   await createMonomerDialog.submit();
   expect(await symbolExistsMessageBanner.isVisible()).toBeTruthy();
-  await symbolExistsMessageBanner.ok();
 
   await createMonomerDialog.discard();
   await CommonTopRightToolbar(page).turnOnMacromoleculesEditor();
@@ -515,7 +514,6 @@ test(`14. Verify that creating a duplicate of a new item is not allowed for newl
     await createMonomerDialog.setCode(phosphate.alias);
     await createMonomerDialog.submit();
     expect(await symbolExistsMessageBanner.isVisible()).toBeTruthy();
-    await symbolExistsMessageBanner.ok();
   }
 
   await createMonomerDialog.discard();
@@ -552,7 +550,6 @@ test(`15. Verify that creating a duplicate of a new item is not allowed for newl
     await createMonomerDialog.setCode(nucleotide.alias);
     await createMonomerDialog.submit();
     expect(await symbolExistsMessageBanner.isVisible()).toBeTruthy();
-    await symbolExistsMessageBanner.ok();
   }
 
   await createMonomerDialog.discard();
@@ -589,7 +586,6 @@ test(`16. Verify that creating a duplicate of a new item is not allowed for newl
     await createMonomerDialog.setCode(chem.alias);
     await createMonomerDialog.submit();
     expect(await symbolExistsMessageBanner.isVisible()).toBeTruthy();
-    await symbolExistsMessageBanner.ok();
   }
 
   await createMonomerDialog.discard();

--- a/packages/ketcher-macromolecules/src/Editor.tsx
+++ b/packages/ketcher-macromolecules/src/Editor.tsx
@@ -331,7 +331,30 @@ function Editor({
     };
   }, [dispatch]);
 
-  const handleCloseErrorTooltip = (text?: string) => {
+  const toastTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  useEffect(() => {
+    errorTooltips.forEach((text) => {
+      if (!toastTimers.current.has(text)) {
+        const timer = setTimeout(() => {
+          dispatch(closeErrorTooltip(text));
+          toastTimers.current.delete(text);
+        }, 6000);
+        toastTimers.current.set(text, timer);
+      }
+    });
+
+    toastTimers.current.forEach((timer, text) => {
+      if (!errorTooltips.includes(text)) {
+        clearTimeout(timer);
+        toastTimers.current.delete(text);
+      }
+    });
+  }, [errorTooltips, dispatch]);
+
+  const handleCloseErrorTooltip = (text: string) => {
     dispatch(closeErrorTooltip(text));
   };
 
@@ -443,8 +466,6 @@ function Editor({
       <Snackbar
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         open={errorTooltips.length > 0}
-        onClose={() => handleCloseErrorTooltip()}
-        autoHideDuration={6000}
       >
         <StyledToastContainer
           id="error-tooltip-list"


### PR DESCRIPTION
## Summary

- Removed the shared `autoHideDuration={6000}` and `onClose` from the single `Snackbar` that wrapped all toasts.
- Added a per-toast `setTimeout` (6 s) started the moment each toast is pushed; only that toast is dismissed when its timer fires.
- `handleCloseErrorTooltip` now requires an explicit `text` argument, eliminating the "clear all" code path that the shared timer triggered.

## Problem

A single `Snackbar` with one `autoHideDuration={6000}` wrapped the full toast list. This caused two bugs:

1. A toast added shortly before the timer expired was cut short.
2. When the timer fired, `onClose` called `handleCloseErrorTooltip()` with no argument, which cleared **all** toasts — so a freshly added toast could vanish immediately.

## Solution

Replaced the shared MUI timer with a `Map<string, timeout>` ref that tracks one independent `setTimeout` per toast message. A `useEffect` watching `errorTooltips`:
- starts a new 6 s timer for each newly added toast
- cancels the timer for any toast that was manually dismissed before it expired

The `Snackbar` is now a pure positioning container; per-toast lifetime is managed in the component.

[The issue](https://github.com/orgs/epam/projects/45/views/2?pane=issue&itemId=195073043&issue=epam%7Cketcher%7C10156)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request