### PR TITLE
#9919 - Refactor: Public "static" fields should be read-only

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
+++ b/packages/ketcher-core/src/application/editor/operations/AlignDescriptors.ts
@@ -21,7 +21,7 @@ import { type SGroup, Vec2 } from 'domain/entities';
 
 class AlignDescriptors extends BaseOperation {
   readonly history: Record<number, Vec2 | null>;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     history: Record<number, Vec2 | null>,
   ) => BaseOperation;
 

--- a/packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentAdd.ts
@@ -23,7 +23,7 @@ import { OperationType } from './OperationType';
 class FragmentAdd extends BaseOperation {
   frid: number | null;
   readonly properties?: Array<StructProperty>;
-  static InverseConstructor: new (fragmentId: number) => BaseOperation;
+  static readonly InverseConstructor: new (fragmentId: number) => BaseOperation;
 
   constructor(fragmentId?: number | null, properties?: Array<StructProperty>) {
     super(OperationType.FRAGMENT_ADD);

--- a/packages/ketcher-core/src/application/editor/operations/FragmentAddStereoAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentAddStereoAtom.ts
@@ -20,7 +20,7 @@ import type { ReStruct } from '../../render';
 
 class FragmentAddStereoAtom extends BaseOperation {
   readonly data: { frid: number; aid: number };
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     fragmentId: number,
     atomId: number,
   ) => BaseOperation;

--- a/packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentDelete.ts
@@ -22,7 +22,7 @@ import { OperationType } from './OperationType';
 
 class FragmentDelete extends BaseOperation {
   readonly frid: number;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     fragmentId?: number | null,
     properties?: Array<StructProperty>,
   ) => BaseOperation;

--- a/packages/ketcher-core/src/application/editor/operations/FragmentDeleteStereoAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/FragmentDeleteStereoAtom.ts
@@ -20,7 +20,7 @@ import type { ReStruct } from '../../render';
 
 class FragmentDeleteStereoAtom extends BaseOperation {
   readonly data: { frid: number; aid: number };
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     fragmentId: number,
     atomId: number,
   ) => BaseOperation;

--- a/packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/RestoreIfThen.ts
@@ -22,7 +22,7 @@ class RestoreIfThen extends BaseOperation {
   readonly rgid_new: number;
   readonly rgid_old: number;
   readonly ifThenHistory: Map<number, number>;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     rgNew: number,
     rgOld: number,
     skipRgids?: Array<number>,

--- a/packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/UpdateIfThen.ts
@@ -23,7 +23,7 @@ class UpdateIfThen extends BaseOperation {
   readonly rgid_old: number;
   readonly ifThenHistory: Map<number, number>;
   readonly skipRgids: Array<number>;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     rgNew: number,
     rgOld: number,
     history: Map<number, number>,

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
@@ -34,7 +34,7 @@ type Data = {
 
 class AtomAdd extends BaseOperation {
   data: Data;
-  static InverseConstructor: new () => BaseOperation;
+  static readonly InverseConstructor: new () => BaseOperation;
 
   constructor(atom?: Partial<AtomAttributes>, pos?: Point) {
     super(OperationType.ATOM_ADD);

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
@@ -28,7 +28,7 @@ type Data = {
 
 class AtomDelete extends BaseOperation {
   data: Data;
-  static InverseConstructor: new () => BaseOperation;
+  static readonly InverseConstructor: new () => BaseOperation;
 
   constructor(atomId?: number) {
     super(OperationType.ATOM_DELETE, OperationPriority.ATOM_DELETE);

--- a/packages/ketcher-core/src/application/editor/operations/atom/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/index.ts
@@ -16,9 +16,10 @@
 
 import { AtomAdd } from './AtomAdd';
 import { AtomDelete } from './AtomDelete';
+import type { Writable } from 'utilities';
 
-AtomAdd.InverseConstructor = AtomDelete;
-AtomDelete.InverseConstructor = AtomAdd;
+(AtomAdd as Writable<typeof AtomAdd>).InverseConstructor = AtomDelete;
+(AtomDelete as Writable<typeof AtomDelete>).InverseConstructor = AtomAdd;
 
 export { AtomAdd, AtomDelete };
 export * from './AtomAttr';

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
@@ -30,7 +30,7 @@ type Data = {
 
 class BondAdd extends BaseOperation {
   data: Data;
-  static InverseConstructor: new (bondId?: number) => BaseOperation;
+  static readonly InverseConstructor: new (bondId?: number) => BaseOperation;
 
   constructor(
     begin?: number,

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts
@@ -30,7 +30,7 @@ type Data = {
 
 class BondDelete extends BaseOperation {
   data: Data;
-  static InverseConstructor: new (
+  static readonly InverseConstructor: new (
     begin?: number,
     end?: number,
     bond?: Partial<BondAttributes>,

--- a/packages/ketcher-core/src/application/editor/operations/bond/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/index.ts
@@ -16,9 +16,10 @@
 
 import { BondAdd } from './BondAdd';
 import { BondDelete } from './BondDelete';
+import type { Writable } from 'utilities';
 
-BondAdd.InverseConstructor = BondDelete;
-BondDelete.InverseConstructor = BondAdd;
+(BondAdd as Writable<typeof BondAdd>).InverseConstructor = BondDelete;
+(BondDelete as Writable<typeof BondDelete>).InverseConstructor = BondAdd;
 
 export { BondAdd, BondDelete };
 export * from './BondAttr';

--- a/packages/ketcher-core/src/application/editor/operations/descriptors.ts
+++ b/packages/ketcher-core/src/application/editor/operations/descriptors.ts
@@ -16,8 +16,10 @@
 
 import { AlignDescriptors } from './AlignDescriptors';
 import { RestoreDescriptorsPosition } from './RestoreDescriptorsPosition';
+import type { Writable } from 'utilities';
 
-AlignDescriptors.InverseConstructor = RestoreDescriptorsPosition;
+(AlignDescriptors as Writable<typeof AlignDescriptors>).InverseConstructor =
+  RestoreDescriptorsPosition;
 RestoreDescriptorsPosition.InverseConstructor = AlignDescriptors;
 
 export { AlignDescriptors, RestoreDescriptorsPosition };

--- a/packages/ketcher-core/src/application/editor/operations/fragment.ts
+++ b/packages/ketcher-core/src/application/editor/operations/fragment.ts
@@ -17,8 +17,11 @@
 import { FragmentAdd } from './FragmentAdd';
 import { FragmentDelete } from './FragmentDelete';
 import { FragmentSetProperties } from './FragmentSetProperties';
+import type { Writable } from 'utilities';
 
-FragmentAdd.InverseConstructor = FragmentDelete;
-FragmentDelete.InverseConstructor = FragmentAdd;
+(FragmentAdd as Writable<typeof FragmentAdd>).InverseConstructor =
+  FragmentDelete;
+(FragmentDelete as Writable<typeof FragmentDelete>).InverseConstructor =
+  FragmentAdd;
 
 export { FragmentAdd, FragmentDelete, FragmentSetProperties };

--- a/packages/ketcher-core/src/application/editor/operations/fragmentStereoAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/fragmentStereoAtom.ts
@@ -16,8 +16,13 @@
 
 import { FragmentAddStereoAtom } from './FragmentAddStereoAtom';
 import { FragmentDeleteStereoAtom } from './FragmentDeleteStereoAtom';
+import type { Writable } from 'utilities';
 
-FragmentAddStereoAtom.InverseConstructor = FragmentDeleteStereoAtom;
-FragmentDeleteStereoAtom.InverseConstructor = FragmentAddStereoAtom;
+(
+  FragmentAddStereoAtom as Writable<typeof FragmentAddStereoAtom>
+).InverseConstructor = FragmentDeleteStereoAtom;
+(
+  FragmentDeleteStereoAtom as Writable<typeof FragmentDeleteStereoAtom>
+).InverseConstructor = FragmentAddStereoAtom;
 
 export { FragmentAddStereoAtom, FragmentDeleteStereoAtom };

--- a/packages/ketcher-core/src/application/editor/operations/ifThen.ts
+++ b/packages/ketcher-core/src/application/editor/operations/ifThen.ts
@@ -16,8 +16,11 @@
 
 import { UpdateIfThen } from './UpdateIfThen';
 import { RestoreIfThen } from './RestoreIfThen';
+import type { Writable } from 'utilities';
 
-UpdateIfThen.InverseConstructor = RestoreIfThen;
-RestoreIfThen.InverseConstructor = UpdateIfThen;
+(UpdateIfThen as Writable<typeof UpdateIfThen>).InverseConstructor =
+  RestoreIfThen;
+(RestoreIfThen as Writable<typeof RestoreIfThen>).InverseConstructor =
+  UpdateIfThen;
 
 export { UpdateIfThen, RestoreIfThen };

--- a/packages/ketcher-core/src/utilities/Writable.ts
+++ b/packages/ketcher-core/src/utilities/Writable.ts
@@ -1,0 +1,9 @@
+/**
+ * Maps an object type to a structurally identical type with all `readonly`
+ * modifiers removed.
+ *
+ * Used to assign a `static readonly` field that must be wired from outside the
+ * declaring class — e.g. an operation's inverse constructor, which is set in a
+ * separate module to avoid a circular dependency between the paired classes.
+ */
+export type Writable<T> = { -readonly [P in keyof T]: T[P] };

--- a/packages/ketcher-core/src/utilities/index.ts
+++ b/packages/ketcher-core/src/utilities/index.ts
@@ -29,3 +29,4 @@ export * from './ensureString';
 export * from './normalizeError';
 export * from './monomers';
 export * from './dom';
+export * from './Writable';


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
- Declared the 11 flagged `static InverseConstructor` fields as `static readonly`.
- The one-time wiring assignment now goes through a new `Writable<T>` utility type (`{ -readonly [P in keyof T]: T[P] }`), imported with `import type` so it is erased at compile time and introduces no runtime import / circular dependency.

  This is a type-level change only — the emitted JavaScript and the runtime undo/redo (`invert()`) behavior are identical.

  Covered the 6 flagged operation pairs: AlignDescriptors, Fragment add/delete,
  Fragment stereo-atom add/delete, IfThen update/restore, Atom add/delete,
  Bond add/delete.

  Out of scope (not in the Sonar report): the unflagged sibling `RestoreDescriptorsPosition` and the `RGroupAttachmentPointAdd/Remove` pair keep the existing mutable pattern.

  Verification: `test:types`, `test:circ`, ESLint and Prettier are green; the ketcher-core unit suite passes (371 tests), confirming `invert()` still resolves.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request