### PR TITLE
#10216 - Refactor: Explicit Any type clean up (part 5.1)

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -222,6 +222,26 @@ export function fromTemplateOnAtom(
   return [action, pasteItems];
 }
 
+type FromTemplateOnBondResult = [Action, { atoms: number[]; bonds: number[] }];
+
+export function fromTemplateOnBondAction(
+  restruct,
+  template,
+  bid,
+  events,
+  flip,
+  force: false,
+  isPreview?: boolean,
+): FromTemplateOnBondResult;
+export function fromTemplateOnBondAction(
+  restruct,
+  template,
+  bid,
+  events,
+  flip,
+  force: true,
+  isPreview?: boolean,
+): Promise<FromTemplateOnBondResult>;
 export function fromTemplateOnBondAction(
   restruct,
   template,

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/imageToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/imageToStruct.ts
@@ -15,10 +15,12 @@
  ***************************************************************************/
 
 import type { Struct } from 'domain/entities/struct';
-import { Image } from 'domain/entities/image';
+import { type KetFileImageNode, Image } from 'domain/entities/image';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function imageToStruct(ketItem: any, struct: Struct): Struct {
+export function imageToStruct(
+  ketItem: KetFileImageNode,
+  struct: Struct,
+): Struct {
   struct.images.add(Image.fromKetNode(ketItem));
   return struct;
 }

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/multitailArrowToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/multitailArrowToStruct.ts
@@ -1,8 +1,14 @@
 import type { Struct } from 'domain/entities/struct';
-import { MultitailArrow } from 'domain/entities/multitailArrow';
+import {
+  type KetFileMultitailArrowNode,
+  MultitailArrow,
+} from 'domain/entities/multitailArrow';
+import type { KetFileNode } from 'domain/serializers/serializers.types';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function multitailArrowToStruct(ketItem: any, struct: Struct) {
+export function multitailArrowToStruct(
+  ketItem: KetFileNode<KetFileMultitailArrowNode>,
+  struct: Struct,
+) {
   struct.addMultitailArrow(MultitailArrow.fromKetNode(ketItem));
   return struct;
 }

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -206,11 +206,9 @@ export class KetSerializer implements Serializer<Struct> {
           break;
         }
         case 'rgroup': {
-          result.root.nodes.push({ $ref: `rg${item.data!.rgnumber}` });
-          result[`rg${item.data!.rgnumber}`] = rgroupToKet(
-            item.fragment!,
-            item.data,
-          );
+          const { rgnumber } = item.data as { rgnumber: number };
+          result.root.nodes.push({ $ref: `rg${rgnumber}` });
+          result[`rg${rgnumber}`] = rgroupToKet(item.fragment!, item.data);
           break;
         }
         case 'plus': {

--- a/packages/ketcher-core/src/domain/serializers/ket/multitailArrowsValidator.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/multitailArrowsValidator.ts
@@ -1,12 +1,14 @@
-import type { KetFileNode } from 'domain/serializers/serializers.types';
+import type {
+  KetFileNode,
+  KetFileRootContent,
+} from 'domain/serializers/serializers.types';
 import {
   type KetFileMultitailArrowNode,
   MultitailArrow,
 } from 'domain/entities/multitailArrow';
 import { MULTITAIL_ARROW_SERIALIZE_KEY } from 'domain/constants';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const validateMultitailArrows = (json: any): boolean => {
+export const validateMultitailArrows = (json: KetFileRootContent): boolean => {
   const nodes: Array<KetFileNode<unknown>> = json.root.nodes;
   return nodes.every((node) => {
     if (node.type === MULTITAIL_ARROW_SERIALIZE_KEY) {

--- a/packages/ketcher-core/src/domain/serializers/serializers.types.ts
+++ b/packages/ketcher-core/src/domain/serializers/serializers.types.ts
@@ -29,6 +29,10 @@ export interface KetFileNode<T = unknown> {
   selected?: boolean;
 }
 
+export interface KetFileRoot {
+  nodes: KetFileNode[];
+}
+
 export interface KetFileRootContent {
-  root: { nodes: KetFileNode[] };
+  root: KetFileRoot;
 }

--- a/packages/ketcher-core/src/domain/serializers/serializers.types.ts
+++ b/packages/ketcher-core/src/domain/serializers/serializers.types.ts
@@ -21,11 +21,14 @@ export interface Serializer<T> {
   serialize: (struct: T) => string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface KetFileNode<T = any> {
+export interface KetFileNode<T = unknown> {
   type: string;
   fragment?: Struct;
   center: Vec2;
   data?: T;
   selected?: boolean;
+}
+
+export interface KetFileRootContent {
+  root: { nodes: KetFileNode[] };
 }

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -614,26 +614,24 @@ function findCloseMerge(
           mergeAtomToFunctionalGroup(atomId, restruct, atomPosition, result);
       });
     } else {
-      result[map] = Array.from(pos[map].keys()).reduce(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (res: Map<any, any>, srcId) => {
-          const skip = { map, id: srcId };
-          const item = findMaps[map](
-            restruct,
-            pos[map].get(srcId),
-            skip,
-            null,
-            options,
-          );
+      result[map] = Array.from<number>(pos[map].keys()).reduce<
+        Map<number, number>
+      >((res, srcId) => {
+        const skip = { map, id: srcId };
+        const item = findMaps[map](
+          restruct,
+          pos[map].get(srcId),
+          skip,
+          null,
+          options,
+        );
 
-          if (item && !selected[map].includes(item.id)) {
-            res.set(srcId, item.id);
-          }
+        if (item && !selected[map].includes(item.id)) {
+          res.set(srcId, item.id);
+        }
 
-          return res;
-        },
-        new Map(),
-      );
+        return res;
+      }, new Map());
     }
   });
 

--- a/packages/ketcher-react/src/script/editor/tool/helper/isMacroMolecule.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/isMacroMolecule.ts
@@ -1,13 +1,15 @@
 import type { Editor } from '../../Editor';
+import type { DragContext } from '../select/select.types';
 
 const isMacroMolecule = (editor: Editor, id: number): boolean => {
   const struct = editor.struct();
   return struct.isFunctionalGroupFromMacromolecule(id);
 };
 
-// dragCtx is actually "any" in the code
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isMergingToMacroMolecule = (editor: Editor, dragCtx: any): boolean => {
+const isMergingToMacroMolecule = (
+  editor: Editor,
+  dragCtx: Pick<NonNullable<DragContext>, 'mergeItems'> | null | undefined,
+): boolean => {
   const funcGroups = dragCtx?.mergeItems?.atomToFunctionalGroup;
   if (!funcGroups?.size) {
     return false;

--- a/packages/ketcher-react/src/script/editor/tool/helper/isMacroMolecule.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/isMacroMolecule.ts
@@ -8,7 +8,7 @@ const isMacroMolecule = (editor: Editor, id: number): boolean => {
 
 const isMergingToMacroMolecule = (
   editor: Editor,
-  dragCtx: Pick<NonNullable<DragContext>, 'mergeItems'> | null | undefined,
+  dragCtx: DragContext,
 ): boolean => {
   const funcGroups = dragCtx?.mergeItems?.atomToFunctionalGroup;
   if (!funcGroups?.size) {

--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -196,8 +196,7 @@ class TemplatePreview {
         shouldFlip,
         true,
         true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ) as Promise<any>;
+      ) as Promise<[Action, { atoms: number[]; bonds: number[] }]>;
 
       promise.then(([action, pasteItems]) => {
         if (!this.isModeFunctionalGroup) {

--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -196,7 +196,7 @@ class TemplatePreview {
         shouldFlip,
         true,
         true,
-      ) as Promise<[Action, { atoms: number[]; bonds: number[] }]>;
+      );
 
       promise.then(([action, pasteItems]) => {
         if (!this.isModeFunctionalGroup) {

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx
@@ -16,6 +16,8 @@
 
 import { type ComponentType, type FC, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 import Form, {
   type FormState,
   Field,
@@ -312,7 +314,7 @@ const mapStateToProps = (state: State): CheckDialogStateProps => ({
 });
 
 const mapDispatchToProps = (
-  dispatch: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  dispatch: ThunkDispatch<State, undefined, AnyAction>,
   ownProps: CheckDialogOwnProps,
 ): CheckDialogDispatchProps => ({
   onCheck: (opts: CheckOption[]) =>

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Recognize/Recognize.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Recognize/Recognize.tsx
@@ -15,6 +15,8 @@
  ***************************************************************************/
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 import {
   changeImage,
   changeVersion,
@@ -241,8 +243,9 @@ function RecognizeDialog(prop: Readonly<RecognizeDialogProps>) {
 
 function url(file: File | null): string | null {
   if (!file) return null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const URL = window.URL || (window as any).webkitURL;
+  const URL =
+    window.URL ||
+    (window as Window & { webkitURL?: typeof globalThis.URL }).webkitURL;
   return URL ? URL.createObjectURL(file) : 'No preview';
 }
 
@@ -269,8 +272,9 @@ const mapStateToProps = (state: RecognizeState) => ({
     state.options.recognize.version ?? state.options.app.imagoVersions[1],
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mapDispatchToProps = (dispatch: any) => ({
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<RecognizeState, undefined, AnyAction>,
+) => ({
   isFragment: (v: boolean) => dispatch(shouldFragment(v)),
   onImage: (file: RecognizeImageFile) => dispatch(changeImage(file)),
   onRecognize: (file: File | null, ver: string) =>

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Recognize/Recognize.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Recognize/Recognize.tsx
@@ -241,11 +241,11 @@ function RecognizeDialog(prop: Readonly<RecognizeDialogProps>) {
   );
 }
 
+type WindowWithWebkitURL = Window & { webkitURL?: typeof globalThis.URL };
+
 function url(file: File | null): string | null {
   if (!file) return null;
-  const URL =
-    window.URL ||
-    (window as Window & { webkitURL?: typeof globalThis.URL }).webkitURL;
+  const URL = window.URL || (window as WindowWithWebkitURL).webkitURL;
   return URL ? URL.createObjectURL(file) : 'No preview';
 }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)
Splitted task: Refactor: Explicit Any type clean up (part 5)
https://github.com/epam/ketcher/issues/9422
 (verified against the full build that they need a refactor/dependency change, not just a type swap):
- `Tool.ts:38` `...args: any[]` — `unknown[]` breaks the tool registry, `never[]` breaks construction; needs the tool constructors refactored.
- `Select.tsx:87` `as any` — duplicate `@types/react` (v18 for MUI vs v19); needs the dependency de-duplicated.
- `Tabs.types.ts:7` `FC<any>` — heterogeneous component list; needs the Tabs API made generic.
- `SettingsManager.ts:37` `selectionTool?: any` — a clean type ripples into ketcher-react consumers outside this issue's scope.

Replaced explicit `any` type annotations with proper types (reusing an existing type where one fit, creating a new reusable one otherwise) or the safer
`unknown`, per the Sonar `typescript:S1444`/no-explicit-any guidance.

This PR covers the 10 locations that can be fixed with a type change alone:

ketcher-core (KET serializers)
- `serializers.types.ts` — `KetFileNode<T = unknown>` default (was `any`); added a reusable `KetFileRootContent` type. The `unknown` default required narrowing the `rgroup` case in `ketSerializer.ts` (it read `item.data.rgnumber`).
- `multitailArrowToStruct.ts` / `imageToStruct.ts` — typed `ketItem` via the entity `fromKetNode` parameter types (`KetFileNode<KetFileMultitailArrowNode>`,
  `KetFileImageNode`).
- `multitailArrowsValidator.ts` — typed `json` as `KetFileRootContent`.

ketcher-react (editor / UI)
- `isMacroMolecule.ts` — typed `dragCtx` via the existing `DragContext`.
- `templatePreview.ts` — typed the action promise as `Promise<[Action, …]>`.
- `closest.ts` — `Map<number, number>` for the merge reducer.
- `Recognize.tsx` / `Check.tsx` — `ThunkDispatch<…>` for `mapDispatchToProps` (matches the existing `Save.tsx`/`Analyse.tsx` pattern); typed `window.webkitURL`.

Verification: `test:types` = 0 errors (ketcher-core + ketcher-react), ESLint = 0 errors, no circular dependencies, ketcher-core unit suite passes (374 tests).
The change is type-only (plus one trivial `rgroup` destructure), so runtime behavior is unchanged.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request