### PR TITLE
Backmerge: #10181 - Stack overflow occurs if there is a cyclic structure with CHEMs at both the beginning and the end

### DIFF
--- a/packages/ketcher-core/src/domain/entities/LinkerSequenceNode.ts
+++ b/packages/ketcher-core/src/domain/entities/LinkerSequenceNode.ts
@@ -13,7 +13,10 @@ import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { KetMonomerClass } from 'domain/constants/monomers';
 
 export class LinkerSequenceNode {
-  constructor(public monomer: BaseMonomer) {}
+  constructor(
+    public monomer: BaseMonomer,
+    private firstMonomerInChain?: BaseMonomer,
+  ) {}
 
   public get SubChainConstructor() {
     return this.monomer.SubChainConstructor;
@@ -31,7 +34,10 @@ export class LinkerSequenceNode {
     const monomers = [this.firstMonomerInNode];
     const firstMonomer = this.firstMonomerInNode;
     let nextMonomer = getNextMonomerInChain(this.firstMonomerInNode);
-    while (LinkerSequenceNode.isValidPartForLinker(nextMonomer)) {
+    while (
+      nextMonomer !== this.firstMonomerInChain &&
+      LinkerSequenceNode.isValidPartForLinker(nextMonomer)
+    ) {
       monomers.push(nextMonomer);
       nextMonomer = getNextMonomerInChain(nextMonomer, firstMonomer);
     }

--- a/packages/ketcher-core/src/domain/entities/monomer-chains/Chain.ts
+++ b/packages/ketcher-core/src/domain/entities/monomer-chains/Chain.ts
@@ -147,7 +147,7 @@ export class Chain {
       this.lastSubChain.add(new MonomerSequenceNode(monomer));
       return;
     }
-    this.lastSubChain.add(new LinkerSequenceNode(monomer));
+    this.lastSubChain.add(new LinkerSequenceNode(monomer, this.firstMonomer));
   }
 
   public addNode(node: SubChainNode) {


### PR DESCRIPTION
(cherry picked from commit 094e6513347fc2318cf6410809712635d42a7e04)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request