### PR TITLE
fix types in getEmptyMonomersLibraryJson

### DIFF
--- a/packages/ketcher-core/src/application/editor/helpers.ts
+++ b/packages/ketcher-core/src/application/editor/helpers.ts
@@ -1,5 +1,8 @@
 import { KetSerializer } from 'domain/serializers';
-import type { IKetMacromoleculesContent } from 'application/formatters';
+import type {
+  IKetMacromoleculesContent,
+  IKetMacromoleculesContentRootProperty,
+} from 'application/formatters';
 
 export const parseMonomersLibrary = (monomersDataRaw: string | JSON) => {
   const monomersLibraryParsedJson =
@@ -14,16 +17,14 @@ export const parseMonomersLibrary = (monomersDataRaw: string | JSON) => {
   return { monomersLibraryParsedJson, monomersLibrary };
 };
 
-export const getEmptyMonomersLibraryJson =
-  function (): IKetMacromoleculesContent {
-    // TODO fix types
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return {
-      root: {
-        templates: [],
-        nodes: [],
-        connections: [],
-      },
-    };
+export const getEmptyMonomersLibraryJson = (): IKetMacromoleculesContent => {
+  const emptyMonomersLibraryJson: IKetMacromoleculesContentRootProperty = {
+    root: {
+      templates: [],
+      nodes: [],
+      connections: [],
+    },
   };
+
+  return emptyMonomersLibraryJson as IKetMacromoleculesContent;
+};


### PR DESCRIPTION
# Summary

## Fix types in `getEmptyMonomersLibraryJson` and remove `@ts-ignore`

### Problem

`getEmptyMonomersLibraryJson` suppressed a TypeScript error with `@ts-ignore` (and a paired `eslint-disable` comment) because the returned object literal didn't satisfy the index signature on `IKetMacromoleculesContentOtherProperties`. The `root` property type is not assignable to `KetNode | IKetMonomerTemplate | IKetMonomerGroupTemplate | IKetAmbiguousMonomerTemplate`, which is an inherent constraint of the intersection type `IKetMacromoleculesContent`.

### Solution

- Import `IKetMacromoleculesContentRootProperty` alongside `IKetMacromoleculesContent`
- Type the intermediate variable explicitly as `IKetMacromoleculesContentRootProperty` so the compiler validates the `root` shape
- Return with an explicit `as IKetMacromoleculesContent` assertion, which is the honest way to bridge the index-signature conflict without silencing the compiler entirely

### Changes

`packages/ketcher-core/src/application/editor/helpers.ts`
- Remove `// @ts-ignore` and `// eslint-disable-next-line @typescript-eslint/ban-ts-comment`
- Remove `// TODO fix types` comment
- Add `IKetMacromoleculesContentRootProperty` import
- Introduce typed intermediate variable for the empty library object

[The issue](https://github.com/orgs/epam/projects/45/views/2?pane=issue&itemId=177922761&issue=epam%7Cketcher%7C9799)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request