### PR TITLE
5227 - System doesn't show IDT aliases in preview tooltip for custom presets

### DIFF
--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.test.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.test.ts
@@ -1,0 +1,88 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+import { MonomerItemType, IKetIdtAliases } from 'ketcher-core';
+import { IRnaPreset } from 'components/monomerLibrary/RnaBuilder/types';
+import { deriveRnaPresetAliasesFromDefaults } from './rnaBuilderSlice.helper';
+
+const monomer = (id: string): MonomerItemType =>
+  ({ props: { id } } as MonomerItemType);
+
+const idtAliases = (base: string): IKetIdtAliases =>
+  ({ base } as unknown as IKetIdtAliases);
+
+const fullPreset = (overrides: Partial<IRnaPreset> = {}): IRnaPreset => ({
+  sugar: monomer('sugarR'),
+  base: monomer('baseA'),
+  phosphate: monomer('phosphateP'),
+  ...overrides,
+});
+
+const defaultPreset = fullPreset({
+  idtAliases: idtAliases('A'),
+  aliasAxoLabs: 'Aax',
+});
+
+describe('deriveRnaPresetAliasesFromDefaults', () => {
+  it('is a no-op when the preset already has both aliases', () => {
+    const preset = fullPreset({
+      idtAliases: idtAliases('X'),
+      aliasAxoLabs: 'Xax',
+    });
+
+    expect(deriveRnaPresetAliasesFromDefaults(preset, [defaultPreset])).toEqual(
+      {},
+    );
+  });
+
+  it('returns nothing when no default preset matches the components', () => {
+    const preset = fullPreset({ base: monomer('baseC') });
+
+    expect(deriveRnaPresetAliasesFromDefaults(preset, [defaultPreset])).toEqual(
+      {},
+    );
+  });
+
+  it('backfills only the missing alias when a default matches', () => {
+    const preset = fullPreset({ aliasAxoLabs: 'existingAx' });
+
+    expect(deriveRnaPresetAliasesFromDefaults(preset, [defaultPreset])).toEqual(
+      { idtAliases: idtAliases('A') },
+    );
+  });
+
+  it('backfills both aliases when the preset has none', () => {
+    const preset = fullPreset();
+
+    expect(deriveRnaPresetAliasesFromDefaults(preset, [defaultPreset])).toEqual(
+      { idtAliases: idtAliases('A'), aliasAxoLabs: 'Aax' },
+    );
+  });
+
+  it('does not match through empty keys when a component id is missing', () => {
+    const presetMissingBase = fullPreset({ base: undefined });
+    const defaultMissingBase = fullPreset({
+      base: undefined,
+      idtAliases: idtAliases('A'),
+      aliasAxoLabs: 'Aax',
+    });
+
+    expect(
+      deriveRnaPresetAliasesFromDefaults(presetMissingBase, [
+        defaultMissingBase,
+      ]),
+    ).toEqual({});
+  });
+});

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
@@ -32,7 +32,7 @@ export const deriveRnaPresetAliasesFromDefaults = (
   preset: IRnaPresetWithAliases,
   defaultPresets: ReadonlyArray<IRnaPresetWithAliases>,
 ): Partial<Pick<IRnaPresetWithAliases, 'idtAliases' | 'aliasAxoLabs'>> => {
-  if (preset.idtAliases) {
+  if (preset.idtAliases && preset.aliasAxoLabs) {
     return {};
   }
 
@@ -46,12 +46,14 @@ export const deriveRnaPresetAliasesFromDefaults = (
   }
 
   return {
-    ...(matchingDefaultPreset.idtAliases && {
-      idtAliases: matchingDefaultPreset.idtAliases,
-    }),
-    ...(matchingDefaultPreset.aliasAxoLabs && {
-      aliasAxoLabs: matchingDefaultPreset.aliasAxoLabs,
-    }),
+    ...(!preset.idtAliases &&
+      matchingDefaultPreset.idtAliases && {
+        idtAliases: matchingDefaultPreset.idtAliases,
+      }),
+    ...(!preset.aliasAxoLabs &&
+      matchingDefaultPreset.aliasAxoLabs && {
+        aliasAxoLabs: matchingDefaultPreset.aliasAxoLabs,
+      }),
   };
 };
 

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
@@ -25,9 +25,10 @@ const getPresetComponentsKey = (preset: IRnaPresetWithAliases): string => {
 };
 
 // A newly created custom preset has no IDT alias of its own. When it is built
-// from the same monomers as one of the default library presets, reuse that
-// preset's IDT alias (and AxoLabs alias) so the preview tooltip shows it. This
-// mirrors the behavior of duplicating a preset, where the aliases are kept.
+// from the same monomers as one of the default library presets, copy that
+// default preset's IDT alias (and AxoLabs alias) so the preview tooltip shows
+// it. Only fields the preset is missing are filled in; existing aliases are
+// left untouched.
 export const deriveRnaPresetAliasesFromDefaults = (
   preset: IRnaPresetWithAliases,
   defaultPresets: ReadonlyArray<IRnaPresetWithAliases>,

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
@@ -5,9 +5,55 @@ import {
   IRnaLabeledPreset,
   IRnaPreset,
   RnaPresetWithOptionalFields,
+  MonomerItemType,
   setAmbiguousMonomerTemplatePrefix,
   setMonomerTemplatePrefix,
 } from 'ketcher-core';
+import { IRnaPreset as IRnaPresetWithAliases } from 'components/monomerLibrary/RnaBuilder/types';
+
+// Build a key identifying the sugar/base/phosphate components of a preset so
+// that two presets built from the same monomers can be recognized as equal.
+const getPresetComponentsKey = (preset: IRnaPresetWithAliases): string => {
+  const getComponentId = (monomer?: MonomerItemType) =>
+    monomer?.props?.id ?? '';
+
+  return [
+    getComponentId(preset.sugar),
+    getComponentId(preset.base),
+    getComponentId(preset.phosphate),
+  ].join('|');
+};
+
+// A newly created custom preset has no IDT alias of its own. When it is built
+// from the same monomers as one of the default library presets, reuse that
+// preset's IDT alias (and AxoLabs alias) so the preview tooltip shows it. This
+// mirrors the behavior of duplicating a preset, where the aliases are kept.
+export const deriveRnaPresetAliasesFromDefaults = (
+  preset: IRnaPresetWithAliases,
+  defaultPresets: ReadonlyArray<IRnaPresetWithAliases>,
+): Partial<Pick<IRnaPresetWithAliases, 'idtAliases' | 'aliasAxoLabs'>> => {
+  if (preset.idtAliases) {
+    return {};
+  }
+
+  const presetKey = getPresetComponentsKey(preset);
+  const matchingDefaultPreset = defaultPresets.find(
+    (defaultPreset) => getPresetComponentsKey(defaultPreset) === presetKey,
+  );
+
+  if (!matchingDefaultPreset) {
+    return {};
+  }
+
+  return {
+    ...(matchingDefaultPreset.idtAliases && {
+      idtAliases: matchingDefaultPreset.idtAliases,
+    }),
+    ...(matchingDefaultPreset.aliasAxoLabs && {
+      aliasAxoLabs: matchingDefaultPreset.aliasAxoLabs,
+    }),
+  };
+};
 
 // transform preset from IRnaPreset to IRnaLabeledPreset
 export const transformRnaPresetToRnaLabeledPreset = (

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.helper.ts
@@ -11,17 +11,21 @@ import {
 } from 'ketcher-core';
 import { IRnaPreset as IRnaPresetWithAliases } from 'components/monomerLibrary/RnaBuilder/types';
 
-// Build a key identifying the sugar/base/phosphate components of a preset so
-// that two presets built from the same monomers can be recognized as equal.
-const getPresetComponentsKey = (preset: IRnaPresetWithAliases): string => {
+// Returns null when any component id is missing so that incomplete presets
+// (which can be saved without a base or phosphate) never match each other or a
+// default preset through empty-string keys like "||".
+const getPresetComponentsKey = (
+  preset: IRnaPresetWithAliases,
+): string | null => {
   const getComponentId = (monomer?: MonomerItemType) =>
     monomer?.props?.id ?? '';
 
-  return [
-    getComponentId(preset.sugar),
-    getComponentId(preset.base),
-    getComponentId(preset.phosphate),
-  ].join('|');
+  const ids = [preset.sugar, preset.base, preset.phosphate].map(getComponentId);
+  if (ids.some((id) => !id)) {
+    return null;
+  }
+
+  return ids.join('|');
 };
 
 // A newly created custom preset has no IDT alias of its own. When it is built
@@ -38,6 +42,10 @@ export const deriveRnaPresetAliasesFromDefaults = (
   }
 
   const presetKey = getPresetComponentsKey(preset);
+  if (presetKey === null) {
+    return {};
+  }
+
   const matchingDefaultPreset = defaultPresets.find(
     (defaultPreset) => getPresetComponentsKey(defaultPreset) === presetKey,
   );

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -36,7 +36,10 @@ import {
   setCachedCustomRnaPreset,
   toggleCachedCustomRnaPresetFavorites,
 } from 'helpers/manipulateCachedRnaPresets';
-import { transformRnaPresetToRnaLabeledPreset } from './rnaBuilderSlice.helper';
+import {
+  deriveRnaPresetAliasesFromDefaults,
+  transformRnaPresetToRnaLabeledPreset,
+} from './rnaBuilderSlice.helper';
 import { getValidations } from 'helpers/rnaValidations';
 import {
   selectAxoLabsAliasesByPresetName,
@@ -239,7 +242,13 @@ export const rnaBuilderSlice = createSlice({
     },
     savePreset: (state, action: PayloadAction<IRnaPreset>) => {
       const preset = action.payload;
-      const newPreset = { ...preset };
+      const newPreset = {
+        ...preset,
+        ...deriveRnaPresetAliasesFromDefaults(
+          preset,
+          state.presetsDefault as IRnaPreset[],
+        ),
+      };
 
       setCachedCustomRnaPreset(transformRnaPresetToRnaLabeledPreset(newPreset));
 

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -244,6 +244,8 @@ export const rnaBuilderSlice = createSlice({
       const preset = action.payload;
       const newPreset = {
         ...preset,
+        // Cast strips Immer's WritableDraft<> wrapper; presetsDefault is
+        // already the local IRnaPreset (with alias fields) the helper expects.
         ...deriveRnaPresetAliasesFromDefaults(
           preset,
           state.presetsDefault as IRnaPreset[],

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -244,12 +244,7 @@ export const rnaBuilderSlice = createSlice({
       const preset = action.payload;
       const newPreset = {
         ...preset,
-        // Cast strips Immer's WritableDraft<> wrapper; presetsDefault is
-        // already the local IRnaPreset (with alias fields) the helper expects.
-        ...deriveRnaPresetAliasesFromDefaults(
-          preset,
-          state.presetsDefault as IRnaPreset[],
-        ),
+        ...deriveRnaPresetAliasesFromDefaults(preset, state.presetsDefault),
       };
 
       setCachedCustomRnaPreset(transformRnaPresetToRnaLabeledPreset(newPreset));

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -244,7 +244,14 @@ export const rnaBuilderSlice = createSlice({
       const preset = action.payload;
       const newPreset = {
         ...preset,
-        ...deriveRnaPresetAliasesFromDefaults(preset, state.presetsDefault),
+        // Cast strips Immer's WritableDraft<> wrapper: state.presetsDefault is
+        // already an IRnaPreset[] (which carries the alias fields), but as an
+        // Immer draft its element type is WritableDraft<IRnaPreset>, whose deep
+        // Draft<Struct> is not assignable to Struct.
+        ...deriveRnaPresetAliasesFromDefaults(
+          preset,
+          state.presetsDefault as IRnaPreset[],
+        ),
       };
 
       setCachedCustomRnaPreset(transformRnaPresetToRnaLabeledPreset(newPreset));


### PR DESCRIPTION
Problem
Hovering over a newly saved custom RNA preset showed no IDT alias in the preview
tooltip, even when the preset used the same standard monomers as a default library
nucleotide (e.g. R + A + P → rA).

Root cause
Custom presets never had idtAliases populated on save. Only default library presets
and duplicated presets carried IDT aliases. Since the preview tooltip reads
preset.idtAliases directly, freshly created presets always rendered without an IDT row.

Changes
- rnaBuilderSlice.helper.ts — added deriveRnaPresetAliasesFromDefaults: matches a
  preset's sugar/base/phosphate monomer IDs against the default presets and returns
  the matching idtAliases/aliasAxoLabs
- rnaBuilderSlice.ts — applied the helper in the savePreset reducer so the alias is
  stored in Redux state and persisted to the cached custom preset (survives page reload)


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request