### PR TITLE
#9914 – Refactor: Implement common approach at BaseOperation class

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/operations/BaseOperation.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/operations/BaseOperation.test.ts
@@ -1,0 +1,69 @@
+import { AtomAdd, AtomDelete } from 'application/editor/operations';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
+import { OperationType } from 'application/editor/operations/OperationType';
+import { Render } from 'application/render';
+import { ReStruct } from 'application/render/restruct';
+import type { RenderOptions } from 'application/render/render.types';
+import { Struct, Vec2 } from 'domain/entities';
+import { KetcherLogger } from 'utilities';
+
+describe('BaseOperation.invert()', () => {
+  let restruct: ReStruct;
+
+  beforeEach(() => {
+    const struct = new Struct();
+    const options = {
+      scale: 40,
+      width: 100,
+      height: 100,
+    } as unknown as RenderOptions;
+    const render = new Render(document as unknown as HTMLElement, options);
+    restruct = new ReStruct(struct, render);
+  });
+
+  it('should round-trip paired operations via the base default invert()', () => {
+    const pos = new Vec2(1, 2);
+    const addOp = new AtomAdd({ label: 'C' }, pos);
+    addOp.execute(restruct);
+
+    const atomId = addOp.data.aid;
+    if (atomId == null) {
+      throw new Error('Atom id was not generated');
+    }
+    expect(restruct.molecule.atoms.has(atomId)).toBe(true);
+
+    const deleteOp = addOp.invert();
+    expect(deleteOp).toBeInstanceOf(AtomDelete);
+    expect(deleteOp.data).toBe(addOp.data);
+
+    deleteOp.execute(restruct);
+    expect(restruct.molecule.atoms.has(atomId)).toBe(false);
+
+    const restoreOp = deleteOp.invert();
+    expect(restoreOp).toBeInstanceOf(AtomAdd);
+    restoreOp.execute(restruct);
+    expect(restruct.molecule.atoms.has(atomId)).toBe(true);
+  });
+
+  it('logs an error and returns itself when InverseConstructor is not wired', () => {
+    class UnwiredOperation extends BaseOperation {
+      constructor() {
+        super(OperationType.ATOM_ADD);
+      }
+    }
+
+    const errorSpy = jest
+      .spyOn(KetcherLogger, 'error')
+      .mockImplementation(() => undefined);
+    const op = new UnwiredOperation();
+
+    const result = op.invert();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Operation.invert() is not implemented',
+    );
+    expect(result).toBe(op);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/ketcher-core/src/application/editor/operations/BaseOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/BaseOperation.ts
@@ -19,6 +19,7 @@ import { StereoLabelStyleType } from '../../render/restruct/generalEnumTypes';
 import type ReStruct from '../../render/restruct/restruct';
 
 import type { OperationType } from './OperationType';
+import { KetcherLogger } from 'utilities';
 
 type ValueOf<TObject extends object> = Readonly<TObject[keyof TObject]>;
 type OperationType = ValueOf<typeof OperationType>;
@@ -30,6 +31,8 @@ class BaseOperation {
   priority: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- operation payload shape varies by operation type
   data: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-use-before-define -- inverse constructor args vary by operation
+  static InverseConstructor: new (...args: any[]) => BaseOperation;
 
   constructor(type: OperationType, priority = 0) {
     this.type = type;
@@ -51,7 +54,15 @@ class BaseOperation {
   }
 
   invert(): BaseOperation {
-    throw new Error('Operation.invert() is not implemented');
+    const InverseConstructor = (this.constructor as typeof BaseOperation)
+      .InverseConstructor;
+    if (!InverseConstructor) {
+      KetcherLogger.error('Operation.invert() is not implemented');
+      return this;
+    }
+    const inverted = new InverseConstructor();
+    inverted.data = this.data;
+    return inverted;
   }
 
   isDummy(_restruct: ReStruct): boolean {

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAdd.ts
@@ -34,7 +34,6 @@ type Data = {
 
 class AtomAdd extends BaseOperation {
   data: Data;
-  static InverseConstructor: new () => BaseOperation;
 
   constructor(atom?: Partial<AtomAttributes>, pos?: Point) {
     super(OperationType.ATOM_ADD);
@@ -82,12 +81,6 @@ class AtomAdd extends BaseOperation {
         );
       }
     }
-  }
-
-  invert() {
-    const inverted = new AtomAdd.InverseConstructor();
-    inverted.data = this.data;
-    return inverted;
   }
 }
 

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
@@ -28,7 +28,6 @@ type Data = {
 
 class AtomDelete extends BaseOperation {
   data: Data;
-  static InverseConstructor: new () => BaseOperation;
 
   constructor(atomId?: number) {
     super(OperationType.ATOM_DELETE, OperationPriority.ATOM_DELETE);
@@ -62,12 +61,6 @@ class AtomDelete extends BaseOperation {
     restruct.atoms.delete(aid);
     restruct.markItemRemoved();
     struct.atoms.delete(aid);
-  }
-
-  invert() {
-    const inverted = new AtomDelete.InverseConstructor();
-    inverted.data = this.data;
-    return inverted;
   }
 }
 

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAdd.ts
@@ -30,7 +30,6 @@ type Data = {
 
 class BondAdd extends BaseOperation {
   data: Data;
-  static InverseConstructor: new (bondId?: number) => BaseOperation;
 
   constructor(
     begin?: number,
@@ -92,12 +91,6 @@ class BondAdd extends BaseOperation {
     // notifyBondAdded
     restruct.bonds.set(bid, new ReBond(structBond));
     restruct.markBond(bid, 1);
-  }
-
-  invert() {
-    const inverted = new BondAdd.InverseConstructor();
-    inverted.data = this.data;
-    return inverted;
   }
 }
 

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondDelete.ts
@@ -30,12 +30,6 @@ type Data = {
 
 class BondDelete extends BaseOperation {
   data: Data;
-  static InverseConstructor: new (
-    begin?: number,
-    end?: number,
-    bond?: Partial<BondAttributes>,
-    needInvalidateAtoms?: boolean,
-  ) => BaseOperation;
 
   constructor(bondId?: number) {
     super(OperationType.BOND_DELETE, OperationPriority.BOND_DELETE);
@@ -99,12 +93,6 @@ class BondDelete extends BaseOperation {
     if (structBond.hb2 !== undefined) struct.halfBonds.delete(structBond.hb2);
 
     struct.bonds.delete(bid);
-  }
-
-  invert() {
-    const inverted = new BondDelete.InverseConstructor();
-    inverted.data = this.data;
-    return inverted;
   }
 }
 

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointAdd.ts
@@ -21,7 +21,6 @@ const INITIAL_DATA: Data = {
 
 class RGroupAttachmentPointAdd extends BaseOperation {
   readonly data: Data;
-  static InverseConstructor: new () => BaseOperation;
 
   constructor(data: Data = INITIAL_DATA) {
     super(

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
@@ -13,7 +13,6 @@ const INITIAL_DATA = {
 
 class RGroupAttachmentPointRemove extends BaseOperation {
   readonly data: Data;
-  static InverseConstructor: new () => BaseOperation;
 
   constructor(attachmentPointId = INITIAL_DATA.attachmentPointId) {
     super(
@@ -41,12 +40,6 @@ class RGroupAttachmentPointRemove extends BaseOperation {
     restruct.rgroupAttachmentPoints.delete(attachmentPointId);
 
     struct.rgroupAttachmentPoints.delete(attachmentPointId);
-  }
-
-  invert() {
-    const inverted = new RGroupAttachmentPointRemove.InverseConstructor();
-    inverted.data = this.data;
-    return inverted;
   }
 }
 

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/index.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
 import type { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { FunctionalGroup } from 'domain/entities/functionalGroup';
@@ -24,8 +23,6 @@ import { type ReStruct, ReSGroup } from '../../../render';
 import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
-
-// todo: separate classes: now here is circular dependency in `invert` method
 
 type Data = {
   sgid: any;
@@ -112,12 +109,6 @@ class SGroupCreate extends BaseOperation {
     }
     this.data.sgid = sgid;
   }
-
-  invert() {
-    const inverted = new SGroupDelete();
-    inverted.data = this.data;
-    return inverted;
-  }
 }
 
 class SGroupDelete extends BaseOperation {
@@ -166,13 +157,10 @@ class SGroupDelete extends BaseOperation {
     restruct.sgroups.delete(sgid);
     struct.sgroups.delete(sgid);
   }
-
-  invert() {
-    const inverted = new SGroupCreate();
-    inverted.data = this.data;
-    return inverted;
-  }
 }
+
+SGroupCreate.InverseConstructor = SGroupDelete;
+SGroupDelete.InverseConstructor = SGroupCreate;
 
 export { SGroupCreate, SGroupDelete };
 export * from './sgroupAtom';

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAtom.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAtom.ts
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
 import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
 import { SGroup } from 'domain/entities/sgroup';
-
-// todo: separate classes: now here is circular dependency in `invert` method
 
 type Data = {
   sgid: any;
@@ -53,12 +50,6 @@ class SGroupAtomAdd extends BaseOperation {
     struct.atomAddToSGroup(sgid, aid);
     BaseOperation.invalidateAtom(restruct, aid);
   }
-
-  invert() {
-    const inverted = new SGroupAtomRemove();
-    inverted.data = this.data;
-    return inverted;
-  }
 }
 
 class SGroupAtomRemove extends BaseOperation {
@@ -84,12 +75,9 @@ class SGroupAtomRemove extends BaseOperation {
     atom.sgs.delete(sgid);
     BaseOperation.invalidateAtom(restruct, aid);
   }
-
-  invert() {
-    const inverted = new SGroupAtomAdd();
-    inverted.data = this.data;
-    return inverted;
-  }
 }
+
+SGroupAtomAdd.InverseConstructor = SGroupAtomRemove;
+SGroupAtomRemove.InverseConstructor = SGroupAtomAdd;
 
 export { SGroupAtomAdd, SGroupAtomRemove };

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-use-before-define */
 
 import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
-
-// todo: separate classes: now here is circular dependency in `invert` method
 
 type Data = {
   sgid: any;
@@ -48,12 +45,6 @@ class SGroupAddToHierarchy extends BaseOperation {
     this.data.parent = relations.parent;
     this.data.children = relations.children;
   }
-
-  invert() {
-    const inverted = new SGroupRemoveFromHierarchy();
-    inverted.data = this.data;
-    return inverted;
-  }
 }
 
 class SGroupRemoveFromHierarchy extends BaseOperation {
@@ -72,12 +63,9 @@ class SGroupRemoveFromHierarchy extends BaseOperation {
     this.data.children = struct.sGroupForest.children.get(sgid);
     struct.sGroupForest.remove(sgid);
   }
-
-  invert() {
-    const inverted = new SGroupAddToHierarchy();
-    inverted.data = this.data;
-    return inverted;
-  }
 }
+
+SGroupAddToHierarchy.InverseConstructor = SGroupRemoveFromHierarchy;
+SGroupRemoveFromHierarchy.InverseConstructor = SGroupAddToHierarchy;
 
 export { SGroupAddToHierarchy, SGroupRemoveFromHierarchy };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Follow-up to #9804, #9808, #9810, #9811, #9812, #9813 — each introduced an identical
`static InverseConstructor` field and `invert()` body to break the circular dependency
in the inverse method. This PR lifts that common idiom into `BaseOperation` to remove the
duplication (Sonar).

**BaseOperation**
- Added `static InverseConstructor: new (...args: any[]) => BaseOperation`. The `any[]`
  signature keeps the narrower per-class signatures (e.g. `FragmentAdd`) assignable, so no
  TS2417.
- `invert()` now builds the inverse via `this.constructor.InverseConstructor`, copies
  `data`, and still throws `Operation.invert() is not implemented` when no inverse is wired.

**Migrated to the base default** (removed duplicated `invert()` / redundant static):
- `AtomAdd`/`AtomDelete`, `BondAdd`/`BondDelete`, `RGroupAttachmentPointRemove`
- Same-file S-group pairs: `SGroupAtomAdd`/`SGroupAtomRemove`,
  `SGroupAddToHierarchy`/`SGroupRemoveFromHierarchy`, `SGroupCreate`/`SGroupDelete` —
  `InverseConstructor` wired in-file, with the obsolete "circular dependency in invert"
  TODOs and file-level `eslint-disable no-use-before-define` removed.

**Left untouched (intentional):**
- `RGroupAttachmentPointAdd` keeps its `invert()` because of its `attachmentPointId` guard.
- Self-inverse (`data`/`data2` swap, copy-data) and constructor-argument operations are not
  duplicated and pass typed arguments — folding them in would regress type-safety or change
  `execute()`/`isDummy()` semantics. The custom-`Base` rxn pairs are out of scope.

No behavior change — each removed `invert()` is reproduced exactly by the base default.
Verified green: `test:prettier`, `test:eslint`, `test:types`, `test:circ`, `test:unit`
(incl. new `BaseOperation.test.ts`).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request