### PR TITLE
#9743 Refactor: Fix Action.isDummy() returning false for most operation types

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/isDummy.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/isDummy.test.ts
@@ -1,0 +1,111 @@
+import { Action } from 'application/editor/actions/action';
+import { BaseOperation } from 'application/editor/operations/BaseOperation';
+import { AtomAttr } from 'application/editor/operations/atom/AtomAttr';
+import { AtomMove } from 'application/editor/operations/atom/AtomMove';
+import { BondAttr } from 'application/editor/operations/bond/BondAttr';
+import { BondMove } from 'application/editor/operations/bond/BondMove';
+import { RGroupAttr } from 'application/editor/operations/rgroup/RGroupAttr';
+import { TextMove } from 'application/editor/operations/Text/TextMove';
+import type { ReStruct } from 'application/render';
+
+// Minimal ReStruct stub – the isDummy() overrides only read from
+// `restruct.molecule.{atoms,bonds,rgroups}`.
+const makeRestruct = (molecule: Record<string, unknown> = {}): ReStruct =>
+  ({
+    molecule: {
+      atoms: new Map(),
+      bonds: new Map(),
+      rgroups: new Map(),
+      ...molecule,
+    },
+  } as unknown as ReStruct);
+
+describe('BaseOperation.isDummy()', () => {
+  it('returns false by default (operation is treated as a real change)', () => {
+    const operation = new BaseOperation('Add atom' as never);
+    expect(operation.isDummy(makeRestruct())).toBe(false);
+  });
+});
+
+describe('attribute operations isDummy()', () => {
+  it('AtomAttr is dummy when the attribute already equals the new value', () => {
+    const restruct = makeRestruct({ atoms: new Map([[1, { label: 'C' }]]) });
+    expect(new AtomAttr(1, 'label', 'C').isDummy(restruct)).toBe(true);
+    expect(new AtomAttr(1, 'label', 'O').isDummy(restruct)).toBe(false);
+  });
+
+  it('AtomAttr does not throw and is not dummy when the atom is gone', () => {
+    const restruct = makeRestruct({ atoms: new Map() });
+    expect(() => new AtomAttr(1, 'label', 'C').isDummy(restruct)).not.toThrow();
+    expect(new AtomAttr(1, 'label', 'C').isDummy(restruct)).toBe(false);
+  });
+
+  it('BondAttr is dummy only when the attribute already matches', () => {
+    const restruct = makeRestruct({ bonds: new Map([[1, { type: 1 }]]) });
+    expect(new BondAttr(1, 'type', 1).isDummy(restruct)).toBe(true);
+    expect(new BondAttr(1, 'type', 2).isDummy(restruct)).toBe(false);
+  });
+
+  it('BondAttr does not throw and is not dummy when the bond is gone', () => {
+    const restruct = makeRestruct({ bonds: new Map() });
+    expect(() => new BondAttr(1, 'type', 1).isDummy(restruct)).not.toThrow();
+    expect(new BondAttr(1, 'type', 1).isDummy(restruct)).toBe(false);
+  });
+
+  it('RGroupAttr does not throw and is not dummy when the r-group is gone', () => {
+    const restruct = makeRestruct({ rgroups: new Map() });
+    expect(() =>
+      new RGroupAttr(1, 'range', '>0').isDummy(restruct),
+    ).not.toThrow();
+    expect(new RGroupAttr(1, 'range', '>0').isDummy(restruct)).toBe(false);
+  });
+});
+
+describe('move operations isDummy()', () => {
+  it('is dummy for a zero displacement and real otherwise', () => {
+    expect(new AtomMove(1, { x: 0, y: 0 }).isDummy()).toBe(true);
+    expect(new AtomMove(1, { x: 1, y: 0 }).isDummy()).toBe(false);
+
+    expect(new BondMove(1, { x: 0, y: 0 }).isDummy()).toBe(true);
+    expect(new BondMove(1, { x: 0, y: 2 }).isDummy()).toBe(false);
+
+    expect(new TextMove(1, { x: 0, y: 0 }).isDummy()).toBe(true);
+    expect(new TextMove(1, { x: 3, y: 4 }).isDummy()).toBe(false);
+  });
+});
+
+describe('Action.isDummy()', () => {
+  const restruct = makeRestruct();
+
+  it('an empty action is a dummy', () => {
+    expect(new Action().isDummy()).toBe(true);
+    expect(new Action().isDummy(restruct)).toBe(true);
+  });
+
+  it('with a restruct, is dummy only when every operation is a no-op', () => {
+    const allDummy = new Action([
+      new AtomMove(1, { x: 0, y: 0 }),
+      new BondMove(2, { x: 0, y: 0 }),
+    ]);
+    expect(allDummy.isDummy(restruct)).toBe(true);
+
+    const oneReal = new Action([
+      new AtomMove(1, { x: 0, y: 0 }),
+      new AtomMove(2, { x: 5, y: 0 }),
+    ]);
+    expect(oneReal.isDummy(restruct)).toBe(false);
+  });
+
+  it('an operation without an isDummy() override keeps the action non-dummy', () => {
+    const action = new Action([
+      new AtomMove(1, { x: 0, y: 0 }),
+      new BaseOperation('Add atom' as never),
+    ]);
+    expect(action.isDummy(restruct)).toBe(false);
+  });
+
+  it('without a restruct, any operation makes the action non-dummy', () => {
+    const action = new Action([new AtomMove(1, { x: 0, y: 0 })]);
+    expect(action.isDummy()).toBe(false);
+  });
+});

--- a/packages/ketcher-core/src/application/editor/actions/action.ts
+++ b/packages/ketcher-core/src/application/editor/actions/action.ts
@@ -54,10 +54,14 @@ export class Action {
   }
 
   isDummy(restruct?: ReStruct) {
+    // An action is a dummy when every one of its operations is a no-op.
+    // When `restruct` is provided each operation is asked whether it changes
+    // anything (operations that don't override `isDummy` always count as a
+    // real change). Without `restruct` we can only tell that an action with no
+    // operations is a dummy.
     return (
-      this.operations.find(
-        // TODO [RB] the condition is always true for op.* operations
-        (operation) => (restruct ? !operation.isDummy(restruct) : true),
+      this.operations.find((operation) =>
+        restruct ? !operation.isDummy(restruct) : true,
       ) === undefined
     );
   }

--- a/packages/ketcher-core/src/application/editor/operations/EnhancedFlagMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/EnhancedFlagMove.ts
@@ -54,4 +54,9 @@ export class EnhancedFlagMove extends BaseOperation {
     inverted.data = this.data;
     return inverted;
   }
+
+  isDummy() {
+    const { p } = this.data;
+    return p?.x === 0 && p?.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/LoopMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/LoopMove.ts
@@ -49,4 +49,9 @@ export class LoopMove extends BaseOperation {
     inverted.data = this.data;
     return inverted;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d?.x === 0 && d?.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/Text/TextMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/Text/TextMove.ts
@@ -69,4 +69,9 @@ export class TextMove extends BaseOperation {
 
     return move;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d?.x === 0 && d?.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAttr.ts
@@ -60,9 +60,10 @@ export class AtomAttr extends BaseOperation {
   }
 
   isDummy(restruct: ReStruct) {
-    return (
-      restruct.molecule.atoms.get(this.data?.aid)![this.data?.attribute] ===
-      this.data?.value
-    );
+    const atom = restruct.molecule.atoms.get(this.data?.aid);
+    if (!atom) {
+      return false;
+    }
+    return atom[this.data?.attribute] === this.data?.value;
   }
 }

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondAttr.ts
@@ -68,8 +68,8 @@ export class BondAttr extends BaseOperation {
   isDummy(restruct: ReStruct) {
     if (this.data) {
       const { attribute, bid, value } = this.data;
-      const bond = restruct.molecule.bonds.get(bid)!;
-      return bond[attribute] === value;
+      const bond = restruct.molecule.bonds.get(bid);
+      return bond ? bond[attribute] === value : false;
     }
     return false;
   }

--- a/packages/ketcher-core/src/application/editor/operations/bond/BondMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/bond/BondMove.ts
@@ -46,4 +46,9 @@ export class BondMove extends BaseOperation {
     inverted.data = this.data;
     return inverted;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d?.x === 0 && d?.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/image/imageMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageMove.ts
@@ -28,4 +28,8 @@ export class ImageMove extends BaseOperation {
   invert(): BaseOperation {
     return new ImageMove(this.id, this.offset.negated());
   }
+
+  isDummy() {
+    return this.offset.x === 0 && this.offset.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
@@ -68,8 +68,8 @@ export class RGroupAttr extends BaseOperation {
   isDummy(restruct: ReStruct) {
     if (this.data) {
       const { rgid, attribute, value } = this.data;
-      const rgroup = restruct.molecule.rgroups.get(rgid)!;
-      return rgroup[attribute] === value;
+      const rgroup = restruct.molecule.rgroups.get(rgid);
+      return rgroup ? rgroup[attribute] === value : false;
     }
     return false;
   }

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowMove.ts
@@ -56,4 +56,9 @@ export class RxnArrowMove extends Base {
     move.data = this.data;
     return move;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d?.x === 0 && d?.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/rxn/plus/RxnPlusMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/plus/RxnPlusMove.ts
@@ -53,4 +53,9 @@ export class RxnPlusMove extends BaseOperation {
     inverted.data = this.data;
     return inverted;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d?.x === 0 && d?.y === 0;
+  }
 }

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupDataMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/SGroupDataMove.ts
@@ -45,4 +45,9 @@ export class SGroupDataMove extends BaseOperation {
     inverted.data = this.data;
     return inverted;
   }
+
+  isDummy() {
+    const { d } = this.data;
+    return d?.x === 0 && d?.y === 0;
+  }
 }

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -2819,7 +2819,7 @@ class Editor implements KetcherEditor {
     if (action === true) {
       this.render.update(true, null); // force
     } else {
-      if (!ignoreHistory && !action.isDummy()) {
+      if (!ignoreHistory && !action.isDummy(this.render.ctab)) {
         this.historyStack.splice(this.historyPtr, HISTORY_SIZE + 1, action);
         if (this.historyStack.length > HISTORY_SIZE) {
           this.historyStack.shift();

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -545,7 +545,7 @@ class TemplateTool implements Tool {
       new AtomAttr(id, 'isPreview', false).perform(restruct);
     }
     const completeAction = dragCtx.action;
-    if (completeAction && !completeAction.isDummy()) {
+    if (completeAction && !completeAction.isDummy(restruct)) {
       this.editor.update(completeAction);
     }
     this.editor.hover(this.editor.findItem(event, null), null, event);


### PR DESCRIPTION
## Problem
`BaseOperation.isDummy()` returns `false` by default and only 4 operation
types overrode it, so `Action.isDummy()` was effectively broken. Investigation
showed the mechanism was entirely dormant: `Action.isDummy()` is only called
from `Editor.update()` and the template tool — both **without** a `restruct`,
which degrades the check to "is the operations array empty". `Action.addOp()`
is never called with its `restruct` argument anywhere either. As a result none
of the per-operation `isDummy()` overrides were ever consulted at runtime.

## What was done
- **Activated the mechanism** — pass `restruct` at the two call sites
  (`Editor.update()` and the template tool `mouseup`). Safe because at those
  points the operations are already inverted and applied, so an `*Attr` op
  compares its stored (pre-change) value against the current value and
  correctly detects "nothing changed". `restruct` was deliberately **not**
  passed into `addOp` — there `perform()` has already run, so checking
  `isDummy` would wrongly drop real operations.
- **Hardened** `AtomAttr` / `BondAttr` / `RGroupAttr` `isDummy()` against
  missing entities (they used `get(id)!` and would throw if the atom/bond/
  r-group was removed in the same action — latent until the mechanism was
  activated).
- **Added meaningful overrides** for zero-displacement move operations
  (mirroring `AtomMove`): `BondMove`, `EnhancedFlagMove`, `LoopMove`,
  `SGroupDataMove`, `TextMove`, `ImageMove`, `RxnArrowMove`, `RxnPlusMove`.
  Resize operations were intentionally left out — their semantics are
  absolute/anchor-based and "dummy" is ambiguous.
- **Replaced** the stale `// TODO [RB]` comment with an accurate description.
- **Added unit tests** (`isDummy.test.ts`) — there were none before — covering
  the overrides, the null-safety regression, and `Action.isDummy()` with and
  without `restruct`.

> Note: macromolecule operations (`monomer/`, `drawingEntity/`, `core*`, …)
> implement a different `Operation` interface with their own history and are
> out of scope for `Action.isDummy()`.

## What to pay attention to (review focus). VERY IMPORTANT!!!
- **Behavioral change in undo/redo**: an action consisting entirely of no-op
  operations (e.g. clicking an atom with the move tool and releasing without
  dragging) is no longer pushed onto the history stack and no longer dispatches
  the `change` event. This is the intended fix, but it changes user-visible
  undo behavior — please confirm nothing relies on a no-op action firing
  `change`.
- **Recommend an e2e/manual pass** (Playwright) on undo/redo, move tools and
  template placement. I ran unit + type-check + lint + the existing unit suites
  (all green) but not the full e2e suite.

## Checks
- New tests: 11/11 pass; existing editor tests pass.
- `tsc --noEmit`: clean in `ketcher-core` and `ketcher-react`.
- ESLint: 0 errors (only pre-existing warnings in legacy files).


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request