### PR TITLE
#5810 - Label of collapsed monomer appears extremely far away from original monomer in expanded state 

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -300,30 +300,6 @@ export function setExpandMonomerSGroup(
   const sGroupWidth = sGroupBBox.p1.x - sGroupBBox.p0.x;
   const sGroupHeight = sGroupBBox.p1.y - sGroupBBox.p0.y;
 
-  // The monomer label is rendered at sGroup.pp, while the molecule occupies
-  // the bounding box of the monomer's own atoms. Keep the two centered on
-  // each other so neither the collapsed label nor the expanded molecule
-  // appears far away from the other.
-  //
-  // Only recenter independent (standalone) monomers. When the monomer is
-  // bonded to outside structure, the connecting bond already anchors it on
-  // its attachment point; recentering onto the bbox center would instead
-  // slide the collapsed label over the neighboring atom.
-  let moleculeMoveVector: Vec2 | undefined;
-  let labelMoveVector: Vec2 | undefined;
-  if (
-    sGroup instanceof MonomerMicromolecule &&
-    sGroup.pp &&
-    bondsToOutside.size === 0
-  ) {
-    const sGroupBBoxCenter = sGroupBBox.centre();
-    if (attrs.expanded) {
-      moleculeMoveVector = sGroup.pp.sub(sGroupBBoxCenter);
-    } else {
-      labelMoveVector = sGroupBBoxCenter.sub(sGroup.pp);
-    }
-  }
-
   const sGroupCenter = sGroup.isContracted()
     ? sGroup.getContractedPosition(struct).position
     : sGroup.pp;
@@ -557,15 +533,34 @@ export function setExpandMonomerSGroup(
     });
   });
 
-  // Apply the recentering computed above (independent monomers only): shift
-  // the monomer's own atoms when expanding, or the label when collapsing, so
-  // the label and the molecule stay centered on each other.
-  if (moleculeMoveVector && moleculeMoveVector.length() > 0) {
+  // The monomer label is rendered at sGroup.pp, while the molecule occupies
+  // the bounding box of the monomer's own atoms. Keep the two centered on
+  // each other so neither the collapsed label nor the expanded molecule
+  // appears far away from the other: shift the monomer's own atoms when
+  // expanding, or the label when collapsing.
+  //
+  // Only recenter independent (standalone) monomers. When the monomer is
+  // bonded to outside structure, the connecting bond already anchors it on
+  // its attachment point; recentering onto the bbox center would instead
+  // slide the collapsed label over the neighboring atom.
+  let recenter: { target: 'atoms' | 'label'; vec: Vec2 } | undefined;
+  if (
+    sGroup instanceof MonomerMicromolecule &&
+    sGroup.pp &&
+    bondsToOutside.size === 0
+  ) {
+    const sGroupBBoxCenter = sGroupBBox.centre();
+    recenter = attrs.expanded
+      ? { target: 'atoms', vec: sGroup.pp.sub(sGroupBBoxCenter) }
+      : { target: 'label', vec: sGroupBBoxCenter.sub(sGroup.pp) };
+  }
+
+  if (recenter?.target === 'atoms') {
     sGroupAtoms.forEach((aid) => {
-      action.addOp(new AtomMove(aid, moleculeMoveVector));
+      action.addOp(new AtomMove(aid, recenter!.vec));
     });
-  } else if (labelMoveVector && labelMoveVector.length() > 0) {
-    action.addOp(new SGroupDataMove(sgid, labelMoveVector));
+  } else if (recenter?.target === 'label') {
+    action.addOp(new SGroupDataMove(sgid, recenter.vec));
   }
 
   sGroupAtoms.forEach((aid) => {

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -532,6 +532,30 @@ export function setExpandMonomerSGroup(
     });
   });
 
+  // The monomer label is rendered at sGroup.pp, while the molecule occupies the
+  // bounding box of the monomer's own atoms. Keep the two centered on each
+  // other so neither the collapsed label nor the expanded molecule appears far
+  // away from the other.
+  if (sGroup instanceof MonomerMicromolecule && sGroup.pp) {
+    const sGroupBBoxCenter = sGroupBBox.centre();
+    if (attrs.expanded) {
+      // Expanding: shift the monomer's own atoms so the expanded molecule is
+      // centered on the label position instead of jumping away from it.
+      const moleculeMoveVector = sGroup.pp.sub(sGroupBBoxCenter);
+      if (moleculeMoveVector.length() > 0) {
+        sGroupAtoms.forEach((aid) => {
+          action.addOp(new AtomMove(aid, moleculeMoveVector));
+        });
+      }
+    } else {
+      // Collapsing: shift the label to the center of the expanded molecule.
+      const labelMoveVector = sGroupBBoxCenter.sub(sGroup.pp);
+      if (labelMoveVector.length() > 0) {
+        action.addOp(new SGroupDataMove(sgid, labelMoveVector));
+      }
+    }
+  }
+
   sGroupAtoms.forEach((aid) => {
     action.mergeWith(
       fromAtomsAttrs(restruct, aid, restruct.atoms.get(aid)?.a, false),

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -299,6 +299,31 @@ export function setExpandMonomerSGroup(
   );
   const sGroupWidth = sGroupBBox.p1.x - sGroupBBox.p0.x;
   const sGroupHeight = sGroupBBox.p1.y - sGroupBBox.p0.y;
+
+  // The monomer label is rendered at sGroup.pp, while the molecule occupies
+  // the bounding box of the monomer's own atoms. Keep the two centered on
+  // each other so neither the collapsed label nor the expanded molecule
+  // appears far away from the other.
+  //
+  // Only recenter independent (standalone) monomers. When the monomer is
+  // bonded to outside structure, the connecting bond already anchors it on
+  // its attachment point; recentering onto the bbox center would instead
+  // slide the collapsed label over the neighboring atom.
+  let moleculeMoveVector: Vec2 | undefined;
+  let labelMoveVector: Vec2 | undefined;
+  if (
+    sGroup instanceof MonomerMicromolecule &&
+    sGroup.pp &&
+    bondsToOutside.size === 0
+  ) {
+    const sGroupBBoxCenter = sGroupBBox.centre();
+    if (attrs.expanded) {
+      moleculeMoveVector = sGroup.pp.sub(sGroupBBoxCenter);
+    } else {
+      labelMoveVector = sGroupBBoxCenter.sub(sGroup.pp);
+    }
+  }
+
   const sGroupCenter = sGroup.isContracted()
     ? sGroup.getContractedPosition(struct).position
     : sGroup.pp;
@@ -532,28 +557,15 @@ export function setExpandMonomerSGroup(
     });
   });
 
-  // The monomer label is rendered at sGroup.pp, while the molecule occupies the
-  // bounding box of the monomer's own atoms. Keep the two centered on each
-  // other so neither the collapsed label nor the expanded molecule appears far
-  // away from the other.
-  if (sGroup instanceof MonomerMicromolecule && sGroup.pp) {
-    const sGroupBBoxCenter = sGroupBBox.centre();
-    if (attrs.expanded) {
-      // Expanding: shift the monomer's own atoms so the expanded molecule is
-      // centered on the label position instead of jumping away from it.
-      const moleculeMoveVector = sGroup.pp.sub(sGroupBBoxCenter);
-      if (moleculeMoveVector.length() > 0) {
-        sGroupAtoms.forEach((aid) => {
-          action.addOp(new AtomMove(aid, moleculeMoveVector));
-        });
-      }
-    } else {
-      // Collapsing: shift the label to the center of the expanded molecule.
-      const labelMoveVector = sGroupBBoxCenter.sub(sGroup.pp);
-      if (labelMoveVector.length() > 0) {
-        action.addOp(new SGroupDataMove(sgid, labelMoveVector));
-      }
-    }
+  // Apply the recentering computed above (independent monomers only): shift
+  // the monomer's own atoms when expanding, or the label when collapsing, so
+  // the label and the molecule stay centered on each other.
+  if (moleculeMoveVector && moleculeMoveVector.length() > 0) {
+    sGroupAtoms.forEach((aid) => {
+      action.addOp(new AtomMove(aid, moleculeMoveVector));
+    });
+  } else if (labelMoveVector && labelMoveVector.length() > 0) {
+    action.addOp(new SGroupDataMove(sgid, labelMoveVector));
   }
 
   sGroupAtoms.forEach((aid) => {


### PR DESCRIPTION
### Problem

When a standalone (independent) monomer is expanded or collapsed, its label and its molecule structure are anchored to two different points:

- The collapsed label is drawn at the s-group position (sGroup.pp).
- The expanded molecule occupies the bounding box of the monomer's own atoms.

These two points don't coincide, so toggling between the collapsed and expanded states made the monomer visibly jump — the expanded molecule appeared far away from where the label had been (and vice-versa on collapse), instead of staying in place.

### Fix

In setExpandMonomerSGroup, recenter the monomer so the label and the molecule stay centered on each other during expand/collapse:

- On expand: shift the monomer's atoms so the molecule's bounding-box center lands on the label position (sGroup.pp).
- On collapse: shift the label onto the bounding-box center.

This recentering is applied only to independent (standalone) monomers (bondsToOutside.size === 0). When a monomer is bonded to outside structure, the connecting bond already anchors it to its attachment point — recentering there would drag the collapsed label over the neighboring atom, so it's deliberately skipped.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request