### PR TITLE
#4663 - Wrong Preset name with technical information while copy/paste Preset name

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -119,6 +119,13 @@ export abstract class BaseMode {
       return;
     }
     const editor = provideEditorInstance();
+
+    // Nothing selected to copy — don't overwrite the clipboard with an empty
+    // KET, so a native text selection is copied as-is.
+    if (editor.drawingEntitiesManager.selectedEntities.length === 0) {
+      return;
+    }
+
     const drawingEntitiesManager =
       editor.drawingEntitiesManager.filterSelection();
     const ketSerializer = new KetSerializer();

--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -19,7 +19,7 @@ import { type SequenceType, Struct, Vec2 } from 'domain/entities';
 import { identifyStructFormat } from 'application/formatters/identifyStructFormat';
 import { SupportedFormat } from 'application/formatters/structFormatter.types';
 import { KetSerializer } from 'domain/serializers/ket/ketSerializer';
-import { ChemicalMimeType } from 'domain/services';
+import { ChemicalMimeType } from 'domain/services/struct/structService.types';
 import { ketcherProvider } from 'application/ketcherProvider';
 import type { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
 
@@ -119,14 +119,8 @@ export abstract class BaseMode {
       return;
     }
     const editor = provideEditorInstance();
-
     const drawingEntitiesManager =
       editor.drawingEntitiesManager.filterSelection();
-
-    if (!drawingEntitiesManager.hasDrawingEntities) {
-      return;
-    }
-
     const ketSerializer = new KetSerializer();
     const serializedKet = ketSerializer.serialize(
       new Struct(),

--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -120,14 +120,13 @@ export abstract class BaseMode {
     }
     const editor = provideEditorInstance();
 
-    // Nothing selected to copy — don't overwrite the clipboard with an empty
-    // KET, so a native text selection is copied as-is.
-    if (editor.drawingEntitiesManager.selectedEntities.length === 0) {
+    const drawingEntitiesManager =
+      editor.drawingEntitiesManager.filterSelection();
+
+    if (!drawingEntitiesManager.monomers.size) {
       return;
     }
 
-    const drawingEntitiesManager =
-      editor.drawingEntitiesManager.filterSelection();
     const ketSerializer = new KetSerializer();
     const serializedKet = ketSerializer.serialize(
       new Struct(),

--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -123,7 +123,7 @@ export abstract class BaseMode {
     const drawingEntitiesManager =
       editor.drawingEntitiesManager.filterSelection();
 
-    if (!drawingEntitiesManager.monomers.size) {
+    if (!drawingEntitiesManager.hasDrawingEntities) {
       return;
     }
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaBuilder.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaBuilder.tsx
@@ -60,7 +60,9 @@ export const RnaBuilder = ({ libraryName, duplicatePreset, editPreset }) => {
       />
       <Modal
         isOpen={
-          !!uniqueNameError || !!invalidPresetError || !!invalidPresetNameError
+          Boolean(uniqueNameError) ||
+          Boolean(invalidPresetError) ||
+          Boolean(invalidPresetNameError)
         }
         title="Error Message"
         onClose={closeErrorModal}

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaBuilder.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaBuilder.tsx
@@ -22,6 +22,8 @@ import {
   setUniqueNameError,
   selectInvalidPresetError,
   setInvalidPresetError,
+  selectInvalidPresetNameError,
+  setInvalidPresetNameError,
 } from 'state/rna-builder';
 import { Modal } from 'components/shared/modal';
 import { StyledButton } from 'components/monomerLibrary/RnaBuilder/RnaElementsView/styles';
@@ -31,6 +33,7 @@ export const RnaBuilder = ({ libraryName, duplicatePreset, editPreset }) => {
   const dispatch = useAppDispatch();
   const uniqueNameError = useAppSelector(selectUniqueNameError);
   const invalidPresetError = useAppSelector(selectInvalidPresetError);
+  const invalidPresetNameError = useAppSelector(selectInvalidPresetNameError);
 
   const isCompactView = useIsCompactView();
 
@@ -40,6 +43,9 @@ export const RnaBuilder = ({ libraryName, duplicatePreset, editPreset }) => {
     }
     if (invalidPresetError.length > 0) {
       dispatch(setInvalidPresetError(''));
+    }
+    if (invalidPresetNameError.length > 0) {
+      dispatch(setInvalidPresetNameError(''));
     }
   };
 
@@ -53,7 +59,9 @@ export const RnaBuilder = ({ libraryName, duplicatePreset, editPreset }) => {
         view={isCompactView ? 'tabs' : 'accordion'}
       />
       <Modal
-        isOpen={!!uniqueNameError || !!invalidPresetError}
+        isOpen={
+          !!uniqueNameError || !!invalidPresetError || !!invalidPresetNameError
+        }
         title="Error Message"
         onClose={closeErrorModal}
       >
@@ -63,6 +71,8 @@ export const RnaBuilder = ({ libraryName, duplicatePreset, editPreset }) => {
               `Preset with name "${uniqueNameError}" already exists. Please choose another name.`}
             {invalidPresetError &&
               `Preset with name "${invalidPresetError}" can't be used. Because it is impossible to establish bonds between monomers. Edit it's structure or choose another one.`}
+            {invalidPresetNameError &&
+              'The preset code must consist only of uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and asterisks (*).'}
           </div>
         </Modal.Content>
         <Modal.Footer>

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -52,6 +52,7 @@ import {
   setIsEditMode,
   selectPresetFullName,
   setUniqueNameError,
+  setInvalidPresetNameError,
   setSequenceSelection,
   setSequenceSelectionName,
   selectIsActivePresetNewAndEmpty,
@@ -79,7 +80,10 @@ import { openModal } from 'state/modal';
 import { getCountOfNucleoelements } from 'helpers/countNucleoelents';
 import clsx from 'clsx';
 import Tooltip from '@mui/material/Tooltip';
-import { getPhosphatePositionAvailability } from 'helpers/rnaValidations';
+import {
+  getPhosphatePositionAvailability,
+  isValidPresetName,
+} from 'helpers/rnaValidations';
 import { Icon } from 'ketcher-react';
 import styles from './RnaEditorExpanded.module.less';
 
@@ -523,6 +527,10 @@ export const RnaEditorExpanded = ({
 
   const onSave = () => {
     if (!newPreset?.name) {
+      return;
+    }
+    if (newPreset.editedName && !isValidPresetName(newPreset.name)) {
+      dispatch(setInvalidPresetNameError(newPreset.name));
       return;
     }
 

--- a/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
+++ b/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
@@ -79,3 +79,8 @@ export const getValidations = (
     baseValidations,
   };
 };
+
+const PRESET_NAME_REGEX = /^[a-zA-Z0-9-_*]+$/;
+
+export const isValidPresetName = (name: string): boolean =>
+  PRESET_NAME_REGEX.test(name);

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -103,6 +103,7 @@ interface IRnaBuilderState {
   isEditMode: boolean;
   uniqueNameError: string;
   invalidPresetError: string;
+  invalidPresetNameError: string;
   activePresetForContextMenu: IRnaPreset | null;
   presetPhosphateFilter: PresetPhosphateFilter;
 }
@@ -125,6 +126,7 @@ const initialState: IRnaBuilderState = {
   isEditMode: false,
   uniqueNameError: '',
   invalidPresetError: '',
+  invalidPresetNameError: '',
   activePresetForContextMenu: null,
   presetPhosphateFilter: readPersistedPresetPhosphateFilter(),
 };
@@ -270,6 +272,9 @@ export const rnaBuilderSlice = createSlice({
     },
     setInvalidPresetError: (state, action: PayloadAction<string>) => {
       state.invalidPresetError = action.payload;
+    },
+    setInvalidPresetNameError: (state, action: PayloadAction<string>) => {
+      state.invalidPresetNameError = action.payload;
     },
     setDefaultPresets: (
       state: RootState,
@@ -460,6 +465,10 @@ export const selectInvalidPresetError = (state: RootState) => {
   return state.rnaBuilder.invalidPresetError;
 };
 
+export const selectInvalidPresetNameError = (state: RootState) => {
+  return state.rnaBuilder.invalidPresetNameError;
+};
+
 export const selectIsActivePresetNewAndEmpty = (state: RootState): boolean => {
   const activePreset = state.rnaBuilder.activePreset;
   return (
@@ -619,6 +628,7 @@ export const {
   setIsEditMode,
   setUniqueNameError,
   setInvalidPresetError,
+  setInvalidPresetNameError,
   setDefaultPresets,
   setCustomPresets,
   setActivePresetForContextMenu,


### PR DESCRIPTION
## Summary

Fix #4663: in the RNA Builder, a preset name containing technical information (e.g. `{"root":{"nodes":[],"connections":[],"templates":[]}}_Copy`) could be saved as-is. The preset name is now validated on save against the same rule used for the preset code in the Monomer Creation Wizard.

## Changes

### Preset Name Validation

**Problem:** The RNA Builder name field accepts any text the user types or pastes and saves it without checking its characters, so an invalid name (including serialized KET JSON) could become a preset name.

**Solution:** Validate the preset name on save. A manually entered name must consist only of uppercase and lowercase letters, numbers, hyphens (`-`), underscores (`_`), and asterisks (`*`) (`/^[a-zA-Z0-9-_*]+$/`); otherwise saving is blocked with the error *"The preset code must consist only of uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and asterisks (*)."* Validation runs only when the user edited the name (`editedName`), so auto-generated names like `R(A)P` — which contain parentheses by design — still save. Pasting any content stays allowed; only saving an invalid name is blocked.

### Files Modified

**`ketcher-macromolecules`**
- `helpers/rnaValidations.ts` — add `isValidPresetName` enforcing the allowed-character rule
- `RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx` — validate an edited preset name in `onSave`, dispatching the error when invalid
- `RnaBuilder/RnaBuilder.tsx` — surface the invalid-name error in the existing error modal
- `state/rna-builder/rnaBuilderSlice.ts` — add `invalidPresetNameError` state, reducer, and selector