### PR TITLE
#4452 - Macro: System doesn't allow to unselect already selected nucleotides

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.0.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.0.0-bugs.spec.ts
@@ -290,7 +290,6 @@ test.describe('Ketcher bugs in 3.0.0', () => {
     );
     await selectAllStructuresOnCanvas(page);
     const symbolU = getSymbolLocator(page, { symbolAlias: 'U' }).first();
-    await symbolU.click();
     await modifyInRnaBuilder(page, symbolU);
     await keyboardPressOnCanvas(page, 'Enter');
     await keyboardTypeOnCanvas(page, 'AAA');

--- a/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.0.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Bugs/ketcher-3.0.0-bugs.spec.ts
@@ -283,7 +283,6 @@ test.describe('Ketcher bugs in 3.0.0', () => {
     );
     await selectAllStructuresOnCanvas(page);
     const symbolU = getSymbolLocator(page, { symbolAlias: 'U' }).first();
-    await symbolU.click();
     await modifyInRnaBuilder(page, symbolU);
     await keyboardPressOnCanvas(page, 'Enter');
     await keyboardTypeOnCanvas(page, 'AAA');

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit-in-rna-builder.spec.ts
@@ -105,7 +105,6 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     const endY = 100;
     await selectRectangleArea(page, startX, startY, endX, endY);
     const symbolT = getSymbolLocator(page, { symbolAlias: 'T' }).nth(2);
-    await symbolT.click();
     await modifyInRnaBuilder(page, symbolT);
 
     // should see uploaded data to RNA Builder and disabled "Update" button
@@ -144,7 +143,6 @@ test.describe('Sequence mode edit in RNA Builder', () => {
     await selectRectangleArea(page, startX, startY, endX, endY);
     await takeEditorScreenshot(page);
     const symbolT = getSymbolLocator(page, { symbolAlias: 'T' }).first();
-    await symbolT.click();
     await modifyInRnaBuilder(page, symbolT);
     // should see uploaded nucleotides data to RNA Builder and disabled "Update" button
     await takeRNABuilderScreenshot(page);

--- a/packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts
+++ b/packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts
@@ -299,7 +299,8 @@ abstract class SelectBase implements BaseTool {
 
     if (!shiftKey && !modKey) {
       this.startMoveIfNeeded(renderer);
-      if (renderer.drawingEntity.selected) {
+      const isSequenceItem = renderer instanceof BaseSequenceItemRenderer;
+      if (renderer.drawingEntity.selected && !isSequenceItem) {
         return;
       }
       modelChanges.merge(


### PR DESCRIPTION
## Summary

In Sequence mode (view mode), clicking an already selected nucleotide did nothing. Now it collapses the selection to that single nucleotide, as expected.

## Changes

### Selection Logic Fix

**Problem:** When one or more nucleotides were selected, clicking an already selected one had no effect. The select tool's `mousedownEntity` returns early when the clicked entity is already selected — this exists to preserve a multi-selection for drag-to-move, but sequence items aren't draggable, so the early return left the click doing nothing.

**Solution:** Skip the early return for sequence items (`BaseSequenceItemRenderer`). The handler then falls through to unselect all and reselect just the clicked item. Flex/snake modes are unaffected since `BaseSequenceItemRenderer` only exists in Sequence mode.

### Files Modified

**`ketcher-core`**
- `application/editor/tools/select/SelectBase.ts` — guard the "already selected" early return with `!isSequenceItem` so re-clicking a selected sequence item collapses the selection to it


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request