### PR TITLE
#9422 - Refactor: Explicit Any type clean up (part 5)

### DIFF
--- a/packages/ketcher-core/src/utilities/SettingsManager.ts
+++ b/packages/ketcher-core/src/utilities/SettingsManager.ts
@@ -32,6 +32,20 @@ const DefaultEditorLineLength: EditorLineLength = {
 
 export const SetEditorLineLengthAction = 'SetEditorLineLength';
 
+/**
+ * Persisted selection-tool state, written to and read from localStorage.
+ *
+ * `tool` is one of the keys registered in `toolsMap` (ketcher-react):
+ * `hand`, `select`, `fragmentSelection`, `eraser`, `atom`, `bond`, `chain`,
+ * `template`, `charge`, `sgroup`, `rgroupatom`, `rgroupfragment`, `apoint`,
+ * `attach`, `reactionarrow`, `reactionplus`, `reactionmap`, `reactionunmap`,
+ * `paste`, `rotate`, `enhancedStereo`, `simpleobject`, `text`, `image`,
+ * `createMonomer`.
+ *
+ * `opts` is persisted as raw JSON and read back without runtime validation.
+ * Consumers **must** narrow `opts` before use — do not assume any particular
+ * shape without checking (e.g. `if (typeof action.opts === 'object' && ...)`).
+ */
 export interface SelectionToolAction {
   tool: string;
   opts?: unknown;

--- a/packages/ketcher-core/src/utilities/SettingsManager.ts
+++ b/packages/ketcher-core/src/utilities/SettingsManager.ts
@@ -32,9 +32,13 @@ const DefaultEditorLineLength: EditorLineLength = {
 
 export const SetEditorLineLengthAction = 'SetEditorLineLength';
 
+export interface SelectionToolAction {
+  tool: string;
+  opts?: unknown;
+}
+
 interface SavedSettings {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  selectionTool?: any;
+  selectionTool?: SelectionToolAction;
   disableCustomQuery?: boolean;
   editorLineLength?: EditorLineLength;
   monomerLibraryUpdates?: string[];

--- a/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.tsx
@@ -21,7 +21,7 @@ import {
   StyledTabs,
   TabPanelContent,
 } from './Tabs.styles';
-import { memo } from 'react';
+import { ComponentType, memo } from 'react';
 import { TabsData } from './Tabs.types';
 
 const a11yProps = (index: number) => {
@@ -41,7 +41,9 @@ type Props = {
 const Tabs = (props: Props) => {
   const { tabs, selectedTabIndex, isLayoutToRight, onChange } = props;
   const tabPanel = tabs[selectedTabIndex];
-  const Component = tabPanel?.component;
+  const Component = tabPanel?.component as ComponentType<
+    Record<string, unknown>
+  >;
   const componentProps = tabPanel?.props;
 
   return (

--- a/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
@@ -1,10 +1,9 @@
-import { FC } from 'react';
+import { ComponentType } from 'react';
 
 export type TabPanelData = {
   caption: string;
   tooltip?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  component: FC<any>;
+  component: ComponentType<never>;
   testId: string;
   props?: Record<string, unknown>;
 };

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -327,7 +327,7 @@ class Editor implements KetcherEditor {
 
     const ToolConstructor: ToolConstructorInterface = toolsMap[name];
 
-    const tool = new ToolConstructor(this, opts);
+    const tool = new ToolConstructor(this, opts as never);
 
     const isAtomToolChosen = name === 'atom';
     if (!isAtomToolChosen) {

--- a/packages/ketcher-react/src/script/editor/tool/Tool.ts
+++ b/packages/ketcher-react/src/script/editor/tool/Tool.ts
@@ -32,10 +32,9 @@ export interface Tool extends ToolEventHandler {
   ci?: HoverTarget;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ToolConstructorInterface = new (
   editor: Editor,
-  ...args: any[]
+  ...args: never[]
 ) => Tool;
 
 export type ToolEventHandlerName = keyof ToolEventHandler;

--- a/packages/ketcher-react/src/script/editor/tool/Tool.ts
+++ b/packages/ketcher-react/src/script/editor/tool/Tool.ts
@@ -32,6 +32,9 @@ export interface Tool extends ToolEventHandler {
   ci?: HoverTarget;
 }
 
+// `never[]` rest params: constructor parameters are contravariant, so a
+// `never`-typed rest accepts any concrete tool constructor in `toolsMap`.
+// Do NOT change to `unknown[]` / `any[]` — it breaks the union.
 export type ToolConstructorInterface = new (
   editor: Editor,
   ...args: never[]

--- a/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Select/Select.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -15,7 +14,10 @@
  * limitations under the License.
  ***************************************************************************/
 
-import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
+import MuiSelect, {
+  type SelectChangeEvent,
+  type BaseSelectProps,
+} from '@mui/material/Select';
 import Divider from '@mui/material/Divider';
 import MenuItem from '@mui/material/MenuItem';
 import type { ReactNode } from 'react';
@@ -79,12 +81,13 @@ const Select = ({
       value={currentValue?.value ?? ''}
       title={title}
       onChange={handleChange}
-      renderValue={(selected: string) =>
-        (currentValue?.children ??
+      renderValue={
+        ((selected: string) =>
+          currentValue?.children ??
           currentValue?.label ??
           placeholder ??
           selected ??
-          '') as any
+          '') as BaseSelectProps['renderValue']
       }
       displayEmpty
       multiple={multiple}

--- a/packages/ketcher-react/src/script/ui/state/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/action/index.ts
@@ -23,6 +23,11 @@ import {
 import actions, { type UiAction, type UiActionAction } from '../../action';
 import type Editor from '../../../editor/Editor';
 
+const isSelectionToolAction = (x: unknown): x is SelectionToolAction =>
+  typeof x === 'object' &&
+  x !== null &&
+  (x as { tool?: unknown }).tool === 'select';
+
 type ActionParams = {
   editor: Editor & {
     struct(): Struct;
@@ -157,8 +162,8 @@ export default function (
         ...(params as ActionParams),
         action: resolvedAction,
       });
-      if ((activeTool as { tool?: string })?.tool === 'select') {
-        SettingsManager.selectionTool = activeTool as SelectionToolAction;
+      if (isSelectionToolAction(activeTool)) {
+        SettingsManager.selectionTool = activeTool;
       }
       return buildStateWithStatuses(
         activeTool || state?.activeTool,
@@ -171,8 +176,8 @@ export default function (
         ...(params as ActionParams),
         action: action as UiActionAction,
       });
-      if ((activeTool as { tool?: string })?.tool === 'select') {
-        SettingsManager.selectionTool = activeTool as SelectionToolAction;
+      if (isSelectionToolAction(activeTool)) {
+        SettingsManager.selectionTool = activeTool;
       }
       return buildStateWithStatuses(
         activeTool || state?.activeTool,

--- a/packages/ketcher-react/src/script/ui/state/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/state/action/index.ts
@@ -15,7 +15,11 @@
  ***************************************************************************/
 
 import { isEmpty, isEqual, pickBy } from 'lodash/fp';
-import { type Struct, SettingsManager } from 'ketcher-core';
+import {
+  type Struct,
+  SettingsManager,
+  type SelectionToolAction,
+} from 'ketcher-core';
 import actions, { type UiAction, type UiActionAction } from '../../action';
 import type Editor from '../../../editor/Editor';
 
@@ -154,7 +158,7 @@ export default function (
         action: resolvedAction,
       });
       if ((activeTool as { tool?: string })?.tool === 'select') {
-        SettingsManager.selectionTool = activeTool;
+        SettingsManager.selectionTool = activeTool as SelectionToolAction;
       }
       return buildStateWithStatuses(
         activeTool || state?.activeTool,
@@ -168,7 +172,7 @@ export default function (
         action: action as UiActionAction,
       });
       if ((activeTool as { tool?: string })?.tool === 'select') {
-        SettingsManager.selectionTool = activeTool;
+        SettingsManager.selectionTool = activeTool as SelectionToolAction;
       }
       return buildStateWithStatuses(
         activeTool || state?.activeTool,

--- a/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/ToolbarMultiToolItem.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/ToolbarMultiToolItem.tsx
@@ -81,7 +81,7 @@ const ToolbarMultiToolItem = (props: Props) => {
   const [portalStyle] = usePortalStyle([ref, isOpen]);
 
   let selected = false;
-  let currentId = id;
+  let currentId: ToolbarItemVariant | undefined = id;
 
   const selectedTool = options.find(
     (toolbarItem) => status[toolbarItem.id]?.selected,
@@ -107,13 +107,12 @@ const ToolbarMultiToolItem = (props: Props) => {
     const savedSelectionToolId =
       savedSelectionTool &&
       `${savedSelectionTool.tool}-${savedSelectionTool.opts}`;
-    currentId =
-      savedSelectionTool &&
-      savedSelectionToolId &&
-      options.filter(
-        (option) =>
-          !status[option.id]?.hidden && option.id === savedSelectionToolId,
-      )[0]?.id;
+    currentId = savedSelectionToolId
+      ? options.filter(
+          (option) =>
+            !status[option.id]?.hidden && option.id === savedSelectionToolId,
+        )[0]?.id
+      : undefined;
 
     if (!currentId) {
       currentId =


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Removes the 4 explicit `any` declarations targeted by issue #9422, replacing each with a precise type and dropping the accompanying `eslint-disable @typescript-eslint/no-explicit-any` comments.

- **`Tool.ts`** — `ToolConstructorInterface` rest param changed from `...args: any[]` to `...args: never[]`, so the heterogeneous `toolsMap` still accepts tool constructors with differently-typed required args (constructor params are contravariant, so `never` is assignable to any of them). The only construct site in `Editor.ts` now casts `opts as never`.

- **`SettingsManager.ts`** — `selectionTool?: any` replaced with a new exported `SelectionToolAction` interface (`{ tool: string; opts?: unknown }`) that reflects the persisted action object. It lives in ketcher-core (which cannot import from ketcher-react). The write sites in `action/index.ts` cast to it, and the read site in `ToolbarMultiToolItem.tsx` was tightened with no behavior change.

- **`Tabs.types.ts`** — `component: FC<any>` replaced with `ComponentType<never>`, which accepts any component including strictly-typed ones. The render site in `Tabs.tsx` casts to `ComponentType<Record<string, unknown>>` to spread `props`.

- **`Select.tsx`** — the `renderValue` `as any` cast replaced with a cast to MUI's own `BaseSelectProps['renderValue']`, which bridges the monorepo's `@types/react` v18/v19 `ReactNode` skew. Removed the file-level eslint-disable.

`tsc --noEmit` passes for ketcher-core and ketcher-react; ESLint passes on all touched files.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request