### PR TITLE
#5406 - In the preview for hovering over a bond, chemical groups are highlighted in blue instead of attachment points R

### DIFF
--- a/packages/ketcher-macromolecules/src/components/preview/components/BondAttachmentPoints/BondAttachmentPoints.styles.ts
+++ b/packages/ketcher-macromolecules/src/components/preview/components/BondAttachmentPoints/BondAttachmentPoints.styles.ts
@@ -16,14 +16,20 @@ export const AttachmentPoint = styled.div<AttachmentPointProps>(
 );
 
 interface AttachmentPointNameProps {
-  connected?: boolean;
+  inBond: boolean;
 }
 
 export const AttachmentPointName = styled.p<AttachmentPointNameProps>(
-  ({ theme }) => ({
+  ({ inBond, theme }) => ({
     margin: 0,
+    padding: '2px 4px',
     fontSize: theme.ketcher.font.size.small,
     lineHeight: '12px',
+    fontWeight: inBond
+      ? theme.ketcher.font.weight.bold
+      : theme.ketcher.font.weight.regular,
+    borderRadius: '4px',
+    backgroundColor: inBond ? '#CDF1FC' : 'transparent',
   }),
 );
 
@@ -31,13 +37,11 @@ interface LeavingGroupProps {
   inBond: boolean;
 }
 
-export const LeavingGroup = styled.p<LeavingGroupProps>(
-  ({ inBond, theme }) => ({
-    margin: 0,
-    padding: '4px',
-    fontWeight: theme.ketcher.font.weight.bold,
-    lineHeight: '14px',
-    borderRadius: '4px',
-    backgroundColor: inBond ? '#CDF1FC' : 'transparent',
-  }),
-);
+export const LeavingGroup = styled.p<LeavingGroupProps>(({ theme }) => ({
+  margin: 0,
+  padding: '4px',
+  fontWeight: theme.ketcher.font.weight.bold,
+  lineHeight: '14px',
+  borderRadius: '4px',
+  backgroundColor: 'transparent',
+}));

--- a/packages/ketcher-macromolecules/src/components/preview/components/BondAttachmentPoints/BondAttachmentPoints.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/BondAttachmentPoints/BondAttachmentPoints.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import BondAttachmentPoints from './BondAttachmentPoints';
+import { PreparedAttachmentPointData } from 'components/preview/hooks/useAttachmentPoints';
+
+describe('BondAttachmentPoints', () => {
+  it('highlights the attachment point name when it is in the bond', () => {
+    const attachmentPoints: PreparedAttachmentPointData[] = [
+      { id: 'R1', label: 'OH', connected: true },
+      { id: 'R2', label: 'H', connected: false },
+    ];
+
+    render(
+      <div>
+        {withThemeProvider(
+          <BondAttachmentPoints
+            attachmentPoints={attachmentPoints}
+            attachmentPointInBond="R1"
+          />,
+        )}
+      </div>,
+    );
+
+    const highlightedName = screen.getByText('R1');
+    const nonHighlightedName = screen.getByText('R2');
+    const leavingGroup = screen.getByText('OH');
+
+    expect(highlightedName).toBeInTheDocument();
+    expect(nonHighlightedName).toBeInTheDocument();
+    expect(leavingGroup).toBeInTheDocument();
+    expect(highlightedName).toHaveStyle('background-color: #CDF1FC');
+    expect(nonHighlightedName).not.toHaveStyle('background-color: #CDF1FC');
+  });
+});

--- a/packages/ketcher-macromolecules/src/components/preview/components/BondAttachmentPoints/BondAttachmentPoints.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/BondAttachmentPoints/BondAttachmentPoints.tsx
@@ -16,18 +16,23 @@ const BondAttachmentPoints = ({
 }: Props) => {
   return (
     <>
-      {attachmentPoints.map((attachmentPoint) => (
-        <AttachmentPoint
-          connected={attachmentPoint.connected}
-          inBond={attachmentPoint.id === attachmentPointInBond}
-          key={attachmentPoint.id}
-        >
-          <AttachmentPointName>{attachmentPoint.id}</AttachmentPointName>
-          <LeavingGroup inBond={attachmentPoint.id === attachmentPointInBond}>
-            {attachmentPoint.label}
-          </LeavingGroup>
-        </AttachmentPoint>
-      ))}
+      {attachmentPoints.map((attachmentPoint) => {
+        const isInBond = attachmentPoint.id === attachmentPointInBond;
+        return (
+          <AttachmentPoint
+            connected={attachmentPoint.connected}
+            inBond={isInBond}
+            key={attachmentPoint.id}
+          >
+            <AttachmentPointName inBond={isInBond}>
+              {attachmentPoint.id}
+            </AttachmentPointName>
+            <LeavingGroup inBond={isInBond}>
+              {attachmentPoint.label}
+            </LeavingGroup>
+          </AttachmentPoint>
+        );
+      })}
     </>
   );
 };


### PR DESCRIPTION
…ted in blue instead of attachment points R

 #5406

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request