### PR TITLE
#9299 - Fixes on new lexical library (2)

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/TextButton/TextButton.module.less
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/TextButton/TextButton.module.less
@@ -46,6 +46,7 @@
 
     & > svg {
       color: @color-background-primary;
+      fill: @color-background-primary;
       transition: 0.2s;
     }
 
@@ -54,6 +55,7 @@
 
       & > svg {
         color: @color-background-primary;
+        fill: @color-background-primary;
         transition: 0.2s;
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #9299: the active (pressed) text-formatting buttons in the Text Editor kept a dark icon on the green background, hurting contrast. This makes the icon white when a button is pressed.

## Changes

### Active Button Icon Contrast

**Problem:** When a formatting button (B, I, X¹, X₂) is in its pressed state, the green background is applied but the icon stays dark. The existing `color` rule did not affect the SVG icons, so the contrast stayed poor.

**Solution:** Set `fill: @color-background-primary` on the active (and active-hover) button's `svg`, so the icon renders white on the green background.

### Files Modified

**`ketcher-react`**
- `TextButton.module.less` — add `fill: @color-background-primary` to the `.isActive` and `.isActive:hover` icon rules so pressed buttons show a white icon


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request