### PR TITLE
#10206 - Autotests: Transform isolated test execution to clear canvas test execution for reaction-am-tool-veryfing-button.spec.ts

### DIFF
--- a/ketcher-autotests/tests/specs/Indigo-Tools/Reaction Auto-mapping tool/reaction-am-tool-veryfing-button.spec.ts
+++ b/ketcher-autotests/tests/specs/Indigo-Tools/Reaction Auto-mapping tool/reaction-am-tool-veryfing-button.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-magic-numbers */
-import { test, expect } from '@fixtures';
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { test, expect, Page } from '@fixtures';
 import {
   openFileAndAddToCanvas,
   takeEditorScreenshot,
@@ -20,12 +21,21 @@ import { getAtomLocator } from '@utils/canvas/atoms/getAtomLocator/getAtomLocato
 import { AtomsSetting } from '@tests/pages/constants/settingsDialog/Constants';
 import { setSettingsOption } from '@tests/pages/molecules/canvas/SettingsDialog';
 
+let page: Page;
+test.beforeAll(async ({ initMoleculesCanvas }) => {
+  page = await initMoleculesCanvas();
+});
+test.afterAll(async ({ closePage }) => {
+  await closePage();
+});
+test.beforeEach(async ({ MoleculesCanvas: _ }) => {});
+
 test.describe('Verifying buttons on reaction am tool dropdown', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async () => {
     await waitForPageInit(page);
   });
 
-  test('open reaction map dropdown', async ({ page }) => {
+  test('open reaction map dropdown', async () => {
     /**
      * Test case: EPMLSOPKET-2865
      * Description: Verifying of the button
@@ -41,9 +51,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Not possible when the reaction is absent on canvas', async ({
-    page,
-  }) => {
+  test('Not possible when the reaction is absent on canvas', async () => {
     /**
      * Test case: EPMLSOPKET-1801
      * Description: Not possible when the reaction is absent on canvas
@@ -74,7 +82,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('UI dialog', async ({ page }) => {
+  test('UI dialog', async () => {
     /**
      * Test case: EPMLSOPKET-1808
      * Description:  UI dialog
@@ -100,7 +108,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
     ];
 
     for (const mode of modes) {
-      test(`${mode} mode`, async ({ page }) => {
+      test(`${mode} mode`, async () => {
         await openFileAndAddToCanvas(page, 'Rxn-V2000/reaction-3.rxn');
         const reactionAutoMappingDialog = ReactionAutoMappingDialog(page);
         await LeftToolbar(page).selectReactionMappingTool(
@@ -133,7 +141,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
   });
 
   test.describe('With autoMapping', () => {
-    test.afterEach(async ({ page }) => {
+    test.afterEach(async () => {
       await CommonLeftToolbar(page).areaSelectionTool(
         SelectionToolType.Rectangle,
       );
@@ -160,9 +168,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
       await takeEditorScreenshot(page);
     });
 
-    test('After the manual mapping with incorrect ordering', async ({
-      page,
-    }) => {
+    test('After the manual mapping with incorrect ordering', async () => {
       /**
        * Test cases: EPMLSOPKET-1817
        * Description: After the manual mapping with incorrect ordering
@@ -180,7 +186,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
       );
     });
 
-    test('After the manual mapping with incorrect pairs', async ({ page }) => {
+    test('After the manual mapping with incorrect pairs', async () => {
       /**
        * Test cases: EPMLSOPKET-1818
        * Description: After the manual mapping with incorrect pairs
@@ -198,7 +204,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
       );
     });
 
-    test('Compare the behavior', async ({ page }) => {
+    test('Compare the behavior', async () => {
       /**
        * Test cases: EPMLSOPKET-1819
        * Description: Compare the behavior
@@ -207,7 +213,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
     });
   });
 
-  test('Clear mode', async ({ page }) => {
+  test('Clear mode', async () => {
     /**
      * Test cases: EPMLSOPKET-1821
      * Description: Clear mode
@@ -240,7 +246,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
     await takeEditorScreenshot(page);
   });
 
-  test('Half reaction on canvas', async ({ page }) => {
+  test('Half reaction on canvas', async () => {
     /**
      * Test cases: EPMLSOPKET-1821
      * Description: Half reaction on canvas
@@ -255,7 +261,7 @@ test.describe('Verifying buttons on reaction am tool dropdown', () => {
   });
 
   // TODO: This test is currently highly unstable, figure out how to wait for rendering to complete properly
-  test.skip('Verifying of the correct automapping', async ({ page }) => {
+  test.skip('Verifying of the correct automapping', async () => {
     /**
      * Test cases: EPMLSOPKET-1832
      * Description:  Verifying of the correct automapping


### PR DESCRIPTION
## Summary

Converted `reaction-am-tool-verifying-button.spec.ts` from isolated test execution to clear canvas execution.

## Changes

- Added shared page lifecycle (`beforeAll`/`afterAll`)
- Added `MoleculesCanvas` fixture
- Removed page fixture usage from tests and hooks
- Updated test setup to follow `mol-files.spec.ts`

## Verification

- Linting passes
- Formatting applied