### PR TITLE
Backmerge: #10260 - Warning message for unusual base leaving group incorrectly refers to "hydroxyl" instead of "hydrogen"

### DIFF
--- a/ketcher-autotests/tests/specs/Chromium-popup/Monomer-creation/monomer-creation6.spec.ts
+++ b/ketcher-autotests/tests/specs/Chromium-popup/Monomer-creation/monomer-creation6.spec.ts
@@ -324,7 +324,7 @@ test(`6. Check warning messages on Base monomer if R1 attachment point with a le
 
   await expect(WarningMessageDialog(page).window).toBeVisible();
   expect(await WarningMessageDialog(page).getWarningMessage()).toContain(
-    'Base monomers typically have a hydroxyl as the leaving group for R1. Do you wish to proceed with the current attachment points?',
+    'Base monomers typically have a hydrogen as the leaving group for R1. Do you wish to proceed with the current attachment points?',
   );
 
   await WarningMessageDialog(page).cancel();

--- a/package-lock.json
+++ b/package-lock.json
@@ -31897,7 +31897,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "3.17.0-rc.1",
+      "version": "3.17.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -33825,7 +33825,7 @@
       }
     },
     "packages/ketcher-macromolecules": {
-      "version": "3.17.0-rc.1",
+      "version": "3.17.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -36904,7 +36904,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "3.17.0-rc.1",
+      "version": "3.17.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -40061,7 +40061,7 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "3.17.0-rc.1",
+      "version": "3.17.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "3.17.0-rc.1",
+  "version": "3.17.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "3.17.0-rc.1",
+  "version": "3.17.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "3.17.0-rc.1",
+  "version": "3.17.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerValidationRules.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerValidationRules.ts
@@ -55,7 +55,7 @@ export const MONOMER_VALIDATION_RULES: MonomerValidationRule[] = [
       },
     ],
     warningMessage:
-      'Base monomers typically have a hydroxyl as the leaving group for R1. Do you wish to proceed with the current attachment points?',
+      'Base monomers typically have a hydrogen as the leaving group for R1. Do you wish to proceed with the current attachment points?',
   },
   {
     monomerType: KetMonomerClass.Phosphate,

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "3.17.0-rc.1",
+  "version": "3.17.0-rc.2",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",


### PR DESCRIPTION
(cherry picked from commit 39c0fc5a2e748e9ca66a58ac4d2d10b40300123d)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request