### PR TITLE
#10283 – Rotation tool: Current rotation angle values remain positive beyond 180 degrees instead of switching to negative

### DIFF
--- a/packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/renderers/TransientView/RotationView.test.ts
@@ -97,9 +97,9 @@ describe('RotationView', () => {
     expect(findArcPath(svg, 'A90,90 0 0,1')).toContain('M190,100A90,90 0 0,1');
   });
 
-  it('uses large-arc-flag for rotation angles above 180 degrees', () => {
+  it('draws the short arc the other way for rotation angles above 180 degrees', () => {
     const svg = renderRotation({ rotationAngle: (210 * Math.PI) / 180 });
 
-    expect(findArcPath(svg, 'A90,90 0 1,1')).toContain('M100,10A90,90 0 1,1');
+    expect(findArcPath(svg, 'A90,90 0 0,0')).toContain('M100,10A90,90 0 0,0');
   });
 });

--- a/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
+++ b/packages/ketcher-core/src/application/render/renderers/TransientView/RotationView.ts
@@ -78,6 +78,18 @@ const getDegreeDifference = (a: number, b: number) => {
   return diff > 180 ? 360 - diff : diff;
 };
 
+const normalizeDegrees = (degrees: number) => {
+  const wrapped = ((degrees % 360) + 360) % 360;
+  return wrapped > 180 ? wrapped - 360 : wrapped;
+};
+
+const normalizeRadians = (angle: number) => {
+  const wrapped = angle % (2 * Math.PI);
+  if (wrapped > Math.PI) return wrapped - 2 * Math.PI;
+  if (wrapped <= -Math.PI) return wrapped + 2 * Math.PI;
+  return wrapped;
+};
+
 const getPointOnCircle = (center: Vec2, radius: number, angle: number) => {
   return {
     x: center.x + radius * Math.cos(angle),
@@ -91,10 +103,11 @@ const getRotationArcPath = (
   startAngle: number,
   rotationAngle: number,
 ) => {
+  const normalizedAngle = normalizeRadians(rotationAngle);
   const start = getPointOnCircle(center, radius, startAngle);
-  const end = getPointOnCircle(center, radius, startAngle + rotationAngle);
-  const largeArcFlag = Math.abs(rotationAngle) > Math.PI ? 1 : 0;
-  const sweepFlag = rotationAngle < 0 ? 0 : 1;
+  const end = getPointOnCircle(center, radius, startAngle + normalizedAngle);
+  const largeArcFlag = Math.abs(normalizedAngle) > Math.PI ? 1 : 0;
+  const sweepFlag = normalizedAngle < 0 ? 0 : 1;
 
   return (
     `M${start.x},${start.y}` +
@@ -355,7 +368,9 @@ export class RotationView extends TransientView {
           0, 30, 45, 60, 90, 120, 135, 150, 180, -150, -135, -120, -90, -60,
           -45, -30,
         ];
-        const currentDegrees = Math.round((rotationAngle * 180) / Math.PI);
+        const currentDegrees = normalizeDegrees(
+          Math.round((rotationAngle * 180) / Math.PI),
+        );
         const tickLength =
           radius >= STYLE.MIN_RADIUS_FOR_TEXT
             ? STYLE.DEGREE_LINE_LENGTH
@@ -416,7 +431,9 @@ export class RotationView extends TransientView {
           .attr('style', 'pointer-events: none');
 
         // Draw angle text
-        const angleInDegrees = Math.round((rotationAngle * 180) / Math.PI);
+        const angleInDegrees = normalizeDegrees(
+          Math.round((rotationAngle * 180) / Math.PI),
+        );
         const textAngle = startAngle;
         const textRadius = radius + 20;
         const textX =


### PR DESCRIPTION
## Summary

Fixes the rotation tool in Macromolecules flex mode so that rotating past 180° shows a decreasing negative angle and draws the short rotation arc, matching the existing Molecules-mode behavior.

## Changes

### Rotation Angle & Arc Normalization

**Problem:** In Macromolecules mode the rotation overlay used the raw, unbounded rotation angle. Past 180° the readout kept climbing (up to 270°) instead of switching to negative, and the blue arc swept the long way (≈3/4 of the circle) instead of the short half.

**Solution:** Normalize the angle to the `(-180, 180]` range before rendering — for the displayed value, the protractor tick highlight, and the arc's sweep/large-arc flags. The helpers mirror Molecules mode (`normalizeAngle` / `degrees()`) so both editors behave identically.

### Files Modified

**`ketcher-core`**
- `RotationView.ts` — added `normalizeDegrees` and `normalizeRadians`; applied them to the angle label, tick highlight, and `getRotationArcPath` so angle and arc stay consistent past 180°
- `RotationView.test.ts` — updated the existing >180° arc test to expect the short-arc (minor path, reverse sweep) behavior


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request