### PR TITLE
#6826 - Undo/Redo after deleting a sequence via right-click places it incorrectly in the sequence list

### DIFF
--- a/packages/ketcher-core/src/domain/entities/monomer-chains/ChainsCollection.ts
+++ b/packages/ketcher-core/src/domain/entities/monomer-chains/ChainsCollection.ts
@@ -81,16 +81,22 @@ export class ChainsCollection {
       // The factor is used to reduce the influence of the X coordinate on the sorting
       // to make the sorting more oriented to Y coordinate
       const X_COORDINATE_REDUCTION_FACTOR = 0.01;
-      if (
-        chain2.firstNode?.monomer.position.x * X_COORDINATE_REDUCTION_FACTOR +
-          chain2.firstNode?.monomer.position.y >
-        chain1.firstNode?.monomer.position.x * X_COORDINATE_REDUCTION_FACTOR +
-          chain1.firstNode?.monomer.position.y
-      ) {
-        return -1;
-      } else {
-        return 1;
+      const chain1Weight =
+        (chain1.firstNode?.monomer.position.x ?? 0) *
+          X_COORDINATE_REDUCTION_FACTOR +
+        (chain1.firstNode?.monomer.position.y ?? 0);
+      const chain2Weight =
+        (chain2.firstNode?.monomer.position.x ?? 0) *
+          X_COORDINATE_REDUCTION_FACTOR +
+        (chain2.firstNode?.monomer.position.y ?? 0);
+
+      if (chain1Weight !== chain2Weight) {
+        return chain1Weight - chain2Weight;
       }
+      return (
+        (chain1.firstNode?.monomer.id ?? 0) -
+        (chain2.firstNode?.monomer.id ?? 0)
+      );
     });
 
     const reorderedChains = new Set<Chain>();


### PR DESCRIPTION
## Summary

Fixes incorrect sequence ordering when a sequence deleted via the right-click context menu is restored with Undo. The restored sequence now returns to its original position in the list instead of sinking below its neighbor and drifting to the bottom on repeated Undo/Redo.

## Changes

### Sequence list ordering on undo

**Problem:** Chain order in the sequence list is derived solely from the first monomer's position (`x * 0.01 + y`). When a sequence is deleted, the snake layout shifts the remaining sequences up to fill the gap; on Undo the restored sequence is re-added at its original position and collides exactly with a shifted neighbor. The position-only sort could not resolve this tie deterministically, so the restored sequence landed below its neighbor — and drifted further down on each Undo/Redo cycle.

**Solution:** Added a deterministic tie-break to `ChainsCollection.rearrange()`: when two chains share the same first-node position, they are ordered by the first monomer's `id`. Since ids increase monotonically at creation and are preserved across delete/undo (the same object is restored), the earlier-created sequence stays higher. The tie-break only activates on an exact positional collision, so normal layouts are unaffected.

### Files Modified

**`ketcher-core`**
- `ChainsCollection.ts` — tie-break the `rearrange()` chain sort by first-monomer `id` on equal positions; refactored the comparator to return the weight difference with `?? 0` guards


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request