### PR TITLE
#10269 – Incorrect monomer name is loaded into the wizard when using …

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.utils.test.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.utils.test.ts
@@ -15,20 +15,23 @@ const createMonomer = (
 describe('getEditInstanceInitialValues', () => {
   it('loads amino acid fields for Edit Instance with copies for user-editable aliases', () => {
     const values = getEditInstanceInitialValues(
-      createMonomer({
-        MonomerClass: KetMonomerClass.AminoAcid,
-        MonomerCode: 'C',
-        MonomerName: 'Cysteine',
-        Name: 'Cysteine',
-        MonomerNaturalAnalogCode: 'C',
-        aliasHELM: 'C',
-        aliasBILN: 'C',
-        aliasAxoLabs: 'IgnoredAxoLabs',
-        idtAliases: {
-          base: 'IgnoredIDT',
+      createMonomer(
+        {
+          MonomerClass: KetMonomerClass.AminoAcid,
+          MonomerName: 'C',
+          Name: 'Cysteine',
+          MonomerFullName: 'Cysteine',
+          MonomerNaturalAnalogCode: 'C',
+          aliasHELM: 'C',
+          aliasBILN: 'C',
+          aliasAxoLabs: 'IgnoredAxoLabs',
+          idtAliases: {
+            base: 'IgnoredIDT',
+          },
+          modificationTypes: ['Natural amino acid'],
         },
-        modificationTypes: ['Natural amino acid'],
-      }),
+        'C',
+      ),
     );
 
     expect(values).toEqual({
@@ -43,16 +46,19 @@ describe('getEditInstanceInitialValues', () => {
 
   it('does not load natural analogue, AxoLabs alias, or modification types for a phosphate', () => {
     const values = getEditInstanceInitialValues(
-      createMonomer({
-        MonomerClass: KetMonomerClass.Phosphate,
-        MonomerCode: 'sP',
-        MonomerName: 'Phosporothioate',
-        Name: 'Phosporothioate',
-        MonomerNaturalAnalogCode: 'P',
-        aliasHELM: 'sp',
-        aliasBILN: 'sp',
-        aliasAxoLabs: 'sp',
-      }),
+      createMonomer(
+        {
+          MonomerClass: KetMonomerClass.Phosphate,
+          MonomerName: 'sP',
+          Name: 'Phosporothioate',
+          MonomerFullName: 'Phosporothioate',
+          MonomerNaturalAnalogCode: 'P',
+          aliasHELM: 'sp',
+          aliasBILN: 'sp',
+          aliasAxoLabs: 'sp',
+        },
+        'sP',
+      ),
     );
 
     expect(values).toEqual({
@@ -63,5 +69,23 @@ describe('getEditInstanceInitialValues', () => {
       aliasHELM: 'sp_Copy',
       aliasBILN: 'sp_Copy',
     });
+  });
+
+  it('falls back to Name when MonomerFullName is absent', () => {
+    const values = getEditInstanceInitialValues(
+      createMonomer(
+        {
+          MonomerClass: KetMonomerClass.AminoAcid,
+          MonomerName: 'C',
+          Name: 'Cysteine',
+          MonomerNaturalAnalogCode: 'C',
+          aliasHELM: 'C',
+          aliasBILN: 'C',
+        },
+        'C',
+      ),
+    );
+
+    expect(values.name).toBe('Cysteine_Copy');
   });
 });

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.utils.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.utils.ts
@@ -22,7 +22,7 @@ export const getEditInstanceInitialValues = (
   const { label, props } = monomer.monomerItem;
   const type = props.MonomerClass ?? KetMonomerClass.CHEM;
   const symbol = props.MonomerCode ?? label;
-  const name = props.MonomerName ?? props.Name ?? symbol;
+  const name = props.MonomerFullName ?? props.Name ?? symbol;
   const naturalAnalogue = isNaturalAnalogueSupported(type)
     ? props.MonomerNaturalAnalogCode
     : '';


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

`getEditInstanceInitialValues` seeded the wizard's **Name** field from `props.MonomerName`,
which holds the monomer's short alias/code (e.g. `C`), not its descriptive name. So
"Edit Instance" loaded `C_Copy` instead of `Cysteine_Copy`.

Fix: read the name from `props.MonomerFullName` (with `props.Name` as fallback) instead of
`props.MonomerName`. This is correct for both library and user-created monomers, since both
store the full name in `Name`/`MonomerFullName` and the code in `MonomerName`/`label`.

| | Name field |
|---|---|
| Before | `C_Copy` |
| After | `Cysteine_Copy` |

The existing unit fixtures used an unrealistic prop shape (`MonomerName` = full name), which is
why this slipped through. They are corrected to match the real parser output, so the suite now
actually guards the regression.

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request