### PR TITLE
#10333 - Refactor: Optional chaining should be preferred

### DIFF
--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -589,7 +589,7 @@ export class MacromoleculesConverter {
 
         // Add stereo flag if the fragment has an enhanced stereo flag
         monomer.monomerItem.struct.frags.forEach((fragment) => {
-          if (fragment && fragment.enhancedStereoFlag) {
+          if (fragment?.enhancedStereoFlag) {
             const stereoFlagPosition =
               fragment.stereoFlagPosition ||
               Fragment.getDefaultStereoFlagPosition(

--- a/packages/ketcher-core/src/application/render/restruct/retext.ts
+++ b/packages/ketcher-core/src/application/render/restruct/retext.ts
@@ -176,7 +176,7 @@ class ReText extends ReObject {
       if (this.item.content) {
         const parsed = JSON.parse(this.item.content);
         // Support Lexical format only (convert at import time).
-        if (parsed && parsed.root) {
+        if (parsed?.root) {
           editorState = parsed as SerializedEditorState;
         } else {
           console.warn(

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/textToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/textToStruct.ts
@@ -179,7 +179,7 @@ export function textToStruct(ketItem: any, struct: Struct) {
 
     // If the incoming node.content is Draft.js shape (stringified or object),
     // convert it to Lexical format at parse time so we store only Lexical JSON.
-    if (node && node.content) {
+    if (node?.content) {
       try {
         // If content is a JSON string, try to parse it
         const parsed =


### PR DESCRIPTION
## Summary

Replace `&&` existence checks with optional chaining (`?.`) at three flagged spots, per #10333. Behavior-preserving readability refactor.

## Files Modified

**`ketcher-core`**
- `MacromoleculesConverter.ts` — `fragment && fragment.enhancedStereoFlag` → `fragment?.enhancedStereoFlag`
- `retext.ts` — `parsed && parsed.root` → `parsed?.root`
- `textToStruct.ts` — `node && node.content` → `node?.content`


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request