### PR TITLE
#10328 - Refactor: Fields that are only assigned in the constructor should be "readonly"

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
@@ -17,7 +17,7 @@ export class RemoveAttachmentPointOperation extends BaseOperation {
     private readonly monomerCreationState: MonomerCreationState,
     private readonly attachmentPointName: AttachmentPointName,
     private readonly potentialLeavingAtoms?: Set<number>,
-    private _assignedAttachmentPoints?: Map<
+    private readonly _assignedAttachmentPoints?: Map<
       AttachmentPointName,
       [number, number]
     >,

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceEventDelegationManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceEventDelegationManager.ts
@@ -13,7 +13,8 @@ export class SequenceEventDelegationManager {
   // eslint-disable-next-line no-use-before-define
   private static _instance: SequenceEventDelegationManager | null = null;
   private canvas: D3SvgElementSelection<SVGGElement, void> | null = null;
-  private boundHandlers: Map<string, (event: MouseEvent) => void> = new Map();
+  private readonly boundHandlers: Map<string, (event: MouseEvent) => void> =
+    new Map();
 
   public static get instance() {
     if (!SequenceEventDelegationManager._instance) {

--- a/packages/ketcher-core/src/application/settings/MemoryStorageAdapter.ts
+++ b/packages/ketcher-core/src/application/settings/MemoryStorageAdapter.ts
@@ -6,7 +6,7 @@
 import type { ISettingsStorage, Settings } from './types';
 
 export class MemoryStorageAdapter implements ISettingsStorage {
-  private storage: Map<string, Settings> = new Map();
+  private readonly storage: Map<string, Settings> = new Map();
 
   /**
    * Load settings from memory

--- a/packages/ketcher-core/src/application/settings/SettingsService.ts
+++ b/packages/ketcher-core/src/application/settings/SettingsService.ts
@@ -62,11 +62,11 @@ export class SettingsService implements ISettingsService {
   private static instance: SettingsService | null = null;
 
   private settings: Settings;
-  private storage: ISettingsStorage;
-  private validator: ISettingsValidator;
-  private emitter: EventEmitter;
-  private storageKey: string;
-  private autoSave: boolean;
+  private readonly storage: ISettingsStorage;
+  private readonly validator: ISettingsValidator;
+  private readonly emitter: EventEmitter;
+  private readonly storageKey: string;
+  private readonly autoSave: boolean;
   private initialized = false;
 
   /**

--- a/packages/ketcher-core/src/domain/entities/LinkerSequenceNode.ts
+++ b/packages/ketcher-core/src/domain/entities/LinkerSequenceNode.ts
@@ -15,7 +15,7 @@ import { KetMonomerClass } from 'domain/constants/monomers';
 export class LinkerSequenceNode {
   constructor(
     public monomer: BaseMonomer,
-    private firstMonomerInChain?: BaseMonomer,
+    private readonly firstMonomerInChain?: BaseMonomer,
   ) {}
 
   public get SubChainConstructor() {


### PR DESCRIPTION
Added the `readonly` modifier to every flagged field that is assigned exactly once — in the constructor or its inline initializer — and never reassigned afterwards. This makes each field's intent explicit and prevents future maintainers from accidentally reassigning it. The change is a compile-time-only modifier with no runtime effect.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request