### PR TITLE
#10322 – Undo operation doesn't work in some cases

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/atomMerge.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/atomMerge.test.ts
@@ -1,0 +1,79 @@
+/****************************************************************************
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { fromAtomMerge } from 'application/editor/actions/atomMerge';
+import { Render } from 'application/render';
+import { RenderOptions } from 'application/render/render.types';
+import { ReStruct } from 'application/render/restruct';
+import {
+  Atom,
+  SGroup,
+  SGroupAttachmentPoint,
+  Struct,
+  Vec2,
+} from 'domain/entities';
+
+describe('fromAtomMerge', () => {
+  // Reproduces merging a functional-group atom (which is an S-group
+  // attachment point) into a canvas atom, then undoing the merge.
+  it('does not throw on undo after merging an S-group attachment-point atom', () => {
+    const struct = new Struct();
+
+    const srcId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(0, 0), fragment: 0 }),
+    );
+    const groupNeighbourId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(1, 0), fragment: 0 }),
+    );
+    const dstId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(0, 0), fragment: 0 }),
+    );
+
+    const sgroup = new SGroup(SGroup.TYPES.SUP);
+    const sgroupId = struct.sgroups.add(sgroup);
+    sgroup.id = sgroupId;
+    struct.atomAddToSGroup(sgroupId, srcId);
+    struct.atomAddToSGroup(sgroupId, groupNeighbourId);
+    sgroup.addAttachmentPoint(
+      new SGroupAttachmentPoint(srcId, undefined, undefined),
+    );
+
+    const options = {
+      scale: 40,
+      width: 100,
+      height: 100,
+    } as unknown as RenderOptions;
+    const render = new Render(document as unknown as HTMLElement, options);
+    const restruct = new ReStruct(struct, render);
+    restruct.assignConnectedComponents();
+
+    // Forward merge (drag functional group onto canvas atom).
+    const undoAction = fromAtomMerge(restruct, srcId, dstId);
+
+    // The attachment point must actually be removed from the S-group once
+    // its atom has been merged away, not silently left dangling.
+    expect(sgroup.getAttachmentPoints()).toHaveLength(0);
+
+    // Undo must not throw "The same attachment point cannot be added to an
+    // S-group more than once".
+    expect(() => undoAction.perform(restruct)).not.toThrow();
+
+    // The attachment point should be restored after undo.
+    const restoredAttachmentPoints = sgroup.getAttachmentPoints();
+    expect(restoredAttachmentPoints).toHaveLength(1);
+    expect(restoredAttachmentPoints[0].atomId).toBe(srcId);
+  });
+});

--- a/packages/ketcher-core/__tests__/application/editor/actions/atomMerge.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/atomMerge.test.ts
@@ -16,7 +16,7 @@
 
 import { fromAtomMerge } from 'application/editor/actions/atomMerge';
 import { Render } from 'application/render';
-import { RenderOptions } from 'application/render/render.types';
+import type { RenderOptions } from 'application/render/render.types';
 import { ReStruct } from 'application/render/restruct';
 import {
   Atom,

--- a/packages/ketcher-core/src/application/editor/actions/atomMerge.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atomMerge.ts
@@ -16,7 +16,6 @@
 
 import { Atom } from 'domain/entities/atom';
 import { Bond } from 'domain/entities/bond';
-import { SGroupAttachmentPoint } from 'domain/entities/sGroupAttachmentPoint';
 import {
   AtomAttr,
   AtomDelete,
@@ -100,10 +99,7 @@ export function fromAtomMerge(
     for (const attachmentPoint of sgroup.getAttachmentPoints()) {
       if (attachmentPoint.atomId === srcId) {
         action.addOp(
-          new SGroupAttachmentPointRemove(
-            sgroupId,
-            new SGroupAttachmentPoint(srcId, undefined, undefined),
-          ),
+          new SGroupAttachmentPointRemove(sgroupId, attachmentPoint),
         );
         return;
       }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Merging an atom onto another (e.g. dragging a functional group template onto a canvas atom) removed its S-group attachment point using a freshly-constructed `SGroupAttachmentPoint` object instead of the one actually stored in the S-group. `SGroup.removeAttachmentPoint` looks the object up by reference (`Array.prototype.indexOf`), so the removal silently failed and the stale attachment point was left in the S-group after its atom was deleted.

On Undo, the inverted `SGroupAttachmentPointRemove` operation re-added that same attachment point. Since the original was never actually removed, this created a duplicate, which threw:
```
Uncaught Error: The same attachment point cannot be added to an S-group more than once
```
This aborted the undo action mid-way, leaving the editor's internal model in an inconsistent state, which then surfaced as a second, unrelated-looking crash in `rebond.ts` during subsequent hit-testing.

**Fix:** reuse the actual attachment point object found while iterating the S-group's attachment points, instead of constructing a new one, so removal actually succeeds during the forward merge and there's nothing left to collide with on undo.

### Repro steps
1. Clear Canvas → add any structure (e.g. cyclopropane) on canvas
2. Structure Library → add a Functional Group (e.g. Bn) from Template on canvas
3. Select the functional group
4. Drag it onto the structure, hovering over an atom to merge
5. Run Undo → uncaught errors in console (before this fix)

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request