### PR TITLE
#10362 – Refactor: Explicit Any type clean up (part 5.3)

### DIFF
--- a/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.tsx
@@ -21,7 +21,7 @@ import {
   StyledTabs,
   TabPanelContent,
 } from './Tabs.styles';
-import { memo } from 'react';
+import { FC, memo } from 'react';
 import { TabsData } from './Tabs.types';
 
 const a11yProps = (index: number) => {
@@ -41,7 +41,7 @@ type Props = {
 const Tabs = (props: Props) => {
   const { tabs, selectedTabIndex, isLayoutToRight, onChange } = props;
   const tabPanel = tabs[selectedTabIndex];
-  const Component = tabPanel?.component;
+  const Component = tabPanel?.component as FC<Record<string, unknown>>;
   const componentProps = tabPanel?.props;
 
   return (

--- a/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
@@ -3,8 +3,7 @@ import { FC } from 'react';
 export type TabPanelData = {
   caption: string;
   tooltip?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  component: FC<any>;
+  component: FC<never>;
   testId: string;
   props?: Record<string, unknown>;
 };

--- a/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
@@ -3,7 +3,7 @@ import { FC } from 'react';
 export type TabPanelData = {
   caption: string;
   tooltip?: string;
-  component: FC<never>;
+  component: FC<unknown>;
   testId: string;
   props?: Record<string, unknown>;
 };

--- a/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
+++ b/packages/ketcher-macromolecules/src/components/shared/Tabs/Tabs.types.ts
@@ -3,7 +3,7 @@ import { FC } from 'react';
 export type TabPanelData = {
   caption: string;
   tooltip?: string;
-  component: FC<unknown>;
+  component: FC<never>;
   testId: string;
   props?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

Removes the explicit `any` from `TabPanelData.component` (`Tabs.types.ts:7`), replacing `FC<any>` with the type-safe `FC<never>` so any tab component can still be assigned without disabling type checking.

### Files Modified

**`ketcher-macromolecules`**
- `Tabs.types.ts` — replaced `FC<any>` (with its `no-explicit-any` disable) with `FC<never>`, the safe universal component type given props are supplied dynamically via `props`
- `Tabs.tsx` — cast the resolved component to `FC<Record<string, unknown>>` at render so the dynamic `props` bag can be applied


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request