### PR TITLE
#10377 - Selecting "Single" from a bond's right-click type menu advances the bond order (Single→Double→Triple) instead of setting it to single

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useBondTypeChange.ts
@@ -2,7 +2,6 @@ import {
   type BondAttributes,
   fromBondsAttrs,
   ketcherProvider,
-  bondChangingAction,
 } from 'ketcher-core';
 import { useCallback } from 'react';
 import { useAppContext } from 'src/hooks';
@@ -35,23 +34,6 @@ const useBondTypeChange = () => {
         bondProps.topology = 0;
         bondProps.reactingCenterStatus = 0;
       }
-
-      // If only one bond is selected, use bondChangingAction to support direction flipping
-      if (bondIds.length === 1) {
-        const bond = molecule.bonds.get(bondIds[0]);
-        if (bond) {
-          const action = bondChangingAction(
-            molecule,
-            bondIds[0],
-            bond.b,
-            bondProps,
-          );
-          editor.update(action);
-          return;
-        }
-      }
-
-      // For multiple bonds, use fromBondsAttrs
       editor.update(fromBondsAttrs(molecule, bondIds, bondProps));
     },
     [ketcherId],


### PR DESCRIPTION
### Problem
Selecting a type from a bond's right-click context menu cycles the bond order instead of setting it. Because `useBondTypeChange` routes an individual-bond selection through `bondChangingAction` (the bond-tool cycling helper), picking **Single** advances the order Single→Double→Triple. Most visibly, right-click a double bond → **Single** produces a **triple** bond. On a triple bond it happens to land on single (the cycle wraps). Selecting Double/Triple works, and selecting multiple bonds works, because the multi-bond path already uses `fromBondsAttrs`.

Fixes [#10377
](https://github.com/epam/ketcher/issues/10377)

### Fix
Use `fromBondsAttrs` (a direct set) for individual bonds, matching the multi-bond path.

`bondChangingAction` was also flipping a wedge bond's direction on re-selection, but bond direction has dedicated context-menu items handled by `useChangeBondDirection`, so switching to `fromBondsAttrs` doesn't remove reachable functionality; it only stops the menu from cycling the bond order.

### Note for reviewers
If you'd prefer to preserve the re-select wedge-flip, a more surgical alternative is to keep the `if (bondIds.length === 1)` guard but take the `bondChangingAction` path only when `bondProps.stereo !== NONE`, so plain type selections always use `fromBondsAttrs`.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [X] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [X] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request