### PR TITLE
#3774 - Enhanced Stereochemistry label is immediately placed on canvas when selecting templates from the library

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -141,8 +141,26 @@ class TemplatePreview {
   private moveFloatingPreview() {
     const dist = this.position.sub(this.previousPosition);
     this.previousPosition = this.position;
-    fromMultipleMove(this.restruct, this.floatingPreview, dist);
+    fromMultipleMove(
+      this.restruct,
+      {
+        ...this.floatingPreview,
+        enhancedFlags: this.getFloatingPreviewFragmentIds(),
+      },
+      dist,
+    );
     this.editor.render.update(false, null);
+  }
+
+  private getFloatingPreviewFragmentIds(): number[] {
+    const fragmentIds = new Set<number>();
+    this.floatingPreview?.atoms.forEach((atomId) => {
+      const atom = this.struct.atoms.get(atomId);
+      if (atom) {
+        fragmentIds.add(atom.fragment);
+      }
+    });
+    return Array.from(fragmentIds);
   }
 
   private showFloatingPreview(position: Vec2) {


### PR DESCRIPTION
## Summary

the Enhanced Stereochemistry label now follows the template while it is attached to the cursor, instead of staying at its initial position until the template is placed.

## Changes

**Problem:** `moveFloatingPreview` only moved the preview's atoms and bonds, so the enhanced stereochemistry label stayed behind and only snapped to the template once it was dropped on the canvas.

**Solution:** Pass the preview fragments' ids as `enhancedFlags` to `fromMultipleMove`, so the stereo label is moved together with the template on every mouse move.

### Files Modified

**`ketcher-react`**
- `templatePreview.ts` - include preview fragment ids as `enhancedFlags` in `moveFloatingPreview`, and add `getFloatingPreviewFragmentIds` helper to collect them from the preview atoms


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request