### PR TITLE
#5169 - Simple Objects are duplicated after saving in Macro mode

### DIFF
--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -2337,6 +2337,7 @@ export class DrawingEntitiesManager {
   }
 
   public setMicromoleculesHiddenEntities(struct: Struct) {
+    this.clearMicromoleculesHiddenEntities();
     struct.mergeInto(this.micromoleculesHiddenEntities);
     this.micromoleculesHiddenEntities.atoms = new Pool();
     this.micromoleculesHiddenEntities.bonds = new Pool();


### PR DESCRIPTION
## Summary
Added cleaning of hidden entities for Macro Save logic. Checked that it's not affecting other places where we use `setMicromoleculesHiddenEntities()`

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request