### PR TITLE
#10332 - Refactor: Redundant casts and non-null assertions should be avoided

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.test.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.test.ts
@@ -28,7 +28,7 @@ const getIsMonomerCreationWizardEnabled = (editor: Editor): boolean => {
     Editor.prototype,
     'isMonomerCreationWizardEnabled',
     editor,
-  ) as boolean;
+  );
 };
 
 const getTerminalRGroupAtoms = (editor: Editor) => {

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -2121,7 +2121,7 @@ class Editor implements KetcherEditor {
         atomIdMap.forEach((newAtomId) => {
           const atom = struct.atoms.get(newAtomId);
           if (atom?.pp) {
-            atom.pp = atom.pp.add(monomerShiftVector as Vec2);
+            atom.pp = atom.pp.add(monomerShiftVector);
           }
         });
       }

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -609,10 +609,10 @@ class SelectTool implements Tool {
         .map(({ item }) => item)
         .filter((sgroup): sgroup is SGroup => !!sgroup);
       isDraggingOnSaltOrSolventAtom = mergeAtoms.some((atomId) =>
-        SGroup.isAtomInSaltOrSolvent(atomId as number, sgroupsOnCanvas),
+        SGroup.isAtomInSaltOrSolvent(atomId, sgroupsOnCanvas),
       );
       isDraggingOnSaltOrSolventBond = mergeBonds.some((bondId) =>
-        SGroup.isBondInSaltOrSolvent(bondId as number, sgroupsOnCanvas),
+        SGroup.isBondInSaltOrSolvent(bondId, sgroupsOnCanvas),
       );
     }
     return isDraggingOnSaltOrSolventAtom || isDraggingOnSaltOrSolventBond;

--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -148,7 +148,7 @@ class Form extends Component<FormProps> {
 
     if (init) {
       const { valid, errors } = this.schema.serialize(init);
-      const errs = getErrorsObj(errors as FormValidationError[]);
+      const errs = getErrorsObj(errors);
       const initialState = { ...init, init: true };
       onUpdate(initialState, valid, errs);
     }
@@ -173,7 +173,7 @@ class Form extends Component<FormProps> {
   updateState(newState: Record<string, unknown>) {
     const { onUpdate } = this.props;
     const { instance, valid, errors } = this.schema.serialize(newState);
-    const errs = getErrorsObj(errors as FormValidationError[]);
+    const errs = getErrorsObj(errors);
     onUpdate(instance as Record<string, unknown>, valid, errs);
   }
 


### PR DESCRIPTION
## Redundant Casts Removed

- **Editor.test.ts:27-31** - Removed `as boolean` (return type already declared)
- **select.ts:612** - Removed `atomId as number` (already number from Map.values())
- **select.ts:615** - Removed `bondId as number` (already number from Map.values())
- **Editor.ts:2124** - Removed `monomerShiftVector as Vec2` (narrowed by if check)
- **form.tsx:151** - Removed `errors as FormValidationError[]` (already cast in serialize)
- **form.tsx:176** - Removed `errors as FormValidationError[]` (already cast in serialize)

**Total: 6 redundant casts fixed**

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request