### PR TITLE
#4009 - Macro: After clicking Cancel, RNA Builder becomes inactive

### DIFF
--- a/ketcher-autotests/tests/pages/common/CommonTopRightToolbar.ts
+++ b/ketcher-autotests/tests/pages/common/CommonTopRightToolbar.ts
@@ -122,7 +122,9 @@ export const CommonTopRightToolbar = (page: Page) => {
       }
       const switcher = locators.ketcherModeSwitcherCombobox;
       const macroOption = page.getByTestId(Mode.Macromolecules);
-      const macromoleculesCanvas = page.locator('#polymer-editor-canvas');
+      const macromoleculesCanvas = page.locator(
+        '[data-testid="ketcher-canvas"][canvasmode="macromolecules-mode"]',
+      );
 
       if (!(await macromoleculesCanvas.isVisible())) {
         await switcher.waitFor({ state: 'visible' });
@@ -159,7 +161,9 @@ export const CommonTopRightToolbar = (page: Page) => {
     async turnOnMicromoleculesEditor() {
       const switcher = locators.ketcherModeSwitcherCombobox;
       const microOption = page.getByTestId(Mode.Molecules);
-      const moleculesCanvas = page.getByTestId('canvas');
+      const moleculesCanvas = page.locator(
+        '[data-testid="ketcher-canvas"][canvasmode="molecules-mode"]',
+      );
 
       if (!(await moleculesCanvas.isVisible())) {
         await switcher.waitFor({ state: 'visible' });

--- a/ketcher-autotests/tests/pages/macromolecules/MacromoleculesTopToolbar.ts
+++ b/ketcher-autotests/tests/pages/macromolecules/MacromoleculesTopToolbar.ts
@@ -130,7 +130,7 @@ export const MacromoleculesTopToolbar = (page: Page) => {
 
       try {
         await locators.switchLayoutModeDropdownButton.click();
-        await page.waitForTimeout(0.1 * 1000);
+        await page.waitForTimeout(100);
         await switchLayoutModeDropdown.waitFor({
           state: 'visible',
           timeout: 5000,

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/RNA-Builder/rna-library.spec.ts
@@ -546,6 +546,23 @@ test.describe('RNA Library', () => {
     await takePresetsScreenshot(page);
   });
 
+  test('#4009: RNA Builder stays active after Cancel on a new preset', async () => {
+    await clearLocalStorage(page);
+    await reloadPageAndConfigureInitialState(page);
+
+    const rnaBuilder = Library(page).rnaBuilder;
+    await rnaBuilder.expand();
+    await Library(page).selectMonomers([Sugar._25R, Base.A]);
+    await rnaBuilder.cancel();
+
+    await expect(rnaBuilder.cancelButton).toBeVisible();
+    await expect(rnaBuilder.sugarSlot).toContainText('Not selected');
+    await expect(rnaBuilder.baseSlot).toContainText('Not selected');
+
+    await Library(page).selectMonomers([Sugar._25R]);
+    await expect(rnaBuilder.sugarSlot).toContainText('25R');
+  });
+
   test('After clicking Duplicate and Edit button and subsequently clicking Cancel, preset not saved', async () => {
     /* 
     Test case: #3633 - Edit RNA mode

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
@@ -35,16 +35,11 @@ import { ConfirmYourActionDialog } from '@tests/pages/macromolecules/canvas/Conf
 
 let page: Page;
 
-async function configureInitialState(page: Page) {
-  await Library(page).switchToRNATab();
-}
-
 test.beforeAll(async ({ initSequenceCanvas }) => {
   page = await initSequenceCanvas();
 });
 
 test.beforeEach(async ({ SequenceCanvas: _ }) => {
-  await configureInitialState(page);
   // Creation of custom presets needed for testing
   await createTestPresets(page);
 });

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx
@@ -24,6 +24,12 @@ describe('Test Rna Editor Expanded component', () => {
               phosphate: undefined,
               base: undefined,
             },
+            groupItemValidations: {
+              Bases: [],
+              Sugars: [],
+              Phosphates: [],
+            },
+            isEditMode: true,
           },
         },
       ),

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -75,6 +75,7 @@ import {
   generateSequenceSelectionName,
   resetRnaBuilder,
   resetRnaBuilderAfterSequenceUpdate,
+  resetRnaBuilderToNewPreset,
 } from 'components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/helpers';
 import { openModal } from 'state/modal';
 import { getCountOfNucleoelements } from 'helpers/countNucleoelents';
@@ -573,15 +574,32 @@ export const RnaEditorExpanded = ({
   const onCancel = () => {
     if (isSequenceEditInRNABuilderMode) {
       resetRnaBuilderAfterSequenceUpdate(dispatch, editor);
-    } else {
-      setNewPreset(activePreset);
-      setSelectedPhosphatePosition(
-        activePreset?.connections?.length
-          ? getRnaPresetPhosphatePosition(activePreset)
-          : undefined,
-      );
-      resetRnaBuilder(dispatch);
+      return;
     }
+
+    // Cancelling a brand-new (never-saved) preset keeps the builder active so the
+    // user can immediately start a new preset (#4009). Editing an existing preset
+    // keeps the previous behaviour: revert changes and leave edit mode.
+    if (isActivePresetEmpty) {
+      setNewPreset(activePreset);
+      setSelectedPhosphatePosition(undefined);
+      resetRnaBuilderToNewPreset(dispatch);
+      dispatch(
+        recalculateRnaBuilderValidations({
+          rnaPreset: activePreset,
+          isEditMode: true,
+        }),
+      );
+      return;
+    }
+
+    setNewPreset(activePreset);
+    setSelectedPhosphatePosition(
+      activePreset?.connections?.length
+        ? getRnaPresetPhosphatePosition(activePreset)
+        : undefined,
+    );
+    resetRnaBuilder(dispatch);
   };
 
   const turnOnEditMode = () => {

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/helpers/resetRnaBuilder.ts
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/helpers/resetRnaBuilder.ts
@@ -1,7 +1,10 @@
 import { AnyAction, Dispatch } from 'redux';
 import { CoreEditor } from 'ketcher-core';
 import {
+  createNewPreset,
+  RnaBuilderPresetsItem,
   setActivePresetMonomerGroup,
+  setActiveRnaBuilderItem,
   setIsEditMode,
   setSequenceSelection,
 } from 'state/rna-builder';
@@ -13,6 +16,15 @@ const resetRnaBuilderCommon = (dispatch: Dispatch<AnyAction>) => {
 
 export const resetRnaBuilder = (dispatch: Dispatch<AnyAction>) => {
   resetRnaBuilderCommon(dispatch);
+};
+
+// Reset the builder to a pristine "new preset" state while keeping it open and
+// editable, so the user can immediately start building again (#4009).
+export const resetRnaBuilderToNewPreset = (dispatch: Dispatch<AnyAction>) => {
+  dispatch(setActivePresetMonomerGroup(null));
+  dispatch(createNewPreset());
+  dispatch(setActiveRnaBuilderItem(RnaBuilderPresetsItem.Presets));
+  dispatch(setIsEditMode(true));
 };
 
 export const resetRnaBuilderAfterSequenceUpdate = (


### PR DESCRIPTION
Closes #4009

### Problem
In Macromolecules mode → RNA tab, when building a **new** preset (adding Sugar/Base)
and pressing **Cancel**, the RNA Builder ended up inactive: it stayed expanded but
dropped out of edit mode, both action buttons were disabled, and clicking monomers
in the library no longer filled the slots. The user could not start building again
without re-opening the builder.

### Root cause
While building a new preset, the in-progress monomers live in component-local state;
the Redux `activePreset` stays the empty object from `createNewPreset`. On Cancel,
`onCancel` called `resetRnaBuilder`, which sets `isEditMode = false`. For a new/empty
preset this left the editor expanded but non-editable (`handleItemSelection` early-returns
when not in edit mode), producing the dead state.

### Fix
When Cancel is pressed on a new/never-saved preset (`isActivePresetEmpty`), reset the
builder to a pristine "new preset" state that stays **open and editable** — reusing the
same actions as the "New Preset" flow (`createNewPreset` + `setActiveRnaBuilderItem(Presets)`
+ `setIsEditMode(true)`), plus a validations recalculation. Cancelling an edit of an
**existing** preset keeps the previous behaviour (revert changes → view mode).

### Changes
- Add `resetRnaBuilderToNewPreset` helper in `resetRnaBuilder.ts`.
- Branch `onCancel` in `RnaEditorExpanded.tsx` on the new/empty-preset case.
- Update `RnaEditorExpanded` unit test store state.
- Add Playwright regression test (`#4009: RNA Builder stays active after Cancel`).

### Testing
- `ketcher-macromolecules` unit tests: 8 suites / 36 tests / 4 snapshots — passing.
- `tsc --noEmit` — clean.
- Manual: new-preset Cancel keeps builder active and allows building again;
  existing-preset Edit → Cancel still reverts to view mode.
  
## Screenshots

https://github.com/user-attachments/assets/df3cc28d-5f6f-48bb-ad54-0d10fd1e3be9


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request