### PR TITLE
#9887 – Fix Paste does not work in Safari

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.test.tsx
@@ -1,0 +1,92 @@
+import type { ComponentProps } from 'react';
+import { render } from '@testing-library/react';
+import ClipArea from './cliparea';
+
+// A Safari UA string (contains "Safari" but not "Chrome"/"Android").
+const SAFARI_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 ' +
+  '(KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+// A Chrome UA string (contains "Chrome" so it is not detected as Safari).
+const CHROME_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+const setUserAgent = (userAgent: string) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  });
+};
+
+const setClipboard = (clipboard: Partial<Clipboard> | undefined) => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: clipboard,
+    configurable: true,
+  });
+};
+
+const renderClipArea = () => {
+  const target = document.createElement('div');
+  const props: ComponentProps<typeof ClipArea> = {
+    formats: ['text/plain'],
+    focused: () => true,
+    onCopy: jest.fn().mockResolvedValue(null),
+    onCut: jest.fn().mockResolvedValue(null),
+    onPaste: jest.fn().mockResolvedValue(undefined),
+    onLegacyCopy: jest.fn(),
+    onLegacyCut: jest.fn(),
+    onLegacyPaste: jest.fn(),
+    target,
+  };
+  render(<ClipArea {...props} />);
+  return { target, props };
+};
+
+const dispatchPaste = (target: HTMLElement, text: string) => {
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      getData: (format: string) => (format === 'text/plain' ? text : ''),
+    },
+    configurable: true,
+  });
+  target.dispatchEvent(event);
+};
+
+describe('ClipArea paste', () => {
+  const originalUserAgent = window.navigator.userAgent;
+  const originalClipboard = window.navigator.clipboard;
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+    setClipboard(originalClipboard);
+  });
+
+  it('reads from the async Clipboard API on non-Safari browsers', () => {
+    setUserAgent(CHROME_USER_AGENT);
+    const read = jest.fn().mockResolvedValue([]);
+    setClipboard({ read, writeText: jest.fn() } as unknown as Clipboard);
+
+    const { target, props } = renderClipArea();
+    dispatchPaste(target, 'CCC');
+
+    expect(read).toHaveBeenCalled();
+    expect(props.onLegacyPaste).not.toHaveBeenCalled();
+  });
+
+  // Safari rejects navigator.clipboard.read() when it is called from a paste
+  // event, so paste has to fall back to the synchronous clipboardData (#9887).
+  it('falls back to the synchronous paste event data on Safari', () => {
+    setUserAgent(SAFARI_USER_AGENT);
+    const read = jest.fn().mockResolvedValue([]);
+    setClipboard({ read, writeText: jest.fn() } as unknown as Clipboard);
+
+    const { target, props } = renderClipArea();
+    dispatchPaste(target, 'CCC');
+
+    expect(read).not.toHaveBeenCalled();
+    expect(props.onLegacyPaste).toHaveBeenCalledWith(
+      expect.objectContaining({ 'text/plain': 'CCC' }),
+    );
+  });
+});

--- a/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
+++ b/packages/ketcher-react/src/script/ui/component/cliparea/cliparea.tsx
@@ -196,7 +196,9 @@ class ClipArea extends Component<ClipAreaProps> {
         if (!this.props.focused() || isUserEditing()) {
           return;
         }
-        if (isClipboardAPIAvailable()) {
+        // Safari rejects navigator.clipboard.read() in this context, so fall
+        // back to the synchronous paste event data (same approach as copy/cut).
+        if (isClipboardAPIAvailable() && !isSafariBrowser()) {
           navigator.clipboard.read().then((data: ClipboardItem[]) => {
             if (!data) {
               return;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Paste (Ctrl/Cmd+V) did not work in Safari. Copy and cut were fixed for Safari in #9887, but the paste handler still called `navigator.clipboard.read()` unconditionally whenever the Clipboard API was present. Safari exposes that API, so it took the async path — but Safari rejects `navigator.clipboard.read()` when it is invoked from within a `paste` event (its user-activation model is stricter than Chromium/Gecko), and the rejected promise had no handler, so paste silently did nothing.

This routes Safari through the **existing** synchronous fallback that copy/cut already use — reading from the paste event's `clipboardData` via `legacyPaste` / `onLegacyPaste` — by gating the async path on `isClipboardAPIAvailable() && !isSafariBrowser()`. Chrome and Firefox are unchanged and continue to use the async Clipboard API.

```diff
-        if (isClipboardAPIAvailable()) {
+        // Safari rejects navigator.clipboard.read() in this context, so fall
+        // back to the synchronous paste event data (same approach as copy/cut).
+        if (isClipboardAPIAvailable() && !isSafariBrowser()) {
           navigator.clipboard.read().then((data: ClipboardItem[]) => {
```

Verified manually: paste now works in Safari, and paste in Chrome and Firefox continues to work.

Completes #9887, which fixed copy/cut for Safari but left the paste path unchanged.

> Note (out of scope): the macromolecules editor (`packages/ketcher-core/src/application/editor/modes/BaseMode.ts`) has the same `navigator.clipboard.read()` pattern and may need the equivalent fallback; happy to follow up in a separate PR.

## Check list
- [x] unit-tests written
- [ ] e2e-tests written — **N/A**: the behavior is Safari-specific and the e2e suite runs on Chromium only, so it cannot exercise this path. A unit test covers both the Safari (legacy fallback) and non-Safari (async Clipboard API) paste branches.
- [ ] documentation updated — N/A
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master) is correct
- [ ] task status changed to "Code review" — N/A (external contribution)
- [ ] reviewers are notified about the pull request — N/A (external contribution)
