### PR TITLE
#10379 - Refactor processMPropertyLine function to reduce its Cognitive Complexity from 26 to the 15 allowed

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.ts
@@ -316,60 +316,85 @@ function processMPropertyLine(
   sGroups: SGroupMap,
   rLogic: Record<number, RGroupAttributes>,
 ): boolean {
-  if (type === 'END') {
-    return true; // Signal to break loop
-  }
-
-  if (type === 'CHG') {
-    handleSimpleAtomProperty('charge', propertyData, props);
-  } else if (type === 'RAD') {
-    handleSimpleAtomProperty('radical', propertyData, props);
-  } else if (type === 'ISO') {
-    handleSimpleAtomProperty('isotope', propertyData, props);
-  } else if (type === 'RBC') {
-    handleSimpleAtomProperty('ringBondCount', propertyData, props);
-  } else if (type === 'SUB') {
-    handleSubstitutionProperty(propertyData, props);
-  } else if (type === 'UNS') {
-    handleSimpleAtomProperty('unsaturatedAtom', propertyData, props);
-  } else if (type === 'RGP') {
-    handleRGroupProperty(propertyData, props);
-  } else if (type === 'LOG') {
-    handleRGroupLogic(propertyData, rLogic);
-  } else if (type === 'APO') {
-    handleSimpleAtomProperty('attachmentPoints', propertyData, props);
-  } else if (type === 'ALS') {
-    handleAtomListProperty(propertyData, props);
-  } else if (type === 'STY') {
-    sGroup.initSGroup(sGroups, propertyData);
-  } else if (type === 'SST') {
-    sGroup.applySGroupProp(sGroups, 'subtype', propertyData);
-  } else if (type === 'SLB') {
-    sGroup.applySGroupProp(sGroups, 'label', propertyData, true);
-  } else if (type === 'SPL') {
-    sGroup.applySGroupProp(sGroups, 'parent', propertyData, true, true);
-  } else if (type === 'SCN') {
-    sGroup.applySGroupProp(sGroups, 'connectivity', propertyData);
-  } else if (type === 'SAL') {
-    sGroup.applySGroupArrayProp(sGroups, 'atoms', propertyData, -1);
-  } else if (type === 'SBL') {
-    sGroup.applySGroupArrayProp(sGroups, 'bonds', propertyData, -1);
-  } else if (type === 'SPA') {
-    sGroup.applySGroupArrayProp(sGroups, 'patoms', propertyData, -1);
-  } else if (type === 'SMT' || type === 'SCL') {
-    handleSGroupDataProperty(type, propertyData, sGroups);
-  } else if (type === 'SDT') {
-    sGroup.applyDataSGroupDesc(sGroups, propertyData);
-  } else if (type === 'SDD') {
-    sGroup.applyDataSGroupInfoLine(sGroups, propertyData);
-  } else if (type === 'SCD') {
-    sGroup.applyDataSGroupDataLine(sGroups, propertyData, false);
-  } else if (type === 'SED') {
-    sGroup.applyDataSGroupDataLine(sGroups, propertyData, true);
-  } else if (type === 'SDS') {
-    handleSGroupExpandedProperty(propertyData, sGroups);
-  } else if (type === 'SAP') {
-    handleSGroupAttachmentProperty(propertyData, sGroups);
+  switch (type) {
+    case 'END':
+      return true; // Signal to break loop
+    case 'CHG':
+      handleSimpleAtomProperty('charge', propertyData, props);
+      break;
+    case 'RAD':
+      handleSimpleAtomProperty('radical', propertyData, props);
+      break;
+    case 'ISO':
+      handleSimpleAtomProperty('isotope', propertyData, props);
+      break;
+    case 'RBC':
+      handleSimpleAtomProperty('ringBondCount', propertyData, props);
+      break;
+    case 'SUB':
+      handleSubstitutionProperty(propertyData, props);
+      break;
+    case 'UNS':
+      handleSimpleAtomProperty('unsaturatedAtom', propertyData, props);
+      break;
+    case 'RGP':
+      handleRGroupProperty(propertyData, props);
+      break;
+    case 'LOG':
+      handleRGroupLogic(propertyData, rLogic);
+      break;
+    case 'APO':
+      handleSimpleAtomProperty('attachmentPoints', propertyData, props);
+      break;
+    case 'ALS':
+      handleAtomListProperty(propertyData, props);
+      break;
+    case 'STY':
+      sGroup.initSGroup(sGroups, propertyData);
+      break;
+    case 'SST':
+      sGroup.applySGroupProp(sGroups, 'subtype', propertyData);
+      break;
+    case 'SLB':
+      sGroup.applySGroupProp(sGroups, 'label', propertyData, true);
+      break;
+    case 'SPL':
+      sGroup.applySGroupProp(sGroups, 'parent', propertyData, true, true);
+      break;
+    case 'SCN':
+      sGroup.applySGroupProp(sGroups, 'connectivity', propertyData);
+      break;
+    case 'SAL':
+      sGroup.applySGroupArrayProp(sGroups, 'atoms', propertyData, -1);
+      break;
+    case 'SBL':
+      sGroup.applySGroupArrayProp(sGroups, 'bonds', propertyData, -1);
+      break;
+    case 'SPA':
+      sGroup.applySGroupArrayProp(sGroups, 'patoms', propertyData, -1);
+      break;
+    case 'SMT':
+    case 'SCL':
+      handleSGroupDataProperty(type, propertyData, sGroups);
+      break;
+    case 'SDT':
+      sGroup.applyDataSGroupDesc(sGroups, propertyData);
+      break;
+    case 'SDD':
+      sGroup.applyDataSGroupInfoLine(sGroups, propertyData);
+      break;
+    case 'SCD':
+      sGroup.applyDataSGroupDataLine(sGroups, propertyData, false);
+      break;
+    case 'SED':
+      sGroup.applyDataSGroupDataLine(sGroups, propertyData, true);
+      break;
+    case 'SDS':
+      handleSGroupExpandedProperty(propertyData, sGroups);
+      break;
+    case 'SAP':
+      handleSGroupAttachmentProperty(propertyData, sGroups);
+      break;
   }
 
   return false; // Continue loop


### PR DESCRIPTION
processMPropertyLine in packages/ketcher-core/src/domain/serializers/mol/v2000.ts is a dispatcher that routes a MOL V2000 M-property type to its handler. It was a flat if / else-if chain of 25 branches (plus a standalone if (type === 'END')), which raised its Cognitive Complexity to 26 — Sonar adds +1 per if/else-if branch and +1 for the compound type === 'SMT' || type === 'SCL' condition.

Fixed by converting the chain to a single switch (type). Sonar counts a switch as +1 and treats case labels as free, so the Cognitive Complexity drops from 26 to ~1 — well under the 15 limit.

The change is mechanical and behavior-identical:
- Each branch maps 1:1 to a case.
- END remains an early return true (loop-break signal).
- SMT/SCL are preserved as an empty-case fall-through to the shared handleSGroupDataProperty(type, …) call.
- Unknown types fall through to return false, exactly as before (there was no else).

No signature change, single caller (parsePropertyLines). Verified with prettier, eslint (--quiet), tsc --noEmit, and the ketcher-core jest suite (553 passed), including the MOL serializer suites that exercise this function directly (v2000.test.ts, v2000.parseSGroup.SAP.test.ts, molfile.monomerPosition.test.ts — 55 tests).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request