### PR TITLE
#10420 – AND/OR center labels overlap atom labels in Macromolecules Flex mode

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts
@@ -900,7 +900,24 @@ export class AtomRenderer extends BaseRenderer {
     direction: Vec2,
   ): number {
     const baseDistance = 3;
-    const labelBox = {
+
+    // Forward shift: clearance past the atom label in the placement direction.
+    // Mirrors visel.exts iteration in molecules mode (reatom.ts lines 1085-1087).
+    let forwardShift = 0;
+    this.labelBBoxes.forEach((labelSymbolBBox) => {
+      const absoluteBox = new Box2Abs(
+        labelSymbolBBox.x,
+        labelSymbolBBox.y,
+        labelSymbolBBox.x + labelSymbolBBox.width,
+        labelSymbolBBox.y + labelSymbolBBox.height,
+      ).translate(this.scaledPosition);
+      forwardShift = Math.max(
+        forwardShift,
+        util.shiftRayBox(this.scaledPosition, direction, absoluteBox),
+      );
+    });
+
+    const stereoLabelBox = {
       x: this.scaledPosition.x - width / 2,
       y: this.scaledPosition.y - height / 2,
       width,
@@ -910,10 +927,10 @@ export class AtomRenderer extends BaseRenderer {
     const backwardShift = util.shiftRayBox(
       this.scaledPosition,
       direction.negated(),
-      Box2Abs.fromRelBox(labelBox),
+      Box2Abs.fromRelBox(stereoLabelBox),
     );
 
-    return LABEL_CLEARANCE_OFFSET + baseDistance + backwardShift;
+    return LABEL_CLEARANCE_OFFSET + baseDistance + forwardShift + backwardShift;
   }
 
   private getLabelProjectionRadius(


### PR DESCRIPTION
Closes #10420

## How the feature works? / How did you fix the issue?

In Macromolecules Flex mode, AND/OR stereo center labels (e.g. `and1`, `or1`) were overlapping atom symbol labels (e.g. `N`, `NH2`).

**Root cause:** `getProjectedLabelDistance()` in `AtomRenderer.ts` was computing the stereo label offset from the atom center using only a constant base (`8px`) plus the stereo label's own backward half-width — but never accounting for how far the atom label itself extends in the placement direction.

**Fix:** Added a forward clearance step that iterates `this.labelBBoxes` (per-tspan bounding boxes of the atom label) and calls `util.shiftRayBox()` to find how far the atom label extends in the stereo label's placement direction. This mirrors the `visel.exts` loop already used in molecules mode (`reatom.ts` lines 1085–1087), and follows the same pattern already used by `BondRenderer` to avoid bond-line/label overlap.

Only one method in one file changed: `getProjectedLabelDistance()` in `packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts`.

## Verification

**Manually verified in Macromolecules Flex mode** using `mixed-and-or-structure.ket` (a sugar with `or1`, `&1`, and `abs` stereocenters):

- `or1` label renders to the right of its ring carbon with clear separation from the flanking `OH` labels — no overlap
- `&1` label renders in the open ring interior — no overlap
- `abs` stereocenters correctly show no center label
- No regression in the AND-only stereo case (single-group molecules suppress the label by design)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request