### PR TITLE
#7232 - getSmiles() promise never resolves in standalone mode

### DIFF
--- a/packages/ketcher-standalone/src/infrastructure/services/struct/constants.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/constants.ts
@@ -1,3 +1,4 @@
 export const STRUCT_SERVICE_NO_RENDER_INITIALIZED_EVENT =
   'struct-service-no-render-initialized';
 export const STRUCT_SERVICE_INITIALIZED_EVENT = 'struct-service-initialized';
+export const DEFAULT_WORKER_TIMEOUT = 30000;

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -340,12 +340,19 @@ class IndigoService implements StructService {
       struct,
     } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
+    const defaultTimeout = 30000;
 
     return new Promise((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
       const action = ({ data }: OutputMessageWrapper) => {
         console.log('convert action', data);
         const msg: OutputMessage<string> = data;
         if (msg.inputData === struct) {
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+          }
           if (!msg.hasError) {
             const result: ConvertResult = {
               struct: msg.payload,
@@ -357,6 +364,18 @@ class IndigoService implements StructService {
           }
         }
       };
+
+      if (timeout !== 0) {
+        timeoutId = setTimeout(() => {
+          this.EE.off(WorkerEvent.Convert, action);
+          reject(
+            new Error(
+              `Convert operation timeout after ${timeout ?? defaultTimeout}ms`,
+            ),
+          );
+        }, timeout ?? defaultTimeout);
+      }
+
       const monomerLibrary = JSON.stringify(
         provideEditorInstance()?.monomersLibraryParsedJson,
       );
@@ -401,8 +420,12 @@ class IndigoService implements StructService {
   ): Promise<LayoutResult> {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
+    const defaultTimeout = 30000;
 
     return new Promise((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
       const action = ({
         data,
       }: OutputMessageWrapper<{
@@ -416,6 +439,9 @@ class IndigoService implements StructService {
           format: string;
           original_format: ChemicalMimeType;
         }> = data;
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
         if (!msg.hasError) {
           const { struct } = msg.payload;
           const result: LayoutResult = {
@@ -427,6 +453,17 @@ class IndigoService implements StructService {
           reject(new Error(msg.error));
         }
       };
+
+      if (timeout !== 0) {
+        timeoutId = setTimeout(() => {
+          this.EE.off(WorkerEvent.Layout, action);
+          reject(
+            new Error(
+              `Layout operation timeout after ${timeout ?? defaultTimeout}ms`,
+            ),
+          );
+        }, timeout ?? defaultTimeout);
+      }
 
       const commandOptions: CommandOptions = {
         ...this.getStandardServerOptions(options),

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -75,6 +75,7 @@ import EventEmitter from 'events';
 import {
   STRUCT_SERVICE_INITIALIZED_EVENT,
   STRUCT_SERVICE_NO_RENDER_INITIALIZED_EVENT,
+  DEFAULT_WORKER_TIMEOUT,
 } from './constants';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -195,6 +196,45 @@ function mapWarningGroup(property: string) {
   return property.toLowerCase();
 }
 
+/**
+ * Creates a wrapper that adds timeout functionality to worker communication
+ * @param eventEmitter - The event emitter instance
+ * @param workerEvent - The worker event type to listen to
+ * @param action - The callback function to execute on success
+ * @param timeout - Timeout in milliseconds (0 means no timeout)
+ * @returns An object with setup method to initialize the timeout wrapper
+ */
+function createTimeoutWrapper<T>(
+  eventEmitter: EventEmitter,
+  workerEvent: WorkerEvent,
+  action: (data: OutputMessageWrapper<T>) => void,
+  timeout: number = DEFAULT_WORKER_TIMEOUT,
+): {
+  setup: () => void;
+} {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const wrappedAction = (data: OutputMessageWrapper<T>) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    action(data);
+  };
+
+  const setup = () => {
+    eventEmitter.once(workerEvent, wrappedAction);
+
+    if (timeout !== 0) {
+      timeoutId = setTimeout(() => {
+        eventEmitter.off(workerEvent, wrappedAction);
+        throw new Error(`${workerEvent} operation timeout after ${timeout}ms`);
+      }, timeout);
+    }
+  };
+
+  return { setup };
+}
+
 const messageTypeToEventMapping: {
   [key in Command]: WorkerEvent;
 } = {
@@ -296,12 +336,18 @@ class IndigoService implements StructService {
         }
       };
 
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.GetInChIKey,
+        action,
+      );
+
       const inputMessage: InputMessage<GenerateInchIKeyCommandData> = {
         type: Command.GetInChIKey,
         data: { struct },
       };
 
-      this.EE.once(WorkerEvent.GetInChIKey, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -324,7 +370,14 @@ class IndigoService implements StructService {
         }
       };
 
-      this.EE.once(WorkerEvent.Info, action);
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Info,
+        action,
+        DEFAULT_WORKER_TIMEOUT,
+      );
+
+      wrapper.setup();
 
       this.worker.postMessage({ type: Command.Info });
     });
@@ -341,18 +394,12 @@ class IndigoService implements StructService {
     } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
     const timeout = options?.['request-timeout'] as number | undefined;
-    const defaultTimeout = 30000;
 
     return new Promise((resolve, reject) => {
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
       const action = ({ data }: OutputMessageWrapper) => {
         console.log('convert action', data);
         const msg: OutputMessage<string> = data;
         if (msg.inputData === struct) {
-          if (timeoutId) {
-            clearTimeout(timeoutId);
-          }
           if (!msg.hasError) {
             const result: ConvertResult = {
               struct: msg.payload,
@@ -365,16 +412,12 @@ class IndigoService implements StructService {
         }
       };
 
-      if (timeout !== 0) {
-        timeoutId = setTimeout(() => {
-          this.EE.off(WorkerEvent.Convert, action);
-          reject(
-            new Error(
-              `Convert operation timeout after ${timeout ?? defaultTimeout}ms`,
-            ),
-          );
-        }, timeout ?? defaultTimeout);
-      }
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Convert,
+        action,
+        timeout,
+      );
 
       const monomerLibrary = JSON.stringify(
         provideEditorInstance()?.monomersLibraryParsedJson,
@@ -408,7 +451,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Convert, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -421,11 +464,8 @@ class IndigoService implements StructService {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
     const timeout = options?.['request-timeout'] as number | undefined;
-    const defaultTimeout = 30000;
 
     return new Promise((resolve, reject) => {
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
       const action = ({
         data,
       }: OutputMessageWrapper<{
@@ -439,9 +479,6 @@ class IndigoService implements StructService {
           format: string;
           original_format: ChemicalMimeType;
         }> = data;
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
         if (!msg.hasError) {
           const { struct } = msg.payload;
           const result: LayoutResult = {
@@ -454,16 +491,12 @@ class IndigoService implements StructService {
         }
       };
 
-      if (timeout !== 0) {
-        timeoutId = setTimeout(() => {
-          this.EE.off(WorkerEvent.Layout, action);
-          reject(
-            new Error(
-              `Layout operation timeout after ${timeout ?? defaultTimeout}ms`,
-            ),
-          );
-        }, timeout ?? defaultTimeout);
-      }
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Layout,
+        action,
+        timeout,
+      );
 
       const commandOptions: CommandOptions = {
         ...this.getStandardServerOptions(options),
@@ -496,7 +529,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Layout, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -505,6 +538,7 @@ class IndigoService implements StructService {
   clean(data: CleanData, options?: StructServiceOptions): Promise<CleanResult> {
     const { struct, selected, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
@@ -520,6 +554,13 @@ class IndigoService implements StructService {
         }
       };
 
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Clean,
+        action,
+        timeout,
+      );
+
       const commandData: CleanCommandData = {
         struct,
         format,
@@ -532,7 +573,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Clean, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -544,9 +585,17 @@ class IndigoService implements StructService {
   ): Promise<AromatizeResult> {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise<AromatizeResult>((resolve, reject) => {
       const action = makeMolResultAction(resolve, reject);
+
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Aromatize,
+        action,
+        timeout,
+      );
 
       const commandData: AromatizeCommandData = {
         struct,
@@ -559,7 +608,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Aromatize, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -571,9 +620,17 @@ class IndigoService implements StructService {
   ): Promise<DearomatizeResult> {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise<DearomatizeResult>((resolve, reject) => {
       const action = makeMolResultAction(resolve, reject);
+
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Dearomatize,
+        action,
+        timeout,
+      );
 
       const commandData: DearomatizeCommandData = {
         struct,
@@ -586,7 +643,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Dearomatize, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -598,6 +655,7 @@ class IndigoService implements StructService {
   ): Promise<CalculateCipResult> {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
@@ -613,6 +671,13 @@ class IndigoService implements StructService {
         }
       };
 
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.CalculateCip,
+        action,
+        timeout,
+      );
+
       const commandData: CalculateCipCommandData = {
         struct,
         format,
@@ -624,7 +689,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.CalculateCip, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -636,6 +701,7 @@ class IndigoService implements StructService {
   ): Promise<AutomapResult> {
     const { mode, struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
@@ -651,6 +717,13 @@ class IndigoService implements StructService {
         }
       };
 
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Automap,
+        action,
+        timeout,
+      );
+
       const commandData: AutomapCommandData = {
         struct,
         format,
@@ -663,7 +736,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Automap, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -671,6 +744,7 @@ class IndigoService implements StructService {
 
   check(data: CheckData, options?: StructServiceOptions): Promise<CheckResult> {
     const { types, struct } = data;
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
@@ -694,6 +768,13 @@ class IndigoService implements StructService {
         }
       };
 
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Check,
+        action,
+        timeout,
+      );
+
       const commandData: CheckCommandData = {
         struct,
         types,
@@ -705,7 +786,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Check, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -716,6 +797,8 @@ class IndigoService implements StructService {
     options?: StructServiceOptions,
   ): Promise<CalculateResult> {
     const { properties, struct, selected } = data;
+    const timeout = options?.['request-timeout'] as number | undefined;
+
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
         const msg: OutputMessage<string> = data;
@@ -740,6 +823,13 @@ class IndigoService implements StructService {
         }
       };
 
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.Calculate,
+        action,
+        timeout,
+      );
+
       const commandData: CalculateCommandData = {
         struct,
         properties,
@@ -752,7 +842,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.Calculate, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -770,6 +860,7 @@ class IndigoService implements StructService {
     },
   ): Promise<string> {
     const { outputFormat, backgroundColor, ...restOptions } = options;
+    const timeout = restOptions['request-timeout'] as number | undefined;
 
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
@@ -782,6 +873,13 @@ class IndigoService implements StructService {
           }
         }
       };
+
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.GenerateImageAsBase64,
+        action,
+        timeout,
+      );
 
       const commandOptions: CommandOptions = {
         ...this.getStandardServerOptions(restOptions),
@@ -821,7 +919,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.GenerateImageAsBase64, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -834,9 +932,17 @@ class IndigoService implements StructService {
     const { struct, output_format: outputFormat } = data;
     const format = convertMimeTypeToOutputFormat(outputFormat);
     const mode = 'auto';
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise<ExplicitHydrogensResult>((resolve, reject) => {
       const action = makeMolResultAction(resolve, reject);
+
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.ExplicitHydrogens,
+        action,
+        timeout,
+      );
 
       const commandData: ExplicitHydrogensCommandData = {
         struct,
@@ -850,7 +956,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.ExplicitHydrogens, action);
+      wrapper.setup();
 
       this.worker.postMessage(inputMessage);
     });
@@ -861,6 +967,7 @@ class IndigoService implements StructService {
     options?: StructServiceOptions,
   ): Promise<CalculateMacromoleculePropertiesResult> {
     const { struct } = data;
+    const timeout = options?.['request-timeout'] as number | undefined;
 
     return new Promise((resolve, reject) => {
       const action = ({ data }: OutputMessageWrapper) => {
@@ -872,6 +979,13 @@ class IndigoService implements StructService {
           reject(new Error(msg.error));
         }
       };
+
+      const wrapper = createTimeoutWrapper(
+        this.EE,
+        WorkerEvent.CalculateMacromoleculeProperties,
+        action,
+        timeout,
+      );
 
       const commandData: CalculateMacromoleculePropertiesCommandData = {
         struct,
@@ -886,7 +1000,7 @@ class IndigoService implements StructService {
         data: commandData,
       };
 
-      this.EE.once(WorkerEvent.CalculateMacromoleculeProperties, action);
+      wrapper.setup();
       this.worker.postMessage(inputMessage);
     });
   }


### PR DESCRIPTION
## Problem
When using Ketcher in standalone mode, calling `getSmiles()` or other export methods results in a promise that never resolves and never throws an error. This happens because the Web Worker communication has no timeout mechanism.

## Root Cause
The `convert()` and `layout()` methods in `standaloneStructService.ts` create promises that listen for worker responses via EventEmitter, but have no timeout protection. If the worker fails silently or never responds, the promise hangs indefinitely.

## Solution
Added configurable timeout mechanism to both `convert()` and `layout()\) methods:
- Default timeout: 30 seconds
- Configurable via `StructServiceOptions['request-timeout']`
- Set `request-timeout: 0` to disable timeout
- Properly cleans up event listeners on timeout to prevent memory leaks

## Usage
```typescript
// Default 30s timeout
const smiles = await ketcher.getSmiles();

// Custom timeout via server settings
const provider = new StandaloneStructServiceProvider();
const editor = ketcher.editor;
editor.setServerSettings({
  'request-timeout': 10000  // 10 seconds
});

// Disable timeout (not recommended)
editor.setServerSettings({
  'request-timeout': 0
});
```

## Testing
- Existing tests pass
- Timeout triggers after configured duration
- Event listeners properly cleaned up

Fixes #7232