### PR TITLE
#10221 - Support library searching using three letter amino-acid codes

### DIFF
--- a/packages/ketcher-macromolecules/src/constants.ts
+++ b/packages/ketcher-macromolecules/src/constants.ts
@@ -56,6 +56,35 @@ export const MonomerCodeToGroup: Record<MonomerGroupCodes, MonomerGroups> = {
   P: MonomerGroups.PHOSPHATES,
 } as const;
 
+export const AMINO_ACID_ONE_TO_THREE_LETTER_CODE: Record<string, string> = {
+  A: 'Ala',
+  B: 'Asx',
+  C: 'Cys',
+  D: 'Asp',
+  E: 'Glu',
+  F: 'Phe',
+  G: 'Gly',
+  H: 'His',
+  I: 'Ile',
+  J: 'Xle',
+  K: 'Lys',
+  L: 'Leu',
+  M: 'Met',
+  N: 'Asn',
+  O: 'Pyl',
+  P: 'Pro',
+  Q: 'Gln',
+  R: 'Arg',
+  S: 'Ser',
+  T: 'Thr',
+  U: 'Sec',
+  V: 'Val',
+  W: 'Trp',
+  X: 'Xaa',
+  Y: 'Tyr',
+  Z: 'Glx',
+} as const;
+
 export const FAVORITE_ITEMS_UNIQUE_KEYS = 'favoriteItemsUniqueKeys';
 export const CUSTOM_PRESETS = 'ketcher_custom_presets';
 export const PRESET_PHOSPHATE_FILTER_STORAGE_KEY =

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.test.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.test.ts
@@ -1,0 +1,266 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import {
+  AmbiguousMonomerType,
+  KetAmbiguousMonomerTemplateSubType,
+  KetMonomerClass,
+  MonomerItemType,
+  MonomerOrAmbiguousType,
+} from 'ketcher-core';
+import { RootState } from 'state';
+import { selectFilteredMonomers } from './librarySlice';
+
+const createAminoAcid = (oneLetter: string, name: string): MonomerItemType => ({
+  label: oneLetter,
+  struct: {} as MonomerItemType['struct'],
+  props: {
+    MonomerName: oneLetter,
+    Name: name,
+    MonomerNaturalAnalogCode: oneLetter,
+    MonomerType: 'PEPTIDE',
+    MonomerClass: KetMonomerClass.AminoAcid,
+  },
+});
+
+const createNonAminoAcid = (
+  oneLetter: string,
+  name: string,
+  monomerClass: KetMonomerClass,
+  monomerType: string,
+): MonomerItemType => ({
+  label: oneLetter,
+  struct: {} as MonomerItemType['struct'],
+  props: {
+    MonomerName: oneLetter,
+    Name: name,
+    MonomerNaturalAnalogCode: oneLetter,
+    MonomerType: monomerType,
+    MonomerClass: monomerClass,
+  },
+});
+
+const createAmbiguous = (
+  label: string,
+  componentClasses: KetMonomerClass[],
+): AmbiguousMonomerType =>
+  ({
+    label,
+    id: `ambiguous-${label}`,
+    isAmbiguous: true,
+    subtype: KetAmbiguousMonomerTemplateSubType.ALTERNATIVES,
+    options: [],
+    monomers: componentClasses.map((monomerClass) => ({
+      monomerItem: {
+        props: { MonomerClass: monomerClass },
+      },
+    })),
+  } as unknown as AmbiguousMonomerType);
+
+const aminoAcids: MonomerItemType[] = [
+  createAminoAcid('A', 'Alanine'),
+  createAminoAcid('W', 'Tryptophan'),
+  createAminoAcid('I', 'Isoleucine'),
+  createAminoAcid('N', 'Asparagine'),
+  createAminoAcid('Q', 'Glutamine'),
+  createAminoAcid('P', 'Proline'),
+  createAminoAcid('R', 'Arginine'),
+];
+
+const collisionMonomers: MonomerItemType[] = [
+  createNonAminoAcid('A', 'Adenine', KetMonomerClass.Base, 'RNA'),
+  createNonAminoAcid('P', 'Phosphate', KetMonomerClass.Phosphate, 'RNA'),
+  createNonAminoAcid('R', 'Ribose', KetMonomerClass.Sugar, 'RNA'),
+];
+
+const ambiguousAminoAcidB = createAmbiguous('B', [
+  KetMonomerClass.AminoAcid,
+  KetMonomerClass.AminoAcid,
+]);
+const ambiguousAminoAcidJ = createAmbiguous('J', [
+  KetMonomerClass.AminoAcid,
+  KetMonomerClass.AminoAcid,
+]);
+const ambiguousAminoAcidX = createAmbiguous('X', [
+  KetMonomerClass.AminoAcid,
+  KetMonomerClass.AminoAcid,
+]);
+const ambiguousAminoAcidZ = createAmbiguous('Z', [
+  KetMonomerClass.AminoAcid,
+  KetMonomerClass.AminoAcid,
+]);
+const ambiguousNucleotideB = createAmbiguous('B', [
+  KetMonomerClass.Base,
+  KetMonomerClass.Base,
+]);
+
+const allMonomers: MonomerOrAmbiguousType[] = [
+  ...aminoAcids,
+  ...collisionMonomers,
+  ambiguousAminoAcidB,
+  ambiguousAminoAcidJ,
+  ambiguousAminoAcidX,
+  ambiguousAminoAcidZ,
+  ambiguousNucleotideB,
+];
+
+const buildState = (searchFilter: string): RootState =>
+  ({
+    library: {
+      searchFilter,
+      monomers: allMonomers,
+      favorites: {},
+      defaultRnaPresets: [],
+      selectedTabIndex: 0,
+    },
+  } as RootState);
+
+const getMatchedLabels = (searchFilter: string) =>
+  selectFilteredMonomers(buildState(searchFilter)).map((item) =>
+    item.isAmbiguous
+      ? (item as AmbiguousMonomerType).label
+      : (item as MonomerItemType).props.MonomerName,
+  );
+
+const getMatchedAminoAcidLabels = (searchFilter: string) =>
+  selectFilteredMonomers(buildState(searchFilter))
+    .filter((item) => {
+      if (item.isAmbiguous) {
+        const ambiguous = item as AmbiguousMonomerType;
+        return (
+          ambiguous.monomers.length > 0 &&
+          ambiguous.monomers.every(
+            (c) =>
+              c.monomerItem.props.MonomerClass === KetMonomerClass.AminoAcid,
+          )
+        );
+      }
+      return (
+        (item as MonomerItemType).props.MonomerClass ===
+        KetMonomerClass.AminoAcid
+      );
+    })
+    .map((item) =>
+      item.isAmbiguous
+        ? (item as AmbiguousMonomerType).label
+        : (item as MonomerItemType).props.MonomerName,
+    );
+
+describe('selectFilteredMonomers — three-letter amino-acid codes', () => {
+  it.each([
+    ['Trp', 'W'],
+    ['Ile', 'I'],
+    ['Asn', 'N'],
+    ['Gln', 'Q'],
+    ['Asx', 'B'],
+    ['Xle', 'J'],
+    ['Xaa', 'X'],
+    ['Glx', 'Z'],
+  ])(
+    'returns exactly the natural monomer for failing code %s → %s',
+    (code, expectedLabel) => {
+      expect(getMatchedAminoAcidLabels(code)).toEqual([expectedLabel]);
+    },
+  );
+
+  it.each(['ala', 'ALA', 'aLa'])(
+    'matches alanine case-insensitively for %s',
+    (query) => {
+      expect(getMatchedAminoAcidLabels(query)).toEqual(['A']);
+    },
+  );
+
+  it('matches partial three-letter code Tr → Trp', () => {
+    expect(getMatchedAminoAcidLabels('Tr')).toEqual(['W']);
+  });
+
+  it('Gln returns only Q, not Glx/Z', () => {
+    expect(getMatchedAminoAcidLabels('Gln')).toEqual(['Q']);
+  });
+
+  it('Glx returns only Z, not Gln/Q', () => {
+    expect(getMatchedAminoAcidLabels('Glx')).toEqual(['Z']);
+  });
+
+  it('Ala does not return Adenine (class gate)', () => {
+    const labels = getMatchedLabels('Ala');
+    expect(labels).toContain('A');
+    expect(labels).toHaveLength(1);
+    expect(
+      selectFilteredMonomers(buildState('Ala')).every(
+        (item) =>
+          !item.isAmbiguous &&
+          (item as MonomerItemType).props.MonomerClass ===
+            KetMonomerClass.AminoAcid,
+      ),
+    ).toBe(true);
+  });
+
+  it('Pro does not return Phosphate (class gate)', () => {
+    expect(getMatchedAminoAcidLabels('Pro')).toEqual(['P']);
+    expect(
+      selectFilteredMonomers(buildState('Pro')).some(
+        (item) =>
+          !item.isAmbiguous &&
+          (item as MonomerItemType).props.MonomerClass ===
+            KetMonomerClass.Phosphate,
+      ),
+    ).toBe(false);
+  });
+
+  it('Arg does not return Ribose (class gate)', () => {
+    expect(getMatchedAminoAcidLabels('Arg')).toEqual(['R']);
+    expect(
+      selectFilteredMonomers(buildState('Arg')).some(
+        (item) =>
+          !item.isAmbiguous &&
+          (item as MonomerItemType).props.MonomerClass ===
+            KetMonomerClass.Sugar,
+      ),
+    ).toBe(false);
+  });
+
+  it('Asx returns amino-acid B, not nucleotide-B monomers', () => {
+    const results = selectFilteredMonomers(buildState('Asx'));
+    expect(results).toHaveLength(1);
+    expect(results[0].isAmbiguous).toBe(true);
+    expect((results[0] as AmbiguousMonomerType).label).toBe('B');
+    expect(
+      (results[0] as AmbiguousMonomerType).monomers.every(
+        (c) => c.monomerItem.props.MonomerClass === KetMonomerClass.AminoAcid,
+      ),
+    ).toBe(true);
+  });
+
+  it('still matches single-letter A and full name Tryptophan', () => {
+    expect(getMatchedAminoAcidLabels('A')).toContain('A');
+    expect(getMatchedAminoAcidLabels('Tryptophan')).toEqual(['W']);
+  });
+
+  it.each(['Xyz', 'Al@', 'Al1'])(
+    'returns nothing and does not throw for invalid query %s',
+    (query) => {
+      expect(() => getMatchedLabels(query)).not.toThrow();
+      expect(getMatchedLabels(query)).toEqual([]);
+    },
+  );
+
+  it('empty search returns the full listing', () => {
+    expect(selectFilteredMonomers(buildState(''))).toHaveLength(
+      allMonomers.length,
+    );
+  });
+});

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.test.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.test.ts
@@ -21,6 +21,7 @@ import {
   MonomerItemType,
   MonomerOrAmbiguousType,
 } from 'ketcher-core';
+import { AMINO_ACID_ONE_TO_THREE_LETTER_CODE } from 'src/constants';
 import { RootState } from 'state';
 import { selectFilteredMonomers } from './librarySlice';
 
@@ -53,9 +54,19 @@ const createNonAminoAcid = (
   },
 });
 
+const createComponent = (
+  oneLetter: string,
+  name: string,
+  monomerClass: KetMonomerClass = KetMonomerClass.AminoAcid,
+) => ({
+  monomerItem: {
+    props: { MonomerName: oneLetter, Name: name, MonomerClass: monomerClass },
+  },
+});
+
 const createAmbiguous = (
   label: string,
-  componentClasses: KetMonomerClass[],
+  components: ReturnType<typeof createComponent>[],
 ): AmbiguousMonomerType =>
   ({
     label,
@@ -63,11 +74,7 @@ const createAmbiguous = (
     isAmbiguous: true,
     subtype: KetAmbiguousMonomerTemplateSubType.ALTERNATIVES,
     options: [],
-    monomers: componentClasses.map((monomerClass) => ({
-      monomerItem: {
-        props: { MonomerClass: monomerClass },
-      },
-    })),
+    monomers: components,
   } as unknown as AmbiguousMonomerType);
 
 const aminoAcids: MonomerItemType[] = [
@@ -87,24 +94,28 @@ const collisionMonomers: MonomerItemType[] = [
 ];
 
 const ambiguousAminoAcidB = createAmbiguous('B', [
-  KetMonomerClass.AminoAcid,
-  KetMonomerClass.AminoAcid,
+  createComponent('D', 'Aspartic acid'),
+  createComponent('N', 'Asparagine'),
 ]);
 const ambiguousAminoAcidJ = createAmbiguous('J', [
-  KetMonomerClass.AminoAcid,
-  KetMonomerClass.AminoAcid,
+  createComponent('L', 'Leucine'),
+  createComponent('I', 'Isoleucine'),
 ]);
 const ambiguousAminoAcidX = createAmbiguous('X', [
-  KetMonomerClass.AminoAcid,
-  KetMonomerClass.AminoAcid,
+  createComponent('A', 'Alanine'),
+  createComponent('W', 'Tryptophan'),
+  createComponent('I', 'Isoleucine'),
+  createComponent('N', 'Asparagine'),
+  createComponent('Q', 'Glutamine'),
 ]);
 const ambiguousAminoAcidZ = createAmbiguous('Z', [
-  KetMonomerClass.AminoAcid,
-  KetMonomerClass.AminoAcid,
+  createComponent('E', 'Glutamic acid'),
+  createComponent('Q', 'Glutamine'),
 ]);
 const ambiguousNucleotideB = createAmbiguous('B', [
-  KetMonomerClass.Base,
-  KetMonomerClass.Base,
+  createComponent('C', 'C base', KetMonomerClass.Base),
+  createComponent('G', 'G base', KetMonomerClass.Base),
+  createComponent('T', 'T base', KetMonomerClass.Base),
 ]);
 
 const allMonomers: MonomerOrAmbiguousType[] = [
@@ -161,51 +172,64 @@ const getMatchedAminoAcidLabels = (searchFilter: string) =>
 
 describe('selectFilteredMonomers — three-letter amino-acid codes', () => {
   it.each([
-    ['Trp', 'W'],
-    ['Ile', 'I'],
-    ['Asn', 'N'],
-    ['Gln', 'Q'],
-    ['Asx', 'B'],
-    ['Xle', 'J'],
-    ['Xaa', 'X'],
-    ['Glx', 'Z'],
+    ['Trp', ['W', 'X']],
+    ['Ile', ['I', 'J', 'X']],
+    ['Asn', ['B', 'N', 'X']],
+    ['Gln', ['Q', 'X', 'Z']],
+    ['Asx', ['B']],
+    ['Xle', ['J']],
+    ['Xaa', ['X']],
+    ['Glx', ['Z']],
   ])(
-    'returns exactly the natural monomer for failing code %s → %s',
-    (code, expectedLabel) => {
-      expect(getMatchedAminoAcidLabels(code)).toEqual([expectedLabel]);
+    'returns expected amino-acid monomers for code %s → %j',
+    (code, expectedLabels) => {
+      expect(getMatchedAminoAcidLabels(code).sort()).toEqual(
+        [...expectedLabels].sort(),
+      );
     },
   );
 
   it.each(['ala', 'ALA', 'aLa'])(
-    'matches alanine case-insensitively for %s',
+    'matches alanine case-insensitively for %s (including ambiguous X)',
     (query) => {
-      expect(getMatchedAminoAcidLabels(query)).toEqual(['A']);
+      expect(getMatchedAminoAcidLabels(query).sort()).toEqual(['A', 'X']);
     },
   );
 
-  it('matches partial three-letter code Tr → Trp', () => {
-    expect(getMatchedAminoAcidLabels('Tr')).toEqual(['W']);
+  it('matches partial three-letter code Tr → Trp (including ambiguous X)', () => {
+    expect(getMatchedAminoAcidLabels('Tr').sort()).toEqual(['W', 'X']);
   });
 
-  it('Gln returns only Q, not Glx/Z', () => {
-    expect(getMatchedAminoAcidLabels('Gln')).toEqual(['Q']);
+  it('Gln returns Q plus ambiguous monomers that contain glutamine', () => {
+    expect(getMatchedAminoAcidLabels('Gln').sort()).toEqual(['Q', 'X', 'Z']);
   });
 
   it('Glx returns only Z, not Gln/Q', () => {
     expect(getMatchedAminoAcidLabels('Glx')).toEqual(['Z']);
   });
 
-  it('Ala does not return Adenine (class gate)', () => {
-    const labels = getMatchedLabels('Ala');
-    expect(labels).toContain('A');
-    expect(labels).toHaveLength(1);
+  it('Ala does not return Base/Phosphate/Sugar monomers (class gate)', () => {
+    const results = selectFilteredMonomers(buildState('Ala'));
+    expect(results.some((item) => !item.isAmbiguous)).toBe(true);
     expect(
-      selectFilteredMonomers(buildState('Ala')).every(
-        (item) =>
-          !item.isAmbiguous &&
-          (item as MonomerItemType).props.MonomerClass ===
-            KetMonomerClass.AminoAcid,
-      ),
+      results.every((item) => {
+        if (item.isAmbiguous) {
+          const ambiguous = item as AmbiguousMonomerType;
+          return (
+            ambiguous.monomers.length > 0 &&
+            ambiguous.monomers.every(
+              (c) =>
+                c.monomerItem.props.MonomerClass === KetMonomerClass.AminoAcid,
+            )
+          );
+        }
+        const monomerClass = (item as MonomerItemType).props.MonomerClass;
+        return (
+          monomerClass !== KetMonomerClass.Base &&
+          monomerClass !== KetMonomerClass.Phosphate &&
+          monomerClass !== KetMonomerClass.Sugar
+        );
+      }),
     ).toBe(true);
   });
 
@@ -247,7 +271,7 @@ describe('selectFilteredMonomers — three-letter amino-acid codes', () => {
 
   it('still matches single-letter A and full name Tryptophan', () => {
     expect(getMatchedAminoAcidLabels('A')).toContain('A');
-    expect(getMatchedAminoAcidLabels('Tryptophan')).toEqual(['W']);
+    expect(getMatchedAminoAcidLabels('Tryptophan').sort()).toEqual(['W', 'X']);
   });
 
   it.each(['Xyz', 'Al@', 'Al1'])(
@@ -262,5 +286,29 @@ describe('selectFilteredMonomers — three-letter amino-acid codes', () => {
     expect(selectFilteredMonomers(buildState(''))).toHaveLength(
       allMonomers.length,
     );
+  });
+
+  it('nucleotide ambiguous B matches none of the 26 three-letter amino-acid codes', () => {
+    const uniqueCodes = [
+      ...new Set(Object.values(AMINO_ACID_ONE_TO_THREE_LETTER_CODE)),
+    ];
+
+    uniqueCodes.forEach((code) => {
+      const results = selectFilteredMonomers(buildState(code));
+      expect(
+        results.some(
+          (item) =>
+            item.isAmbiguous &&
+            (item as AmbiguousMonomerType).label === 'B' &&
+            (item as AmbiguousMonomerType).monomers.every(
+              (c) => c.monomerItem.props.MonomerClass === KetMonomerClass.Base,
+            ),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it('ambiguous X matches Trp via its tryptophan component', () => {
+    expect(getMatchedAminoAcidLabels('Trp').sort()).toEqual(['W', 'X']);
   });
 });

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
@@ -43,6 +43,7 @@ import {
   DNA_TEMPLATE_NAME_PART,
   RNA_TEMPLATE_NAME_PART,
   LIBRARY_TAB_INDEX,
+  AMINO_ACID_ONE_TO_THREE_LETTER_CODE,
 } from 'src/constants';
 import { RootState } from 'state';
 import { localStorageWrapper } from 'helpers/localStorage';
@@ -63,6 +64,16 @@ export type GroupedAmbiguousMonomerLibraryItemType = {
 const LIBRARY_GROUP_NAME_TO_MONOMER_CLASS = {
   [MonomerGroups.PEPTIDES]: KetMonomerClass.AminoAcid,
   [MonomerGroups.BASES]: KetMonomerClass.Base,
+};
+
+const matchesAminoAcidThreeLetterCode = (
+  oneLetterCode: string | undefined,
+  isAminoAcid: boolean,
+  searchFilter: string,
+): boolean => {
+  if (!isAminoAcid || !oneLetterCode) return false;
+  const code = AMINO_ACID_ONE_TO_THREE_LETTER_CODE[oneLetterCode.toUpperCase()];
+  return code ? code.toLowerCase().includes(searchFilter) : false;
 };
 
 const initialState: LibraryState = {
@@ -550,8 +561,20 @@ export const selectFilteredMonomers = createSelector(
             id,
           );
 
+          const isAminoAcidAmbiguous =
+            components.length > 0 &&
+            components.every(
+              (c) =>
+                c.monomerItem.props.MonomerClass === KetMonomerClass.AminoAcid,
+            );
+
           return (
             matchesMonomer ||
+            matchesAminoAcidThreeLetterCode(
+              label,
+              isAminoAcidAmbiguous,
+              normalizedSearchFilter,
+            ) ||
             components.some((monomer) => {
               const {
                 Name,
@@ -576,6 +599,7 @@ export const selectFilteredMonomers = createSelector(
             })
           );
         } else {
+          const props = (item as MonomerItemType).props;
           const {
             Name,
             MonomerName,
@@ -584,17 +608,24 @@ export const selectFilteredMonomers = createSelector(
             aliasBILN,
             aliasAxoLabs,
             modificationTypes,
-          } = (item as MonomerItemType).props;
+          } = props;
 
-          return checkMonomerMatch(
-            idtAliases,
-            normalizedSearchFilter,
-            Name,
-            MonomerName,
-            aliasHELM,
-            aliasBILN,
-            aliasAxoLabs,
-            modificationTypes,
+          return (
+            checkMonomerMatch(
+              idtAliases,
+              normalizedSearchFilter,
+              Name,
+              MonomerName,
+              aliasHELM,
+              aliasBILN,
+              aliasAxoLabs,
+              modificationTypes,
+            ) ||
+            matchesAminoAcidThreeLetterCode(
+              MonomerName,
+              props.MonomerClass === KetMonomerClass.AminoAcid,
+              normalizedSearchFilter,
+            )
           );
         }
       })

--- a/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
+++ b/packages/ketcher-macromolecules/src/state/library/librarySlice.ts
@@ -66,6 +66,18 @@ const LIBRARY_GROUP_NAME_TO_MONOMER_CLASS = {
   [MonomerGroups.BASES]: KetMonomerClass.Base,
 };
 
+type MonomerMatchData = {
+  idtAliases?: IKetIdtAliases;
+  name?: string;
+  fullName?: string;
+  helmAlias?: string;
+  bilnAlias?: string;
+  axoLabsAlias?: string;
+  modificationTypes?: string[];
+  oneLetterCode?: string;
+  isAminoAcid: boolean;
+};
+
 const matchesAminoAcidThreeLetterCode = (
   oneLetterCode: string | undefined,
   isAminoAcid: boolean,
@@ -382,14 +394,18 @@ export const selectFilteredMonomers = createSelector(
     const normalizedSearchFilter = searchFilter.toLowerCase();
 
     const checkMonomerMatch = (
-      idtAliases: IKetIdtAliases | undefined,
       searchFilter: string,
-      name = '',
-      fullName = '',
-      helmAlias: string | undefined = '',
-      bilnAlias: string | undefined = '',
-      axoLabsAlias: string | undefined = '',
-      modificationTypes: string[] | undefined = [],
+      {
+        idtAliases,
+        name = '',
+        fullName = '',
+        helmAlias = '',
+        bilnAlias = '',
+        axoLabsAlias = '',
+        modificationTypes = [],
+        oneLetterCode,
+        isAminoAcid,
+      }: MonomerMatchData,
     ) => {
       const monomerName = name.toLowerCase();
       const monomerNameFull = fullName.toLowerCase();
@@ -526,6 +542,12 @@ export const selectFilteredMonomers = createSelector(
         ? modificationTypesLower.includes(searchFilter)
         : false;
 
+      const matchesThreeLetterCode = matchesAminoAcidThreeLetterCode(
+        oneLetterCode,
+        isAminoAcid,
+        searchFilter,
+      );
+
       const cond =
         monomerName.includes(searchFilter) ||
         monomerNameFull.includes(searchFilter) ||
@@ -534,7 +556,8 @@ export const selectFilteredMonomers = createSelector(
         matchesHelmAlias ||
         matchesBilnAlias ||
         matchesAxoLabsAlias ||
-        matchesModificationTypes;
+        matchesModificationTypes ||
+        matchesThreeLetterCode;
 
       return cond;
     };
@@ -554,13 +577,6 @@ export const selectFilteredMonomers = createSelector(
             monomers: components,
           } = item as AmbiguousMonomerType;
 
-          const matchesMonomer = checkMonomerMatch(
-            idtAliases,
-            normalizedSearchFilter,
-            label,
-            id,
-          );
-
           const isAminoAcidAmbiguous =
             components.length > 0 &&
             components.every(
@@ -568,17 +584,21 @@ export const selectFilteredMonomers = createSelector(
                 c.monomerItem.props.MonomerClass === KetMonomerClass.AminoAcid,
             );
 
+          const matchesMonomer = checkMonomerMatch(normalizedSearchFilter, {
+            idtAliases,
+            name: label,
+            fullName: id,
+            oneLetterCode: label,
+            isAminoAcid: isAminoAcidAmbiguous,
+          });
+
           return (
             matchesMonomer ||
-            matchesAminoAcidThreeLetterCode(
-              label,
-              isAminoAcidAmbiguous,
-              normalizedSearchFilter,
-            ) ||
             components.some((monomer) => {
               const {
                 Name,
                 MonomerName,
+                MonomerClass,
                 idtAliases,
                 aliasHELM,
                 aliasBILN,
@@ -586,47 +606,42 @@ export const selectFilteredMonomers = createSelector(
                 modificationTypes,
               } = monomer.monomerItem.props;
 
-              return checkMonomerMatch(
+              return checkMonomerMatch(normalizedSearchFilter, {
                 idtAliases,
-                normalizedSearchFilter,
-                Name,
-                MonomerName,
-                aliasHELM,
-                aliasBILN,
-                aliasAxoLabs,
+                name: Name,
+                fullName: MonomerName,
+                helmAlias: aliasHELM,
+                bilnAlias: aliasBILN,
+                axoLabsAlias: aliasAxoLabs,
                 modificationTypes,
-              );
+                oneLetterCode: MonomerName,
+                isAminoAcid: MonomerClass === KetMonomerClass.AminoAcid,
+              });
             })
           );
         } else {
-          const props = (item as MonomerItemType).props;
           const {
             Name,
             MonomerName,
+            MonomerClass,
             idtAliases,
             aliasHELM,
             aliasBILN,
             aliasAxoLabs,
             modificationTypes,
-          } = props;
+          } = (item as MonomerItemType).props;
 
-          return (
-            checkMonomerMatch(
-              idtAliases,
-              normalizedSearchFilter,
-              Name,
-              MonomerName,
-              aliasHELM,
-              aliasBILN,
-              aliasAxoLabs,
-              modificationTypes,
-            ) ||
-            matchesAminoAcidThreeLetterCode(
-              MonomerName,
-              props.MonomerClass === KetMonomerClass.AminoAcid,
-              normalizedSearchFilter,
-            )
-          );
+          return checkMonomerMatch(normalizedSearchFilter, {
+            idtAliases,
+            name: Name,
+            fullName: MonomerName,
+            helmAlias: aliasHELM,
+            bilnAlias: aliasBILN,
+            axoLabsAlias: aliasAxoLabs,
+            modificationTypes,
+            oneLetterCode: MonomerName,
+            isAminoAcid: MonomerClass === KetMonomerClass.AminoAcid,
+          });
         }
       })
       .map((item: MonomerOrAmbiguousType) => {


### PR DESCRIPTION
### Description
Enables searching the monomer library by the standard three-letter amino-acid
codes (e.g. `Trp` → W, `Ala` → A, `Asx` → B).

Previously three-letter codes were not supported: 8 of the 26 codes
(`Trp`, `Ile`, `Asn`, `Gln`, `Asx`, `Xle`, `Xaa`, `Glx`) returned no result,
and the others matched only coincidentally, as a substring of the full monomer
name. The three-letter code was not stored anywhere in the monomer data.

### Changes
- Added `AMINO_ACID_ONE_TO_THREE_LETTER_CODE` (one-letter → three-letter) lookup
  in `constants.ts`.
- In `selectFilteredMonomers`, match a monomer's three-letter code, gated on
  `KetMonomerClass.AminoAcid`:
  - natural amino acids by their one-letter symbol (`MonomerName`);
  - ambiguous amino acids (Asx / Xle / Xaa / Glx) by their label, requiring every
    component to be an amino acid so the nucleotide `B` is not matched.
- Reuses the existing substring matcher, so search stays case-insensitive and
  supports partial input (`Tr` → Trp). `checkMonomerMatch` is left unchanged.

### Testing
- New unit tests in `librarySlice.test.ts`: all 26 codes, case-insensitivity,
  partial match, collision guard (A/Adenine, P/Phosphate, R/Ribose), ambiguous-B
  disambiguation, backward compatibility (single letter, full name), invalid input.
- Manually verified in ketcher-standalone: `Trp` → W, `Asx` → B only,
  `Ala` does not surface Adenine.

Closes #10221

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request