### PR TITLE
#7126 - Merging all chains on the canvas to one doesn't trigger recalculation in Calculate Properties window

### DIFF
--- a/packages/ketcher-core/src/application/editor/EditorHistory.ts
+++ b/packages/ketcher-core/src/application/editor/EditorHistory.ts
@@ -62,6 +62,12 @@ export class EditorHistory {
       this.historyPointer = this.historyStack.length;
     }
     ketcherProvider.getKetcher(this.editor.ketcherId)?.changeEvent.dispatch();
+    // Fire a dedicated model-change signal only when something actually
+    // changed, so a no-op command doesn't trigger needless macromolecule
+    // properties recalculation.
+    if (command.operations.length > 0) {
+      this.editor.events.modelChange.dispatch();
+    }
   }
 
   undo() {
@@ -77,6 +83,9 @@ export class EditorHistory {
     const turnOffSelectionCommand =
       this.editor?.drawingEntitiesManager.unselectAllDrawingEntities();
     this.editor?.renderersContainer.update(turnOffSelectionCommand);
+    // Dispatch after the model has been reverted so subscribers observe the
+    // up-to-date structure.
+    this.editor.events.modelChange.dispatch();
   }
 
   redo() {
@@ -92,6 +101,9 @@ export class EditorHistory {
     const turnOffSelectionCommand =
       this.editor?.drawingEntitiesManager.unselectAllDrawingEntities();
     this.editor?.renderersContainer.update(turnOffSelectionCommand);
+    // Dispatch after the model has been re-applied so subscribers observe the
+    // up-to-date structure.
+    this.editor.events.modelChange.dispatch();
   }
 
   public get previousCommand() {

--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -65,6 +65,7 @@ export interface IEditorEvents {
   pasteFromClipboard: Subscription;
   deleteSelectedStructure: Subscription;
   selectEntities: Subscription;
+  modelChange: Subscription;
   toggleMacromoleculesPropertiesVisibility: Subscription;
   modifyAminoAcids: Subscription;
   setEditorLineLength: Subscription;
@@ -142,6 +143,7 @@ export function createEditorEvents(): IEditorEvents {
     pasteFromClipboard: new Subscription(),
     deleteSelectedStructure: new Subscription(),
     selectEntities: new Subscription(),
+    modelChange: new Subscription(),
     toggleMacromoleculesPropertiesVisibility: new Subscription(),
     modifyAminoAcids: new Subscription(),
     setEditorLineLength: new Subscription(),

--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -360,6 +360,11 @@ class PolymerBond implements BaseTool {
         this.bondRenderer.polymerBond,
       );
       this.bondRenderer = undefined;
+      this.editor.events.selectEntities.dispatch(
+        this.editor.drawingEntitiesManager.selectedEntities.map(
+          (entity) => entity[1],
+        ),
+      );
       event.stopPropagation();
     }
   }
@@ -492,6 +497,11 @@ class PolymerBond implements BaseTool {
       );
       this.bondRenderer = undefined;
       this.history.update(modelChanges);
+      this.editor.events.selectEntities.dispatch(
+        this.editor.drawingEntitiesManager.selectedEntities.map(
+          (entity) => entity[1],
+        ),
+      );
       event.stopPropagation();
     }
   }
@@ -593,6 +603,11 @@ class PolymerBond implements BaseTool {
       this.bondRenderer.polymerBond,
     );
     this.bondRenderer = undefined;
+    this.editor.events.selectEntities.dispatch(
+      this.editor.drawingEntitiesManager.selectedEntities.map(
+        (entity) => entity[1],
+      ),
+    );
   };
 
   public handleBondCreationCancellation = (

--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -360,11 +360,6 @@ class PolymerBond implements BaseTool {
         this.bondRenderer.polymerBond,
       );
       this.bondRenderer = undefined;
-      this.editor.events.selectEntities.dispatch(
-        this.editor.drawingEntitiesManager.selectedEntities.map(
-          (entity) => entity[1],
-        ),
-      );
       event.stopPropagation();
     }
   }
@@ -497,11 +492,6 @@ class PolymerBond implements BaseTool {
       );
       this.bondRenderer = undefined;
       this.history.update(modelChanges);
-      this.editor.events.selectEntities.dispatch(
-        this.editor.drawingEntitiesManager.selectedEntities.map(
-          (entity) => entity[1],
-        ),
-      );
       event.stopPropagation();
     }
   }
@@ -603,11 +593,6 @@ class PolymerBond implements BaseTool {
       this.bondRenderer.polymerBond,
     );
     this.bondRenderer = undefined;
-    this.editor.events.selectEntities.dispatch(
-      this.editor.drawingEntitiesManager.selectedEntities.map(
-        (entity) => entity[1],
-      ),
-    );
   };
 
   public handleBondCreationCancellation = (

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -936,7 +936,7 @@ const calculateMassMeasurementUnit = (mass?: number) => {
   return MassMeasurementUnit.MDa;
 };
 
-let selectEntitiesHandler: () => void;
+let recalculatePropertiesHandler: () => void;
 
 export const MacromoleculePropertiesWindow = () => {
   const dispatch = useAppDispatch();
@@ -987,21 +987,30 @@ export const MacromoleculePropertiesWindow = () => {
   }, [recalculateMacromoleculeProperties]);
 
   useEffect(() => {
-    if (
-      selectEntitiesHandler &&
-      editor?.events.selectEntities.hasHandler(selectEntitiesHandler)
-    ) {
-      editor?.events.selectEntities.remove(selectEntitiesHandler);
+    if (recalculatePropertiesHandler) {
+      if (
+        editor?.events.selectEntities.hasHandler(recalculatePropertiesHandler)
+      ) {
+        editor?.events.selectEntities.remove(recalculatePropertiesHandler);
+      }
+      if (editor?.events.modelChange.hasHandler(recalculatePropertiesHandler)) {
+        editor?.events.modelChange.remove(recalculatePropertiesHandler);
+      }
     }
 
-    selectEntitiesHandler = () => {
+    recalculatePropertiesHandler = () => {
       debouncedRecalculateMacromoleculeProperties(skipDataFetch);
     };
 
-    editor?.events.selectEntities.add(selectEntitiesHandler);
+    // selectEntities covers recalculation when the selection changes;
+    // modelChange covers recalculation when the structure itself changes
+    // (e.g. merging chains on the canvas) without necessarily changing selection.
+    editor?.events.selectEntities.add(recalculatePropertiesHandler);
+    editor?.events.modelChange.add(recalculatePropertiesHandler);
 
     return () => {
-      editor?.events.selectEntities.remove(selectEntitiesHandler);
+      editor?.events.selectEntities.remove(recalculatePropertiesHandler);
+      editor?.events.modelChange.remove(recalculatePropertiesHandler);
     };
   }, [debouncedRecalculateMacromoleculeProperties, editor, skipDataFetch]);
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

The "Calculate Properties" panel only recalculated in response to the editor's `selectEntities` event. Actions like deleting, flipping, or selecting entities happen to re-fire that event as a side effect, so recalculation looked automatic for them — but finishing a bond via the Single Bond tool never touches selection. As a result, merging two chains into one left the panel showing stale ("No Data Available") data until the user manually closed and reopened it.

**Root cause:** recalculation was tied to a selection event rather than a model-change event, so any model mutation that doesn't alter selection was missed.

**Fix:** introduce a dedicated `modelChange` editor event and dispatch it from the central history choke point (`EditorHistory` — `update`, `undo`, `redo`), right next to the existing `changeEvent` dispatch. This way every model mutation — including bond creation that merges chains — signals the panel, regardless of selection. In `update`, the event is fired only when the command actually changed something (`command.operations.length > 0`) to avoid needless recalculation on no-op commands; in `undo`/`redo` it is dispatched after the model has been reverted/re-applied so subscribers observe the up-to-date structure.

The "Calculate Properties" panel now subscribes to both `selectEntities` (selection-driven recalculation) and `modelChange` (structure-driven recalculation), with the existing 500 ms debounce coalescing overlapping dispatches into a single recalculation.

The three temporary `selectEntities` dispatches previously added to `Bond.ts` (`mouseUpAttachmentPoint`, `mouseUpMonomer`, `handleBondCreation`) are removed, since bond finalization already routes through `EditorHistory.update` and is now covered by `modelChange`.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request