### PR TITLE
#10436 - Refactor: Explicit Any type clean up from packages\ketcher-core\src\application\editor\operations\atom\AtomAttr.ts file

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomAttr.ts
@@ -19,16 +19,16 @@ import { OperationPriority, OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
 
 type Data = {
-  aid?: any;
-  attribute?: any;
-  value?: any;
+  aid?: number;
+  attribute?: string;
+  value?: unknown;
 };
 
 export class AtomAttr extends BaseOperation {
   data: Data | null;
   data2: Data | null;
 
-  constructor(atomId?: any, attribute?: any, value?: any) {
+  constructor(atomId?: number, attribute?: string, value?: unknown) {
     super(OperationType.ATOM_ATTR, OperationPriority.ATOM_ATTR);
     this.data = { aid: atomId, attribute, value };
     this.data2 = null;
@@ -37,17 +37,20 @@ export class AtomAttr extends BaseOperation {
   execute(restruct: ReStruct) {
     if (this.data) {
       const { aid, attribute, value } = this.data;
+      if (aid === undefined || attribute === undefined) {
+        return;
+      }
 
       const atom = restruct.molecule.atoms.get(aid)!;
       if (!this.data2) {
         this.data2 = {
           aid,
           attribute,
-          value: atom[attribute],
+          value: Reflect.get(atom, attribute),
         };
       }
 
-      atom[attribute] = value;
+      Reflect.set(atom, attribute, value);
       BaseOperation.invalidateAtom(restruct, aid);
     }
   }
@@ -60,10 +63,18 @@ export class AtomAttr extends BaseOperation {
   }
 
   isDummy(restruct: ReStruct) {
-    const atom = restruct.molecule.atoms.get(this.data?.aid);
+    const data = this.data;
+    if (!data) {
+      return false;
+    }
+    const { aid, attribute, value } = data;
+    if (aid === undefined || attribute === undefined) {
+      return false;
+    }
+    const atom = restruct.molecule.atoms.get(aid);
     if (!atom) {
       return false;
     }
-    return atom[this.data?.attribute] === this.data?.value;
+    return Reflect.get(atom, attribute) === value;
   }
 }


### PR DESCRIPTION
Replaced explicit any annotations with number, string, and unknown; added safe guards and reflective access for dynamic atom attributes.

Closes #10436