### PR TITLE
#10453 - Keyboard shortcuts tooltip text should be shown correct on Mac

### DIFF
--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -210,19 +210,19 @@ const selectBondTool = (editor: CoreEditor, toolName: ToolName) => {
 
 export const hotkeysConfiguration = {
   RNASequenceType: {
-    shortcut: ['Control+Alt+r'],
+    shortcut: ['Mod+Alt+r'],
     handler: (editor: CoreEditor) => {
       editor.events.changeSequenceTypeEnterMode.dispatch(SequenceType.RNA);
     },
   },
   DNASequenceType: {
-    shortcut: ['Control+Alt+d'],
+    shortcut: ['Mod+Alt+d'],
     handler: (editor: CoreEditor) => {
       editor.events.changeSequenceTypeEnterMode.dispatch(SequenceType.DNA);
     },
   },
   PEPTIDESequenceTYpe: {
-    shortcut: ['Control+Alt+p'],
+    shortcut: ['Mod+Alt+p'],
     handler: (editor: CoreEditor) => {
       editor.events.changeSequenceTypeEnterMode.dispatch(SequenceType.PEPTIDE);
     },

--- a/packages/ketcher-react/src/script/ui/action/server.ts
+++ b/packages/ketcher-react/src/script/ui/action/server.ts
@@ -51,7 +51,7 @@ const config: ServerConfig = {
     hidden: (options) => isHidden(options, 'arom'),
   },
   dearom: {
-    shortcut: 'Ctrl+Alt+a',
+    shortcut: 'Mod+Alt+a',
     title: 'Dearomatize',
     action: {
       thunk: serverTransform('dearomatize'),


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request