### PR TITLE
#10372 - Structure layout is changed while add and expand a Functional Group

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/sgroup.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/sgroup.test.ts
@@ -73,6 +73,52 @@ const addAttachmentPoint = (
   );
 };
 
+// Two S-group atoms (so the S-group has a non-zero bounding box) plus one
+// outside atom bonded to the S-group's attachment atom — the minimal shape
+// that triggers the "make room" repositioning of the attached structure.
+const buildAttachedStructure = () => {
+  const struct = new Struct();
+  const insideAtom1Id = struct.atoms.add(
+    new Atom({ label: 'C', pp: new Vec2(0, 0) }),
+  );
+  const insideAtom2Id = struct.atoms.add(
+    new Atom({ label: 'C', pp: new Vec2(1, 0) }),
+  );
+  const outsideAtomId = struct.atoms.add(
+    new Atom({ label: 'C', pp: new Vec2(0, 2) }),
+  );
+
+  const insideBondId = struct.bonds.add(
+    new Bond({
+      begin: insideAtom1Id,
+      end: insideAtom2Id,
+      type: Bond.PATTERN.TYPE.SINGLE,
+    }),
+  );
+  struct.bondInitHalfBonds(insideBondId);
+  const attachBondId = struct.bonds.add(
+    new Bond({
+      begin: insideAtom1Id,
+      end: outsideAtomId,
+      type: Bond.PATTERN.TYPE.SINGLE,
+    }),
+  );
+  struct.bondInitHalfBonds(attachBondId);
+  struct.initNeighbors();
+
+  return { struct, insideAtom1Id, insideAtom2Id, outsideAtomId };
+};
+
+const makeRestruct = (struct: Struct) => {
+  const options = {
+    scale: 40,
+    width: 100,
+    height: 100,
+  } as unknown as RenderOptions;
+  const render = new Render(document as unknown as HTMLElement, options);
+  return new ReStruct(struct, render);
+};
+
 describe('setExpandMonomerSGroup', () => {
   afterEach(() => {
     (getAttachmentPointStereoBond as jest.Mock).mockReset();
@@ -231,5 +277,46 @@ describe('setExpandMonomerSGroup', () => {
     expect(moleculeNodes).toHaveLength(1);
     expect(moleculeNodes[0].fragment?.atoms.size).toBe(2);
     expect(moleculeNodes[0].fragment?.bonds.size).toBe(1);
+  });
+
+  it('does not move the attached structure when collapsing a functional group (#10372)', () => {
+    const { struct, insideAtom1Id, insideAtom2Id, outsideAtomId } =
+      buildAttachedStructure();
+    // A plain SUP S-group is a functional group, not a monomer (isMonomer=false).
+    const sgroup = new SGroup(SGroup.TYPES.SUP);
+    const sgroupId = struct.sgroups.add(sgroup);
+    sgroup.id = sgroupId;
+    sgroup.data.name = 'Cbz';
+    sgroup.data.expanded = true;
+    sgroup.pp = new Vec2(struct.atoms.get(insideAtom1Id)?.pp ?? new Vec2());
+    struct.atomAddToSGroup(sgroupId, insideAtom1Id);
+    struct.atomAddToSGroup(sgroupId, insideAtom2Id);
+    addAttachmentPoint(struct, sgroupId, insideAtom1Id, 1);
+
+    const restruct = makeRestruct(struct);
+    const before = new Vec2(struct.atoms.get(outsideAtomId)?.pp ?? new Vec2());
+
+    setExpandMonomerSGroup(restruct, sgroupId, { expanded: false });
+
+    const after = struct.atoms.get(outsideAtomId)?.pp;
+    expect(after?.x).toBe(before.x);
+    expect(after?.y).toBe(before.y);
+  });
+
+  it('still repositions the attached structure when collapsing a monomer', () => {
+    const { struct, insideAtom1Id, insideAtom2Id, outsideAtomId } =
+      buildAttachedStructure();
+    const sgroupId = createMonomerSGroup(struct, insideAtom1Id);
+    struct.atomAddToSGroup(sgroupId, insideAtom2Id);
+    addAttachmentPoint(struct, sgroupId, insideAtom1Id, 1);
+
+    const restruct = makeRestruct(struct);
+    const before = new Vec2(struct.atoms.get(outsideAtomId)?.pp ?? new Vec2());
+
+    setExpandMonomerSGroup(restruct, sgroupId, { expanded: false });
+
+    const after = struct.atoms.get(outsideAtomId)?.pp;
+    const moved = after ? after.x !== before.x || after.y !== before.y : false;
+    expect(moved).toBe(true);
   });
 });

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -293,244 +293,262 @@ export function setExpandMonomerSGroup(
     }
   });
 
-  const sGroupBBox = SGroup.getObjBBox(
-    Array.from(sGroupAtoms.values()),
-    struct,
-  );
-  const sGroupWidth = sGroupBBox.p1.x - sGroupBBox.p0.x;
-  const sGroupHeight = sGroupBBox.p1.y - sGroupBBox.p0.y;
-  const sGroupCenter = sGroup.isContracted()
-    ? sGroup.getContractedPosition(struct).position
-    : sGroup.pp;
+  // Repositioning neighbors and the attached substructure to make room on
+  // expand/collapse applies only to macro monomers. Micro functional groups
+  // keep their fixed template layout, so skip it — otherwise expanding or
+  // collapsing an FG shifts the connected structure (#10372).
+  if (sGroup.isMonomer) {
+    const sGroupBBox = SGroup.getObjBBox(
+      Array.from(sGroupAtoms.values()),
+      struct,
+    );
+    const sGroupWidth = sGroupBBox.p1.x - sGroupBBox.p0.x;
+    const sGroupHeight = sGroupBBox.p1.y - sGroupBBox.p0.y;
+    const sGroupCenter = sGroup.isContracted()
+      ? sGroup.getContractedPosition(struct).position
+      : sGroup.pp;
 
-  const visitedAtoms = new Set<number>();
-  const visitedSGroups = new Set<number>();
+    const visitedAtoms = new Set<number>();
+    const visitedSGroups = new Set<number>();
 
-  const atomsToMove = new Map<number, number[]>();
-  const sGroupsToMove = new Map<number, number[]>();
+    const atomsToMove = new Map<number, number[]>();
+    const sGroupsToMove = new Map<number, number[]>();
 
-  attachmentAtomsFromOutside.forEach((startAtomId, index) => {
-    const queue: number[] = [startAtomId];
+    attachmentAtomsFromOutside.forEach((startAtomId, index) => {
+      const queue: number[] = [startAtomId];
 
-    while (queue.length > 0) {
-      const currentAtomId = queue.shift() as number;
+      while (queue.length > 0) {
+        const currentAtomId = queue.shift() as number;
 
-      if (visitedAtoms.has(currentAtomId)) {
-        continue;
-      }
-      visitedAtoms.add(currentAtomId);
+        if (visitedAtoms.has(currentAtomId)) {
+          continue;
+        }
+        visitedAtoms.add(currentAtomId);
 
-      const atomSGroups = restruct.atoms.get(currentAtomId)?.a.sgs;
-      const atomInSGroup = atomSGroups && atomSGroups.size > 0;
-      if (atomInSGroup) {
-        for (const anotherSGroupId of atomSGroups.values()) {
-          if (visitedSGroups.has(anotherSGroupId) || anotherSGroupId === sgid) {
-            continue;
+        const atomSGroups = restruct.atoms.get(currentAtomId)?.a.sgs;
+        const atomInSGroup = atomSGroups && atomSGroups.size > 0;
+        if (atomInSGroup) {
+          for (const anotherSGroupId of atomSGroups.values()) {
+            if (
+              visitedSGroups.has(anotherSGroupId) ||
+              anotherSGroupId === sgid
+            ) {
+              continue;
+            }
+            visitedSGroups.add(anotherSGroupId);
+
+            const anotherSGroup = struct.sgroups.get(anotherSGroupId);
+            if (!anotherSGroup) {
+              continue;
+            }
+
+            const previousArray = sGroupsToMove.get(index) ?? [];
+            sGroupsToMove.set(index, previousArray.concat(anotherSGroupId));
           }
-          visitedSGroups.add(anotherSGroupId);
+        }
 
-          const anotherSGroup = struct.sgroups.get(anotherSGroupId);
-          if (!anotherSGroup) {
-            continue;
-          }
+        const atom = struct.atoms.get(currentAtomId);
+        if (atom) {
+          const previousArray = atomsToMove.get(index) ?? [];
+          atomsToMove.set(index, previousArray.concat(currentAtomId));
 
-          const previousArray = sGroupsToMove.get(index) ?? [];
-          sGroupsToMove.set(index, previousArray.concat(anotherSGroupId));
+          atom.neighbors.forEach((halfBondId) => {
+            const neighborAtomId = struct?.halfBonds?.get(halfBondId)?.end;
+            if (
+              neighborAtomId === undefined ||
+              sGroupAtoms.has(neighborAtomId)
+            ) {
+              return;
+            }
+            queue.push(neighborAtomId);
+          });
         }
       }
-
-      const atom = struct.atoms.get(currentAtomId);
-      if (atom) {
-        const previousArray = atomsToMove.get(index) ?? [];
-        atomsToMove.set(index, previousArray.concat(currentAtomId));
-
-        atom.neighbors.forEach((halfBondId) => {
-          const neighborAtomId = struct?.halfBonds?.get(halfBondId)?.end;
-          if (neighborAtomId === undefined || sGroupAtoms.has(neighborAtomId)) {
-            return;
-          }
-          queue.push(neighborAtomId);
-        });
-      }
-    }
-  });
-
-  const sameLine = new Set<number>();
-
-  sGroupsToMove.forEach((sGroupIds) => {
-    sGroupIds.forEach((sGroupId) => {
-      const movableSGroup = struct.sgroups.get(sGroupId);
-      if (!movableSGroup) {
-        return;
-      }
-
-      const movableSGroupCenter = movableSGroup.isContracted()
-        ? movableSGroup.getContractedPosition(struct).position
-        : movableSGroup?.pp;
-      if (!sGroupCenter || !movableSGroupCenter) {
-        return;
-      }
-
-      const SAME_LINE_THRESHOLD = 0.5;
-      const inOneLine =
-        movableSGroupCenter.y < sGroupCenter.y + SAME_LINE_THRESHOLD &&
-        movableSGroupCenter.y > sGroupCenter.y - SAME_LINE_THRESHOLD;
-
-      if (inOneLine) {
-        sameLine.add(sGroupId);
-        return;
-      }
-
-      const WIDE_LINE_THRESHOLD = 2;
-      const inWideLine =
-        movableSGroupCenter.y < sGroupCenter.y + WIDE_LINE_THRESHOLD &&
-        movableSGroupCenter.y > sGroupCenter.y - WIDE_LINE_THRESHOLD;
-
-      const movableSGroupAtoms: Set<number> = new Set(
-        SGroup.getAtoms(struct, movableSGroup),
-      );
-      const movableSGroupBondsToOutside = struct.bonds.filter((_, bond) => {
-        return (
-          (movableSGroupAtoms.has(bond.begin) &&
-            !movableSGroupAtoms.has(bond.end)) ||
-          (movableSGroupAtoms.has(bond.end) &&
-            !movableSGroupAtoms.has(bond.begin))
-        );
-      });
-
-      const hasComplementaryBondToMainLine =
-        movableSGroupBondsToOutside.size === 1 &&
-        [...sameLine.values()].some((sGroupId) => {
-          const mainLineSGroup = struct.sgroups.get(sGroupId);
-          if (!mainLineSGroup) {
-            return false;
-          }
-
-          const mainLineSGroupAtoms: Set<number> = new Set(
-            SGroup.getAtoms(struct, mainLineSGroup),
-          );
-          const bond = [...movableSGroupBondsToOutside.values()][0];
-          return (
-            mainLineSGroupAtoms.has(bond.begin) ||
-            mainLineSGroupAtoms.has(bond.end)
-          );
-        });
-
-      if (inWideLine && hasComplementaryBondToMainLine) {
-        sameLine.add(sGroupId);
-      }
     });
-  });
 
-  const largestHeightInLine = [...sameLine.values()].reduce((acc, sGroupId) => {
-    const sGroupInLine = restruct.molecule.sgroups.get(sGroupId);
-    if (!sGroupInLine) {
-      return acc;
-    }
+    const sameLine = new Set<number>();
 
-    if (sGroupInLine.isContracted()) {
-      return acc;
-    }
+    sGroupsToMove.forEach((sGroupIds) => {
+      sGroupIds.forEach((sGroupId) => {
+        const movableSGroup = struct.sgroups.get(sGroupId);
+        if (!movableSGroup) {
+          return;
+        }
 
-    const sGroupInLineAtoms = SGroup.getAtoms(struct, sGroupInLine);
-    const sGroupInLineBBox = SGroup.getObjBBox(
-      sGroupInLineAtoms,
-      restruct.molecule,
+        const movableSGroupCenter = movableSGroup.isContracted()
+          ? movableSGroup.getContractedPosition(struct).position
+          : movableSGroup?.pp;
+        if (!sGroupCenter || !movableSGroupCenter) {
+          return;
+        }
+
+        const SAME_LINE_THRESHOLD = 0.5;
+        const inOneLine =
+          movableSGroupCenter.y < sGroupCenter.y + SAME_LINE_THRESHOLD &&
+          movableSGroupCenter.y > sGroupCenter.y - SAME_LINE_THRESHOLD;
+
+        if (inOneLine) {
+          sameLine.add(sGroupId);
+          return;
+        }
+
+        const WIDE_LINE_THRESHOLD = 2;
+        const inWideLine =
+          movableSGroupCenter.y < sGroupCenter.y + WIDE_LINE_THRESHOLD &&
+          movableSGroupCenter.y > sGroupCenter.y - WIDE_LINE_THRESHOLD;
+
+        const movableSGroupAtoms: Set<number> = new Set(
+          SGroup.getAtoms(struct, movableSGroup),
+        );
+        const movableSGroupBondsToOutside = struct.bonds.filter((_, bond) => {
+          return (
+            (movableSGroupAtoms.has(bond.begin) &&
+              !movableSGroupAtoms.has(bond.end)) ||
+            (movableSGroupAtoms.has(bond.end) &&
+              !movableSGroupAtoms.has(bond.begin))
+          );
+        });
+
+        const hasComplementaryBondToMainLine =
+          movableSGroupBondsToOutside.size === 1 &&
+          [...sameLine.values()].some((sGroupId) => {
+            const mainLineSGroup = struct.sgroups.get(sGroupId);
+            if (!mainLineSGroup) {
+              return false;
+            }
+
+            const mainLineSGroupAtoms: Set<number> = new Set(
+              SGroup.getAtoms(struct, mainLineSGroup),
+            );
+            const bond = [...movableSGroupBondsToOutside.values()][0];
+            return (
+              mainLineSGroupAtoms.has(bond.begin) ||
+              mainLineSGroupAtoms.has(bond.end)
+            );
+          });
+
+        if (inWideLine && hasComplementaryBondToMainLine) {
+          sameLine.add(sGroupId);
+        }
+      });
+    });
+
+    const largestHeightInLine = [...sameLine.values()].reduce(
+      (acc, sGroupId) => {
+        const sGroupInLine = restruct.molecule.sgroups.get(sGroupId);
+        if (!sGroupInLine) {
+          return acc;
+        }
+
+        if (sGroupInLine.isContracted()) {
+          return acc;
+        }
+
+        const sGroupInLineAtoms = SGroup.getAtoms(struct, sGroupInLine);
+        const sGroupInLineBBox = SGroup.getObjBBox(
+          sGroupInLineAtoms,
+          restruct.molecule,
+        );
+        const sGroupInLineHeight =
+          sGroupInLineBBox.p1.y - sGroupInLineBBox.p0.y;
+
+        return Math.max(acc, sGroupInLineHeight);
+      },
+      0,
     );
-    const sGroupInLineHeight = sGroupInLineBBox.p1.y - sGroupInLineBBox.p0.y;
+    const baseVerticalOffset =
+      largestHeightInLine > sGroupHeight
+        ? 0
+        : (sGroupHeight - largestHeightInLine) / 2;
+    const horizontalOffset = sGroupWidth / 2;
 
-    return Math.max(acc, sGroupInLineHeight);
-  }, 0);
-  const baseVerticalOffset =
-    largestHeightInLine > sGroupHeight
-      ? 0
-      : (sGroupHeight - largestHeightInLine) / 2;
-  const horizontalOffset = sGroupWidth / 2;
+    const handledAtoms = new Set<number>();
+    sGroupsToMove.forEach((sGroupIds) => {
+      sGroupIds.forEach((sGroupId) => {
+        const movableSGroup = restruct.molecule.sgroups.get(sGroupId);
+        if (!movableSGroup) {
+          return;
+        }
 
-  const handledAtoms = new Set<number>();
-  sGroupsToMove.forEach((sGroupIds) => {
-    sGroupIds.forEach((sGroupId) => {
-      const movableSGroup = restruct.molecule.sgroups.get(sGroupId);
-      if (!movableSGroup) {
+        const movableSGroupCenter = movableSGroup.isContracted()
+          ? movableSGroup.getContractedPosition(restruct.molecule).position
+          : movableSGroup?.pp;
+        if (!sGroupCenter || !movableSGroupCenter) {
+          return;
+        }
+
+        const moveDown = movableSGroupCenter.y > sGroupCenter.y;
+        const moveUp = movableSGroupCenter.y < sGroupCenter.y;
+        const moveRight = movableSGroupCenter.x > sGroupCenter.x;
+        const moveLeft = movableSGroupCenter.x < sGroupCenter.x;
+        const moveHorizontally = sameLine.has(sGroupId);
+        const moveVertically = !moveHorizontally;
+
+        let horizontalDirection = 0;
+        if (moveRight) {
+          horizontalDirection = 1;
+        } else if (moveLeft) {
+          horizontalDirection = -1;
+        }
+
+        let verticalDirection = 0;
+        if (moveDown) {
+          verticalDirection = 1;
+        } else if (moveUp) {
+          verticalDirection = -1;
+        }
+
+        const moveVector = new Vec2(
+          (moveHorizontally ? 1 : 0) * horizontalDirection * horizontalOffset,
+          (moveVertically ? 1 : 0) * verticalDirection * baseVerticalOffset,
+        );
+        const finalMoveVector = attrs.expanded
+          ? moveVector
+          : moveVector.negated();
+
+        const movableSGroupAtoms = SGroup.getAtoms(struct, movableSGroup);
+        movableSGroupAtoms.forEach((aid) => {
+          action.addOp(new AtomMove(aid, finalMoveVector));
+          handledAtoms.add(aid);
+        });
+        action.addOp(new SGroupDataMove(sGroupId, finalMoveVector));
+      });
+    });
+
+    atomsToMove.forEach((atomIds) => {
+      const intactAtoms = atomIds.filter((aid) => !handledAtoms.has(aid));
+      if (intactAtoms.length === 0) {
         return;
       }
 
-      const movableSGroupCenter = movableSGroup.isContracted()
-        ? movableSGroup.getContractedPosition(restruct.molecule).position
-        : movableSGroup?.pp;
-      if (!sGroupCenter || !movableSGroupCenter) {
-        return;
-      }
-
-      const moveDown = movableSGroupCenter.y > sGroupCenter.y;
-      const moveUp = movableSGroupCenter.y < sGroupCenter.y;
-      const moveRight = movableSGroupCenter.x > sGroupCenter.x;
-      const moveLeft = movableSGroupCenter.x < sGroupCenter.x;
-      const moveHorizontally = sameLine.has(sGroupId);
-      const moveVertically = !moveHorizontally;
-
-      let horizontalDirection = 0;
-      if (moveRight) {
-        horizontalDirection = 1;
-      } else if (moveLeft) {
-        horizontalDirection = -1;
-      }
-
-      let verticalDirection = 0;
-      if (moveDown) {
-        verticalDirection = 1;
-      } else if (moveUp) {
-        verticalDirection = -1;
-      }
-
-      const moveVector = new Vec2(
-        (moveHorizontally ? 1 : 0) * horizontalDirection * horizontalOffset,
-        (moveVertically ? 1 : 0) * verticalDirection * baseVerticalOffset,
+      const subStructBBox = SGroup.getObjBBox(
+        intactAtoms,
+        restruct.molecule,
+        true,
       );
+      const subStructCenter = new Vec2(
+        subStructBBox.p0.x + (subStructBBox.p1.x - subStructBBox.p0.x) / 2,
+        subStructBBox.p0.y + (subStructBBox.p1.y - subStructBBox.p0.y) / 2,
+      );
+      const sGroupCenter = new Vec2(
+        sGroupBBox.p0.x + (sGroupBBox.p1.x - sGroupBBox.p0.x) / 2,
+        sGroupBBox.p0.y + (sGroupBBox.p1.y - sGroupBBox.p0.y) / 2,
+      );
+      const direction = subStructCenter.sub(sGroupCenter).normalized();
+      const moveVector = new Vec2(
+        (direction.x * sGroupWidth) / 2,
+        (direction.y * sGroupHeight) / 2,
+      );
+
       const finalMoveVector = attrs.expanded
         ? moveVector
         : moveVector.negated();
 
-      const movableSGroupAtoms = SGroup.getAtoms(struct, movableSGroup);
-      movableSGroupAtoms.forEach((aid) => {
-        action.addOp(new AtomMove(aid, finalMoveVector));
-        handledAtoms.add(aid);
+      intactAtoms.forEach((atomId) => {
+        action.addOp(new AtomMove(atomId, finalMoveVector));
       });
-      action.addOp(new SGroupDataMove(sGroupId, finalMoveVector));
     });
-  });
-
-  atomsToMove.forEach((atomIds) => {
-    const intactAtoms = atomIds.filter((aid) => !handledAtoms.has(aid));
-    if (intactAtoms.length === 0) {
-      return;
-    }
-
-    const subStructBBox = SGroup.getObjBBox(
-      intactAtoms,
-      restruct.molecule,
-      true,
-    );
-    const subStructCenter = new Vec2(
-      subStructBBox.p0.x + (subStructBBox.p1.x - subStructBBox.p0.x) / 2,
-      subStructBBox.p0.y + (subStructBBox.p1.y - subStructBBox.p0.y) / 2,
-    );
-    const sGroupCenter = new Vec2(
-      sGroupBBox.p0.x + (sGroupBBox.p1.x - sGroupBBox.p0.x) / 2,
-      sGroupBBox.p0.y + (sGroupBBox.p1.y - sGroupBBox.p0.y) / 2,
-    );
-    const direction = subStructCenter.sub(sGroupCenter).normalized();
-    const moveVector = new Vec2(
-      (direction.x * sGroupWidth) / 2,
-      (direction.y * sGroupHeight) / 2,
-    );
-
-    const finalMoveVector = attrs.expanded ? moveVector : moveVector.negated();
-
-    intactAtoms.forEach((atomId) => {
-      action.addOp(new AtomMove(atomId, finalMoveVector));
-    });
-  });
+  }
 
   sGroupAtoms.forEach((aid) => {
     action.mergeWith(


### PR DESCRIPTION

<img width="321" height="238" alt="Screenshot 2026-07-13 223547" src="https://github.com/user-attachments/assets/4d972138-088a-4d96-80b2-0d2f6c31921e" />

Fix: the reposition pass now runs only for monomers, guarded by if (sGroup.isMonomer) (false for a plain SUP functional group, true only for MonomerMicromolecule). Functional groups keep their fixed template layout, so their expand/collapse no longer moves the connected structure.

Note on the diff: it looks large, but it's almost entirely re-indentation from wrapping the existing move block in the if — the only logic change is the guard.

Scope: this closes the expand/collapse part of the issue (the distortion shown in the video when cycling Expand/Collapse). The separate "add" symptom — a functional group rendering distorted while contracted on attach — is a pre-existing bug on master with a different root cause (contracted-superatom rendering, not the reposition logic); it's tracked as a separate issue.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request