### PR TITLE
#10442 - Refactor: Explicit Any type clean up from packages\ketcher-core\src\application\editor\operations\rgroup\RGroupAttr.ts file

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/rgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rgroup.ts
@@ -15,13 +15,15 @@
  ***************************************************************************/
 
 import { RGroupAttr, RGroupFragment, UpdateIfThen } from '../operations';
+import type { RGroupAttributeKey } from '../operations/rgroup/RGroupAttr';
+import type { RGroupAttributes } from 'domain/entities/rgroup';
 
 import { Action } from './action';
 
-export function fromRGroupAttrs(restruct, id, attrs) {
+export function fromRGroupAttrs(restruct, id, attrs: RGroupAttributes) {
   const action = new Action();
 
-  Object.keys(attrs).forEach((key) => {
+  (Object.keys(attrs) as Array<RGroupAttributeKey>).forEach((key) => {
     action.addOp(new RGroupAttr(id, key, attrs[key]));
   });
 

--- a/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
@@ -19,7 +19,7 @@ import { OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
 import type { RGroup, RGroupAttributes } from 'domain/entities/rgroup';
 
-export type RGroupAttributeKey = keyof RGroupAttributes & keyof RGroup;
+export type RGroupAttributeKey = keyof RGroupAttributes;
 
 type Data<K extends RGroupAttributeKey = RGroupAttributeKey> = {
   rgid?: number;

--- a/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroup/RGroupAttr.ts
@@ -17,60 +17,77 @@
 import { BaseOperation } from '../BaseOperation';
 import { OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
+import type { RGroup, RGroupAttributes } from 'domain/entities/rgroup';
 
-type Data = {
-  rgid: any;
-  attribute: any;
-  value: any;
+export type RGroupAttributeKey = keyof RGroupAttributes & keyof RGroup;
+
+type Data<K extends RGroupAttributeKey = RGroupAttributeKey> = {
+  rgid?: number;
+  attribute?: K;
+  value?: RGroup[K];
 };
 
-export class RGroupAttr extends BaseOperation {
-  data: Data | null;
-  data2: Data | null;
+export class RGroupAttr<
+  K extends RGroupAttributeKey = RGroupAttributeKey,
+> extends BaseOperation {
+  data: Data<K> | null;
+  data2: Data<K> | null;
 
-  constructor(rgroupId?: any, attribute?: any, value?: any) {
+  constructor(rgroupId?: number, attribute?: K, value?: RGroup[K]) {
     super(OperationType.R_GROUP_ATTR);
     this.data = { rgid: rgroupId, attribute, value };
     this.data2 = null;
   }
 
   execute(restruct: ReStruct) {
-    if (this.data) {
-      const { rgid, attribute, value } = this.data;
-
-      const rgp = restruct.molecule.rgroups.get(rgid)!;
-
-      if (!rgp) {
-        return;
-      }
-
-      if (!this.data2) {
-        this.data2 = {
-          rgid,
-          attribute,
-          value: rgp[attribute],
-        };
-      }
-
-      rgp[attribute] = value;
-
-      BaseOperation.invalidateItem(restruct, 'rgroups', rgid);
+    if (!this.data) {
+      return;
     }
+
+    const { rgid, attribute, value } = this.data;
+
+    if (rgid === undefined || attribute === undefined || value === undefined) {
+      return;
+    }
+
+    const rgp = restruct.molecule.rgroups.get(rgid);
+
+    if (!rgp) {
+      return;
+    }
+
+    if (!this.data2) {
+      this.data2 = {
+        rgid,
+        attribute,
+        value: rgp[attribute],
+      };
+    }
+
+    rgp[attribute] = value;
+
+    BaseOperation.invalidateItem(restruct, 'rgroups', rgid);
   }
 
   invert() {
-    const inverted = new RGroupAttr();
+    const inverted = new RGroupAttr<K>();
     inverted.data = this.data2;
     inverted.data2 = this.data;
     return inverted;
   }
 
   isDummy(restruct: ReStruct) {
-    if (this.data) {
-      const { rgid, attribute, value } = this.data;
-      const rgroup = restruct.molecule.rgroups.get(rgid);
-      return rgroup ? rgroup[attribute] === value : false;
+    if (!this.data) {
+      return false;
     }
-    return false;
+
+    const { rgid, attribute, value } = this.data;
+
+    if (rgid === undefined || attribute === undefined) {
+      return false;
+    }
+
+    const rgroup = restruct.molecule.rgroups.get(rgid);
+    return rgroup ? rgroup[attribute] === value : false;
   }
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Removed all explicit `any` from `RGroupAttr.ts`:
- The `RGroupAttr<K>` class is now parameterized with a generic `K`, linking `attribute: K` and `value: RGroup[K]` — it's no longer possible to pass a value of the wrong type for a given attribute.
- `Data` fields are now optional (no `as` casts), with explicit `undefined` checks in `execute()` / `isDummy()`.
- Updated the call site in `rgroup.ts` (`fromRGroupAttrs`) to match the new signature.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request