### PR TITLE
#10444 – Refactor: Explicit Any type clean up from packages\ketcher-c…

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/isDummy.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/isDummy.test.ts
@@ -6,6 +6,7 @@ import { BondAttr } from 'application/editor/operations/bond/BondAttr';
 import { BondMove } from 'application/editor/operations/bond/BondMove';
 import { RGroupAttr } from 'application/editor/operations/rgroup/RGroupAttr';
 import { TextMove } from 'application/editor/operations/Text/TextMove';
+import { Vec2 } from 'domain/entities';
 import type { ReStruct } from 'application/render';
 
 // Minimal ReStruct stub – the isDummy() overrides only read from
@@ -63,8 +64,8 @@ describe('attribute operations isDummy()', () => {
 
 describe('move operations isDummy()', () => {
   it('is dummy for a zero displacement and real otherwise', () => {
-    expect(new AtomMove(1, { x: 0, y: 0 }).isDummy()).toBe(true);
-    expect(new AtomMove(1, { x: 1, y: 0 }).isDummy()).toBe(false);
+    expect(new AtomMove(1, new Vec2(0, 0)).isDummy()).toBe(true);
+    expect(new AtomMove(1, new Vec2(1, 0)).isDummy()).toBe(false);
 
     expect(new BondMove(1, { x: 0, y: 0 }).isDummy()).toBe(true);
     expect(new BondMove(1, { x: 0, y: 2 }).isDummy()).toBe(false);
@@ -84,28 +85,28 @@ describe('Action.isDummy()', () => {
 
   it('with a restruct, is dummy only when every operation is a no-op', () => {
     const allDummy = new Action([
-      new AtomMove(1, { x: 0, y: 0 }),
+      new AtomMove(1, new Vec2(0, 0)),
       new BondMove(2, { x: 0, y: 0 }),
     ]);
     expect(allDummy.isDummy(restruct)).toBe(true);
 
     const oneReal = new Action([
-      new AtomMove(1, { x: 0, y: 0 }),
-      new AtomMove(2, { x: 5, y: 0 }),
+      new AtomMove(1, new Vec2(0, 0)),
+      new AtomMove(2, new Vec2(5, 0)),
     ]);
     expect(oneReal.isDummy(restruct)).toBe(false);
   });
 
   it('an operation without an isDummy() override keeps the action non-dummy', () => {
     const action = new Action([
-      new AtomMove(1, { x: 0, y: 0 }),
+      new AtomMove(1, new Vec2(0, 0)),
       new BaseOperation('Add atom' as never),
     ]);
     expect(action.isDummy(restruct)).toBe(false);
   });
 
   it('without a restruct, any operation makes the action non-dummy', () => {
-    const action = new Action([new AtomMove(1, { x: 0, y: 0 })]);
+    const action = new Action([new AtomMove(1, new Vec2(0, 0))]);
     expect(action.isDummy()).toBe(false);
   });
 });

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomMove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomMove.ts
@@ -18,22 +18,30 @@ import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
 import { Scale } from 'domain/helpers';
+import type { Vec2 } from 'domain/entities';
+
+type Data = {
+  aid: number | null;
+  d: Vec2 | null;
+  noinvalidate: boolean;
+};
 
 export class AtomMove extends BaseOperation {
-  data: {
-    aid: any;
-    d: any;
-    noinvalidate: any;
-  };
+  data: Data;
 
-  constructor(atomId?: any, d?: any, noinvalidate?: any) {
+  constructor(atomId?: number, d?: Vec2, noinvalidate?: boolean) {
     super(OperationType.ATOM_MOVE, OperationPriority.ATOM_MOVE);
-    this.data = { aid: atomId, d, noinvalidate };
+    this.data = {
+      aid: atomId ?? null,
+      d: d ?? null,
+      noinvalidate: noinvalidate ?? false,
+    };
   }
 
   execute(restruct: ReStruct) {
     const struct = restruct.molecule;
     const { aid, d } = this.data;
+    if (aid === null || !d) return;
     const atom = struct.atoms.get(aid);
     if (!atom) return;
     atom.pp.add_(d); // eslint-disable-line no-underscore-dangle
@@ -58,6 +66,6 @@ export class AtomMove extends BaseOperation {
 
   isDummy() {
     const { d } = this.data;
-    return d.x === 0 && d.y === 0;
+    return d?.x === 0 && d?.y === 0;
   }
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Replaced the three explicit `any` fields (`aid`, `d`, `noinvalidate`) on `AtomMove`'s `data` object
with a properly typed local `Data` type (`aid: number | null`, `d: Vec2 | null`,
`noinvalidate: boolean`), matching the existing local-type convention already used by sibling
operations (`AtomAdd.ts`, `TextMove.ts`, `RxnArrowMove.ts`). Types were derived from actual usage:
`struct.atoms.get()` requires `number`, `atom.pp`/`Scale.modelToCanvas` require `Vec2`, and all
call sites (`fragment.ts`, `rotate.ts`, `sgroup.ts`) pass exactly these types. Constructor params
stay optional and default to `null`/`false` since `invert()` calls `new AtomMove()` with no args
before immediately overwriting `.data` with the real shared data object.

Also fixed `isDummy.test.ts`, which was relying on the `any` escape hatch to pass plain `{ x, y }`
object literals instead of real `Vec2` instances — updated those call sites to `new Vec2(x, y)`.

No behavior change: `tsc --noEmit`, `eslint`, and the full `ketcher-core` test suite (565 tests)
pass unchanged.

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request