### PR TITLE
#7406 - Rotation angle for monomer is not preserved correctly in KET …

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/monomer/RotateMonomerOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomer/RotateMonomerOperation.ts
@@ -50,9 +50,16 @@ export class RotateMonomerOperation extends BaseOperation {
   }
 
   invert() {
+    // When the original operation cleared the rotation (value === null), the
+    // only way to restore it is to set the previously stored absolute value
+    // back, since the current rotation is 0/undefined at that point.
+    // Otherwise this operation just adds a delta to whatever the current
+    // rotation is, so undoing it must add the opposite delta rather than the
+    // absolute previous value - otherwise repeated rotate/undo/rotate cycles
+    // would accumulate an incorrect angle.
     return new RotateMonomerOperation({
       id: this.data.id,
-      value: this.previousValue,
+      value: this.data.value === null ? this.previousValue : -this.data.value,
     });
   }
 

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -295,8 +295,14 @@ class RotateTool implements Tool {
             );
           }
         });
-        monomerRotateAction.perform(this.reStruct);
-        action = action.mergeWith(monomerRotateAction);
+        // `perform` executes the rotation and returns the inverted action
+        // (the one that must go into the undo history). Merging the
+        // un-inverted `monomerRotateAction` here instead would make `undo`
+        // re-apply the rotation instead of reverting it.
+        const invertedMonomerRotateAction = monomerRotateAction.perform(
+          this.reStruct,
+        );
+        action = action.mergeWith(invertedMonomerRotateAction);
       }
 
       delete this.dragCtx;


### PR DESCRIPTION
#7406 - Rotation angle for monomer is not preserved correctly in KET format upon multiple rotations and reverts
Problem

Repeatedly rotating a monomer and undoing it (rotate → undo → rotate...) produced an incorrect angle value stored in the transformation.rotate metadata (exported to the KET format) — the angle accumulated incorrectly (e.g., became double/triple the intended value), even though the rotation looked visually correct on the canvas.

Root cause (two independent, compounding bugs)

1. [RotateMonomerOperation.ts:52]— incorrect invert() logic

execute() always computes the new rotation as previousValue (at execution time) + data.value (i.e., data.value is a delta, not an absolute value). Despite this, invert() always returned an operation with value: this.previousValue, i.e., it tried to restore the previous absolute value instead of adding the negated delta. Since undo needs to reverse a delta (not set an absolute value), this produced a wrong angle after a few rotate/undo cycles.
Exception: when data.value === null (meaning the operation cleared the rotation), the restore must set the absolute previousValue — because the current value at that point is 0/undefined, so there's no delta to subtract from. This branch of logic was already correct.

2. [rotate.ts:295]— discarded return value of perform()

monomerRotateAction.perform(this.reStruct) executes the action and returns the inverted action (which is what must go into the history so that undo works correctly — this is the standard pattern used throughout the codebase, e.g., fromRotate() in application/editor/actions/rotate.ts). However, the code ignored the returned value and merged the original (non-inverted) monomerRotateAction into the history instead. As a result, undo re-applied the rotation instead of reverting it.

Together, both bugs meant that even after fixing invert() alone, undo still corrupted the angle, because the wrong (incorrectly directed) action was being pushed to history.

Solution

- invert() now branches: when data.value === null → returns previousValue (absolute restore); otherwise → returns -this.data.value (negated delta).

- In rotate.ts, the returned (already inverted) action from monomerRotateAction.perform(this.reStruct) is now captured and merged into action (instead of the original object) before it's pushed to editor.update()/the history stack.

Why it works
Editor.undo() simply calls stack.perform(this.render.ctab) on the action stored in history — it does not invert anything itself. This means whatever gets pushed to history must already be a ready-made "undo action". After the fix:

- the rotation metadata (transformation.rotate) is correctly accumulated as deltas, matching how execute() actually computes it,

- the correctly inverted action is pushed to history, so undo actually reverts the rotation instead of repeating it,

- as a result, repeated rotate/undo/rotate cycles no longer accumulate error, and the angle stored in KET stays consistent with what's visible on the canvas.

Why it's safe

- The change is narrow and localized — it only affects the invert() logic of a single operation and how its result is passed to history; execute() is untouched, so normal (non-undo) rotation behaves exactly as before.

- The data.value === null path (clearing the rotation) — the one case where the logic was already correct — was deliberately left unchanged, so there's no regression for that scenario.

- The visual atom rotation mechanism on the canvas (a separate, independent piece of code in the same rotate.ts file) was not touched — the change only affects the path that writes metadata to history/undo, so rendering is unaffected.

- The pattern "use the returned, inverted action from perform()" is already the established standard elsewhere in the code (e.g., fromRotate()), so the fix aligns this code path with the rest of the architecture rather than introducing a new approach.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request