### PR TITLE
#8182-forbided to define preset (group) name with wrong symbols

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -103,7 +103,12 @@ import { HandTool } from 'application/editor/tools/Hand';
 import { HydrogenBond } from 'domain/entities/HydrogenBond';
 import type { ToolName } from 'application/editor/tools/types';
 import { BaseMonomerRenderer } from 'application/render';
-import { getEmptyMonomersLibraryJson, parseMonomersLibrary } from './helpers';
+import {
+  getEmptyMonomersLibraryJson,
+  MonomerNameValidationErrorType,
+  parseMonomersLibrary,
+  validateMonomerName,
+} from './helpers';
 import { TransientDrawingView } from 'application/render/renderers/TransientView/TransientDrawingView';
 import { SelectLayoutModeOperation } from 'application/editor/operations/polymerBond';
 import { ReinitializeModeOperation } from 'application/editor/operations';
@@ -728,25 +733,34 @@ export class CoreEditor {
         return;
       }
 
-      if (!templateDefinition.name?.trim()) {
-        reportValidationError(
-          templateRef.$ref,
-          `Monomer group template name cannot be empty or whitespace. The template was not added to the library.`,
-        );
-        return;
-      }
+      const monomerNameValidationResult = validateMonomerName(
+        templateDefinition.name,
+      );
 
-      if (
-        templateDefinition.name.length > MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH
-      ) {
-        const truncatedTemplateName = `${templateDefinition.name.slice(
-          0,
-          MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
-        )}...`;
-        KetcherLogger.error(
-          `Editor::updateMonomersLibrary: Load of monomer group template "${truncatedTemplateName}" (length: ${templateDefinition.name.length}, template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE} The template was not added to the library.`,
-        );
-        return;
+      if (!monomerNameValidationResult.isValid) {
+        switch (monomerNameValidationResult.error) {
+          case MonomerNameValidationErrorType.Empty:
+            reportValidationError(
+              templateRef.$ref,
+              `Monomer group template name cannot be empty or whitespace. The template was not added to the library.`,
+            );
+            return;
+          case MonomerNameValidationErrorType.TooLong: {
+            const truncatedTemplateName = `${templateDefinition.name.slice(
+              0,
+              MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
+            )}...`;
+            KetcherLogger.error(
+              `Editor::updateMonomersLibrary: Load of monomer group template "${truncatedTemplateName}" (length: ${templateDefinition.name.length}, template: ${templateRef.$ref}) has failed. ${MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE} The template was not added to the library.`,
+            );
+            return;
+          }
+          case MonomerNameValidationErrorType.InvalidCharacters:
+            KetcherLogger.error(
+              `Editor::updateMonomersLibrary: Load of monomer group template "${templateDefinition.name}" (template: ${templateRef.$ref}) has failed. Monomer group template name must consist only of letters, numbers, hyphens, underscores and asterisks. The template was not added to the library.`,
+            );
+            return;
+        }
       }
 
       // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion

--- a/packages/ketcher-core/src/application/editor/__tests__/helpers.test.ts
+++ b/packages/ketcher-core/src/application/editor/__tests__/helpers.test.ts
@@ -1,0 +1,62 @@
+import {
+  MonomerNameValidationErrorType,
+  validateMonomerName,
+} from '../helpers';
+import { MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH } from 'utilities';
+
+describe('validateMonomerName', () => {
+  describe('positive scenarios', () => {
+    it('should return isValid: true for a valid name', () => {
+      expect(validateMonomerName('Valid-Monomer_Name*1')).toEqual({
+        isValid: true,
+      });
+    });
+
+    it('should return isValid: true for a name at the max length', () => {
+      const name = 'a'.repeat(MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH);
+      expect(validateMonomerName(name)).toEqual({ isValid: true });
+    });
+  });
+
+  describe('negative scenarios', () => {
+    it('should return an Empty error for an empty string', () => {
+      expect(validateMonomerName('')).toEqual({
+        isValid: false,
+        error: MonomerNameValidationErrorType.Empty,
+      });
+    });
+
+    it('should return an Empty error for a whitespace-only string', () => {
+      expect(validateMonomerName('   ')).toEqual({
+        isValid: false,
+        error: MonomerNameValidationErrorType.Empty,
+      });
+    });
+
+    it('should return a TooLong error for a name exceeding the max length', () => {
+      const name = 'a'.repeat(MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH + 1);
+      expect(validateMonomerName(name)).toEqual({
+        isValid: false,
+        error: MonomerNameValidationErrorType.TooLong,
+      });
+    });
+
+    it.each([
+      'name with spaces',
+      'name.with.dots',
+      'name!with!exclamation',
+      'name?with?questions',
+      'name/with/slash',
+      'name@with@at',
+      'name\nwith\nnewline',
+      'name#with#hash',
+      'name$with$dollar',
+      'name%with%percent',
+    ])('should return an InvalidCharacters error for %s', (name) => {
+      expect(validateMonomerName(name)).toEqual({
+        isValid: false,
+        error: MonomerNameValidationErrorType.InvalidCharacters,
+      });
+    });
+  });
+});

--- a/packages/ketcher-core/src/application/editor/helpers.ts
+++ b/packages/ketcher-core/src/application/editor/helpers.ts
@@ -3,6 +3,7 @@ import type {
   IKetMacromoleculesContent,
   IKetMacromoleculesContentRootProperty,
 } from 'application/formatters';
+import { MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH } from 'utilities';
 
 export const parseMonomersLibrary = (monomersDataRaw: string | JSON) => {
   const monomersLibraryParsedJson =
@@ -15,6 +16,39 @@ export const parseMonomersLibrary = (monomersDataRaw: string | JSON) => {
   );
 
   return { monomersLibraryParsedJson, monomersLibrary };
+};
+
+export enum MonomerNameValidationErrorType {
+  Empty = 'empty',
+  TooLong = 'tooLong',
+  InvalidCharacters = 'invalidCharacters',
+}
+
+export type MonomerNameValidationResult =
+  | { isValid: true }
+  | { isValid: false; error: MonomerNameValidationErrorType };
+
+const MONOMER_NAME_ALLOWED_CHARACTERS_REGEXP = /^[A-Za-z0-9_*-]+$/;
+
+export const validateMonomerName = (
+  monomerName: string,
+): MonomerNameValidationResult => {
+  if (!monomerName?.trim()) {
+    return { isValid: false, error: MonomerNameValidationErrorType.Empty };
+  }
+
+  if (monomerName.length > MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH) {
+    return { isValid: false, error: MonomerNameValidationErrorType.TooLong };
+  }
+
+  if (!MONOMER_NAME_ALLOWED_CHARACTERS_REGEXP.test(monomerName)) {
+    return {
+      isValid: false,
+      error: MonomerNameValidationErrorType.InvalidCharacters,
+    };
+  }
+
+  return { isValid: true };
 };
 
 export const getEmptyMonomersLibraryJson = (): IKetMacromoleculesContent => {


### PR DESCRIPTION
##  name with wrong symbols is not allowed

the new logic checks the name for group with a regexp. The regexp checks that name contains only letter, underscores, asterisks and dash

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request