### PR TITLE
#10398 – Fix keyboard events (Ghost molecule appears after typing on inactive ketcher canvas)

### DIFF
--- a/ketcher-autotests/tests/specs/Structure-Creating-&-Editing/Actions-With-Structures/S-Group-Tool/SRU-Polymer/copolymer-S-Group-type.spec.ts
+++ b/ketcher-autotests/tests/specs/Structure-Creating-&-Editing/Actions-With-Structures/S-Group-Tool/SRU-Polymer/copolymer-S-Group-type.spec.ts
@@ -94,8 +94,8 @@ test.describe('Copolymer S-Group type', () => {
      * Version 3.12.0
      */
     await openFileAndAddToCanvas(page, 'KET/simple-chain.ket');
-    await LeftToolbar(page).sGroup();
 
+    await LeftToolbar(page).sGroup();
     await getAtomLocator(page, { atomLabel: 'C', atomId: 10 }).click({
       force: true,
     });
@@ -131,7 +131,6 @@ test.describe('Copolymer S-Group type', () => {
     await expect(
       SGroupPropertiesDialog(page).repeatPatternDropdown,
     ).toBeVisible();
-    await page.keyboard.press('Escape');
     await SGroupPropertiesDialog(page).cancel();
   });
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -880,6 +880,9 @@ export class CoreEditor {
 
   private setupKeyboardEvents() {
     this.keydownEventHandler = (event: KeyboardEvent) => {
+      if (this._type === EditorType.Micromolecules) {
+        return;
+      }
       let isPropagationStopped = false;
       const originalStopPropagation = event.stopPropagation.bind(event);
       event.stopPropagation = () => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Added check to prevent macromolecules changes when we are not in macromolecules mode.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request