### PR TITLE
#3406 - Structures reduce size after paste if there are functional groups

### DIFF
--- a/packages/ketcher-core/__tests__/domain/entities/struct.rescale.test.ts
+++ b/packages/ketcher-core/__tests__/domain/entities/struct.rescale.test.ts
@@ -1,0 +1,57 @@
+import { Atom, Bond, Struct, Vec2 } from 'domain/entities';
+
+const bondLength = (struct: Struct, a: number, b: number) =>
+  Vec2.dist(
+    struct.atoms.get(a)?.pp ?? new Vec2(),
+    struct.atoms.get(b)?.pp ?? new Vec2(),
+  );
+
+describe('Struct.rescale normalizes by the median bond length (#3406)', () => {
+  it('does not shrink the structure when a long outlier bond is present', () => {
+    const struct = new Struct();
+    // A hexagon with bond length 1 — the "real" structure.
+    const ring: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const a = (Math.PI / 3) * i;
+      ring.push(
+        struct.atoms.add(
+          new Atom({ label: 'C', pp: new Vec2(Math.cos(a), Math.sin(a)) }),
+        ),
+      );
+    }
+    for (let i = 0; i < 6; i++) {
+      const b = struct.bonds.add(
+        new Bond({ begin: ring[i], end: ring[(i + 1) % 6], type: 1 }),
+      );
+      struct.bondInitHalfBonds(b);
+    }
+    // One long bond (length 9) — e.g. between two functional groups far apart.
+    const l1 = struct.atoms.add(new Atom({ label: 'C', pp: new Vec2(5, -5) }));
+    const l2 = struct.atoms.add(new Atom({ label: 'C', pp: new Vec2(14, -5) }));
+    const lb = struct.bonds.add(new Bond({ begin: l1, end: l2, type: 1 }));
+    struct.bondInitHalfBonds(lb);
+    struct.initNeighbors();
+
+    const ringBefore = bondLength(struct, ring[0], ring[1]);
+    struct.rescale();
+    const ringAfter = bondLength(struct, ring[0], ring[1]);
+
+    // Median bond length is 1, so the ring keeps its size (the mean would have
+    // shrunk it to ~0.47).
+    expect(ringBefore).toBeCloseTo(1);
+    expect(ringAfter).toBeCloseTo(1);
+  });
+
+  it('still normalizes a uniform structure to bond length 1', () => {
+    const struct = new Struct();
+    const a1 = struct.atoms.add(new Atom({ label: 'C', pp: new Vec2(0, 0) }));
+    const a2 = struct.atoms.add(new Atom({ label: 'C', pp: new Vec2(2, 0) }));
+    const b = struct.bonds.add(new Bond({ begin: a1, end: a2, type: 1 }));
+    struct.bondInitHalfBonds(b);
+    struct.initNeighbors();
+
+    struct.rescale();
+
+    expect(bondLength(struct, a1, a2)).toBeCloseTo(1);
+  });
+});

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -812,6 +812,23 @@ export class Struct {
     return bld.cnt > 0 ? bld.totalLength / bld.cnt : -1;
   }
 
+  getMedianBondLength(): number {
+    const lengths: number[] = [];
+    this.bonds.forEach((bond) => {
+      lengths.push(
+        Vec2.dist(this.atoms.get(bond.begin)!.pp, this.atoms.get(bond.end)!.pp),
+      );
+    });
+    if (lengths.length === 0) {
+      return -1;
+    }
+    lengths.sort((a, b) => a - b);
+    const middle = Math.floor(lengths.length / 2);
+    return lengths.length % 2 === 0
+      ? (lengths[middle - 1] + lengths[middle]) / 2
+      : lengths[middle];
+  }
+
   getAvgClosestAtomDistance(): number {
     let totalDist = 0;
     let minDist;
@@ -984,13 +1001,17 @@ export class Struct {
   }
 
   rescale() {
-    let avg = this.getAvgBondLength();
-    if (avg <= 0) {
+    // Normalize by the MEDIAN bond length, not the mean: a few long bonds — such
+    // as the bond between two contracted functional groups drawn far apart —
+    // inflate the mean and shrink the whole structure on open/paste (#3406).
+    // The median reflects the typical bond and is robust to those outliers.
+    let bondLength = this.getMedianBondLength();
+    if (bondLength <= 0) {
       return;
     }
-    if (avg < 1e-3) avg = 1;
+    if (bondLength < 1e-3) bondLength = 1;
 
-    const scale = 1 / avg;
+    const scale = 1 / bondLength;
     this.scale(scale);
   }
 


### PR DESCRIPTION

<img width="959" height="501" alt="Screenshot 2026-07-15 193215" src="https://github.com/user-attachments/assets/939af46c-abd6-4956-8296-3d6a67579ec8" />
<img width="959" height="499" alt="Screenshot 2026-07-15 193311" src="https://github.com/user-attachments/assets/6e556620-ea3a-4e7d-8a18-8854b1c8565f" />

Root cause

Struct.rescale() — called on every open / paste / render — normalizes the structure's coordinates by the mean bond length (getAvgBondLength), i.e. scale = 1 / meanBondLength. When two contracted functional groups are drawn far apart, the bond connecting them is a long outlier that inflates the mean, so the scale factor drops below 1 and the whole structure is shrunk.

Changes

- packages/ketcher-core/src/domain/entities/struct.ts
  - Added getMedianBondLength().
  - rescale() now normalizes by the median bond length instead of the mean. The median reflects the typical bond and is robust to a few long outlier bonds, so those no longer shrink the structure. For uniform-bond structures (mean == median) the behavior is unchanged.

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request