### PR TITLE
5329 - Prevent Structure Library crash for R-Group templates

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/view/SaveButton.test.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/SaveButton.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { SaveButton } from './savebutton';
 
 jest.mock('../../../../hooks', () => {
@@ -50,5 +50,18 @@ describe('SaveButton', () => {
       const btn = screen.getByRole('button');
       expect(btn).toBeDisabled();
     });
+  });
+
+  it('Should get file data only after the button is clicked', () => {
+    const getData = jest.fn(() => '');
+    render(
+      <SaveButton filename="test.sdf" getData={getData}>
+        Save
+      </SaveButton>,
+    );
+
+    expect(getData).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button'));
+    expect(getData).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ketcher-react/src/script/ui/component/view/savebutton.tsx
+++ b/packages/ketcher-react/src/script/ui/component/view/savebutton.tsx
@@ -28,7 +28,8 @@ import type { SaverType } from './saveButton.types';
 type Props = {
   server?: any;
   filename: string;
-  data: any;
+  data?: Blob | string;
+  getData?: () => Blob | string;
   type?: string;
   mode?: string;
   options?: GenerateImageOptions;
@@ -48,6 +49,7 @@ const SaveButton = (props: SaveButtonProps) => {
     server,
     filename = 'unnamed',
     data,
+    getData,
     type,
     mode = 'saveFile',
     options,
@@ -61,21 +63,22 @@ const SaveButton = (props: SaveButtonProps) => {
   const { ketcherId } = useAppContext();
 
   const saveFile = async () => {
-    if (data) {
-      try {
+    try {
+      const dataToSave = getData ? getData() : data;
+      if (dataToSave) {
         const saver: SaverType = await fileSaver(server);
-        saver(data, filename, type);
+        saver(dataToSave, filename, type);
         onSave();
-      } catch (e) {
-        KetcherLogger.error('savebutton.tsx::SaveButton::saveFile', e);
-        onError(e);
       }
+    } catch (e) {
+      KetcherLogger.error('savebutton.tsx::SaveButton::saveFile', e);
+      onError(e);
     }
   };
 
   const saveImage = () => {
     const ketcherInstance = ketcherProvider.getKetcher(ketcherId);
-    if (options?.outputFormat) {
+    if (options?.outputFormat && typeof data === 'string') {
       ketcherInstance
         .generateImage(data, options)
         .then((blob) => {

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.test.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Struct } from 'ketcher-core';
+import { TemplateDialog } from './TemplateDialog';
+
+const mockSerialize = jest.fn();
+
+jest.mock('ketcher-core', () => ({
+  ...jest.requireActual('ketcher-core'),
+  SdfSerializer: jest.fn().mockImplementation(() => ({
+    serialize: mockSerialize,
+  })),
+}));
+
+jest.mock('../../views/components', () => ({
+  Dialog: ({ children, footerContent }) => (
+    <div>
+      {children}
+      {footerContent}
+    </div>
+  ),
+}));
+
+jest.mock('../../component/view/savebutton', () => ({
+  SaveButton: ({ children, getData }) => (
+    <button type="button" onClick={getData}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('./TemplateTable', () => () => null);
+jest.mock('components', () => ({ Icon: () => null }));
+jest.mock('./useSaltsAndSolvets', () => () => []);
+
+describe('TemplateDialog', () => {
+  it('does not serialize a reaction with an R-Group fragment when opened', () => {
+    const struct = new Struct();
+    struct.name = 'Reaction with R-Group fragment';
+    const template = {
+      struct,
+      props: {
+        atomid: 0,
+        bondid: 0,
+        group: 'User Templates',
+        name: 'Reaction with R-Group fragment',
+      },
+    };
+    mockSerialize.mockImplementation(() => {
+      throw new Error(
+        'Reactions with r-groups are not supported at the moment',
+      );
+    });
+
+    expect(() =>
+      render(
+        <TemplateDialog
+          filter=""
+          group="User Templates"
+          lib={[template]}
+          selected={null}
+          tab={0}
+          initialTab={0}
+          saltsAndSolvents={[]}
+          functionalGroups={[]}
+          onAttach={jest.fn()}
+          onCancel={jest.fn()}
+          onChangeGroup={jest.fn()}
+          onDelete={jest.fn()}
+          onFilter={jest.fn()}
+          onOk={jest.fn()}
+          onSelect={jest.fn()}
+          onTabChange={jest.fn()}
+        />,
+      ),
+    ).not.toThrow();
+    expect(mockSerialize).not.toHaveBeenCalled();
+
+    mockSerialize.mockReturnValue('serialized template');
+    fireEvent.click(screen.getByRole('button', { name: 'Save to SDF' }));
+
+    expect(mockSerialize).toHaveBeenCalledWith([template]);
+  });
+});

--- a/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/template/TemplateDialog.tsx
@@ -129,7 +129,7 @@ const HeaderContent = () => (
   </div>
 );
 
-const FooterContent = ({ data, tab, isMonomerCreationWizardActive }) => {
+const FooterContent = ({ getData, tab, isMonomerCreationWizardActive }) => {
   const clickToAddToCanvas = (
     <span data-testid="add-to-canvas-button">Click to add to canvas</span>
   );
@@ -155,7 +155,7 @@ const FooterContent = ({ data, tab, isMonomerCreationWizardActive }) => {
     >
       <SaveButton
         key="save-to-SDF"
-        data={data}
+        getData={getData}
         className={clsx(
           classes.saveButton,
           isMonomerCreationWizardActive && classes.disabled,
@@ -173,7 +173,7 @@ const FooterContent = ({ data, tab, isMonomerCreationWizardActive }) => {
 
 const EMPTY_TEMPLATES: ReadonlyArray<Template> = [];
 
-const TemplateDialog: FC<Props> = (props) => {
+export const TemplateDialog: FC<Props> = (props) => {
   const {
     filter,
     onFilter,
@@ -242,9 +242,7 @@ const TemplateDialog: FC<Props> = (props) => {
     onTabChange(value);
   };
 
-  // Memoize SDF serialization to prevent recomputation on accordion toggles
-  // Only recompute when tab or library data actually changes
-  const data = useMemo(() => {
+  const getData = useCallback(() => {
     const sdfSerializer = new SdfSerializer();
     const serializerMapper = {
       [TemplateTabs.TemplateLibrary]: templateLib,
@@ -275,7 +273,7 @@ const TemplateDialog: FC<Props> = (props) => {
       footerContent={
         <FooterContent
           tab={tab}
-          data={data}
+          getData={getData}
           isMonomerCreationWizardActive={isMonomerCreationWizardActive}
         />
       }


### PR DESCRIPTION
SDF serialization is now deferred until the user clicks Save to SDF, allowing affected templates to be opened and added to the canvas normally.

Added unit tests covering deferred serialization and the Structure Library integration.