### PR TITLE
#10445 - Refactor: Explicit Any type clean up from packages\ketcher-react\src\script\editor\Editor.ts file

### DIFF
--- a/packages/ketcher-core/src/application/formatters/types/ket.ts
+++ b/packages/ketcher-core/src/application/formatters/types/ket.ts
@@ -143,6 +143,14 @@ export type KetMonomerTemplateAtom = {
   location: [number, number, number];
 };
 
+export interface IKetMonomerTemplateRef {
+  $ref: string;
+}
+
+export interface IKetNodeRef {
+  $ref: string;
+}
+
 export interface IKetMonomerTemplate {
   type: KetTemplateType.MONOMER_TEMPLATE;
   class?: KetMonomerClass;
@@ -163,7 +171,9 @@ export interface IKetMonomerTemplate {
   naturalAnalog?: string;
   attachmentPoints?: IKetAttachmentPoint[];
   root: {
-    nodes;
+    nodes: IKetNodeRef[];
+    connections?: IKetTemplateConnection[];
+    templates?: IKetMonomerTemplateRef[];
   };
   classHELM?: string;
   name?: string;
@@ -186,10 +196,6 @@ export interface IKetAmbiguousMonomerTemplate {
   alias?: string;
 }
 
-export interface IKetMonomerTemplateRef {
-  $ref: string;
-}
-
 export enum KetMonomerGroupTemplateClass {
   RNA = 'RNA',
 }
@@ -204,10 +210,6 @@ export interface IKetMonomerGroupTemplate {
   idtAliases?: IKetIdtAliases;
   aliasAxoLabs?: string;
   aliasBILN?: string;
-}
-
-export interface IKetNodeRef {
-  $ref: string;
 }
 
 export interface IKetMacromoleculesContentRootProperty {

--- a/packages/ketcher-core/src/application/render/raphaelRender.ts
+++ b/packages/ketcher-core/src/application/render/raphaelRender.ts
@@ -21,6 +21,7 @@ import type { RaphaelPaper } from 'raphael';
 
 import Raphael from './raphael-ext';
 import ReStruct from './restruct/restruct';
+import type Visel from './restruct/visel';
 import { Scale } from 'domain/helpers';
 import defaultOptions from './options';
 import draw from './draw';
@@ -88,6 +89,7 @@ export class Render {
   // TODO https://github.com/epam/ketcher/issues/2630
   public ctab: ReStruct;
   public options: RenderOptions;
+  public combinedHover: Visel | null = null;
   public viewBox!: ViewBox;
   private readonly userOpts: RenderOptions;
   private oldCb: Box2Abs | null = null;

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -24,6 +24,7 @@ import {
   type MonomerCreationState,
   type Pool,
   type ReStruct,
+  type RenderOptions,
   type SGroupAttachmentPoint,
   type RnaPresetComponentKey,
   type ComponentStructureUpdateData,
@@ -182,11 +183,17 @@ function selectStereoFlagsIfNecessary(
 export interface Selection {
   atoms?: Array<number>;
   bonds?: Array<number>;
+  frags?: Array<number>;
+  sgroups?: Array<number>;
+  sgroupData?: Array<number>;
+  rgroups?: Array<number>;
   enhancedFlags?: Array<number>;
   rxnPluses?: Array<number>;
   rxnArrows?: Array<number>;
+  simpleObjects?: Array<number>;
   texts?: Array<number>;
   rgroupAttachmentPoints?: Array<number>;
+  [IMAGE_KEY]?: Array<number>;
   [MULTITAIL_ARROW_KEY]?: Array<number>;
 }
 
@@ -215,9 +222,30 @@ type MonomerExternalBond = {
   attachmentPointNumber?: number;
 };
 
+type SaveNewMonomerData = {
+  type: KetMonomerClass;
+  symbol: string;
+  name: string;
+  naturalAnalogue: string;
+  modificationTypes: string[];
+  aliasHELM: string;
+  aliasBILN: string;
+  hidden?: boolean;
+  structure: Struct;
+  attachmentPoints: Map<AttachmentPointName, [number, number]>;
+};
+
+export type FinishNewMonomersCreationData = {
+  monomer: BaseMonomer;
+  monomerTemplate: IKetMonomerTemplate;
+  monomerRef: string;
+  monomerStructureInWizard: Selection;
+  atomIdMap: Map<number, number>;
+};
+
 class Editor implements KetcherEditor {
   ketcherId: string;
-  #origin?: any;
+  #origin?: Action | null;
   render: Render;
   _selection: Selection | null;
   _tool: Tool | null;
@@ -255,20 +283,26 @@ class Editor implements KetcherEditor {
     updateFloatingTools: Subscription<FloatingToolsParams>;
   };
 
-  public serverSettings = {};
+  public serverSettings: Record<string, unknown> = {};
 
-  lastEvent: any;
+  lastEvent: Event | null;
   macromoleculeConvertionError: string | null | undefined;
 
-  constructor(ketcherId, clientArea, options, serverSettings, prevEditor?) {
+  constructor(
+    ketcherId: string,
+    clientArea: HTMLElement,
+    options?: Record<string, unknown>,
+    serverSettings?: Record<string, unknown>,
+    prevEditor?: KetcherEditor,
+  ) {
     this.render = new Render(
       clientArea,
       {
         microModeScale: SCALE,
         ...(options ?? {}),
-      },
+      } as RenderOptions,
       prevEditor?.render,
-      options.reuseRestructIfExist !== false,
+      options?.reuseRestructIfExist !== false,
     );
 
     this.ketcherId = ketcherId;
@@ -290,6 +324,7 @@ class Editor implements KetcherEditor {
     this.hoverIcon.updatePosition();
     this.contextMenu = {};
     this.rotateController = new RotateController(this);
+    this.lastEvent = null;
 
     this.event = {
       message: new Subscription(),
@@ -336,7 +371,7 @@ class Editor implements KetcherEditor {
     this.#origin = position ? this.historyStack[position - 1] : null;
   }
 
-  tool(name?: any, opts?: any): Tool | null {
+  tool(name?: string, opts?: unknown): Tool | null {
     /* eslint-disable no-underscore-dangle */
     if (arguments.length === 0) {
       return this._tool;
@@ -346,7 +381,7 @@ class Editor implements KetcherEditor {
       this._tool.cancel();
     }
 
-    const ToolConstructor: ToolConstructorInterface = toolsMap[name];
+    const ToolConstructor: ToolConstructorInterface = toolsMap[name as string];
 
     const tool = new ToolConstructor(this, opts);
 
@@ -455,7 +490,7 @@ class Editor implements KetcherEditor {
   }
 
   /** Apply options from {@link value} */
-  options(value?: any) {
+  options(value?: Record<string, unknown>) {
     if (arguments.length === 0) {
       return this.render.options;
     }
@@ -468,7 +503,7 @@ class Editor implements KetcherEditor {
     this.render = new Render(this.render.clientArea, {
       microModeScale: SCALE,
       ...(value ?? {}),
-    });
+    } as RenderOptions);
     this.updateToolAfterOptionsChange(wasViewOnlyEnabled);
     this.render.setMolecule(struct);
 
@@ -483,8 +518,8 @@ class Editor implements KetcherEditor {
     return this.render.options;
   }
 
-  public setServerSettings(serverSettings) {
-    this.serverSettings = serverSettings;
+  public setServerSettings(serverSettings?: Record<string, unknown>) {
+    this.serverSettings = serverSettings ?? {};
   }
 
   /**
@@ -493,9 +528,12 @@ class Editor implements KetcherEditor {
    * This prevents structures from shifting when enabling/disabling viewOnlyMode.
    * In all other cases (opening files, changing settings), structures are centered as before.
    */
-  private shouldPreserveStructPosition(options: any, struct: Struct): boolean {
+  private shouldPreserveStructPosition(
+    options: Record<string, unknown> | undefined,
+    struct: Struct,
+  ): boolean {
     const hasAtoms = struct.atoms.size > 0;
-    const isSettingViewOnlyMode = options && 'viewOnlyMode' in options;
+    const isSettingViewOnlyMode = !!options && 'viewOnlyMode' in options;
     return hasAtoms && isSettingViewOnlyMode;
   }
 
@@ -512,8 +550,12 @@ class Editor implements KetcherEditor {
     }
   }
 
-  zoom(value?: any, event?: WheelEvent) {
-    if (arguments.length === 0 || this.render.options.zoom === value) {
+  zoom(value?: number, event?: WheelEvent) {
+    if (
+      arguments.length === 0 ||
+      value === undefined ||
+      this.render.options.zoom === value
+    ) {
       return this.render.options.zoom;
     }
 
@@ -999,7 +1041,9 @@ class Editor implements KetcherEditor {
   private originalHistoryPointer = 0;
   private readonly selectedToOriginalAtomsIdMap = new Map<number, number>();
 
-  private changeEventSubscriber: any = null;
+  private changeEventSubscriber: {
+    handler: ((action?: unknown) => void) | ((data: ChangeEventData[]) => void);
+  } | null = null;
 
   openMonomerCreationWizard(
     selectionOverride?: Selection,
@@ -1416,7 +1460,7 @@ class Editor implements KetcherEditor {
     this.tool('select');
   }
 
-  saveNewMonomer(data) {
+  saveNewMonomer(data: SaveNewMonomerData) {
     if (!this.monomerCreationState) {
       throw new Error(
         'Monomer creation wizard is not active, cannot save new monomer',
@@ -1491,9 +1535,6 @@ class Editor implements KetcherEditor {
       ...(hidden ? { hidden: true } : {}),
       root: {
         nodes: [],
-        // TODO: Revisit IKetMonomerTemplate type
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         connections: [],
         templates: [
           {
@@ -1885,7 +1926,7 @@ class Editor implements KetcherEditor {
   }
 
   finishNewMonomersCreation(
-    monomersData,
+    monomersData: FinishNewMonomersCreationData[],
     { rnaPresetName, phosphatePosition }: FinishNewMonomersCreationOptions = {},
   ) {
     const ketcher = ketcherProvider.getKetcher(this.ketcherId);
@@ -1947,7 +1988,7 @@ class Editor implements KetcherEditor {
     let ket = {
       root: {
         templates: libraryItems.map((libraryItem) => {
-          return libraryItem.root.templates[0];
+          return libraryItem.root.templates![0];
         }),
       },
     };
@@ -2242,7 +2283,10 @@ class Editor implements KetcherEditor {
 
       finalStruct.sgroups.forEach((sgroup) => {
         const sgroupMonomer = (sgroup as { monomer?: unknown }).monomer;
-        if (!sgroup.isMonomer || !createdMonomers.has(sgroupMonomer)) {
+        if (
+          !sgroup.isMonomer ||
+          !createdMonomers.has(sgroupMonomer as BaseMonomer)
+        ) {
           return;
         }
 
@@ -3110,7 +3154,7 @@ class Editor implements KetcherEditor {
     this.monomerCreationState.isRnaPresetMode = isActive;
   }
 
-  selection(ci?: any) {
+  selection(ci?: Selection | 'all' | 'descriptors' | null) {
     if (arguments.length === 0) {
       return this._selection; // eslint-disable-line
     }
@@ -3118,14 +3162,20 @@ class Editor implements KetcherEditor {
     let ReStruct = this.render.ctab;
     let selectAll = false;
     this._selection = null; // eslint-disable-line
-    let resolvedCi = ci;
+    let resolvedCi: Record<string, number[]> | null;
+    if (typeof ci === 'object' && ci !== null) {
+      resolvedCi = ci as Record<string, number[]>;
+    } else {
+      resolvedCi = null;
+    }
+
     if (ci === 'all') {
       selectAll = true;
       // TODO: better way will be this.struct()
       resolvedCi = structObjects.reduce((res, key) => {
         res[key] = Array.from(ReStruct[key].keys());
         return res;
-      }, {});
+      }, {} as Record<string, number[]>);
     }
 
     if (ci === 'descriptors') {
@@ -3137,7 +3187,7 @@ class Editor implements KetcherEditor {
       const res: Selection = {};
 
       Object.keys(resolvedCi).forEach((key) => {
-        if (resolvedCi[key].length > 0)
+        if (resolvedCi && resolvedCi[key] && resolvedCi[key].length > 0)
           // TODO: deep merge
           res[key] = resolvedCi[key].slice();
       });
@@ -3147,7 +3197,7 @@ class Editor implements KetcherEditor {
       }
       const stereoFlags = selectStereoFlagsIfNecessary(
         this.struct().atoms,
-        this.explicitSelected().atoms,
+        this.explicitSelected().atoms ?? [],
       );
       if (stereoFlags.length !== 0) {
         if (this._selection?.enhancedFlags) {
@@ -3173,10 +3223,10 @@ class Editor implements KetcherEditor {
     return this._selection; // eslint-disable-line
   }
 
-  hover(ci: HoverTarget | null, newTool?: any, event?: PointerEvent) {
+  hover(ci: HoverTarget | null, newTool?: Tool | null, event?: PointerEvent) {
     const tool = newTool ?? this._tool; // eslint-disable-line
 
-    const hoverState = (tool as { ci?: HoverTarget }).ci;
+    const hoverState = (tool as unknown as { ci?: HoverTarget })?.ci;
     let isSameHoverTarget = false;
 
     if (hoverState) {
@@ -3188,12 +3238,12 @@ class Editor implements KetcherEditor {
 
       if (!isSameHoverTarget) {
         setHover(hoverState, false, this.render);
-        delete (tool as { ci?: HoverTarget }).ci;
+        delete (tool as unknown as { ci?: HoverTarget }).ci;
       }
     }
 
     if (ci && !isSameHoverTarget && setHover(ci, true, this.render)) {
-      tool.ci = ci;
+      (tool as unknown as { ci: HoverTarget }).ci = ci;
     }
 
     if (!ci) {
@@ -3335,15 +3385,24 @@ class Editor implements KetcherEditor {
     this.historyPtr = 0;
   }
 
-  subscribe(eventName: any, handler: any) {
-    const subscriber = {
+  subscribe(
+    eventName: string,
+    handler: ((data?: unknown) => void) | ((data: ChangeEventData[]) => void),
+  ) {
+    const subscriber: {
+      handler: ((data?: unknown) => void) | ((data: ChangeEventData[]) => void);
+    } = {
       handler,
     };
 
     switch (eventName) {
       case 'change': {
-        const subscribeFuncWrapper = (action) =>
-          customOnChangeHandler(action, handler);
+        const subscribeFuncWrapper = (action: unknown) => {
+          customOnChangeHandler(
+            action as unknown,
+            handler as (data?: unknown) => void,
+          );
+        };
         subscriber.handler = subscribeFuncWrapper;
         ketcherProvider
           .getKetcher(this.ketcherId)
@@ -3365,34 +3424,50 @@ class Editor implements KetcherEditor {
     return subscriber;
   }
 
-  unsubscribe(eventName: any, subscriber: any) {
+  unsubscribe(
+    eventName: string,
+    subscriber: {
+      handler: ((data?: unknown) => void) | ((data: ChangeEventData[]) => void);
+    },
+  ): void {
     switch (eventName) {
       case 'change': {
         ketcherProvider
           .getKetcher(this.ketcherId)
-          .changeEvent.remove(subscriber.handler);
+          .changeEvent.remove(subscriber.handler as (action?: unknown) => void);
         break;
       }
 
       case 'libraryUpdate': {
         ketcherProvider
           .getKetcher(this.ketcherId)
-          .libraryUpdateEvent.remove(subscriber.handler);
+          .libraryUpdateEvent.remove(
+            subscriber.handler as (action?: unknown) => void,
+          );
         break;
       }
 
       default:
-        this.event[eventName].remove(subscriber.handler);
+        this.event[eventName].remove(
+          subscriber.handler as (action?: unknown) => void,
+        );
     }
   }
 
-  findItem(event: any, maps: Array<string> | null, skip: any = null) {
-    const pos = CoordinateTransformation.pageToModel(event, this.render);
+  findItem(
+    event: Event | MouseEvent | { clientX: number; clientY: number },
+    maps: Array<string> | null,
+    skip: unknown = null,
+  ) {
+    const pos = CoordinateTransformation.pageToModel(
+      event as MouseEvent | { clientX: number; clientY: number },
+      this.render,
+    );
 
     return closest.item(this.render.ctab, pos, maps, skip, this.render.options);
   }
 
-  findMerge(srcItems: any, maps: any) {
+  findMerge(srcItems: unknown, maps: string[] | undefined) {
     return closest.merge(this.render.ctab, srcItems, this.render.options, maps);
   }
 
@@ -3401,7 +3476,7 @@ class Editor implements KetcherEditor {
     const res = structObjects.reduce((acc, key) => {
       acc[key] = selection[key] ? selection[key].slice() : [];
       return acc;
-    }, {} as any);
+    }, {} as Selection);
 
     const struct = this.render.ctab.molecule;
 
@@ -3426,11 +3501,12 @@ class Editor implements KetcherEditor {
     if (autoSelectBonds && res.atoms && res.bonds) {
       struct.bonds.forEach((bond, bid) => {
         if (
+          res.bonds &&
+          res.atoms &&
           res.bonds.indexOf(bid) < 0 &&
           res.atoms.indexOf(bond.begin) >= 0 &&
           res.atoms.indexOf(bond.end) >= 0
         ) {
-          res.bonds = res.bonds ?? [];
           res.bonds.push(bid);
         }
       });
@@ -3462,11 +3538,11 @@ class Editor implements KetcherEditor {
     // Copy by its own as Struct.clone doesn't support
     // arrows/pluses id sets
     struct.rxnArrows.forEach((item, id) => {
-      if (selection.rxnArrows.indexOf(id) !== -1)
+      if ((selection.rxnArrows ?? []).indexOf(id) !== -1)
         dst.rxnArrows.add(item.clone());
     });
     struct.rxnPluses.forEach((item, id) => {
-      if (selection.rxnPluses.indexOf(id) !== -1)
+      if ((selection.rxnPluses ?? []).indexOf(id) !== -1)
         dst.rxnPluses.add(item.clone());
     });
 
@@ -3508,20 +3584,20 @@ function resetSelectionOnCanvasClick(
   editor: Editor,
   eventName: string,
   clientArea: HTMLElement,
-  event,
+  event: Event,
 ) {
   if (
     eventName === 'mouseup' &&
     editor.selection() &&
-    clientArea.contains(event.target)
+    clientArea.contains(event.target as Node | null)
   ) {
     editor.selection(null);
   }
 }
 
-function updateLastCursorPosition(editor: Editor, event) {
+function updateLastCursorPosition(editor: Editor, event: Event) {
   const events = ['mousemove', 'click', 'mousedown', 'mouseup', 'mouseover'];
-  if (events.includes(event.type)) {
+  if (events.includes(event.type) && event instanceof MouseEvent) {
     const clientAreaBoundingBox =
       editor.render.clientArea.getBoundingClientRect();
 
@@ -3540,7 +3616,7 @@ function useToolIfNeeded(
   editor: Editor,
   eventHandlerName: ToolEventHandlerName,
   clientArea: HTMLElement,
-  event,
+  event: Event,
 ) {
   const editorTool = editor.tool();
   if (!editorTool) {
@@ -3550,7 +3626,8 @@ function useToolIfNeeded(
   editor.lastEvent = event;
   const conditions = [
     eventHandlerName in editorTool,
-    clientArea.contains(event.target) || editorTool.isSelectionRunning?.(),
+    clientArea.contains(event.target as Node | null) ||
+      editorTool.isSelectionRunning?.(),
     isContextMenuClosed(editor.contextMenu),
   ];
 
@@ -3667,17 +3744,37 @@ function domEventSetup(editor: Editor, clientArea: HTMLElement) {
 export { Editor };
 export default Editor;
 
-function setHover(ci: any, visible: any, render: any) {
+type HoverableReObject = {
+  item?: { type: string };
+  makeHoverPlate?: (render: Render) => { node?: Element } | undefined;
+  setHover(visible: boolean, render: Render, drawOutline?: boolean): void;
+};
+
+function getReStructMap(
+  render: Render,
+  map: string,
+): Map<number, HoverableReObject> {
+  return (
+    render.ctab as unknown as Record<string, Map<number, HoverableReObject>>
+  )[map];
+}
+
+function setHover(ci: HoverTarget, visible: boolean, render: Render) {
   if (highlightTargets.indexOf(ci.map) === -1) {
     return false;
   }
 
-  let item: any = null;
+  let item: HoverableReObject | null = null;
 
   if (ci.map === 'merge') {
-    Object.keys(ci.items).forEach((mp) => {
-      ci.items[mp].forEach((dstId) => {
-        item = render.ctab[mp].get(dstId)!;
+    const mergeCi = ci as {
+      id: string;
+      map: 'merge';
+      items: Record<string, number[]>;
+    };
+    Object.keys(mergeCi.items).forEach((mp) => {
+      mergeCi.items[mp].forEach((dstId) => {
+        item = getReStructMap(render, mp).get(dstId) ?? null;
 
         if (item) {
           item.setHover(visible, render, false);
@@ -3686,9 +3783,9 @@ function setHover(ci: any, visible: any, render: any) {
     });
 
     if (visible) {
-      const hoveredRenderers = Object.keys(ci.items).flatMap((mp) => {
-        return ci.items[mp].flatMap((dstId) => {
-          return render.ctab[mp].get(dstId);
+      const hoveredRenderers = Object.keys(mergeCi.items).flatMap((mp) => {
+        return mergeCi.items[mp].flatMap((dstId) => {
+          return getReStructMap(render, mp).get(dstId);
         });
       });
 
@@ -3699,7 +3796,7 @@ function setHover(ci: any, visible: any, render: any) {
       paperjs.setup(document.createElement('canvas')); // Paper.js works on an offscreen canvas
 
       // Generate Paper.js paths from all SVG elements
-      let combinedPath: any = null;
+      let combinedPath: paper.PathItem | null = null;
       const options = render.options;
       const hoverVisel = new Visel('mergedHover');
       const elements: Element[] = [];
@@ -3711,11 +3808,14 @@ function setHover(ci: any, visible: any, render: any) {
         }
       });
 
-      elements.forEach((element) => {
-        const paperPath = paperPathFromSVGElement(element);
+      for (const element of elements) {
+        const paperPath = paperPathFromSVGElement(element) as
+          | paper.Path
+          | paper.CompoundPath
+          | undefined;
 
         if (!paperPath) {
-          return;
+          continue;
         }
 
         if (!paperPath.closed) {
@@ -3727,7 +3827,7 @@ function setHover(ci: any, visible: any, render: any) {
         } else {
           combinedPath = combinedPath.unite(paperPath);
         }
-      });
+      }
 
       if (!combinedPath) {
         return;
@@ -3756,24 +3856,25 @@ function setHover(ci: any, visible: any, render: any) {
     return true;
   }
 
-  if (ci.map === 'functionalGroups') ci.map = 'sgroups'; // TODO: Refactor object
+  const targetCi = ci as { id: number; map: string };
+  if (targetCi.map === 'functionalGroups') targetCi.map = 'sgroups'; // TODO: Refactor object
 
-  item = (render.ctab[ci.map] as Map<any, any>).get(ci.id);
+  item = getReStructMap(render, targetCi.map).get(targetCi.id) ?? null;
   if (!item) {
     return true; // TODO: fix, attempt to highlight a deleted item
   }
 
   if (
-    (ci.map === 'sgroups' && item.item.type === 'DAT') ||
-    ci.map === 'sgroupData'
+    (targetCi.map === 'sgroups' && item.item?.type === 'DAT') ||
+    targetCi.map === 'sgroupData'
   ) {
     // set highlight for both the group and the data item
-    const item1 = render.ctab.sgroups.get(ci.id);
+    const item1 = render.ctab.sgroups.get(targetCi.id);
     if (item1) {
       item1.setHover(visible, render);
     }
 
-    const item2 = render.ctab.sgroupData.get(ci.id);
+    const item2 = render.ctab.sgroupData.get(targetCi.id);
     if (item2) {
       item2.setHover(visible, render);
     }

--- a/packages/ketcher-react/src/script/editor/tool/hand.ts
+++ b/packages/ketcher-react/src/script/editor/tool/hand.ts
@@ -25,7 +25,7 @@ class HandTool implements Tool {
 
   constructor(editor) {
     this.editor = editor;
-    const { clientX, clientY } = this.editor.lastEvent || {
+    const { clientX, clientY } = (this.editor.lastEvent as MouseEvent) || {
       clientX: 0,
       clientY: 0,
     };

--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -73,7 +73,10 @@ class PasteTool implements Tool {
     const { clientHeight, clientWidth } = rnd.clientArea;
     const clientAreaRect = rnd.clientArea.getBoundingClientRect();
     const point = this.editor.lastEvent
-      ? CoordinateTransformation.pageToModel(this.editor.lastEvent, rnd)
+      ? CoordinateTransformation.pageToModel(
+          this.editor.lastEvent as MouseEvent,
+          rnd,
+        )
       : CoordinateTransformation.pageToModel(
           {
             clientX: clientAreaRect.left + clientWidth / 2,

--- a/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate-controller.test.ts
@@ -58,7 +58,12 @@ describe('Rotate controller', () => {
    */
   it('hides when active tool is not SelectTool', () => {
     const ketcherId = '1';
-    const editor = new Editor(ketcherId, document, {}, {});
+    const editor = new Editor(
+      ketcherId,
+      document as unknown as HTMLElement,
+      {},
+      {},
+    );
     const NonSelectTool = new RotateTool(editor, undefined);
     const paper = jest.fn();
     const visibleAtoms = [0, 1];
@@ -91,7 +96,12 @@ describe('Rotate controller', () => {
    */
   it('rerenders while zooming', () => {
     const ketcherId = '1';
-    const editor = new Editor(ketcherId, document, {}, {});
+    const editor = new Editor(
+      ketcherId,
+      document as unknown as HTMLElement,
+      {},
+      {},
+    );
     editor.rotateController.rerender = jest.fn();
 
     editor.zoom(2);
@@ -246,7 +256,12 @@ describe('Rotate controller', () => {
    */
   it(`cancels rotation without modifying history stack`, () => {
     const ketcherId = '1';
-    const editor = new Editor(ketcherId, document, {}, {});
+    const editor = new Editor(
+      ketcherId,
+      document as unknown as HTMLElement,
+      {},
+      {},
+    );
     editor.render.ctab.molecule.getSelectedVisibleAtoms = () => [];
     // @ts-ignore
     editor.rotateController.rotateTool.dragCtx = {

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -122,7 +122,7 @@ class TemplateTool implements Tool {
   }
 
   private get closestItem() {
-    return this.editor.findItem(this.event, [
+    return this.editor.findItem(this.event as Event, [
       'atoms',
       'bonds',
       'sgroups',

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -143,7 +143,7 @@ export function setFunctionalGroupsTooltip({
   let infoPanelData: null | InfoPanelData = null;
   const checkFunctionGroupTypes = ['sgroups', 'functionalGroups'];
   const closestCollapsibleStructures = editor.findItem(
-    event,
+    event as Event,
     checkFunctionGroupTypes,
   );
   if (closestCollapsibleStructures && event) {

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/MonomerCreationWizard.tsx
@@ -4,9 +4,7 @@ import { Dialog, Icon } from 'components';
 import {
   type AtomLabel,
   type AttachmentPointClickData,
-  type BaseMonomer,
   type ComponentStructureUpdateData,
-  type IKetMonomerTemplate,
   type MonomerCreationInitialValues,
   type MonomerCreationState,
   type RnaPresetComponentKey,
@@ -74,7 +72,10 @@ import {
   getLeavingAtomForAttachmentPoint,
   hasPhosphatePositionAttachmentPointConflict,
 } from './RnaPresetAttachmentPointValidation';
-import type { Selection } from '../../../../editor/Editor';
+import type {
+  FinishNewMonomersCreationData,
+  Selection,
+} from '../../../../editor/Editor';
 import { isNumber } from 'lodash';
 import { showSnackbarNotification } from '../../../state/notifications';
 
@@ -1620,13 +1621,7 @@ const MonomerCreationWizardInternal = ({
           (componentKey) => rnaPresetWizardState[componentKey],
         )
       : [wizardState];
-    const monomersData: Array<{
-      atomIdMap: Map<number, number>;
-      monomerStructureInWizard: Selection | null | undefined;
-      monomer: BaseMonomer;
-      monomerTemplate: IKetMonomerTemplate;
-      monomerRef: string;
-    }> = [];
+    const monomersData: FinishNewMonomersCreationData[] = [];
     const assignedAttachmentPointsByMonomer: AssignedAttachmentPointsByMonomerType =
       new Map();
 
@@ -1871,7 +1866,7 @@ const MonomerCreationWizardInternal = ({
         }
 
         const result = editor.saveNewMonomer({
-          type: valuesToSave.type,
+          type: valuesToSave.type as KetMonomerClass,
           symbol: valuesToSave.symbol,
           name: valuesToSave.name || valuesToSave.symbol,
           naturalAnalogue: valuesToSave.naturalAnalogue,
@@ -1879,14 +1874,17 @@ const MonomerCreationWizardInternal = ({
           aliasHELM: valuesToSave.aliasHELM,
           aliasBILN: valuesToSave.aliasBILN,
           structure,
-          attachmentPoints: monomerAssignedAttachmentPoints,
+          attachmentPoints: monomerAssignedAttachmentPoints as Map<
+            AttachmentPointName,
+            [number, number]
+          >,
           // Mark monomers as hidden when they are part of a preset and don't have all properties filled
           hidden: shouldBeHidden,
         });
 
         monomersData.push({
           ...result,
-          monomerStructureInWizard: monomerToSave.structure,
+          monomerStructureInWizard: monomerToSave.structure as Selection,
           atomIdMap,
         });
       });
@@ -2083,7 +2081,7 @@ const MonomerCreationWizardInternal = ({
                     bondIdMap,
                   );
                   const monomerData = editor.saveNewMonomer({
-                    type,
+                    type: type as KetMonomerClass,
                     symbol,
                     name: name || symbol,
                     naturalAnalogue,

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/StructEditor.tsx
@@ -148,7 +148,9 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
       this.scrollCanvas(event);
       this.editor.rotateController.updateFloatingToolsPosition();
       this.editor.hoverIcon.updatePosition();
-      this.editor.tool()?.mousemove?.(this.editor.lastEvent);
+      if (this.editor.lastEvent) {
+        this.editor.tool()?.mousemove?.(this.editor.lastEvent);
+      }
     }
   };
 
@@ -218,7 +220,7 @@ class StructEditor extends Component<StructEditorProps, StructEditorState> {
 
     this.editor = new Editor(
       this.props.ketcherId,
-      this.editorRef.current,
+      this.editorRef.current as HTMLDivElement,
       {
         ...this.props.options,
       },


### PR DESCRIPTION
## Replace explicit any usages in Editor.ts
Replace explicit any usages in Editor.ts with proper types (RenderOptions,
Selection, HoverTarget, FinishNewMonomersCreationData, etc.), and fix the
resulting type errors in files that call into Editor.ts so the whole
workspace passes tsc --noEmit again.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request