### PR TITLE
#10247 - Nucleotide preset: Incorrect highlighting of tabs in case of missing components

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.test.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.test.tsx
@@ -876,3 +876,103 @@ describe('RnaPresetTabs - applyHighlights function', () => {
     expect(screen.queryByText('R3')).not.toBeInTheDocument();
   });
 });
+
+describe('RnaPresetTabs - missing-component tab highlighting (#10247)', () => {
+  let mockEditor: ReturnType<typeof createMockEditor>;
+  let mockStore: ReturnType<typeof createMockStore>;
+  let mockDispatch: jest.Mock;
+  let mockOnPhosphatePositionChange: jest.Mock;
+  let wizardState: RnaPresetWizardState;
+
+  beforeEach(() => {
+    mockEditor = createMockEditor();
+    mockStore = createMockStore();
+    mockDispatch = jest.fn();
+    mockOnPhosphatePositionChange = jest.fn();
+    wizardState = createInitialWizardState();
+    jest.clearAllMocks();
+  });
+
+  const renderTabs = () =>
+    render(
+      <Provider store={mockStore}>
+        <RnaPresetTabs
+          wizardState={wizardState}
+          editor={mockEditor}
+          wizardStateDispatch={mockDispatch}
+          phosphatePosition={undefined}
+          onPhosphatePositionChange={mockOnPhosphatePositionChange}
+        />
+      </Provider>,
+    );
+
+  const definedStructure = () => ({ atoms: [1, 2, 3], bonds: [1, 2] });
+
+  const tabErrors = () => ({
+    preset: screen
+      .getByTestId('nucleotide-preset-tab')
+      .classList.contains('errorTab'),
+    base: screen
+      .getByTestId('nucleotide-base-tab')
+      .classList.contains('errorTab'),
+    sugar: screen
+      .getByTestId('nucleotide-sugar-tab')
+      .classList.contains('errorTab'),
+    phosphate: screen
+      .getByTestId('nucleotide-phosphate-tab')
+      .classList.contains('errorTab'),
+  });
+
+  it('highlights only the missing components when only a base is defined', () => {
+    wizardState.base.structure = definedStructure();
+    wizardState.preset.errors.components = true;
+
+    renderTabs();
+
+    expect(tabErrors()).toEqual({
+      preset: false,
+      base: false,
+      sugar: true,
+      phosphate: true,
+    });
+  });
+
+  it('highlights no tabs once the preset is valid (sugar + base)', () => {
+    wizardState.sugar.structure = definedStructure();
+    wizardState.base.structure = definedStructure();
+    // Even with a stale "components" flag, a valid preset must not highlight.
+    wizardState.preset.errors.components = true;
+
+    renderTabs();
+
+    expect(tabErrors()).toEqual({
+      preset: false,
+      base: false,
+      sugar: false,
+      phosphate: false,
+    });
+  });
+
+  it('highlights only the mandatory sugar when base and phosphate are defined', () => {
+    wizardState.base.structure = definedStructure();
+    wizardState.phosphate.structure = definedStructure();
+    wizardState.preset.errors.components = true;
+
+    renderTabs();
+
+    expect(tabErrors()).toEqual({
+      preset: false,
+      base: false,
+      sugar: true,
+      phosphate: false,
+    });
+  });
+
+  it('still highlights the Preset tab for its own (Code) error', () => {
+    wizardState.preset.errors.name = true;
+
+    renderTabs();
+
+    expect(screen.getByTestId('nucleotide-preset-tab')).toHaveClass('errorTab');
+  });
+});

--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/RnaPresetTabs.tsx
@@ -50,7 +50,10 @@ import {
   getConnectionAttachmentPointsForRnaPresetComponent,
   getVisibleAttachmentPointsForRnaPreset,
 } from './RnaPresetAttachmentPointsVisibility';
-import { hasRequiredRnaPresetComponents } from './RnaPresetStructureValidation';
+import {
+  getRnaPresetComponentKeysToSave,
+  hasRequiredRnaPresetComponents,
+} from './RnaPresetStructureValidation';
 
 interface IRnaPresetTabsProps {
   wizardState: RnaPresetWizardState;
@@ -316,11 +319,22 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
       Boolean(errorValue),
     );
   };
-  // Keep component tabs red only while the missing-components condition still
-  // applies; marking the required components clears the visual state immediately.
-  const hasComponentsError =
+  // A "missing components" error must colour only the tabs of the components
+  // that are actually missing — not every component tab, and not the Preset
+  // (overview) tab. A valid preset is sugar (mandatory) plus base and/or
+  // phosphate; marking the required components clears the state immediately (#10247).
+  const hasMissingComponentsError =
     Boolean(wizardState.preset.errors.components) &&
     !hasRequiredRnaPresetComponents(wizardState);
+  const definedComponentKeys = getRnaPresetComponentKeysToSave(wizardState);
+  const isMissingComponentTab = (componentKey: RnaPresetComponentKey) =>
+    hasMissingComponentsError && !definedComponentKeys.includes(componentKey);
+  // The Preset tab reflects only its own errors (e.g. the Code field), never the
+  // whole-preset "missing components" error.
+  const hasPresetOwnError = Object.entries(wizardState.preset.errors).some(
+    ([errorKey, errorValue]) =>
+      errorKey !== 'components' && Boolean(errorValue),
+  );
 
   return (
     <div>
@@ -332,7 +346,7 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
         <Tab
           className={clsx(
             styles.styledTab,
-            hasErrorInTab(wizardState.preset) && styles.errorTab,
+            hasPresetOwnError && styles.errorTab,
           )}
           data-testid="nucleotide-preset-tab"
           label={<div className={styles.tabLabel}>Preset</div>}
@@ -341,7 +355,8 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
         <Tab
           className={clsx(
             styles.styledTab,
-            (hasErrorInTab(wizardState.base) || hasComponentsError) &&
+            (hasErrorInTab(wizardState.base) ||
+              isMissingComponentTab('base')) &&
               styles.errorTab,
           )}
           data-testid="nucleotide-base-tab"
@@ -351,7 +366,8 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
         <Tab
           className={clsx(
             styles.styledTab,
-            (hasErrorInTab(wizardState.sugar) || hasComponentsError) &&
+            (hasErrorInTab(wizardState.sugar) ||
+              isMissingComponentTab('sugar')) &&
               styles.errorTab,
           )}
           data-testid="nucleotide-sugar-tab"
@@ -361,7 +377,8 @@ export const RnaPresetTabs = (props: IRnaPresetTabsProps) => {
         <Tab
           className={clsx(
             styles.styledTab,
-            (hasErrorInTab(wizardState.phosphate) || hasComponentsError) &&
+            (hasErrorInTab(wizardState.phosphate) ||
+              isMissingComponentTab('phosphate')) &&
               styles.errorTab,
           )}
           data-testid="nucleotide-phosphate-tab"


### PR DESCRIPTION

<img width="959" height="499" alt="new" src="https://github.com/user-attachments/assets/1a59806f-9793-41c5-b54c-2bd5b874a5b9" />

Root cause

In RnaPresetTabs.tsx:
- The "missing components" condition was a single boolean OR'd into every component tab (Base/Sugar/Phosphate), so all three lit up regardless of which were actually missing — including components that were already defined.
- The Preset tab used hasErrorInTab(wizardState.preset), which is true for any preset error — including the whole-preset components error — so it lit up too.

Changes

- packages/ketcher-react/.../MonomerCreationWizard/RnaPresetTabs.tsx
  - Added isMissingComponentTab(componentKey) = preset invalid due to missing components and that component is not defined (using the existing getRnaPresetComponentKeysToSave / hasRequiredRnaPresetComponents validation). Base/Sugar/Phosphate tabs now use it, so only the missing components are highlighted.
  - The Preset tab now uses hasPresetOwnError (any preset error except components), so it no longer reddens for the missing-components case but still reddens for its own Code-field error.
- packages/ketcher-react/.../MonomerCreationWizard/RnaPresetTabs.test.tsx
  - Four unit tests covering the rule (base-only → Sugar + Phosphate; sugar + base → none; base + phosphate → Sugar only; Preset tab still reddens for its own Code error).

Out of scope (unchanged): the validation error toasts, and phosphatePosition highlighting (a separate scenario that only occurs when a phosphate is defined).

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request