### PR TITLE
#3269 – When click on the dividing lines, the context menu disappears

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/MenuSeparator.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/MenuSeparator.tsx
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import type { FC } from 'react';
+import { Separator, type SeparatorProps } from 'react-contexify';
+
+/**
+ * react-contexify's own `Separator` never stops click propagation, so a
+ * click on it bubbles to the `window`-level listener the menu uses to
+ * detect outside clicks, closing the menu (see #3269). `Item`/`Submenu`
+ * avoid this by stopping propagation themselves; this wrapper does the
+ * same for separators.
+ */
+const MenuSeparator: FC<SeparatorProps> = (props) => (
+  // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- purely stops click propagation for a decorative divider, not a keyboard-operable control
+  <div onClick={(event) => event.stopPropagation()}>
+    <Separator {...props} />
+  </div>
+);
+
+export default MenuSeparator;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AtomMenuItems.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
-import { Item, Submenu, Separator } from 'react-contexify';
+import { Item, Submenu } from 'react-contexify';
+import MenuSeparator from '../MenuSeparator';
 import useAtomEdit from '../hooks/useAtomEdit';
 import useAtomStereo from '../hooks/useAtomStereo';
 import useDelete from '../hooks/useDelete';
@@ -180,7 +181,7 @@ const AtomMenuItems: FC<MenuItemsProps<AtomContextMenuProps>> = (props) => {
     return (
       <>
         <HighlightMenu onHighlight={highlightAtomWithColor} />
-        <Separator />
+        <MenuSeparator />
         <Item {...props} data-testid="Delete-option" onClick={handleDelete}>
           <Icon name="deleteMenu" className={styles.icon} />
           <span className={styles.contextMenuText}>Delete</span>
@@ -245,7 +246,7 @@ const AtomMenuItems: FC<MenuItemsProps<AtomContextMenuProps>> = (props) => {
       {makeAttachmentPointMenuItems && (
         <>
           {makeAttachmentPointMenuItems}
-          <Separator />
+          <MenuSeparator />
         </>
       )}
       <Item
@@ -296,7 +297,7 @@ const AtomMenuItems: FC<MenuItemsProps<AtomContextMenuProps>> = (props) => {
         onHighlight={highlightAtomWithColor}
         disabled={disabledForMonomerCreation}
       />
-      <Separator />
+      <MenuSeparator />
       <Item {...props} data-testid="Delete-option" onClick={handleDelete}>
         <Icon name="deleteMenu" className={styles.icon} />
         <span className={styles.contextMenuText}>Delete</span>

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -1,8 +1,9 @@
 import { type FC, useEffect, useState } from 'react';
-import { Item, Submenu, Separator } from 'react-contexify';
+import { Item, Submenu } from 'react-contexify';
 import type Editor from 'src/script/editor';
 import tools from '../../../../action/tools';
 import styles from '../ContextMenu.module.less';
+import MenuSeparator from '../MenuSeparator';
 import useBondEdit from '../hooks/useBondEdit';
 import useBondSGroupAttach from '../hooks/useBondSGroupAttach';
 import useBondSGroupEdit from '../hooks/useBondSGroupEdit';
@@ -107,7 +108,7 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
             : 'Edit...'}
         </span>
       </Item>
-      <Separator />
+      <MenuSeparator />
       {bondNamesWithoutEmptyValue.map((name) => {
         const iconName = getIconName(name);
         const classNames = styles.sameGroup;
@@ -127,7 +128,7 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
           </Item>
         );
       })}
-      <Separator />
+      <MenuSeparator />
 
       <Submenu
         {...props}
@@ -186,7 +187,7 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
       >
         Edit S-Group...
       </Item>
-      <Separator />
+      <MenuSeparator />
       <Item {...props} data-testid="Delete-option" onClick={handleDelete}>
         <Icon name="deleteMenu" className={styles.icon} />
         <span className={styles.contextMenuText}>Delete</span>

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/SelectionMenuItems.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
-import { Item, Submenu, Separator } from 'react-contexify';
+import { Item, Submenu } from 'react-contexify';
+import MenuSeparator from '../MenuSeparator';
 import tools from '../../../../action/tools';
 import styles from '../ContextMenu.module.less';
 import useAtomEdit from '../hooks/useAtomEdit';
@@ -173,7 +174,7 @@ const SelectionMenuItems: FC<MenuItemsProps<SelectionContextMenuProps>> = (
         Enhanced stereochemistry...
       </Item>
       <HighlightMenu onHighlight={highlightBondWithColor} />
-      <Separator />
+      <MenuSeparator />
       <Item {...props} data-testid="Delete-option" onClick={handleDelete}>
         Delete
       </Item>


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The classic Molecules-mode right-click context menu (bond/atom/selection) is built with
`react-contexify`'s `Menu`/`Item`/`Submenu`/`Separator` components. `Menu` registers a
`window`-level `click` listener while open to detect outside clicks and close itself.
`Item` and `Submenu` both call `event.stopPropagation()` to protect against this, but
`Separator` is just a plain `<div>` with no click handler at all — so a click on a
dividing line bubbles straight to `window` and is treated as an outside click, closing
the menu (#3269).

Fix: added `MenuSeparator.tsx`, a thin wrapper around `react-contexify`'s `Separator`
that stops click propagation the same way `Item`/`Submenu` already do, and replaced all
`<Separator />` usages in `BondMenuItems.tsx`, `AtomMenuItems.tsx`, and
`SelectionMenuItems.tsx` with it.

Verified manually in a real browser (`dev:standalone`): reproduced the bug on the
unpatched code (menu closes on separator click), confirmed the fix keeps the menu open,
and confirmed no regression — clicking a real menu item still closes the menu and
applies the action, and clicking genuinely outside the menu still closes it as expected.
No automated test covers this interaction yet.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request