### PR TITLE
#10438 - Refactor: Explicit Any type clean up from packages\ketcher-core\src\application\editor\operations\sgroup\sgroupHierarchy.ts file

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts
@@ -19,15 +19,15 @@ import { OperationPriority, OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
 
 type Data = {
-  sgid: any;
-  parent?: any;
-  children?: any;
+  sgid: number;
+  parent?: number;
+  children?: number[];
 };
 
 class SGroupAddToHierarchy extends BaseOperation {
   data: Data;
 
-  constructor(sgroupId?: any, parent?: any, children?: any) {
+  constructor(sgroupId: number, parent?: number, children?: number[]) {
     super(
       OperationType.S_GROUP_ADD_TO_HIERACHY,
       OperationPriority.S_GROUP_ADD_TO_HIERACHY,
@@ -50,12 +50,12 @@ class SGroupAddToHierarchy extends BaseOperation {
 class SGroupRemoveFromHierarchy extends BaseOperation {
   data: Data;
 
-  constructor(sgroupId?: any) {
+  constructor(sgroupId: number) {
     super(OperationType.S_GROUP_REMOVE_FROM_HIERACHY, 110);
     this.data = { sgid: sgroupId };
   }
 
-  execute(restruct: any) {
+  execute(restruct: ReStruct) {
     const { sgid } = this.data;
     const struct = restruct.molecule;
 


### PR DESCRIPTION
How the feature works? / How did you fix the issue?

Removed all explicit any usages from packages/ketcher-core/src/application/editor/operations/sgroup/sgroupHierarchy.ts, replacing each with the concrete type derived from the surrounding code. This is a type-only refactor — no runtime behavior change, no casts, no new non-null assertions.

Type changes:
- Data → { sgid: number; parent?: number; children?: number[] } — SGroupForest declares parent: Map<number, number> and children: Map<number, number[]> with remove(id: number), and struct.sgroups is Pool<SGroup> extends Map<number, SGroup>, so an s-group id is number.
- SGroupAddToHierarchy constructor → (sgroupId: number, parent?: number, children?: number[]).
- SGroupRemoveFromHierarchy constructor → (sgroupId: number). sgroupId is required because the operation cannot run without it; every call site passes it, and BaseOperation.invert() creates the inverse through the loosely-typed InverseConstructor and overwrites data, so the tighter signature remains type-safe (verified with tsc).
- SGroupRemoveFromHierarchy.execute(restruct: any) → execute(restruct: ReStruct) — ReStruct is already imported and is what the other execute and the sibling operation use.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request