### PR TITLE
#8969 - Ketcher crashes in dev mode

### DIFF
--- a/packages/ketcher-react/src/Editor.tsx
+++ b/packages/ketcher-react/src/Editor.tsx
@@ -6,10 +6,11 @@ import {
 import { ModeControl } from './script/ui/views/toolbars/ModeControl';
 import { LoadingCircles } from './script/ui/views/components';
 import styles from './Editor.module.less';
-import type {
-  Ketcher,
-  Editor as MoleculesEditor,
-  CoreEditor,
+import {
+  type Ketcher,
+  type Editor as MoleculesEditor,
+  type CoreEditor,
+  ketcherProvider,
 } from 'ketcher-core';
 
 type Props = Omit<EditorProps, 'ketcherId'> & {
@@ -118,7 +119,9 @@ export const Editor = (props: Props) => {
       moleculesEditor &&
       (macromoleculesEditor || props.disableMacromoleculesEditor)
     ) {
-      props.onInit?.(ketcher);
+      if (ketcherProvider.getIndexById(ketcher.id) !== -1) {
+        props.onInit?.(ketcher);
+      }
     }
   }, [moleculesEditor, macromoleculesEditor]);
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Reopening the editor in dev mode crashed with `couldn't find ketcher instance N`. In `React.StrictMode`, a stale `Ketcher` gets removed from `ketcherProvider`, but the `onInit` effect in `Editor.tsx` could still fire for it — so the consumer's `subscribe('change')` called `getKetcher(staleId)` and threw.

**Fix**: in` Editor.tsx`, only call `onInit` when the ketcher is still registered:
```
if (ketcherProvider.getIndexById(ketcher.id) !== -1) {
  props.onInit?.(ketcher);
}
```
Production behavior is unchanged (single mount). 


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request