### PR TITLE
7369 – Structures with nucleotide component or S-group brackets disappear or become corrupted after overlapping, modifying, and using undo/redo

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/sgroup.ts
+++ b/packages/ketcher-react/src/script/editor/tool/sgroup.ts
@@ -21,6 +21,7 @@ import {
   checkOverlapping,
   fromSeveralSgroupAddition,
   fromSgroupAction,
+  fromSgroupAttrs,
   fromSgroupDeletion,
   FunctionalGroup,
   SGroup,
@@ -772,6 +773,21 @@ class SGroupTool implements Tool {
 
           const canReplaceExistingDataSg =
             sg?.getAttrs().context === newSg.attrs.context && !isQuerySGroup;
+
+          const currentSGroupType =
+            sg?.type === SGroup.TYPES.SUP && sg.data.class
+              ? SGroup.TYPES.nucleotideComponent
+              : sg?.type;
+
+          if (
+            sg &&
+            canReplaceExistingDataSg &&
+            currentSGroupType === newSg.type
+          ) {
+            editor.update(fromSgroupAttrs(restruct, id, newSg.attrs));
+            editor.selection(selection);
+            return;
+          }
 
           if (sg && canReplaceExistingDataSg) {
             const action = fromSeveralSgroupAddition(


### PR DESCRIPTION
Editing an existing S-group previously deleted and recreated it, even when only attributes of the same logical S-group type changed. This could corrupt the undo/redo redraw path when S-group brackets overlapped.

Same-type edits now update the existing S-group attributes in place. This preserves the group identity, hierarchy, and atom membership while producing a clean attribute-based undo action. Switching to a genuinely different S-group type continues to use the existing replacement flow.

Closes #7369