### PR TITLE
#10440 - Refactor: Explicit Any type clean up from packages\ketcher-core\src\application\editor\operations\sgroup\index.ts file

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/sgroup/index.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/index.ts
@@ -25,15 +25,15 @@ import { OperationPriority, OperationType } from '../OperationType';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 
 type Data = {
-  sgid: any;
-  type?: any;
-  pp?: any;
+  sgid?: number;
+  type?: string;
+  pp?: Vec2 | null;
   expanded?: boolean;
   name?: string;
   oldSgroup?: SGroup;
 };
 
-const SGROUP_TYPE_MAPPING = {
+const SGROUP_TYPE_MAPPING: Record<string, string> = {
   nucleotideComponent: SGroup.TYPES.SUP,
 };
 
@@ -41,9 +41,9 @@ class SGroupCreate extends BaseOperation {
   data: Data;
 
   constructor(
-    sgroupId?: any,
-    type?: any,
-    pp?: any,
+    sgroupId?: number,
+    type?: string,
+    pp?: Vec2,
     expanded?: boolean,
     name?: string,
     oldSgroup?: SGroup,
@@ -62,7 +62,12 @@ class SGroupCreate extends BaseOperation {
 
   execute(restruct: ReStruct) {
     const struct = restruct.molecule;
-    const { sgid, pp, expanded, name, oldSgroup } = this.data;
+    const { sgid, type, pp, expanded, name, oldSgroup } = this.data;
+
+    if (sgid === undefined || type === undefined) {
+      return;
+    }
+
     let sgroup: SGroup;
 
     if (oldSgroup && oldSgroup instanceof MonomerMicromolecule) {
@@ -70,9 +75,7 @@ class SGroupCreate extends BaseOperation {
     } else if (this.monomer) {
       sgroup = new MonomerMicromolecule(SGroup.TYPES.SUP, this.monomer);
     } else {
-      sgroup = new SGroup(
-        SGROUP_TYPE_MAPPING[this.data.type] || this.data.type,
-      );
+      sgroup = new SGroup(SGROUP_TYPE_MAPPING[type] || type);
     }
 
     sgroup.id = sgid;
@@ -114,7 +117,7 @@ class SGroupCreate extends BaseOperation {
 class SGroupDelete extends BaseOperation {
   data: Data;
 
-  constructor(sgroupId?: any) {
+  constructor(sgroupId?: number) {
     super(OperationType.S_GROUP_DELETE, OperationPriority.S_GROUP_DELETE);
     this.data = { sgid: sgroupId };
   }
@@ -122,6 +125,11 @@ class SGroupDelete extends BaseOperation {
   execute(restruct: ReStruct) {
     const struct = restruct.molecule;
     const { sgid } = this.data;
+
+    if (sgid === undefined) {
+      return;
+    }
+
     const sgroup = restruct.sgroups.get(sgid);
     const sgroupData = restruct.sgroupData.get(sgid);
     if (!sgroup) return;


### PR DESCRIPTION
How the feature works? / How did you fix the issue?

Removes all 7 explicit any usages from packages/ketcher-core/src/application/editor/operations/sgroup/index.ts, following the convention from the recently-merged #10493 (SGroupAttr.ts): concrete types, optional fields kept optional, and undefined guarded with an early return — no casts, no non-null assertions. Type-only intent, no functional behavior change.

Type changes:
- Data → sgid?: number, type?: string, pp?: Vec2 | null. pp mirrors SGroup.pp (Vec2 | null), which SGroupDelete.execute reads back into the field.
- SGROUP_TYPE_MAPPING annotated Record<string, string> so it can be indexed by the string type (the object itself is unchanged).
- SGroupCreate constructor → (sgroupId?: number, type?: string, pp?: Vec2, …); execute guards sgid/type (using === undefined, so id 0 stays valid) and constructs the SGroup from the narrowed type.
- SGroupDelete constructor → (sgroupId?: number); execute guards sgid.

Both execute methods already used ReStruct. The pre-existing implicit-any let relatedFGroupId is left as-is (no any keyword, so outside this task).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request