### PR TITLE
#5331 - Attempt to replace monomer on inpropper one from the library to the sequence causes wrong error message

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
@@ -1469,9 +1469,9 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
   }
 }
 
-test(`Case 4878. Replacing selected monomer with a monomer that lacks the required R1 shows a specific error message`, async () => {
+test(`Case 5331. Replacing selected monomer with a monomer that lacks the required R1 shows a specific error message`, async () => {
   /*
-    Test case: https://github.com/epam/ketcher/issues/4878
+    Test case: https://github.com/epam/ketcher/issues/5331
     Description:
       When a monomer is selected in the sequence and the user tries to replace it
       with a monomer from the library that lacks the R1 connection point needed to

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
@@ -753,7 +753,7 @@ function addAnnotation(message: string) {
   test.info().annotations.push({ type: 'WARNING', description: message });
 }
 
-function noConnectionPointErrorMessage(missingAttachmentPoint: 'R1' | 'R2') {
+function noAttachmentPointErrorMessage(missingAttachmentPoint: 'R1' | 'R2') {
   return `The monomer lacks ${missingAttachmentPoint} attachment point and cannot be inserted at current position`;
 }
 
@@ -1076,7 +1076,7 @@ for (const noR2AttachmentPointReplaceMonomer of noR2AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(noConnectionPointErrorMessage('R2'));
+      expect(errorMessage).toContain(noAttachmentPointErrorMessage('R2'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1143,7 +1143,7 @@ for (const noR1orR2AttachmentPointReplaceMonomer of noR1orR2AttachmentPointRepla
           : 'R1';
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
       expect(errorMessage).toContain(
-        noConnectionPointErrorMessage(missingAttachmentPoint),
+        noAttachmentPointErrorMessage(missingAttachmentPoint),
       );
 
       await ErrorMessageDialog(page).close();
@@ -1182,7 +1182,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
+      expect(errorMessage).toContain(noAttachmentPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1218,7 +1218,7 @@ for (const noR2AttachmentPointReplaceMonomer of noR2AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(noConnectionPointErrorMessage('R2'));
+      expect(errorMessage).toContain(noAttachmentPointErrorMessage('R2'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1263,7 +1263,7 @@ for (const noR1orR2AttachmentPointReplaceMonomer of noR1orR2AttachmentPointRepla
           : 'R1';
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
       expect(errorMessage).toContain(
-        noConnectionPointErrorMessage(missingAttachmentPoint),
+        noAttachmentPointErrorMessage(missingAttachmentPoint),
       );
 
       await ErrorMessageDialog(page).close();
@@ -1302,7 +1302,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
+      expect(errorMessage).toContain(noAttachmentPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1418,7 +1418,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
+      expect(errorMessage).toContain(noAttachmentPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1456,7 +1456,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
+      expect(errorMessage).toContain(noAttachmentPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1499,7 +1499,7 @@ test(`Case 5331. Replacing selected monomer with a monomer that lacks the requir
   );
 
   const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-  expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
+  expect(errorMessage).toContain(noAttachmentPointErrorMessage('R1'));
 
   await ErrorMessageDialog(page).close();
 });

--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-replacement.spec.ts
@@ -753,6 +753,10 @@ function addAnnotation(message: string) {
   test.info().annotations.push({ type: 'WARNING', description: message });
 }
 
+function noConnectionPointErrorMessage(missingAttachmentPoint: 'R1' | 'R2') {
+  return `The monomer lacks ${missingAttachmentPoint} attachment point and cannot be inserted at current position`;
+}
+
 async function checkForKnownBugs(
   replaceMonomer: IReplaceMonomer,
   sequence: ISequence,
@@ -1072,9 +1076,7 @@ for (const noR2AttachmentPointReplaceMonomer of noR2AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
-      );
+      expect(errorMessage).toContain(noConnectionPointErrorMessage('R2'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1133,9 +1135,15 @@ for (const noR1orR2AttachmentPointReplaceMonomer of noR1orR2AttachmentPointRepla
         noR1orR2AttachmentPointReplaceMonomer,
         sequence.ReplacementPositions.Center,
       );
+      const missingAttachmentPoint =
+        noR2AttachmentPointReplaceMonomers.includes(
+          noR1orR2AttachmentPointReplaceMonomer,
+        )
+          ? 'R2'
+          : 'R1';
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
       expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
+        noConnectionPointErrorMessage(missingAttachmentPoint),
       );
 
       await ErrorMessageDialog(page).close();
@@ -1174,9 +1182,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
-      );
+      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1212,9 +1218,7 @@ for (const noR2AttachmentPointReplaceMonomer of noR2AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
-      );
+      expect(errorMessage).toContain(noConnectionPointErrorMessage('R2'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1251,9 +1255,15 @@ for (const noR1orR2AttachmentPointReplaceMonomer of noR1orR2AttachmentPointRepla
         sequence.ReplacementPositions.Center,
       );
 
+      const missingAttachmentPoint =
+        noR2AttachmentPointReplaceMonomers.includes(
+          noR1orR2AttachmentPointReplaceMonomer,
+        )
+          ? 'R2'
+          : 'R1';
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
       expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
+        noConnectionPointErrorMessage(missingAttachmentPoint),
       );
 
       await ErrorMessageDialog(page).close();
@@ -1292,9 +1302,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
-      );
+      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1410,9 +1418,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
-      );
+      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1450,9 +1456,7 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
       );
 
       const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
-      expect(errorMessage).toContain(
-        'It is impossible to merge fragments. Attachment point to establish bonds are not available.',
-      );
+      expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
 
       await ErrorMessageDialog(page).close();
       // skip that test if bug(s) exists
@@ -1464,6 +1468,41 @@ for (const noR1AttachmentPointReplaceMonomer of noR1AttachmentPointReplaceMonome
     });
   }
 }
+
+test(`Case 4878. Replacing selected monomer with a monomer that lacks the required R1 shows a specific error message`, async () => {
+  /*
+    Test case: https://github.com/epam/ketcher/issues/4878
+    Description:
+      When a monomer is selected in the sequence and the user tries to replace it
+      with a monomer from the library that lacks the R1 connection point needed to
+      preserve the backbone connection, a specific error message must be shown
+      instead of the generic "It is impossible to merge fragments..." one.
+    Scenario:
+      1. Go to Macromolecules - Sequence mode
+      2. Load a sequence of peptides (A)
+      3. Select the last peptide (A)
+      4. Click on a peptide without R1 connection point (D-OAla) in the library
+      5. Validate that the specific error message is shown
+  */
+  await openFileAndAddToCanvasMacro(
+    page,
+    'KET/Sequence-Mode-Replacement/sequence of peptides (A).ket',
+  );
+  await selectAndReplaceSymbolWithError(
+    page,
+    {
+      Id: <number>monomerIDs.peptide_w_o_R1_D_OAla,
+      Monomer: Peptide.D_OAla,
+      MonomerDescription: 'peptide w/o R1 (D-OAla)',
+    },
+    2,
+  );
+
+  const errorMessage = await ErrorMessageDialog(page).getErrorMessage();
+  expect(errorMessage).toContain(noConnectionPointErrorMessage('R1'));
+
+  await ErrorMessageDialog(page).close();
+});
 
 const twoSequences: ISequence[] = [
   {

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2237,6 +2237,61 @@ export class SequenceMode extends BaseMode {
     );
   }
 
+  private getMissingBackboneAttachmentPointForSelections(
+    selections: TwoStrandedNodesSelection,
+    monomerItem: MonomerItemType,
+  ): AttachmentPointName | null {
+    if (!monomerItem.attachmentPoints) {
+      return null;
+    }
+
+    const newMonomerAttachmentPoints =
+      BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
+        monomerItem.attachmentPoints,
+      );
+
+    for (const selectionRange of selections) {
+      for (const nodeSelection of selectionRange) {
+        const senseNode = nodeSelection.node.senseNode;
+        if (!senseNode) {
+          continue;
+        }
+
+        const backboneBonds: [
+          AttachmentPointName,
+          PolymerBond | MonomerToAtomBond | null | undefined,
+        ][] = [
+          [
+            AttachmentPointName.R1,
+            senseNode.firstMonomerInNode.attachmentPointsToBonds.R1,
+          ],
+          [
+            AttachmentPointName.R2,
+            senseNode.lastMonomerInNode.attachmentPointsToBonds.R2,
+          ],
+        ];
+
+        for (const [attachmentPointName, bond] of backboneBonds) {
+          const isBackboneBond =
+            bond &&
+            (bond instanceof MonomerToAtomBond ||
+              bond.isBackBoneChainConnection);
+
+          if (
+            isBackboneBond &&
+            !newMonomerAttachmentPoints.attachmentPointsList.includes(
+              attachmentPointName,
+            )
+          ) {
+            return attachmentPointName;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
   private presetHasNeededAttachmentPoints(preset) {
     // TODO: This check is not universal, it won't allow to put presets without R1 in sugar, revisit later
     if (!preset.sugar) {
@@ -2358,7 +2413,15 @@ export class SequenceMode extends BaseMode {
           monomerItem,
         )
       ) {
-        this.showMergeWarningModal();
+        const missingAttachmentPoint =
+          this.getMissingBackboneAttachmentPointForSelections(
+            selections,
+            monomerItem,
+          );
+        const message =
+          missingAttachmentPoint &&
+          `The monomer lacks ${missingAttachmentPoint} attachment point and cannot be inserted at current position`;
+        this.showMergeWarningModal(message);
         return;
       }
 

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2219,36 +2219,16 @@ export class SequenceMode extends BaseMode {
     );
   }
 
-  private selectionsCantPreserveConnectionsWithMonomer(
+  private getFirstMissingAttachmentPoint(
     selections: TwoStrandedNodesSelection,
     monomerItem: MonomerItemType,
     sideChainConnections?: boolean,
-  ) {
-    return selections.some((selectionRange) =>
-      selectionRange.some(
-        (nodeSelection) =>
-          nodeSelection.node.senseNode &&
-          !this.checkIfNewMonomerCouldEstablishConnections(
-            nodeSelection.node.senseNode,
-            monomerItem,
-            sideChainConnections,
-          ),
-      ),
-    );
-  }
-
-  private getMissingBackboneAttachmentPointForSelections(
-    selections: TwoStrandedNodesSelection,
-    monomerItem: MonomerItemType,
   ): AttachmentPointName | null {
-    if (!monomerItem.attachmentPoints) {
-      return null;
-    }
-
-    const newMonomerAttachmentPoints =
-      BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
-        monomerItem.attachmentPoints,
-      );
+    const newMonomerAttachmentPoints = monomerItem.attachmentPoints
+      ? BaseMonomer.getAttachmentPointDictFromMonomerDefinition(
+          monomerItem.attachmentPoints,
+        )
+      : null;
 
     for (const selectionRange of selections) {
       for (const nodeSelection of selectionRange) {
@@ -2257,33 +2237,45 @@ export class SequenceMode extends BaseMode {
           continue;
         }
 
-        const backboneBonds: [
-          AttachmentPointName,
-          PolymerBond | MonomerToAtomBond | null | undefined,
-        ][] = [
-          [
-            AttachmentPointName.R1,
-            senseNode.firstMonomerInNode.attachmentPointsToBonds.R1,
-          ],
-          [
-            AttachmentPointName.R2,
-            senseNode.lastMonomerInNode.attachmentPointsToBonds.R2,
-          ],
-        ];
+        if (
+          !this.checkIfNewMonomerCouldEstablishConnections(
+            senseNode,
+            monomerItem,
+            sideChainConnections,
+          )
+        ) {
+          if (sideChainConnections || !newMonomerAttachmentPoints) {
+            return AttachmentPointName.R1;
+          }
 
-        for (const [attachmentPointName, bond] of backboneBonds) {
-          const isBackboneBond =
-            bond &&
-            (bond instanceof MonomerToAtomBond ||
-              bond.isBackBoneChainConnection);
+          const backboneBonds: [
+            AttachmentPointName,
+            PolymerBond | MonomerToAtomBond | null | undefined,
+          ][] = [
+            [
+              AttachmentPointName.R1,
+              senseNode.firstMonomerInNode.attachmentPointsToBonds.R1,
+            ],
+            [
+              AttachmentPointName.R2,
+              senseNode.lastMonomerInNode.attachmentPointsToBonds.R2,
+            ],
+          ];
 
-          if (
-            isBackboneBond &&
-            !newMonomerAttachmentPoints.attachmentPointsList.includes(
-              attachmentPointName,
-            )
-          ) {
-            return attachmentPointName;
+          for (const [attachmentPointName, bond] of backboneBonds) {
+            const isBackboneBond =
+              bond &&
+              (bond instanceof MonomerToAtomBond ||
+                bond.isBackBoneChainConnection);
+
+            if (
+              isBackboneBond &&
+              !newMonomerAttachmentPoints.attachmentPointsList.includes(
+                attachmentPointName,
+              )
+            ) {
+              return attachmentPointName;
+            }
           }
         }
       }
@@ -2407,20 +2399,13 @@ export class SequenceMode extends BaseMode {
         return;
       }
 
-      if (
-        this.selectionsCantPreserveConnectionsWithMonomer(
-          selections,
-          monomerItem,
-        )
-      ) {
-        const missingAttachmentPoint =
-          this.getMissingBackboneAttachmentPointForSelections(
-            selections,
-            monomerItem,
-          );
-        const message =
-          missingAttachmentPoint &&
-          `The monomer lacks ${missingAttachmentPoint} attachment point and cannot be inserted at current position`;
+      const missingAttachmentPoint = this.getFirstMissingAttachmentPoint(
+        selections,
+        monomerItem,
+      );
+
+      if (missingAttachmentPoint) {
+        const message = `The monomer lacks ${missingAttachmentPoint} attachment point and cannot be inserted at current position`;
         this.showMergeWarningModal(message);
         return;
       }
@@ -2434,11 +2419,7 @@ export class SequenceMode extends BaseMode {
           },
         });
       } else if (
-        this.selectionsCantPreserveConnectionsWithMonomer(
-          selections,
-          monomerItem,
-          true,
-        )
+        this.getFirstMissingAttachmentPoint(selections, monomerItem, true)
       ) {
         editor.events.openConfirmationDialog.dispatch({
           confirmationText:


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
When replacing a selected monomer in Sequence mode with a monomer from the
library that lacks the connection point required to keep the backbone bond
(e.g. selecting the last `A` and picking `DACys`, which has no R1), the editor
used to show a generic error: "It is impossible to merge fragments. Attachment
point to establish bonds are not available."

Now the same specific message used in edit mode is shown for the selection-based
replacement path:
`The monomer lacks R1 attachment point and cannot be inserted at current position`
(R1 or R2 depending on which backbone connection point is missing).

Changes:
- Added `getMissingBackboneAttachmentPointForSelections` in `SequenceMode` to
  detect which backbone attachment point (R1/R2) the new monomer is missing.
- `insertMonomerFromLibrary` now passes the specific message to the error modal.
- Updated existing replacement e2e tests (Cases 7–16) to expect the specific
  message and added a regression test.

### Note on wording ("attachment point" vs "connection point")
The original requirement phrases the message as "...lacks R1 **connection
point**...", but the current codebase consistently uses "...lacks R1
**attachment point**..." for this message (three places in `SequenceMode.ts`).
I kept "attachment point" to stay consistent with the existing code and the
edit-mode message. If we prefer the exact wording from the requirement, it
should be changed in all three places in `SequenceMode.ts` plus the test helper
so everything stays in sync.
## Check list
- [ ] unit-tests written
- [x] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request