### PR TITLE
#6743 – Able to move the leaving groups (R-atoms) of expanded monomers

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/helper/getGroupIdsFromItems.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/getGroupIdsFromItems.ts
@@ -5,14 +5,32 @@ type Items = {
   bonds?: number[];
 };
 
-function getGroupIdsFromItemArrays(struct: Struct, items?: Items): number[] {
+type GetGroupIdsFromItemArraysOptions = {
+  // Once a superatom is expanded, its leaving-group (R#) atoms become
+  // ordinary atoms of the structure and should be treated the same as any
+  // other atom when resolving which group a click belongs to (#6743).
+  includeExpandedLeavingGroupAtoms?: boolean;
+};
+
+function getGroupIdsFromItemArrays(
+  struct: Struct,
+  items?: Items,
+  options?: GetGroupIdsFromItemArraysOptions,
+): number[] {
   if (!struct.sgroups.size) return [];
 
   const groupsIds = new Set<number>();
   if (items?.atoms) {
     items.atoms
       .filter((atomId) => {
-        return !Atom.isSuperatomLeavingGroupAtom(struct, atomId);
+        if (!Atom.isSuperatomLeavingGroupAtom(struct, atomId)) {
+          return true;
+        }
+
+        return (
+          options?.includeExpandedLeavingGroupAtoms &&
+          Boolean(struct.getGroupFromAtomId(atomId)?.isExpanded())
+        );
       })
       .forEach((atomId) => {
         const groupId = struct.getGroupIdFromAtomId(atomId);

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -136,7 +136,9 @@ class SelectTool implements Tool {
       ...(ci?.map === 'bonds' && { bonds: [ci.id] }),
     };
     const selectedSgroups = ci
-      ? getGroupIdsFromItemArrays(molecule, selected)
+      ? getGroupIdsFromItemArrays(molecule, selected, {
+          includeExpandedLeavingGroupAtoms: true,
+        })
       : [];
     const newSelected = getNewSelectedItems(this.editor, selectedSgroups);
     // Only auto-expand the selection to the enclosing sgroup(s) when the


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Dragging an atom in Molecules mode already moves the whole related sgroup correctly
(via `fromMultipleMove`/`getRelSGroupsBySelection` in ketcher-core, which is unconditional
and doesn't check leaving-group status). However, after dragging a leaving-group (R#) atom
of an *expanded* monomer, `editor.selection()` was left containing only that one atom
(`{"atoms":[2]}`), instead of the whole structure (`{"atoms":[0,1,2,3,4,5,6],"bonds":[...]}`)
as happens when dragging any other atom (e.g. nitrogen). Verified this discrepancy directly
in a real browser by introspecting the app's internal selection state before/after a drag,
toggling the fix on and off.

Practical impact: after dragging R1, only R1 remains "selected" — so a follow-up Delete,
arrow-key nudge, or re-drag would only affect that one atom, not the structure, even though
it visually looks like everything moved together. That's the real substance of "R-groups
should behave like any other atom" from the issue.

Root cause: `getGroupIdsFromItemArrays` (shared helper used by `select.ts`'s mousedown
handler to decide whether a click should auto-expand into "select the whole enclosing
group") explicitly excludes leaving-group atoms via `Atom.isSuperatomLeavingGroupAtom`.
That exclusion was added for a narrower, different purpose (#4927 — prevent the
atom-relabeling tool from accidentally relabeling a whole group when clicking an R# atom
to rename it), but it leaked into the shared selection-click logic used by the Select/Move
tool too.

Fix: added an opt-in `includeExpandedLeavingGroupAtoms` option to `getGroupIdsFromItemArrays`
(default `false`, so the #4927 fix and every other call site are untouched), and enabled it
only in `select.ts`'s mousedown handler — so a leaving-group atom is only treated as an
ordinary atom of the structure for selection purposes once its owning sgroup is actually
expanded (`sgroup.isExpanded()`), matching the ticket's exact scenario.

Verified in a real browser (`dev:standalone`): expanded an Alanine monomer, dragged the R1
(leaving-group) atom, and confirmed the resulting selection now includes the whole structure
— reproduced the bug on the unpatched code first (selection stayed `{"atoms":[2]}`), then
confirmed the fix.

## Minor observations (not blockers):

Lasso-selection (`onSelectionEnd` in `select.helpers.ts:216-218`) still uses the old
(no-options) call. If a user lasso-selects just an R1 atom and drags, it could exhibit the
same independent-move bug — untested by you since it's not in the ticket's repro steps, but
worth confirming intentionally out of scope.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request