### PR TITLE
#9422 - Replace explicit any type in packages/ketcher-react/src/script/editor/tool/Tool.ts:38 with unknown

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-2.28.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-2.28.0-bugs.spec.ts
@@ -20,7 +20,6 @@ import {
   resetZoomLevelToDefault,
   selectCanvasArea,
   takeEditorScreenshot,
-  takeElementScreenshot,
 } from '@utils';
 import { selectAllStructuresOnCanvas } from '@utils/canvas';
 import {

--- a/packages/ketcher-react/src/script/editor/tool/Tool.ts
+++ b/packages/ketcher-react/src/script/editor/tool/Tool.ts
@@ -32,10 +32,9 @@ export interface Tool extends ToolEventHandler {
   ci?: HoverTarget;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ToolConstructorInterface = new (
   editor: Editor,
-  ...args: any[]
+  ...args: unknown[]
 ) => Tool;
 
 export type ToolEventHandlerName = keyof ToolEventHandler;

--- a/packages/ketcher-react/src/script/editor/tool/index.ts
+++ b/packages/ketcher-react/src/script/editor/tool/index.ts
@@ -57,14 +57,20 @@ export const toolsMap: Record<string, ToolConstructorInterface> = {
   rgroupfragment: RGroupFragmentTool,
   apoint: APointTool,
   attach: AttachTool,
-  reactionarrow: CommonArrowTool,
+  // Cast to ToolConstructorInterface: constructor param types are narrower
+  // than `unknown[]`, but toolsMap only ever calls these with the correct args.
+  reactionarrow: CommonArrowTool as unknown as ToolConstructorInterface,
   reactionplus: ReactionPlusTool,
   reactionmap: ReactionMapTool,
   reactionunmap: ReactionUnmapTool,
   paste: PasteTool,
-  rotate: RotateTool,
+  // Cast to ToolConstructorInterface: constructor param types are narrower
+  // than `unknown[]`, but toolsMap only ever calls these with the correct args.
+  rotate: RotateTool as unknown as ToolConstructorInterface,
   enhancedStereo: EnhancedStereoTool,
-  simpleobject: SimpleObjectTool,
+  // Cast to ToolConstructorInterface: constructor param types are narrower
+  // than `unknown[]`, but toolsMap only ever calls these with the correct args.
+  simpleobject: SimpleObjectTool as unknown as ToolConstructorInterface,
   text: TextTool,
   [IMAGE_KEY]: ImageTool,
   [CREATE_MONOMER_TOOL_NAME]: CreateMonomerTool,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
* Replaced the explicit any in ToolConstructorInterface (Tool.ts:38) with unknown[] for the constructor rest args, removing the need for the eslint-disable @typescript-eslint/no-explicit-any comment.
* The three tools with narrower, strictly-typed constructor params (CommonArrowTool, RotateTool, SimpleObjectTool) needed an explicit as unknown as ToolConstructorInterface cast in toolsMap (tool/index.ts) to satisfy the tightened signature — this mirrors the existing pattern already used for SelectCommonTool.
* Fixed an unrelated tsc --noEmit failure (TS6133) caused by an unused takeElementScreenshot import in ketcher-2.28.0-bugs.spec.ts.



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request