### PR TITLE
#10434 – Refactor: Explicit Any type clean up from packages\ketcher-core\src\application\render\restruct\reatom.ts file

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-2.28.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-2.28.0-bugs.spec.ts
@@ -20,7 +20,6 @@ import {
   resetZoomLevelToDefault,
   selectCanvasArea,
   takeEditorScreenshot,
-  takeElementScreenshot,
 } from '@utils';
 import { selectAllStructuresOnCanvas } from '@utils/canvas';
 import {

--- a/packages/ketcher-core/src/application/render/render.types.ts
+++ b/packages/ketcher-core/src/application/render/render.types.ts
@@ -4,6 +4,7 @@ import type {
   StereoColoringType,
   StereoLabelStyleType,
 } from 'application/render/restruct/generalEnumTypes';
+import type { ShowHydrogenLabels } from 'application/render/restruct/showHydrogenLabels';
 import type { UsageInMacromolecule } from './render.constants';
 
 export { UsageInMacromolecule } from './render.constants';
@@ -51,7 +52,7 @@ export type RenderOptions = {
   hideTerminalLabels: boolean;
   carbonExplicitly: boolean;
   showCharge: boolean;
-  showHydrogenLabels: string;
+  showHydrogenLabels: ShowHydrogenLabels;
   showValence: boolean;
   aromaticCircle: boolean;
   microModeScale: number;
@@ -92,6 +93,10 @@ export type RenderOptions = {
 
   stereoLabelStyle?: StereoLabelStyleType;
   colorStereogenicCenters: StereoColoringType;
+  colorOfAbsoluteCenters?: string;
+  colorOfAndCenters?: string;
+  colorOfOrCenters?: string;
+  autoFadeOfStereoLabels?: boolean;
 
   previewOpacity: number;
 

--- a/packages/ketcher-core/src/application/render/render.types.ts
+++ b/packages/ketcher-core/src/application/render/render.types.ts
@@ -1,5 +1,6 @@
 import type { RxnArrowMode } from 'domain/entities/rxnArrow';
 import type { Vec2 } from 'domain/entities/vec2';
+import type { Element, RaphaelSet } from 'raphael';
 import type {
   StereoColoringType,
   StereoLabelStyleType,
@@ -10,6 +11,7 @@ import type { UsageInMacromolecule } from './render.constants';
 export { UsageInMacromolecule } from './render.constants';
 
 export type RenderOptionStyles = Record<string, string | number>;
+export type RenderPath = Element | RaphaelSet;
 
 export enum MeasurementUnits {
   Px = 'px',

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -38,6 +38,7 @@ import draw from '../draw';
 import util from '../util';
 import { toFixed } from 'utilities';
 import type {
+  RelativeBox,
   RenderOptions,
   RenderOptionStyles,
 } from 'application/render/render.types';
@@ -54,11 +55,12 @@ import { ShowHydrogenLabels } from './showHydrogenLabels';
 interface ElemAttr {
   text: string;
   path: Element | RaphaelSet;
-  rbb: { x: number; y: number; width: number; height: number };
+  rbb: RelativeBox;
   background?: Element;
 }
 
 const StereoLabelMinOpacity = 0.3;
+const DEFAULT_STEREO_COLOR = '#000';
 const MAX_LABEL_LENGTH = 8;
 
 export enum ShowHydrogenLabelNames {
@@ -556,21 +558,21 @@ class ReAtom extends ReObject {
     }
 
     if (options.showAtomIds) {
-      index = {} as ElemAttr;
-      index.text = aid.toString();
+      const text = aid.toString();
       let idPos = this.hydrogenOnTheLeft
         ? Vec2.lc(ps, 1, new Vec2({ x: -2, y: 0, z: 0 }), 6)
         : Vec2.lc(ps, 1, new Vec2({ x: 2, y: 0, z: 0 }), 6);
       if (this.showLabel) {
         idPos = Vec2.lc(idPos, 1, new Vec2({ x: 1, y: -3, z: 0 }), 6);
       }
-      index.path = render.paper.text(idPos.x, idPos.y, index.text).attr({
+      const path = render.paper.text(idPos.x, idPos.y, text).attr({
         font: options.font,
         'font-size': options.fontszsubInPx,
         fill: '#070',
       });
-      index.rbb = util.relBox(index.path.getBBox());
-      draw.recenterText(index.path, index.rbb);
+      const rbb = util.relBox(path.getBBox());
+      draw.recenterText(path, rbb);
+      index = { text, path, rbb };
       restruct.addReObjectPath(LayerMap.indices, this.visel, index.path, ps);
     }
 
@@ -629,7 +631,6 @@ class ReAtom extends ReObject {
         !shouldHideHydrogenInPreview
       ) {
         const data = showHydrogen(this, render, implh, {
-          hydrogen: {} as ElemAttr,
           hydroIndex,
           rightMargin,
           leftMargin,
@@ -1074,7 +1075,9 @@ class ReAtom extends ReObject {
         // of just created text
         // text -> tspan
         const color = getStereoAtomColor(render.options, stereoLabel);
-        aamPath.node.childNodes[0].setAttribute('fill', color);
+        if (color !== undefined) {
+          aamPath.node.childNodes[0].setAttribute('fill', color);
+        }
         const opacity = getStereoAtomOpacity(render.options, stereoLabel);
         aamPath.node.childNodes[0].setAttribute('fill-opacity', opacity);
       }
@@ -1322,13 +1325,13 @@ class ReAtom extends ReObject {
 function getStereoAtomColor(
   options: RenderOptions,
   stereoLabel: string | null | undefined,
-) {
+): string | undefined {
   if (
     !stereoLabel ||
     options.colorStereogenicCenters === StereoColoringType.Off ||
     options.colorStereogenicCenters === StereoColoringType.BondsOnly
   ) {
-    return '#000';
+    return DEFAULT_STEREO_COLOR;
   }
 
   return getColorFromStereoLabel(options, stereoLabel);
@@ -1337,18 +1340,18 @@ function getStereoAtomColor(
 export function getColorFromStereoLabel(
   options: RenderOptions,
   stereoLabel: string,
-) {
+): string | undefined {
   const stereoLabelType = stereoLabel.match(/\D+/g)?.[0] ?? '';
 
   switch (stereoLabelType) {
     case StereoLabel.And:
-      return options.colorOfAndCenters ?? '#000';
+      return options.colorOfAndCenters ?? DEFAULT_STEREO_COLOR;
     case StereoLabel.Or:
-      return options.colorOfOrCenters ?? '#000';
+      return options.colorOfOrCenters ?? DEFAULT_STEREO_COLOR;
     case StereoLabel.Abs:
-      return options.colorOfAbsoluteCenters ?? '#000';
+      return options.colorOfAbsoluteCenters;
     default:
-      return '#000';
+      return DEFAULT_STEREO_COLOR;
   }
 }
 
@@ -1498,8 +1501,9 @@ function shouldHydrogenBeOnLeft(struct: Struct, atom: ReAtom) {
   if (visibleNeighbors.length === 1) {
     const neighbor = visibleNeighbors[0];
     const neighborHalfBond = struct.halfBonds.get(neighbor);
+    const neighborDirX = neighborHalfBond?.dir.x ?? 0;
 
-    return (neighborHalfBond?.dir.x ?? 0) > 0;
+    return neighborDirX > 0;
   }
 
   return false;
@@ -1561,24 +1565,23 @@ function buildLabel(
     usageInMacromolecule,
   } = options;
   // eslint-disable-line max-statements
-  const label = {} as ElemAttr;
-  label.text = getLabelText(atom.a, atomId, sgroup, options) || 'R#';
+  let text = getLabelText(atom.a, atomId, sgroup, options) || 'R#';
 
   let tooltip: string | null = null;
 
-  if (label.text === atom.a.label) {
-    const element = Elements.get(label.text);
+  if (text === atom.a.label) {
+    const element = Elements.get(text);
     if (atomColoring && element) {
-      atom.color = ElementColor[label.text] ?? '#000';
+      atom.color = ElementColor[text] ?? '#000';
     }
   }
 
   const shouldStyleLabel = usageInMacromolecule !== undefined;
-  const isMonomerAttachmentPoint = attachmentPointNames.includes(label.text);
+  const isMonomerAttachmentPoint = attachmentPointNames.includes(text);
   const isMonomerAttachmentPointSelected =
-    currentlySelectedMonomerAttachmentPoint === label.text;
+    currentlySelectedMonomerAttachmentPoint === text;
   const isMonomerAttachmentPointUsed =
-    connectedMonomerAttachmentPoints?.includes(label.text) ?? false;
+    connectedMonomerAttachmentPoints?.includes(text) ?? false;
 
   const { color, fill, stroke } = util.useLabelStyles(
     isMonomerAttachmentPointSelected,
@@ -1590,20 +1593,20 @@ function buildLabel(
     atom.color = color;
   }
 
-  if (label.text?.length > MAX_LABEL_LENGTH) {
-    tooltip = label.text;
-    label.text = `${label.text?.substring(0, 8)}...`;
+  if (text.length > MAX_LABEL_LENGTH) {
+    tooltip = text;
+    text = `${text.substring(0, 8)}...`;
   }
 
   const { previewOpacity } = options;
 
   // not properly centered otherwise
-  if (label.text === '*') {
+  if (text === '*') {
     ps.x = ps.x - 1;
     ps.y = ps.y + 3;
   }
 
-  label.path = paper.text(ps.x, ps.y, label.text).attr({
+  const path = paper.text(ps.x, ps.y, text).attr({
     font,
     'font-size': fontszInPx,
     fill: atom.color,
@@ -1611,47 +1614,38 @@ function buildLabel(
     'fill-opacity': atom.a.isPreview ? previewOpacity : 1,
   });
 
-  if (isMonomerAttachmentPoint && shouldStyleLabel) {
-    const backgroundSize = fontszInPx * 2;
+  const background =
+    isMonomerAttachmentPoint && shouldStyleLabel
+      ? paper
+          .rect(
+            ps.x - (fontszInPx * 2) / 2,
+            ps.y - (fontszInPx * 2) / 2,
+            fontszInPx * 2,
+            fontszInPx * 2,
+            10,
+          )
+          .attr({ fill })
+          .attr({ stroke })
+      : undefined;
 
-    label.background = paper
-      .rect(
-        ps.x - backgroundSize / 2,
-        ps.y - backgroundSize / 2,
-        backgroundSize,
-        backgroundSize,
-        10,
-      )
-      .attr({ fill })
-      .attr({ stroke });
-  }
   if (tooltip) {
-    addTooltip(label.path.node, tooltip);
+    addTooltip(path.node, tooltip);
   }
 
-  label.rbb = util.relBox(label.path.getBBox());
-  draw.recenterText(label.path, label.rbb);
-  let rightMargin =
-    (label.rbb.width / 2) * (options.zoom > 1 ? 1 : options.zoom); //
-  let leftMargin =
-    (-label.rbb.width / 2) * (options.zoom > 1 ? 1 : options.zoom);
+  const rbb = util.relBox(path.getBBox());
+  draw.recenterText(path, rbb);
+  let rightMargin = (rbb.width / 2) * (options.zoom > 1 ? 1 : options.zoom);
+  let leftMargin = (-rbb.width / 2) * (options.zoom > 1 ? 1 : options.zoom);
 
   if (atom.a.atomList !== null) {
     const xShift =
-      ((atom.hydrogenOnTheLeft ? -1 : 1) *
-        (label.rbb.width - label.rbb.height)) /
-      2;
-    pathAndRBoxTranslate(
-      label.path,
-      label.rbb,
-      xShift,
-
-      0,
-    );
+      ((atom.hydrogenOnTheLeft ? -1 : 1) * (rbb.width - rbb.height)) / 2;
+    pathAndRBoxTranslate(path, rbb, xShift, 0);
     rightMargin += xShift;
     leftMargin += xShift;
   }
 
+  const label: ElemAttr = { text, path, rbb, background };
   atom.label = label;
   return { label, rightMargin, leftMargin };
 }
@@ -1723,64 +1717,65 @@ function showHydroIndex(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const hydroIndex = {} as ElemAttr;
-  hydroIndex.text = (implh + 1).toString();
-  hydroIndex.path = render.paper.text(ps.x, ps.y, hydroIndex.text).attr({
+  const text = (implh + 1).toString();
+  const path = render.paper.text(ps.x, ps.y, text).attr({
     font: options.font,
     'font-size': options.fontszsubInPx,
     fill: atom.color,
   });
-  hydroIndex.rbb = util.relBox(hydroIndex.path.getBBox());
-  draw.recenterText(hydroIndex.path, hydroIndex.rbb);
+  const rbb = util.relBox(path.getBBox());
+  draw.recenterText(path, rbb);
+  const labelHeight = atom.label?.rbb.height ?? 0;
   /* eslint-disable no-mixed-operators */
   pathAndRBoxTranslate(
-    hydroIndex.path,
-    hydroIndex.rbb,
-    rightMargin + 0.5 * hydroIndex.rbb.width + delta,
-    0.2 * (atom.label?.rbb.height ?? 0),
+    path,
+    rbb,
+    rightMargin + 0.5 * rbb.width + delta,
+    0.2 * labelHeight,
   );
   /* eslint-enable no-mixed-operators */
-  return hydroIndex;
+  return { text, path, rbb };
 }
 
 function showRadical(atom: ReAtom, render: Render): Omit<ElemAttr, 'text'> {
   const ps: Vec2 = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const paper = render.paper;
-  const radical = {} as Omit<ElemAttr, 'text'>;
+  let path = paper.set();
   let hshift: number;
   switch (atom.a.radical) {
     case 1:
-      radical.path = paper.set();
+      path = paper.set();
       hshift = 1.6 * options.lineWidth;
-      radical.path.push(
+      path.push(
         draw.radicalBullet(paper, ps.add(new Vec2(-hshift, 0)), options),
         draw.radicalBullet(paper, ps.add(new Vec2(hshift, 0)), options),
       );
-      radical.path.attr('fill', atom.color);
+      path.attr('fill', atom.color);
       break;
     case 2:
-      radical.path = paper.set();
-      radical.path.push(draw.radicalBullet(paper, ps, options));
-      radical.path.attr('fill', atom.color);
+      path = paper.set();
+      path.push(draw.radicalBullet(paper, ps, options));
+      path.attr('fill', atom.color);
       break;
     case 3:
-      radical.path = paper.set();
+      path = paper.set();
       hshift = 1.6 * options.lineWidth;
-      radical.path.push(
+      path.push(
         draw.radicalCap(paper, ps.add(new Vec2(-hshift, 0)), options),
         draw.radicalCap(paper, ps.add(new Vec2(hshift, 0)), options),
       );
-      radical.path.attr('stroke', atom.color);
+      path.attr('stroke', atom.color);
       break;
     default:
       break;
   }
-  radical.rbb = util.relBox(radical.path.getBBox());
-  let vshift = -0.5 * (atom.label!.rbb.height + radical.rbb.height);
+  const rbb = util.relBox(path.getBBox());
+  const labelHeight = atom.label?.rbb.height ?? 0;
+  let vshift = -0.5 * (labelHeight + rbb.height);
   if (atom.a.radical === 3) vshift -= options.lineWidth / 2;
-  pathAndRBoxTranslate(radical.path, radical.rbb, 0, vshift);
-  return radical;
+  pathAndRBoxTranslate(path, rbb, 0, vshift);
+  return { path, rbb };
 }
 
 function showIsotope(
@@ -1791,24 +1786,23 @@ function showIsotope(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const isotope = {} as ElemAttr;
-  isotope.text = atom.a.isotope?.toString() ?? '';
-  isotope.path = render.paper.text(ps.x, ps.y, isotope.text).attr({
+  const text = atom.a.isotope?.toString() ?? '';
+  const path = render.paper.text(ps.x, ps.y, text).attr({
     font: options.font,
     'font-size': options.fontszsubInPx,
     fill: atom.color,
   });
-  isotope.rbb = util.relBox(isotope.path.getBBox());
-  draw.recenterText(isotope.path, isotope.rbb);
+  const rbb = util.relBox(path.getBBox());
+  draw.recenterText(path, rbb);
   /* eslint-disable no-mixed-operators */
   pathAndRBoxTranslate(
-    isotope.path,
-    isotope.rbb,
-    leftMargin - 0.5 * isotope.rbb.width - delta,
-    -0.3 * atom.label!.rbb.height,
+    path,
+    rbb,
+    leftMargin - 0.5 * rbb.width - delta,
+    -0.3 * (atom.label?.rbb.height ?? 0),
   );
   /* eslint-enable no-mixed-operators */
-  return isotope;
+  return { text, path, rbb };
 }
 
 function showCharge(
@@ -1819,33 +1813,29 @@ function showCharge(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const charge = {} as ElemAttr;
-  charge.text = '';
+  let text = '';
   if (atom.a.charge !== null) {
     const absCharge = Math.abs(atom.a.charge);
-    if (absCharge !== 1) charge.text = absCharge.toString();
-    if (atom.a.charge < 0) charge.text += '\u2013';
-    else charge.text += '+';
-  } else {
-    charge.text = '';
+    if (absCharge !== 1) text = absCharge.toString();
+    if (atom.a.charge < 0) text += '\u2013';
+    else text += '+';
   }
-
-  charge.path = render.paper.text(ps.x, ps.y, charge.text).attr({
+  const path = render.paper.text(ps.x, ps.y, text).attr({
     font: options.font,
     'font-size': options.fontszsubInPx,
     fill: atom.color,
   });
-  charge.rbb = util.relBox(charge.path.getBBox());
-  draw.recenterText(charge.path, charge.rbb);
+  const rbb = util.relBox(path.getBBox());
+  draw.recenterText(path, rbb);
   /* eslint-disable no-mixed-operators */
   pathAndRBoxTranslate(
-    charge.path,
-    charge.rbb,
-    rightMargin + 0.5 * charge.rbb.width + delta,
-    -0.3 * atom.label!.rbb.height,
+    path,
+    rbb,
+    rightMargin + 0.5 * rbb.width + delta,
+    -0.3 * (atom.label?.rbb.height ?? 0),
   );
   /* eslint-enable no-mixed-operators */
-  return charge;
+  return { text, path, rbb };
 }
 
 function showExplicitValence(
@@ -1856,28 +1846,27 @@ function showExplicitValence(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const valence = {} as ElemAttr;
-  valence.text = VALENCE_MAP[atom.a.explicitValence];
-  if (!valence.text) {
+  const baseText = VALENCE_MAP[atom.a.explicitValence];
+  if (!baseText) {
     throw new Error('invalid valence ' + atom.a.explicitValence.toString());
   }
-  valence.text = '(' + valence.text + ')';
-  valence.path = render.paper.text(ps.x, ps.y, valence.text).attr({
+  const text = '(' + baseText + ')';
+  const path = render.paper.text(ps.x, ps.y, text).attr({
     font: options.font,
     'font-size': options.fontszsubInPx,
     fill: atom.color,
   });
-  valence.rbb = util.relBox(valence.path.getBBox());
-  draw.recenterText(valence.path, valence.rbb);
+  const rbb = util.relBox(path.getBBox());
+  draw.recenterText(path, rbb);
   /* eslint-disable no-mixed-operators */
   pathAndRBoxTranslate(
-    valence.path,
-    valence.rbb,
-    rightMargin + 0.5 * valence.rbb.width + delta,
-    -0.3 * atom.label!.rbb.height,
+    path,
+    rbb,
+    rightMargin + 0.5 * rbb.width + delta,
+    -0.3 * (atom.label?.rbb.height ?? 0),
   );
   /* eslint-enable no-mixed-operators */
-  return valence;
+  return { text, path, rbb };
 }
 
 function showHydrogen(
@@ -1885,7 +1874,6 @@ function showHydrogen(
   render: Render,
   implh: number,
   data: {
-    hydrogen: ElemAttr;
     hydroIndex: ElemAttr | null;
     rightMargin: number;
     leftMargin: number;
@@ -1902,44 +1890,47 @@ function showHydrogen(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const hydrogen = data.hydrogen;
-  hydrogen.text = 'H';
-  hydrogen.path = render.paper.text(ps.x, ps.y, hydrogen.text).attr({
+  const hydrogenText = 'H';
+  const hydrogenPath = render.paper.text(ps.x, ps.y, hydrogenText).attr({
     font: options.font,
     'font-size': options.fontszInPx,
     fill: atom.color,
   });
-  hydrogen.rbb = util.relBox(hydrogen.path.getBBox());
-  draw.recenterText(hydrogen.path, hydrogen.rbb);
+  const hydrogenRbb = util.relBox(hydrogenPath.getBBox());
+  draw.recenterText(hydrogenPath, hydrogenRbb);
   if (!hydrogenLeft) {
     pathAndRBoxTranslate(
-      hydrogen.path,
-      hydrogen.rbb,
-      data.rightMargin + 0.35 * hydrogen.rbb.width + delta,
+      hydrogenPath,
+      hydrogenRbb,
+      data.rightMargin + 0.35 * hydrogenRbb.width + delta,
       0,
     );
-    data.rightMargin += hydrogen.rbb.width + delta;
+    data.rightMargin += hydrogenRbb.width + delta;
   }
   if (implh > 1) {
-    hydroIndex = {} as ElemAttr;
-    hydroIndex.text = implh.toString();
-    hydroIndex.path = render.paper.text(ps.x, ps.y, hydroIndex.text).attr({
+    const hydroIndexText = implh.toString();
+    const hydroIndexPath = render.paper.text(ps.x, ps.y, hydroIndexText).attr({
       font: options.font,
       'font-size': options.fontszsubInPx,
       fill: atom.color,
     });
-    hydroIndex.rbb = util.relBox(hydroIndex.path.getBBox());
-    draw.recenterText(hydroIndex.path, hydroIndex.rbb);
+    const hydroIndexRbb = util.relBox(hydroIndexPath.getBBox());
+    draw.recenterText(hydroIndexPath, hydroIndexRbb);
+    hydroIndex = {
+      text: hydroIndexText,
+      path: hydroIndexPath,
+      rbb: hydroIndexRbb,
+    };
     if (!hydrogenLeft) {
       pathAndRBoxTranslate(
-        hydroIndex.path,
-        hydroIndex.rbb,
+        hydroIndexPath,
+        hydroIndexRbb,
         data.rightMargin +
-          0.15 * hydroIndex.rbb.width * (options.zoom > 1 ? 1 : options.zoom) +
+          0.15 * hydroIndexRbb.width * (options.zoom > 1 ? 1 : options.zoom) +
           delta,
-        0.2 * atom.label!.rbb.height,
+        0.2 * (atom.label?.rbb.height ?? 0),
       );
-      data.rightMargin += hydroIndex.rbb.width + delta;
+      data.rightMargin += hydroIndexRbb.width + delta;
     }
   }
   if (hydrogenLeft) {
@@ -1948,22 +1939,27 @@ function showHydrogen(
         hydroIndex.path,
         hydroIndex.rbb,
         data.leftMargin - 0.4 * hydroIndex.rbb.width - delta,
-        0.2 * atom.label!.rbb.height,
+        0.2 * (atom.label?.rbb.height ?? 0),
       );
       data.leftMargin -= hydroIndex.rbb.width + delta;
     }
     pathAndRBoxTranslate(
-      hydrogen.path,
-      hydrogen.rbb,
+      hydrogenPath,
+      hydrogenRbb,
       data.leftMargin -
         0.4 *
-          hydrogen.rbb.width *
+          hydrogenRbb.width *
           (implh > 1 && options.zoom < 1 ? options.zoom : 1) -
         delta,
       0,
     );
-    data.leftMargin -= hydrogen.rbb.width + delta;
+    data.leftMargin -= hydrogenRbb.width + delta;
   }
+  const hydrogen: ElemAttr = {
+    text: hydrogenText,
+    path: hydrogenPath,
+    rbb: hydrogenRbb,
+  };
   return Object.assign(data, { hydrogen, hydroIndex });
 }
 
@@ -1975,9 +1971,9 @@ function showWarning(
 ): Omit<ElemAttr, 'text'> {
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const delta = 0.5 * render.options.lineWidth;
-  const warning = {} as Omit<ElemAttr, 'text'>;
-  const y = ps.y + (atom.label?.rbb.height ?? 0) / 2 + delta;
-  warning.path = render.paper
+  const labelHeight = atom.label?.rbb.height ?? 0;
+  const y = ps.y + labelHeight / 2 + delta;
+  const path = render.paper
     .path(
       'M{0},{1}L{2},{3}',
       toFixed(ps.x + leftMargin),
@@ -1987,8 +1983,8 @@ function showWarning(
     )
     .attr(render.options.lineattr)
     .attr({ stroke: '#F00' });
-  warning.rbb = util.relBox(warning.path.getBBox());
-  return warning;
+  const rbb = util.relBox(path.getBBox());
+  return { path, rbb };
 }
 
 function getAamText(atom: ReAtom) {
@@ -2091,7 +2087,7 @@ export function getAtomCustomQuery(
     if (queryAttrsText.length > 0) queryAttrsText += ';';
   };
   const patterns: {
-    [key: string]: (value: string, atom: unknown) => string;
+    [key: string]: (value: string, atom: Record<string, unknown>) => string;
   } = {
     isotope: (value) => value,
     aromaticity: (value) => (value === 'aromatic' ? 'a' : 'A'),
@@ -2128,7 +2124,9 @@ export function getAtomCustomQuery(
 
     const value = atom[propertyName];
     if (propertyName in atom && value !== null) {
-      const attrText = patterns[propertyName](value as unknown as string, atom);
+      const normalizedValue =
+        typeof value === 'boolean' ? Number(value) : value;
+      const attrText = patterns[propertyName](String(normalizedValue), atom);
       if (attrText) {
         addSemicolon();
       }
@@ -2169,7 +2167,7 @@ function getQueryAttrsText(atom: ReAtom): string {
 
 function pathAndRBoxTranslate(
   path: Element | RaphaelSet,
-  rbb: { x: number; y: number; width: number; height: number },
+  rbb: RelativeBox,
   x: number,
   y: number,
 ) {

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -32,6 +32,7 @@ import {
 import ReObject from './reobject';
 import type ReStruct from './restruct';
 import type { Render } from '../raphaelRender';
+import type { Element, RaphaelSet } from 'raphael';
 import { Scale } from 'domain/helpers';
 import draw from '../draw';
 import util from '../util';
@@ -52,8 +53,9 @@ import { ShowHydrogenLabels } from './showHydrogenLabels';
 
 interface ElemAttr {
   text: string;
-  path: any;
+  path: Element | RaphaelSet;
   rbb: { x: number; y: number; width: number; height: number };
+  background?: Element;
 }
 
 const StereoLabelMinOpacity = 0.3;
@@ -78,12 +80,12 @@ class ReAtom extends ReObject {
   infoLabel?: string;
   cip?: {
     // Raphael paths
-    path: any;
-    text: any;
-    rectangle: any;
+    path: RaphaelSet;
+    text: Element;
+    rectangle: Element;
   };
 
-  private expandedMonomerAttachmentPoints?: any; // Raphael paths
+  private expandedMonomerAttachmentPoints?: Element | null;
 
   constructor(atom: Atom) {
     super('atom');
@@ -122,7 +124,7 @@ class ReAtom extends ReObject {
   }
 
   private attachHighlightTriggerForAttachmentPointAtom(
-    hoverElement: any,
+    hoverElement: Element | null,
     render: Render,
   ) {
     if (!render.monomerCreationState) {
@@ -143,7 +145,7 @@ class ReAtom extends ReObject {
       return attachmentAtomId === atomId || leavingAtomId === atomId;
     });
 
-    if (attachmentPointEntry) {
+    if (attachmentPointEntry && hoverElement) {
       const [attachmentPointName] = attachmentPointEntry;
       hoverElement.hover(
         () => {
@@ -458,7 +460,7 @@ class ReAtom extends ReObject {
     return Boolean(this.a.attachmentPoints);
   }
 
-  show(restruct: ReStruct, aid: number, options: any): void {
+  show(restruct: ReStruct, aid: number, options: RenderOptions): void {
     // eslint-disable-line max-statements
     const struct = restruct.molecule;
     const atom = struct.atoms.get(aid)!;
@@ -524,13 +526,13 @@ class ReAtom extends ReObject {
     this.showLabel = isLabelVisible(restruct, render.options, this);
     this.color = 'black'; // reset color
 
-    let delta;
-    let rightMargin;
-    let leftMargin;
-    let implh;
-    let isHydrogen;
-    let label;
-    let index: any = null;
+    let delta = 0;
+    let rightMargin = 0;
+    let leftMargin = 0;
+    let implh = 0;
+    let isHydrogen = false;
+    let label!: ElemAttr;
+    let index: ElemAttr | null = null;
 
     if (this.showLabel) {
       const data = buildLabel(this, render.paper, ps, options, aid, sgroup);
@@ -554,7 +556,7 @@ class ReAtom extends ReObject {
     }
 
     if (options.showAtomIds) {
-      index = {};
+      index = {} as ElemAttr;
       index.text = aid.toString();
       let idPos = this.hydrogenOnTheLeft
         ? Vec2.lc(ps, 1, new Vec2({ x: -2, y: 0, z: 0 }), 6)
@@ -573,7 +575,7 @@ class ReAtom extends ReObject {
     }
 
     if (this.showLabel) {
-      let hydroIndex: any = null;
+      let hydroIndex: ElemAttr | null = null;
       if (isHydrogen && implh > 0) {
         hydroIndex = showHydroIndex(this, render, implh, rightMargin);
         rightMargin += hydroIndex.rbb.width + delta;
@@ -627,7 +629,7 @@ class ReAtom extends ReObject {
         !shouldHideHydrogenInPreview
       ) {
         const data = showHydrogen(this, render, implh, {
-          hydrogen: {},
+          hydrogen: {} as ElemAttr,
           hydroIndex,
           rightMargin,
           leftMargin,
@@ -850,7 +852,7 @@ class ReAtom extends ReObject {
           const labelGroup = render.paper.set();
           labelGroup.push(background, rLabelElement);
 
-          labelGroup.forEach((element) => {
+          labelGroup.forEach((element: Element) => {
             element.node?.setAttribute(
               'data-attachment-point-alias',
               attachmentPointName,
@@ -1317,7 +1319,10 @@ class ReAtom extends ReObject {
   }
 }
 
-function getStereoAtomColor(options, stereoLabel) {
+function getStereoAtomColor(
+  options: RenderOptions,
+  stereoLabel: string | null | undefined,
+) {
   if (
     !stereoLabel ||
     options.colorStereogenicCenters === StereoColoringType.Off ||
@@ -1329,23 +1334,26 @@ function getStereoAtomColor(options, stereoLabel) {
   return getColorFromStereoLabel(options, stereoLabel);
 }
 
-export function getColorFromStereoLabel(options, stereoLabel) {
-  const stereoLabelType = stereoLabel.match(/\D+/g)[0];
+export function getColorFromStereoLabel(
+  options: RenderOptions,
+  stereoLabel: string,
+) {
+  const stereoLabelType = stereoLabel.match(/\D+/g)?.[0] ?? '';
 
   switch (stereoLabelType) {
     case StereoLabel.And:
-      return options.colorOfAndCenters;
+      return options.colorOfAndCenters ?? '#000';
     case StereoLabel.Or:
-      return options.colorOfOrCenters;
+      return options.colorOfOrCenters ?? '#000';
     case StereoLabel.Abs:
-      return options.colorOfAbsoluteCenters;
+      return options.colorOfAbsoluteCenters ?? '#000';
     default:
       return '#000';
   }
 }
 
-function getStereoAtomOpacity(options, stereoLabel) {
-  const stereoLabelType = stereoLabel.match(/\D+/g)[0];
+function getStereoAtomOpacity(options: RenderOptions, stereoLabel: string) {
+  const stereoLabelType = stereoLabel.match(/\D+/g)?.[0] ?? '';
   const stereoLabelNumber = +stereoLabel.replace(stereoLabelType, '');
   if (
     !options.autoFadeOfStereoLabels ||
@@ -1359,16 +1367,16 @@ function getStereoAtomOpacity(options, stereoLabel) {
 }
 
 function shouldDisplayStereoLabel(
-  stereoLabel,
-  labelStyle,
-  ignoreChiralFlag,
+  stereoLabel: string | null | undefined,
+  labelStyle: StereoLabelStyleType | undefined,
+  ignoreChiralFlag: boolean | undefined,
   flag: StereoFlag | undefined,
 ): boolean {
   if (!stereoLabel) {
     return false;
   }
 
-  const stereoLabelType = stereoLabel.match(/\D+/g)[0];
+  const stereoLabelType = stereoLabel.match(/\D+/g)?.[0] ?? '';
 
   if (ignoreChiralFlag && stereoLabelType === StereoLabel.Abs) {
     return false;
@@ -1395,7 +1403,11 @@ function shouldDisplayStereoLabel(
   }
 }
 
-function isLabelVisible(restruct, options, atom: ReAtom) {
+function isLabelVisible(
+  restruct: ReStruct,
+  options: RenderOptions,
+  atom: ReAtom,
+) {
   const isAttachmentPointAtom = Boolean(atom.a.attachmentPoints);
   const isCarbon = atom.a.label.toLowerCase() === 'c';
   const visibleNeighbors = getVisibleNeighborHalfBondIds(
@@ -1435,8 +1447,10 @@ function isLabelVisible(restruct, options, atom: ReAtom) {
     const nei2 = visibleNeighbors[1];
     const hb1 = restruct.molecule.halfBonds.get(nei1);
     const hb2 = restruct.molecule.halfBonds.get(nei2);
+    if (!hb1 || !hb2) return false;
     const bond1 = restruct.bonds.get(hb1.bid);
     const bond2 = restruct.bonds.get(hb2.bid);
+    if (!bond1 || !bond2) return false;
 
     const sameNotStereo =
       bond1.b.type === bond2.b.type &&
@@ -1469,7 +1483,7 @@ function displayHydrogen(
   );
 }
 
-function shouldHydrogenBeOnLeft(struct, atom) {
+function shouldHydrogenBeOnLeft(struct: Struct, atom: ReAtom) {
   const visibleNeighbors = getVisibleNeighborHalfBondIds(struct, atom);
 
   if (visibleNeighbors.length === 0) {
@@ -1483,9 +1497,9 @@ function shouldHydrogenBeOnLeft(struct, atom) {
 
   if (visibleNeighbors.length === 1) {
     const neighbor = visibleNeighbors[0];
-    const neighborDirection = struct.halfBonds.get(neighbor).dir;
+    const neighborHalfBond = struct.halfBonds.get(neighbor);
 
-    return neighborDirection.x > 0;
+    return (neighborHalfBond?.dir.x ?? 0) > 0;
   }
 
   return false;
@@ -1518,16 +1532,19 @@ function getOnlyQueryAttributesCustomQuery(atom: Atom) {
   return queryText;
 }
 
-function addTooltip(node, text: string) {
+function addTooltip(node: SVGElement, text: string) {
   const tooltip = text.split(/(?<=[;,])/).join(' ');
-  node.childNodes[0].setAttribute('data-tooltip', util.escapeHtml(tooltip));
+  (node.childNodes[0] as SVGElement).setAttribute(
+    'data-tooltip',
+    util.escapeHtml(tooltip),
+  );
 }
 
 function buildLabel(
   atom: ReAtom,
-  paper: any,
+  paper: Render['paper'],
   ps: Vec2,
-  options: any,
+  options: RenderOptions,
   atomId: number,
   sgroup?: SGroup,
 ): {
@@ -1544,14 +1561,10 @@ function buildLabel(
     usageInMacromolecule,
   } = options;
   // eslint-disable-line max-statements
-  const label: any = {
-    text: getLabelText(atom.a, atomId, sgroup, options),
-  };
+  const label = {} as ElemAttr;
+  label.text = getLabelText(atom.a, atomId, sgroup, options) || 'R#';
 
   let tooltip: string | null = null;
-  if (!label.text) {
-    label.text = 'R#';
-  }
 
   if (label.text === atom.a.label) {
     const element = Elements.get(label.text);
@@ -1565,12 +1578,12 @@ function buildLabel(
   const isMonomerAttachmentPointSelected =
     currentlySelectedMonomerAttachmentPoint === label.text;
   const isMonomerAttachmentPointUsed =
-    connectedMonomerAttachmentPoints?.includes(label.text);
+    connectedMonomerAttachmentPoints?.includes(label.text) ?? false;
 
   const { color, fill, stroke } = util.useLabelStyles(
     isMonomerAttachmentPointSelected,
     isMonomerAttachmentPointUsed,
-    usageInMacromolecule,
+    usageInMacromolecule ?? UsageInMacromolecule.MonomerConnectionsModal,
   );
 
   if (isMonomerAttachmentPoint && shouldStyleLabel) {
@@ -1643,7 +1656,12 @@ function buildLabel(
   return { label, rightMargin, leftMargin };
 }
 
-function getLabelText(atom, atomId: number, sgroup?: SGroup, options?: any) {
+function getLabelText(
+  atom: Atom,
+  atomId: number,
+  sgroup?: SGroup,
+  options?: RenderOptions,
+) {
   if (sgroup?.isSuperatomWithoutLabel) {
     const attachmentPoint = sgroup
       .getAttachmentPoints()
@@ -1679,8 +1697,9 @@ function getLabelText(atom, atomId: number, sgroup?: SGroup, options?: any) {
 
   if (atom.label && atom.rglabel !== null) {
     let text = '';
+    const rglabelNum = atom.rglabel as unknown as number;
     for (let rgi = 0; rgi < 32; rgi++) {
-      if (atom.rglabel & (1 << rgi)) {
+      if (rglabelNum & (1 << rgi)) {
         text += 'R' + (rgi + 1).toString();
       }
     }
@@ -1695,11 +1714,16 @@ function getLabelText(atom, atomId: number, sgroup?: SGroup, options?: any) {
   return atom.label;
 }
 
-function showHydroIndex(atom, render, implh, rightMargin): ElemAttr {
+function showHydroIndex(
+  atom: ReAtom,
+  render: Render,
+  implh: number,
+  rightMargin: number,
+): ElemAttr {
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const hydroIndex: any = {};
+  const hydroIndex = {} as ElemAttr;
   hydroIndex.text = (implh + 1).toString();
   hydroIndex.path = render.paper.text(ps.x, ps.y, hydroIndex.text).attr({
     font: options.font,
@@ -1713,7 +1737,7 @@ function showHydroIndex(atom, render, implh, rightMargin): ElemAttr {
     hydroIndex.path,
     hydroIndex.rbb,
     rightMargin + 0.5 * hydroIndex.rbb.width + delta,
-    0.2 * atom.label.rbb.height,
+    0.2 * (atom.label?.rbb.height ?? 0),
   );
   /* eslint-enable no-mixed-operators */
   return hydroIndex;
@@ -1722,9 +1746,9 @@ function showHydroIndex(atom, render, implh, rightMargin): ElemAttr {
 function showRadical(atom: ReAtom, render: Render): Omit<ElemAttr, 'text'> {
   const ps: Vec2 = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
-  const paper: any = render.paper;
-  const radical: any = {};
-  let hshift;
+  const paper = render.paper;
+  const radical = {} as Omit<ElemAttr, 'text'>;
+  let hshift: number;
   switch (atom.a.radical) {
     case 1:
       radical.path = paper.set();
@@ -1767,7 +1791,7 @@ function showIsotope(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const isotope: any = {};
+  const isotope = {} as ElemAttr;
   isotope.text = atom.a.isotope?.toString() ?? '';
   isotope.path = render.paper.text(ps.x, ps.y, isotope.text).attr({
     font: options.font,
@@ -1795,7 +1819,7 @@ function showCharge(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const charge: any = {};
+  const charge = {} as ElemAttr;
   charge.text = '';
   if (atom.a.charge !== null) {
     const absCharge = Math.abs(atom.a.charge);
@@ -1832,7 +1856,7 @@ function showExplicitValence(
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
   const delta = 0.5 * options.lineWidth;
-  const valence: any = {};
+  const valence = {} as ElemAttr;
   valence.text = VALENCE_MAP[atom.a.explicitValence];
   if (!valence.text) {
     throw new Error('invalid valence ' + atom.a.explicitValence.toString());
@@ -1861,19 +1885,19 @@ function showHydrogen(
   render: Render,
   implh: number,
   data: {
-    hydrogen: any;
-    hydroIndex: number;
+    hydrogen: ElemAttr;
+    hydroIndex: ElemAttr | null;
     rightMargin: number;
     leftMargin: number;
   },
 ): {
   hydrogen: ElemAttr;
-  hydroIndex: ElemAttr;
+  hydroIndex: ElemAttr | null;
   rightMargin: number;
   leftMargin: number;
 } {
   // eslint-disable-line max-statements
-  let hydroIndex: any = data.hydroIndex;
+  let hydroIndex: ElemAttr | null = data.hydroIndex;
   const hydrogenLeft = atom.hydrogenOnTheLeft;
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const options = render.options;
@@ -1897,7 +1921,7 @@ function showHydrogen(
     data.rightMargin += hydrogen.rbb.width + delta;
   }
   if (implh > 1) {
-    hydroIndex = {};
+    hydroIndex = {} as ElemAttr;
     hydroIndex.text = implh.toString();
     hydroIndex.path = render.paper.text(ps.x, ps.y, hydroIndex.text).attr({
       font: options.font,
@@ -1944,15 +1968,15 @@ function showHydrogen(
 }
 
 function showWarning(
-  atom,
-  render,
-  leftMargin,
-  rightMargin,
-): { rbb: DOMRect; path: any } {
+  atom: ReAtom,
+  render: Render,
+  leftMargin: number,
+  rightMargin: number,
+): Omit<ElemAttr, 'text'> {
   const ps = Scale.modelToCanvas(atom.a.pp, render.options);
   const delta = 0.5 * render.options.lineWidth;
-  const warning: any = {};
-  const y = ps.y + atom.label.rbb.height / 2 + delta;
+  const warning = {} as Omit<ElemAttr, 'text'>;
+  const y = ps.y + (atom.label?.rbb.height ?? 0) / 2 + delta;
   warning.path = render.paper
     .path(
       'M{0},{1}L{2},{3}',
@@ -1967,7 +1991,7 @@ function showWarning(
   return warning;
 }
 
-function getAamText(atom) {
+function getAamText(atom: ReAtom) {
   let aamText = '';
   if (atom.a.aam > 0) aamText += atom.a.aam;
   if (atom.a.invRet > 0) {
@@ -2044,7 +2068,7 @@ export function getAtomType(atom: Atom) {
   return 'single';
 }
 
-export function checkIsSmartPropertiesExist(atom) {
+export function checkIsSmartPropertiesExist(atom: Atom) {
   const smartsSpecificProperties = [
     'ringMembership',
     'ringSize',
@@ -2056,7 +2080,10 @@ export function checkIsSmartPropertiesExist(atom) {
   return smartsSpecificProperties.some((name) => atom.queryProperties?.[name]);
 }
 
-export function getAtomCustomQuery(atom, includeOnlyQueryAttributes?: boolean) {
+export function getAtomCustomQuery(
+  atom: Record<string, unknown>,
+  includeOnlyQueryAttributes?: boolean,
+) {
   let queryAttrsText = '';
   const nonQueryAttributes = ['charge', 'explicitValence', 'isotope'];
 
@@ -2064,7 +2091,7 @@ export function getAtomCustomQuery(atom, includeOnlyQueryAttributes?: boolean) {
     if (queryAttrsText.length > 0) queryAttrsText += ';';
   };
   const patterns: {
-    [key: string]: (value: string, atom) => string;
+    [key: string]: (value: string, atom: unknown) => string;
   } = {
     isotope: (value) => value,
     aromaticity: (value) => (value === 'aromatic' ? 'a' : 'A'),
@@ -2101,7 +2128,7 @@ export function getAtomCustomQuery(atom, includeOnlyQueryAttributes?: boolean) {
 
     const value = atom[propertyName];
     if (propertyName in atom && value !== null) {
-      const attrText = patterns[propertyName](value, atom);
+      const attrText = patterns[propertyName](value as unknown as string, atom);
       if (attrText) {
         addSemicolon();
       }
@@ -2112,7 +2139,7 @@ export function getAtomCustomQuery(atom, includeOnlyQueryAttributes?: boolean) {
   return queryAttrsText;
 }
 
-function getQueryAttrsText(atom): string {
+function getQueryAttrsText(atom: ReAtom): string {
   let queryAttrsText = '';
 
   const addSemicolon = () => {
@@ -2140,7 +2167,12 @@ function getQueryAttrsText(atom): string {
   return queryAttrsText;
 }
 
-function pathAndRBoxTranslate(path, rbb, x, y) {
+function pathAndRBoxTranslate(
+  path: Element | RaphaelSet,
+  rbb: { x: number; y: number; width: number; height: number },
+  x: number,
+  y: number,
+) {
   path.translateAbs(x, y);
   rbb.x += x;
   rbb.y += y;

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -2139,7 +2139,7 @@ const atomCustomQueryPatterns: readonly AtomCustomQueryPattern[] = [
   {
     propertyName: 'unsaturatedAtom',
     getValue: (atom) => atom.unsaturatedAtom,
-    format: (value) => (Number(value) === 1 ? 'u' : ''),
+    format: (value) => (value === 'true' || Number(value) === 1 ? 'u' : ''),
   },
   {
     propertyName: 'explicitValence',

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -16,8 +16,8 @@
 
 import {
   Atom,
-  StereoLabel,
   type AtomQueryProperties,
+  StereoLabel,
 } from 'domain/entities/atom';
 import { Bond } from 'domain/entities/bond';
 import { FunctionalGroup } from 'domain/entities/functionalGroup';
@@ -2054,6 +2054,33 @@ function getSubstitutionCountAttrText(value: number) {
 }
 
 type AtomCustomQueryValue = string | number | boolean;
+
+/**
+ * Minimum shape required by getAtomCustomQuery.
+ * Satisfied by both a full Atom instance (query-specific fields nested
+ * under queryProperties) and the flat Redux form state produced by the
+ * Atom dialog (those fields hoisted to top level by fromAtom).
+ */
+type AtomQueryInput = Partial<
+  Pick<
+    Atom,
+    | 'isotope'
+    | 'charge'
+    | 'explicitValence'
+    | 'ringBondCount'
+    | 'substitutionCount'
+    | 'hCount'
+    | 'implicitHCount'
+  >
+> & {
+  unsaturatedAtom?: number | boolean; // number on Atom, boolean in form state
+  queryProperties?: Partial<AtomQueryProperties>;
+} & Partial<AtomQueryProperties>; // flat query fields (form state path)
+
+/**
+ * Maps atom properties and SMARTS/query-specific atom fields to the textual
+ * Molfile query attributes rendered by getAtomCustomQuery().
+ */
 type AtomCustomQueryPropertyName =
   | 'aromaticity'
   | 'charge'
@@ -2069,22 +2096,21 @@ type AtomCustomQueryPropertyName =
   | 'substitutionCount'
   | 'unsaturatedAtom';
 type AtomCustomQueryPattern = {
+  /** Atom property name used to determine whether the query attribute applies. */
   propertyName: AtomCustomQueryPropertyName;
-  getValue: (atom: Atom) => AtomCustomQueryValue | null | undefined;
+  /** Reads the raw atom/query-property value before text normalization. */
+  getValue: (atom: AtomQueryInput) => AtomCustomQueryValue | null | undefined;
+  /** Converts a normalized value to its Molfile query attribute representation. */
   format: (value: string) => string;
 };
 
-const NON_QUERY_ATOM_CUSTOM_QUERY_ATTRIBUTES: readonly AtomCustomQueryPropertyName[] =
-  ['charge', 'explicitValence', 'isotope'];
+const EXCLUDED_QUERY_ATTRIBUTES: readonly AtomCustomQueryPropertyName[] = [
+  'charge',
+  'explicitValence',
+  'isotope',
+];
 
-const getAtomCustomQueryProperty =
-  <PropertyName extends keyof AtomQueryProperties>(
-    propertyName: PropertyName,
-  ) =>
-  (atom: Atom): AtomQueryProperties[PropertyName] =>
-    atom.queryProperties[propertyName];
-
-const atomCustomQueryPatterns: AtomCustomQueryPattern[] = [
+const atomCustomQueryPatterns: readonly AtomCustomQueryPattern[] = [
   {
     propertyName: 'isotope',
     getValue: (atom) => atom.isotope,
@@ -2092,7 +2118,8 @@ const atomCustomQueryPatterns: AtomCustomQueryPattern[] = [
   },
   {
     propertyName: 'aromaticity',
-    getValue: getAtomCustomQueryProperty('aromaticity'),
+    getValue: (atom) =>
+      atom.queryProperties?.aromaticity ?? atom.aromaticity ?? null,
     format: (value) => (value === 'aromatic' ? 'a' : 'A'),
   },
   {
@@ -2132,6 +2159,7 @@ const atomCustomQueryPatterns: AtomCustomQueryPattern[] = [
   {
     propertyName: 'hCount',
     getValue: (atom) => atom.hCount,
+    // Molfile query hydrogen counts are encoded as H<count - 1>.
     format: (value) =>
       Number(value) > 0 ? 'H' + (Number(value) - 1).toString() : '',
   },
@@ -2142,22 +2170,25 @@ const atomCustomQueryPatterns: AtomCustomQueryPattern[] = [
   },
   {
     propertyName: 'ringMembership',
-    getValue: getAtomCustomQueryProperty('ringMembership'),
+    getValue: (atom) =>
+      atom.queryProperties?.ringMembership ?? atom.ringMembership ?? null,
     format: (value) => `R${value}`,
   },
   {
     propertyName: 'ringSize',
-    getValue: getAtomCustomQueryProperty('ringSize'),
+    getValue: (atom) => atom.queryProperties?.ringSize ?? atom.ringSize ?? null,
     format: (value) => `r${value}`,
   },
   {
     propertyName: 'connectivity',
-    getValue: getAtomCustomQueryProperty('connectivity'),
+    getValue: (atom) =>
+      atom.queryProperties?.connectivity ?? atom.connectivity ?? null,
     format: (value) => `X${value}`,
   },
   {
     propertyName: 'chirality',
-    getValue: getAtomCustomQueryProperty('chirality'),
+    getValue: (atom) =>
+      atom.queryProperties?.chirality ?? atom.chirality ?? null,
     format: (value) => (value === 'clockwise' ? '@@' : '@'),
   },
 ];
@@ -2187,7 +2218,7 @@ export function checkIsSmartPropertiesExist(atom: Atom) {
 }
 
 export function getAtomCustomQuery(
-  atom: Atom,
+  atom: AtomQueryInput,
   includeOnlyQueryAttributes?: boolean,
 ) {
   let queryAttrsText = '';
@@ -2199,7 +2230,7 @@ export function getAtomCustomQuery(
   for (const { propertyName, getValue, format } of atomCustomQueryPatterns) {
     if (
       includeOnlyQueryAttributes &&
-      NON_QUERY_ATOM_CUSTOM_QUERY_ATTRIBUTES.includes(propertyName)
+      EXCLUDED_QUERY_ATTRIBUTES.includes(propertyName)
     ) {
       continue;
     }

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -2053,7 +2053,7 @@ function getSubstitutionCountAttrText(value: number) {
   return attrText;
 }
 
-type AtomCustomQueryValue = string | number | boolean | null | undefined;
+type AtomCustomQueryValue = string | number | boolean;
 type AtomCustomQueryPropertyName =
   | 'aromaticity'
   | 'charge'
@@ -2070,7 +2070,7 @@ type AtomCustomQueryPropertyName =
   | 'unsaturatedAtom';
 type AtomCustomQueryPattern = {
   propertyName: AtomCustomQueryPropertyName;
-  getValue: (atom: Atom) => AtomCustomQueryValue;
+  getValue: (atom: Atom) => AtomCustomQueryValue | null | undefined;
   format: (value: string) => string;
 };
 
@@ -2132,7 +2132,8 @@ const atomCustomQueryPatterns: AtomCustomQueryPattern[] = [
   {
     propertyName: 'hCount',
     getValue: (atom) => atom.hCount,
-    format: (value) => (Number(value) > 0 ? 'H' + (Number(value) - 1) : ''),
+    format: (value) =>
+      Number(value) > 0 ? 'H' + (Number(value) - 1).toString() : '',
   },
   {
     propertyName: 'implicitHCount',

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Atom, StereoLabel } from 'domain/entities/atom';
+import {
+  Atom,
+  StereoLabel,
+  type AtomQueryProperties,
+} from 'domain/entities/atom';
 import { Bond } from 'domain/entities/bond';
 import { FunctionalGroup } from 'domain/entities/functionalGroup';
 import type { SGroup } from 'domain/entities/sgroup';
@@ -39,6 +43,7 @@ import util from '../util';
 import { toFixed } from 'utilities';
 import type {
   RelativeBox,
+  RenderPath,
   RenderOptions,
   RenderOptionStyles,
 } from 'application/render/render.types';
@@ -54,12 +59,13 @@ import { ShowHydrogenLabels } from './showHydrogenLabels';
 
 interface ElemAttr {
   text: string;
-  path: Element | RaphaelSet;
+  path: RenderPath;
   rbb: RelativeBox;
   background?: Element;
 }
 
 const StereoLabelMinOpacity = 0.3;
+const DEFAULT_ATOM_COLOR = '#000';
 const DEFAULT_STEREO_COLOR = '#000';
 const MAX_LABEL_LENGTH = 8;
 
@@ -379,7 +385,7 @@ class ReAtom extends ReObject {
   ) {
     const invisibleAtomTarget = this.getSelectionContour(render).attr({
       opacity: 0,
-      fill: '#000',
+      fill: DEFAULT_ATOM_COLOR,
       stroke: 'none',
       'stroke-width': 0,
     });
@@ -1068,7 +1074,9 @@ class ReAtom extends ReObject {
         font: options.font,
         'font-size': options.fontszsubInPx,
         fill:
-          options.atomColoring && elem ? ElementColor[this.a.label] : '#000',
+          options.atomColoring && elem
+            ? ElementColor[this.a.label]
+            : DEFAULT_ATOM_COLOR,
       });
       if (stereoLabel) {
         // use dom element to change color of stereo label which is the first element
@@ -1525,14 +1533,7 @@ function getVisibleNeighborHalfBondIds(struct: Struct, atom: ReAtom): number[] {
 
 function getOnlyQueryAttributesCustomQuery(atom: Atom) {
   const queryText =
-    atom.queryProperties.customQuery ??
-    getAtomCustomQuery(
-      {
-        ...atom,
-        ...atom.queryProperties,
-      },
-      true,
-    );
+    atom.queryProperties.customQuery ?? getAtomCustomQuery(atom, true);
   return queryText;
 }
 
@@ -1572,7 +1573,7 @@ function buildLabel(
   if (text === atom.a.label) {
     const element = Elements.get(text);
     if (atomColoring && element) {
-      atom.color = ElementColor[text] ?? '#000';
+      atom.color = ElementColor[text] ?? DEFAULT_ATOM_COLOR;
     }
   }
 
@@ -2077,44 +2078,124 @@ export function checkIsSmartPropertiesExist(atom: Atom) {
 }
 
 export function getAtomCustomQuery(
-  atom: Record<string, unknown>,
+  atom: Atom,
   includeOnlyQueryAttributes?: boolean,
 ) {
   let queryAttrsText = '';
-  const nonQueryAttributes = ['charge', 'explicitValence', 'isotope'];
+  type AtomCustomQueryValue = string | number | boolean | null | undefined;
+  type AtomCustomQueryPropertyName =
+    | 'aromaticity'
+    | 'charge'
+    | 'chirality'
+    | 'connectivity'
+    | 'explicitValence'
+    | 'hCount'
+    | 'implicitHCount'
+    | 'isotope'
+    | 'ringBondCount'
+    | 'ringMembership'
+    | 'ringSize'
+    | 'substitutionCount'
+    | 'unsaturatedAtom';
+  type AtomCustomQueryPattern = {
+    propertyName: AtomCustomQueryPropertyName;
+    getValue: (atom: Atom) => AtomCustomQueryValue;
+    format: (value: string) => string;
+  };
+  const nonQueryAttributes: readonly AtomCustomQueryPropertyName[] = [
+    'charge',
+    'explicitValence',
+    'isotope',
+  ];
+  const getQueryProperty =
+    <PropertyName extends keyof AtomQueryProperties>(
+      propertyName: PropertyName,
+    ) =>
+    (currentAtom: Atom): AtomQueryProperties[PropertyName] =>
+      currentAtom.queryProperties[propertyName];
 
   const addSemicolon = () => {
     if (queryAttrsText.length > 0) queryAttrsText += ';';
   };
-  const patterns: {
-    [key: string]: (value: string, atom: Record<string, unknown>) => string;
-  } = {
-    isotope: (value) => value,
-    aromaticity: (value) => (value === 'aromatic' ? 'a' : 'A'),
-    charge: (value) => {
-      if (value === '') return value;
-      const regExpResult = /^([+-]?)(\d{1,3}|1000)([+-]?)$/.exec(value);
-      const charge = regExpResult
-        ? parseInt(
-            regExpResult[1] + regExpResult[3] + regExpResult[2],
-          ).toString()
-        : value;
-      return !charge.startsWith('-') ? `+${charge}` : charge;
+  const patterns: AtomCustomQueryPattern[] = [
+    {
+      propertyName: 'isotope',
+      getValue: (currentAtom) => currentAtom.isotope,
+      format: (value) => value,
     },
-    unsaturatedAtom: (value) => (Number(value) === 1 ? 'u' : ''),
-    explicitValence: (value) => (Number(value) !== -1 ? `v${value}` : ''),
-    ringBondCount: (value) => getRingConnectivity(Number(value)),
-    substitutionCount: (value) => getDegree(Number(value)),
-    hCount: (value) =>
-      Number(value) > 0 ? 'H' + (Number(value) - 1).toString() : '',
-    implicitHCount: (value) => `h${value}`,
-    ringMembership: (value) => `R${value}`,
-    ringSize: (value) => `r${value}`,
-    connectivity: (value) => `X${value}`,
-    chirality: (value) => (value === 'clockwise' ? '@@' : '@'),
-  };
+    {
+      propertyName: 'aromaticity',
+      getValue: getQueryProperty('aromaticity'),
+      format: (value) => (value === 'aromatic' ? 'a' : 'A'),
+    },
+    {
+      propertyName: 'charge',
+      getValue: (currentAtom) => currentAtom.charge,
+      format: (value) => {
+        if (value === '') return value;
+        const regExpResult = /^([+-]?)(\d{1,3}|1000)([+-]?)$/.exec(value);
+        const charge = regExpResult
+          ? parseInt(
+              regExpResult[1] + regExpResult[3] + regExpResult[2],
+            ).toString()
+          : value;
+        return !charge.startsWith('-') ? `+${charge}` : charge;
+      },
+    },
+    {
+      propertyName: 'unsaturatedAtom',
+      getValue: (currentAtom) => currentAtom.unsaturatedAtom,
+      format: (value) => (Number(value) === 1 ? 'u' : ''),
+    },
+    {
+      propertyName: 'explicitValence',
+      getValue: (currentAtom) => currentAtom.explicitValence,
+      format: (value) => (Number(value) !== -1 ? `v${value}` : ''),
+    },
+    {
+      propertyName: 'ringBondCount',
+      getValue: (currentAtom) => currentAtom.ringBondCount,
+      format: (value) => getRingConnectivity(Number(value)),
+    },
+    {
+      propertyName: 'substitutionCount',
+      getValue: (currentAtom) => currentAtom.substitutionCount,
+      format: (value) => getDegree(Number(value)),
+    },
+    {
+      propertyName: 'hCount',
+      getValue: (currentAtom) => currentAtom.hCount,
+      format: (value) =>
+        Number(value) > 0 ? 'H' + (Number(value) - 1).toString() : '',
+    },
+    {
+      propertyName: 'implicitHCount',
+      getValue: (currentAtom) => currentAtom.implicitHCount,
+      format: (value) => `h${value}`,
+    },
+    {
+      propertyName: 'ringMembership',
+      getValue: getQueryProperty('ringMembership'),
+      format: (value) => `R${value}`,
+    },
+    {
+      propertyName: 'ringSize',
+      getValue: getQueryProperty('ringSize'),
+      format: (value) => `r${value}`,
+    },
+    {
+      propertyName: 'connectivity',
+      getValue: getQueryProperty('connectivity'),
+      format: (value) => `X${value}`,
+    },
+    {
+      propertyName: 'chirality',
+      getValue: getQueryProperty('chirality'),
+      format: (value) => (value === 'clockwise' ? '@@' : '@'),
+    },
+  ];
 
-  for (const propertyName in patterns) {
+  for (const { propertyName, getValue, format } of patterns) {
     if (
       includeOnlyQueryAttributes &&
       nonQueryAttributes.includes(propertyName)
@@ -2122,16 +2203,17 @@ export function getAtomCustomQuery(
       continue;
     }
 
-    const value = atom[propertyName];
-    if (propertyName in atom && value !== null) {
-      const normalizedValue =
-        typeof value === 'boolean' ? Number(value) : value;
-      const attrText = patterns[propertyName](String(normalizedValue), atom);
-      if (attrText) {
-        addSemicolon();
-      }
-      queryAttrsText += attrText;
+    const value = getValue(atom);
+    if (value === null || value === undefined) {
+      continue;
     }
+
+    const normalizedValue = typeof value === 'boolean' ? Number(value) : value;
+    const attrText = format(String(normalizedValue));
+    if (attrText) {
+      addSemicolon();
+    }
+    queryAttrsText += attrText;
   }
 
   return queryAttrsText;
@@ -2166,7 +2248,7 @@ function getQueryAttrsText(atom: ReAtom): string {
 }
 
 function pathAndRBoxTranslate(
-  path: Element | RaphaelSet,
+  path: RenderPath,
   rbb: RelativeBox,
   x: number,
   y: number,

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -2240,8 +2240,7 @@ export function getAtomCustomQuery(
       continue;
     }
 
-    const normalizedValue = typeof value === 'boolean' ? Number(value) : value;
-    const attrText = format(String(normalizedValue));
+    const attrText = format(String(value));
     if (attrText) {
       addSemicolon();
     }

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -2053,6 +2053,114 @@ function getSubstitutionCountAttrText(value: number) {
   return attrText;
 }
 
+type AtomCustomQueryValue = string | number | boolean | null | undefined;
+type AtomCustomQueryPropertyName =
+  | 'aromaticity'
+  | 'charge'
+  | 'chirality'
+  | 'connectivity'
+  | 'explicitValence'
+  | 'hCount'
+  | 'implicitHCount'
+  | 'isotope'
+  | 'ringBondCount'
+  | 'ringMembership'
+  | 'ringSize'
+  | 'substitutionCount'
+  | 'unsaturatedAtom';
+type AtomCustomQueryPattern = {
+  propertyName: AtomCustomQueryPropertyName;
+  getValue: (atom: Atom) => AtomCustomQueryValue;
+  format: (value: string) => string;
+};
+
+const NON_QUERY_ATOM_CUSTOM_QUERY_ATTRIBUTES: readonly AtomCustomQueryPropertyName[] =
+  ['charge', 'explicitValence', 'isotope'];
+
+const getAtomCustomQueryProperty =
+  <PropertyName extends keyof AtomQueryProperties>(
+    propertyName: PropertyName,
+  ) =>
+  (atom: Atom): AtomQueryProperties[PropertyName] =>
+    atom.queryProperties[propertyName];
+
+const atomCustomQueryPatterns: AtomCustomQueryPattern[] = [
+  {
+    propertyName: 'isotope',
+    getValue: (atom) => atom.isotope,
+    format: (value) => value,
+  },
+  {
+    propertyName: 'aromaticity',
+    getValue: getAtomCustomQueryProperty('aromaticity'),
+    format: (value) => (value === 'aromatic' ? 'a' : 'A'),
+  },
+  {
+    propertyName: 'charge',
+    getValue: (atom) => atom.charge,
+    format: (value) => {
+      if (value === '') return value;
+      const regExpResult = /^([+-]?)(\d{1,3}|1000)([+-]?)$/.exec(value);
+      const charge = regExpResult
+        ? parseInt(
+            regExpResult[1] + regExpResult[3] + regExpResult[2],
+          ).toString()
+        : value;
+      return !charge.startsWith('-') ? `+${charge}` : charge;
+    },
+  },
+  {
+    propertyName: 'unsaturatedAtom',
+    getValue: (atom) => atom.unsaturatedAtom,
+    format: (value) => (Number(value) === 1 ? 'u' : ''),
+  },
+  {
+    propertyName: 'explicitValence',
+    getValue: (atom) => atom.explicitValence,
+    format: (value) => (Number(value) !== -1 ? `v${value}` : ''),
+  },
+  {
+    propertyName: 'ringBondCount',
+    getValue: (atom) => atom.ringBondCount,
+    format: (value) => getRingConnectivity(Number(value)),
+  },
+  {
+    propertyName: 'substitutionCount',
+    getValue: (atom) => atom.substitutionCount,
+    format: (value) => getDegree(Number(value)),
+  },
+  {
+    propertyName: 'hCount',
+    getValue: (atom) => atom.hCount,
+    format: (value) => (Number(value) > 0 ? 'H' + (Number(value) - 1) : ''),
+  },
+  {
+    propertyName: 'implicitHCount',
+    getValue: (atom) => atom.implicitHCount,
+    format: (value) => `h${value}`,
+  },
+  {
+    propertyName: 'ringMembership',
+    getValue: getAtomCustomQueryProperty('ringMembership'),
+    format: (value) => `R${value}`,
+  },
+  {
+    propertyName: 'ringSize',
+    getValue: getAtomCustomQueryProperty('ringSize'),
+    format: (value) => `r${value}`,
+  },
+  {
+    propertyName: 'connectivity',
+    getValue: getAtomCustomQueryProperty('connectivity'),
+    format: (value) => `X${value}`,
+  },
+  {
+    propertyName: 'chirality',
+    getValue: getAtomCustomQueryProperty('chirality'),
+    format: (value) => (value === 'clockwise' ? '@@' : '@'),
+  },
+];
+
 export function getAtomType(atom: Atom) {
   if (atom.atomList) {
     return 'list';
@@ -2082,123 +2190,15 @@ export function getAtomCustomQuery(
   includeOnlyQueryAttributes?: boolean,
 ) {
   let queryAttrsText = '';
-  type AtomCustomQueryValue = string | number | boolean | null | undefined;
-  type AtomCustomQueryPropertyName =
-    | 'aromaticity'
-    | 'charge'
-    | 'chirality'
-    | 'connectivity'
-    | 'explicitValence'
-    | 'hCount'
-    | 'implicitHCount'
-    | 'isotope'
-    | 'ringBondCount'
-    | 'ringMembership'
-    | 'ringSize'
-    | 'substitutionCount'
-    | 'unsaturatedAtom';
-  type AtomCustomQueryPattern = {
-    propertyName: AtomCustomQueryPropertyName;
-    getValue: (atom: Atom) => AtomCustomQueryValue;
-    format: (value: string) => string;
-  };
-  const nonQueryAttributes: readonly AtomCustomQueryPropertyName[] = [
-    'charge',
-    'explicitValence',
-    'isotope',
-  ];
-  const getQueryProperty =
-    <PropertyName extends keyof AtomQueryProperties>(
-      propertyName: PropertyName,
-    ) =>
-    (currentAtom: Atom): AtomQueryProperties[PropertyName] =>
-      currentAtom.queryProperties[propertyName];
 
   const addSemicolon = () => {
     if (queryAttrsText.length > 0) queryAttrsText += ';';
   };
-  const patterns: AtomCustomQueryPattern[] = [
-    {
-      propertyName: 'isotope',
-      getValue: (currentAtom) => currentAtom.isotope,
-      format: (value) => value,
-    },
-    {
-      propertyName: 'aromaticity',
-      getValue: getQueryProperty('aromaticity'),
-      format: (value) => (value === 'aromatic' ? 'a' : 'A'),
-    },
-    {
-      propertyName: 'charge',
-      getValue: (currentAtom) => currentAtom.charge,
-      format: (value) => {
-        if (value === '') return value;
-        const regExpResult = /^([+-]?)(\d{1,3}|1000)([+-]?)$/.exec(value);
-        const charge = regExpResult
-          ? parseInt(
-              regExpResult[1] + regExpResult[3] + regExpResult[2],
-            ).toString()
-          : value;
-        return !charge.startsWith('-') ? `+${charge}` : charge;
-      },
-    },
-    {
-      propertyName: 'unsaturatedAtom',
-      getValue: (currentAtom) => currentAtom.unsaturatedAtom,
-      format: (value) => (Number(value) === 1 ? 'u' : ''),
-    },
-    {
-      propertyName: 'explicitValence',
-      getValue: (currentAtom) => currentAtom.explicitValence,
-      format: (value) => (Number(value) !== -1 ? `v${value}` : ''),
-    },
-    {
-      propertyName: 'ringBondCount',
-      getValue: (currentAtom) => currentAtom.ringBondCount,
-      format: (value) => getRingConnectivity(Number(value)),
-    },
-    {
-      propertyName: 'substitutionCount',
-      getValue: (currentAtom) => currentAtom.substitutionCount,
-      format: (value) => getDegree(Number(value)),
-    },
-    {
-      propertyName: 'hCount',
-      getValue: (currentAtom) => currentAtom.hCount,
-      format: (value) =>
-        Number(value) > 0 ? 'H' + (Number(value) - 1).toString() : '',
-    },
-    {
-      propertyName: 'implicitHCount',
-      getValue: (currentAtom) => currentAtom.implicitHCount,
-      format: (value) => `h${value}`,
-    },
-    {
-      propertyName: 'ringMembership',
-      getValue: getQueryProperty('ringMembership'),
-      format: (value) => `R${value}`,
-    },
-    {
-      propertyName: 'ringSize',
-      getValue: getQueryProperty('ringSize'),
-      format: (value) => `r${value}`,
-    },
-    {
-      propertyName: 'connectivity',
-      getValue: getQueryProperty('connectivity'),
-      format: (value) => `X${value}`,
-    },
-    {
-      propertyName: 'chirality',
-      getValue: getQueryProperty('chirality'),
-      format: (value) => (value === 'clockwise' ? '@@' : '@'),
-    },
-  ];
 
-  for (const { propertyName, getValue, format } of patterns) {
+  for (const { propertyName, getValue, format } of atomCustomQueryPatterns) {
     if (
       includeOnlyQueryAttributes &&
-      nonQueryAttributes.includes(propertyName)
+      NON_QUERY_ATOM_CUSTOM_QUERY_ATTRIBUTES.includes(propertyName)
     ) {
       continue;
     }

--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -56,7 +56,7 @@ class ReBond extends ReObject {
   neihbid1 = -1;
   neihbid2 = -1;
   boldStereo?: boolean;
-  rbb?: { x: number; y: number; width: number; height: number };
+  rbb?: RelativeBox;
   cip?: {
     // Raphael paths
     path: RaphaelSet;
@@ -1057,7 +1057,7 @@ function getStereoBondColor(
     return defaultColor;
   }
 
-  return getColorFromStereoLabel(options, stereoLabel);
+  return getColorFromStereoLabel(options, stereoLabel) ?? defaultColor;
 }
 
 function getBondSingleStereoBoldPath(

--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -33,6 +33,7 @@ import util from '../util';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import type {
   RelativeBox,
+  RenderPath,
   RenderOptions,
   RenderOptionStyles,
 } from '../render.types';
@@ -45,14 +46,12 @@ type FragmentSelectionPreviewOptions = {
   disabled?: boolean;
 };
 
-// A bond's rendered path is a single Element for most bond types, or a
-// RaphaelSet (paper.set([...])) for aromatic bonds.
-type BondPath = Element | RaphaelSet;
-
 class ReBond extends ReObject {
   b: Bond;
   doubleBondShift: number;
-  path: BondPath;
+  // A bond's rendered path is a single Element for most bond types, or a
+  // RaphaelSet (paper.set([...])) for aromatic bonds.
+  path: RenderPath;
   neihbid1 = -1;
   neihbid2 = -1;
   boldStereo?: boolean;
@@ -784,8 +783,8 @@ function getBondPath(
   hb1: HalfBond,
   hb2: HalfBond,
   isSnapping: boolean,
-): BondPath | null {
-  let path: BondPath | null = null;
+): RenderPath | null {
+  let path: RenderPath | null = null;
   const render = restruct.render;
   const struct = restruct.molecule;
   const shiftA = !restruct.atoms.get(hb1.begin)?.showLabel;

--- a/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/Atom/Atom.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/Atom/Atom.tsx
@@ -125,9 +125,9 @@ const Atom: FC<Props> = (props: Props) => {
     }
 
     const query = value ? getAtomCustomQuery(formState) : '';
-    setCustomQuery(query);
     setIsCustomQuery(value);
     setExpandedAccordions([]);
+    setCustomQuery(query);
   };
 
   const customValid = useMemo(() => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

- Removed explicit `any` usages from `packages/ketcher-core/src/application/render/restruct/reatom.ts`.
- Replaced them with explicit types to improve type safety.
- Updated the related render option typings where required.
- Added safe fallback values to preserve the existing behavior while satisfying TypeScript.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request