### PR TITLE
#10433 - Refactor: Explicit/implicit Any type clean up from packages\ketcher-react\src\script\editor\tool\helper\lasso.ts file

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/helper/lasso.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/lasso.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { CoordinateTransformation, Scale } from 'ketcher-core';
+import { CoordinateTransformation, Scale, type Vec2 } from 'ketcher-core';
 import locate from './locate';
 import type Editor from '../../Editor';
 
 class LassoHelper {
-  mode: any;
+  mode: number;
   editor: Editor;
-  fragment: any;
-  points: any;
-  selection: any;
+  fragment: boolean | null;
+  points: Vec2[] | null = null;
+  selection: ReturnType<Editor['render']['selectionPolygon']> | null = null;
 
-  constructor(mode, editor, fragment) {
+  constructor(mode: number, editor: Editor, fragment: boolean | null) {
     this.mode = mode;
     this.fragment = fragment;
     this.editor = editor;
@@ -33,6 +33,10 @@ class LassoHelper {
 
   getSelection() {
     const rnd = this.editor.render;
+
+    if (!this.points) {
+      throw new Error('Lasso points are not initialized');
+    }
 
     if (this.mode === 0) {
       return locate.inPolygon(rnd.ctab, this.points);
@@ -45,7 +49,7 @@ class LassoHelper {
     throw new Error('Selector mode unknown'); // eslint-disable-line no-else-return
   }
 
-  begin(event) {
+  begin(event: MouseEvent) {
     const rnd = this.editor.render;
     this.points = [CoordinateTransformation.pageToModel(event, rnd)];
     if (this.mode === 1) {
@@ -57,7 +61,7 @@ class LassoHelper {
     return !!this.points;
   }
 
-  addPoint(event) {
+  addPoint(event: MouseEvent) {
     if (!this.points) {
       return null;
     }


### PR DESCRIPTION
How the feature works? / How did you fix the issue?

Removes all explicit and implicit any from packages/ketcher-react/src/script/editor/tool/helper/lasso.ts (the issue covers both). Concrete types derived from actual usage and call sites:

- mode: number (compared to 0/1), editor: Editor (already the field type)
- fragment: boolean | null — select.ts/selectViewOnly.ts pass mode === 'fragment' (boolean) and read it as fragment || event.altKey; eraser.ts/sgroup.ts pass null
- points: Vec2[] | null — pageToModel returns Vec2; set to null in end/cancel
- selection: ReturnType<Editor['render']['selectionPolygon']> | null — the render returns a raphael Element, derived via the already-imported Editor type (raphael isn't a ketcher-react dependency and Render isn't exported from ketcher-core)
- begin(event: MouseEvent), addPoint(event: MouseEvent) — forwarded to pageToModel
- Constructor params typed accordingly

points/selection are initialized to null (strictPropertyInitialization), and getSelection gets an early null-guard so the newly-typed points type-checks. All method bodies are otherwise unchanged; existing guards already narrow the nullable fields. Behavior is preserved.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request