### PR TITLE
#10574 - Refactor: Non-null assertion clean up from packages\ketcher-react\src\script\editor\tool\paste.ts file

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/paste.ts
+++ b/packages/ketcher-react/src/script/editor/tool/paste.ts
@@ -117,9 +117,10 @@ class PasteTool implements Tool {
       this.action?.perform(this.restruct);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const closestGroupItem = this.editor.findItem(event, ['functionalGroups'])!;
-    const closestGroup = this.editor.struct().sgroups.get(closestGroupItem?.id);
+    const closestGroupItem = this.editor.findItem(event, ['functionalGroups']);
+    const closestGroup = closestGroupItem
+      ? this.editor.struct().sgroups.get(closestGroupItem.id)
+      : undefined;
 
     // not dropping on a group (tmp, should be removed when dealing with other entities)
     if (!closestGroupItem || SGroup.isSaltOrSolvent(closestGroup?.data.name)) {
@@ -172,9 +173,17 @@ class PasteTool implements Tool {
         pos0 = atom?.pp;
       }
 
+      if (!pos0) {
+        // Invariant: dragCtx.item always refers to a functional group with a
+        // resolvable attachment atom (validated in mousedown). Reaching here
+        // with no position indicates a programming error, not a runtime case.
+        throw new Error(
+          'PasteTool: attachment atom position is missing for the dragged group',
+        );
+      }
+
       // calc angle
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      let angle = vectorUtils.calcAngle(pos0!, pos1);
+      let angle = vectorUtils.calcAngle(pos0, pos1);
 
       if (!event.ctrlKey) {
         angle = vectorUtils.fracAngle(angle, null);


### PR DESCRIPTION
## Replace unsafe `!` assertions packages\ketcher-react\src\script\editor\tool\paste.ts file
Replace unsafe `!` assertions with control-flow guards: narrow closestGroupItem before use, and guard pos0 with an explicit invariant check instead of asserting it away.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request