### PR TITLE
#10572 Remove non-null assertion in atom.ts

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -205,9 +205,9 @@ class AtomTool implements Tool {
       atomId = sGroup?.getAttachmentAtomId();
     }
 
-    if (atomId !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const atom = molecule.atoms.get(atomId)!;
+    const atom = atomId !== undefined ? molecule.atoms.get(atomId) : undefined;
+
+    if (atomId !== undefined && atom) {
       let angle = vectorUtils.calcAngle(
         atom.pp,
         CoordinateTransformation.pageToModel(event, rnd),

--- a/packages/ketcher-react/src/script/editor/tool/atom.ts
+++ b/packages/ketcher-react/src/script/editor/tool/atom.ts
@@ -205,37 +205,43 @@ class AtomTool implements Tool {
       atomId = sGroup?.getAttachmentAtomId();
     }
 
-    const atom = atomId !== undefined ? molecule.atoms.get(atomId) : undefined;
-
-    if (atomId !== undefined && atom) {
-      let angle = vectorUtils.calcAngle(
-        atom.pp,
-        CoordinateTransformation.pageToModel(event, rnd),
-      );
-      if (!event.ctrlKey) angle = vectorUtils.fracAngle(angle, null);
-      const degrees = vectorUtils.degrees(angle);
-      editor.event.message.dispatch({ info: degrees + 'º' });
-      const newAtomPos = vectorUtils.calcNewAtomPos(
-        atom.pp,
-        CoordinateTransformation.pageToModel(event, rnd),
-        event.ctrlKey,
-      );
-
-      if (dragCtx.action) {
-        dragCtx.action.perform(reStruct);
-      }
-
-      dragCtx.action = fromBondAddition(
-        rnd.ctab,
-        this.#bondProps,
-        atomId,
-        { ...(atomProps ?? {}) },
-        undefined,
-        newAtomPos,
-      )[0];
-
-      editor.update(dragCtx.action, true);
+    if (atomId === undefined) {
+      return;
     }
+
+    const atom = molecule.atoms.get(atomId);
+
+    if (!atom) {
+      return;
+    }
+
+    let angle = vectorUtils.calcAngle(
+      atom.pp,
+      CoordinateTransformation.pageToModel(event, rnd),
+    );
+    if (!event.ctrlKey) angle = vectorUtils.fracAngle(angle, null);
+    const degrees = vectorUtils.degrees(angle);
+    editor.event.message.dispatch({ info: degrees + 'º' });
+    const newAtomPos = vectorUtils.calcNewAtomPos(
+      atom.pp,
+      CoordinateTransformation.pageToModel(event, rnd),
+      event.ctrlKey,
+    );
+
+    if (dragCtx.action) {
+      dragCtx.action.perform(reStruct);
+    }
+
+    dragCtx.action = fromBondAddition(
+      rnd.ctab,
+      this.#bondProps,
+      atomId,
+      { ...(atomProps ?? {}) },
+      undefined,
+      newAtomPos,
+    )[0];
+
+    editor.update(dragCtx.action, true);
   }
 
   mouseup(event) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The forced unwrap on `molecule.atoms.get(atomId)` assumed the atom always exists once an id was resolved from the drag context, which isn't guaranteed by the types. Replaced it with an explicit lookup and guard so the branch only runs when the atom is actually found, removing the suppression comment without changing behavior.

Fixes #10572

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
