### PR TITLE
#10570 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\render\renderers\BaseMonomerRenderer.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -267,6 +267,17 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
     attachmentPointName: AttachmentPointName,
     customAngle?: number,
   ): AttachmentPointConstructorParams {
+    // Attachment points are only ever prepared/drawn after the root element
+    // has been appended (see drawAttachmentPoints callers, which bail out
+    // early when `rootElement` is not yet set). Reaching this point without
+    // a root element would indicate a programming error, not a normal
+    // runtime case.
+    if (!this.rootElement) {
+      throw new Error(
+        'Cannot prepare attachment point params before the root element is appended.',
+      );
+    }
+
     let rotation;
 
     if (!this.monomer.isAttachmentPointUsed(attachmentPointName)) {
@@ -274,8 +285,7 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
     }
 
     return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      rootElement: this.rootElement!,
+      rootElement: this.rootElement,
       monomer: this.monomer,
       bodyWidth: this.monomerSize.width,
       bodyHeight: this.monomerSize.height,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Replace the suppressed `this.rootElement!` assertion in prepareAttachmentPointsParams with an explicit guard that throws a descriptive error if the root element is missing, documenting the invariant instead of silencing the linter.

Fixes #10570

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
