### PR TITLE
#10569 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\render\renderers\AtomRenderer.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts
@@ -833,12 +833,11 @@ export class AtomRenderer extends BaseRenderer {
   }
 
   private appendStereoLabel() {
-    if (!this.shouldDisplayStereoLabel()) {
+    const stereoLabel = this.atom.properties.stereoLabel;
+
+    if (!stereoLabel || !this.shouldDisplayStereoLabel()) {
       return;
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const stereoLabel = this.atom.properties.stereoLabel!;
 
     this.stereoLabelElement = this.canvas
       ?.append('g')


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Narrow the stereo label to a truthy local before using it, instead of asserting non-null on the properties field. This removes the eslint-disable suppression while keeping the same early-return behavior when no stereo label is set.

Fixes #10569

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
