### PR TITLE
#10567 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\editor\operations\multitailArrow\multitailArrowUpsertDelete.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowUpsertDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowUpsertDelete.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import type { MultitailArrow } from 'domain/entities/multitailArrow';
 import { OperationType } from 'application/editor/operations/OperationType';
@@ -43,7 +43,13 @@ export class MultitailArrowUpsert extends BaseOperation {
   }
 
   invert(): BaseOperation {
-    return new MultitailArrowDelete(this.data.id!);
+    if (this.data.id === undefined) {
+      // execute() always assigns an id before invert() can be called via
+      // BaseOperation.perform(), so a missing id here would be a programming error.
+      throw new Error('MultitailArrowUpsert.invert() called before execute()');
+    }
+
+    return new MultitailArrowDelete(this.data.id);
   }
 }
 
@@ -71,8 +77,14 @@ export class MultitailArrowDelete extends BaseOperation {
   }
 
   invert(): BaseOperation {
+    if (!this.multitailArrow) {
+      // execute() always clones the multitail arrow before invert() can be called
+      // via BaseOperation.perform(), so a missing value here would be a programming error.
+      throw new Error('MultitailArrowDelete.invert() called before execute()');
+    }
+
     return new MultitailArrowUpsert(
-      this.multitailArrow!,
+      this.multitailArrow,
       this.data.id,
       this.data.arrowId,
     );


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Both assertions were guarding against invert() being called before execute(), which BaseOperation.perform() never does. Replaced them with explicit guard clauses that throw a descriptive error if that invariant is ever violated, instead of silently asserting non-null.

Fixes #10567

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
