### PR TITLE
#10566 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\editor\operations\multitailArrow\multitailArrowAddRemoveTail.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowAddRemoveTail.ts
+++ b/packages/ketcher-core/src/application/editor/operations/multitailArrow/multitailArrowAddRemoveTail.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor/operations/OperationType';
 import type { ReStruct } from 'application/render';
@@ -25,7 +25,13 @@ export class MultitailArrowAddTail extends BaseOperation {
   }
 
   invert() {
-    return new MultitailArrowRemoveTail(this.itemId, this.tailId!);
+    if (this.tailId === undefined) {
+      // `tailId` is assigned in `execute()` before `invert()` can be
+      // meaningfully called; reaching this branch means `invert()` was
+      // called before `execute()`, which is a programming error.
+      throw new Error('MultitailArrowAddTail.invert() called before execute()');
+    }
+    return new MultitailArrowRemoveTail(this.itemId, this.tailId);
   }
 }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
tailId was force-unwrapped in invert() even though it is only guaranteed to be set after execute() runs. Replace the assertion with an explicit guard that narrows the type and throws a descriptive error if invert() is ever called before execute(), documenting the invariant instead of silently trusting it.

Fixes #10566

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
