### PR TITLE
#10565 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\editor\operations\image\imageUpsertDelete.ts

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/image/imageUpsertDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageUpsertDelete.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor/operations/OperationType';
@@ -52,7 +51,13 @@ export class ImageUpsert extends BaseOperation {
   }
 
   invert(): BaseOperation {
-    return new ImageDelete(this.data.id!);
+    // `data.id` is always assigned by `execute` before `invert` can be
+    // meaningfully called; a missing id here indicates a programming error.
+    if (this.data.id === undefined) {
+      throw new Error('ImageUpsert.invert: operation has not been executed');
+    }
+
+    return new ImageDelete(this.data.id);
   }
 }
 
@@ -79,6 +84,12 @@ export class ImageDelete extends BaseOperation {
   }
 
   invert(): BaseOperation {
-    return new ImageUpsert(this.image!, this.data.id);
+    // `image` is always captured by `execute` before `invert` can be
+    // meaningfully called; a missing image here indicates a programming error.
+    if (!this.image) {
+      throw new Error('ImageDelete.invert: operation has not been executed');
+    }
+
+    return new ImageUpsert(this.image, this.data.id);
   }
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
ImageUpsert.invert() and ImageDelete.invert() relied on non-null assertions to treat data.id/image as always present, even though both are only populated after execute() has run. Replace the assertions with guard clauses that throw a descriptive error if invert() is called before execute(), removing the need for the file-level no-non-null-assertion eslint-disable.

Fixes #10565

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
