### PR TITLE
#10564 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\editor\operations\image\imageResize.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/editor/operations/image/imageResize.ts
+++ b/packages/ketcher-core/src/application/editor/operations/image/imageResize.ts
@@ -71,10 +71,18 @@ export class ImageResize extends BaseOperation {
   }
 
   invert(): BaseOperation {
+    // `previousPosition` is only null before `execute` has run. `invert` is
+    // only ever called on an operation that has already been executed, so
+    // reaching this with a null value indicates a programming error.
+    if (!this.previousPosition) {
+      throw new Error(
+        'ImageResize: cannot invert an operation that has not been executed yet',
+      );
+    }
+
     return new ImageResize(
       this.id,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.previousPosition!,
+      this.previousPosition,
       this.referencePositionName,
     );
   }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
`previousPosition` is only null before `execute()` has run. `invert()` is only ever called on an already-executed operation, so I replaced the non-null assertion with a guard clause that throws a descriptive error if that invariant is ever violated — this narrows the type via control flow instead of asserting past it, and removes the need for the `eslint-disable-next-line @typescript-eslint/no-non-null-assertion` suppression.

Fixes #10564

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request
