### PR TITLE
#10563 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\editor\modes\SequenceMode.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2177,21 +2177,21 @@ export class SequenceMode extends BaseMode {
         monomerItem.attachmentPoints,
       );
     // Side chains
-    const oldMonomerBonds: [string, PolymerBond | MonomerToAtomBond | null][] =
-      sideChainConnections
-        ? Object.entries(selectedNode.monomer.attachmentPointsToBonds)
-        : [
-            [
-              AttachmentPointName.R1 as string,
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              selectedNode.firstMonomerInNode.attachmentPointsToBonds.R1!,
-            ],
-            [
-              AttachmentPointName.R2 as string,
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2!,
-            ],
-          ];
+    const oldMonomerBonds: [
+      string,
+      PolymerBond | MonomerToAtomBond | null | undefined,
+    ][] = sideChainConnections
+      ? Object.entries(selectedNode.monomer.attachmentPointsToBonds)
+      : [
+          [
+            AttachmentPointName.R1 as string,
+            selectedNode.firstMonomerInNode.attachmentPointsToBonds.R1,
+          ],
+          [
+            AttachmentPointName.R2 as string,
+            selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2,
+          ],
+        ];
     // Backbone
     return oldMonomerBonds.every(([key, bond]) => {
       if (

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -2178,17 +2178,20 @@ export class SequenceMode extends BaseMode {
       );
     // Side chains
     const oldMonomerBonds: [
-      string,
+      AttachmentPointName,
       PolymerBond | MonomerToAtomBond | null | undefined,
     ][] = sideChainConnections
-      ? Object.entries(selectedNode.monomer.attachmentPointsToBonds)
+      ? (Object.entries(selectedNode.monomer.attachmentPointsToBonds) as [
+          AttachmentPointName,
+          PolymerBond | MonomerToAtomBond | null | undefined,
+        ][])
       : [
           [
-            AttachmentPointName.R1 as string,
+            AttachmentPointName.R1,
             selectedNode.firstMonomerInNode.attachmentPointsToBonds.R1,
           ],
           [
-            AttachmentPointName.R2 as string,
+            AttachmentPointName.R2,
             selectedNode.lastMonomerInNode.attachmentPointsToBonds.R2,
           ],
         ];
@@ -2204,9 +2207,7 @@ export class SequenceMode extends BaseMode {
         return true;
       }
 
-      return newMonomerAttachmentPoints.attachmentPointsList.includes(
-        key as AttachmentPointName,
-      );
+      return newMonomerAttachmentPoints.attachmentPointsList.includes(key);
     });
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The `oldMonomerBonds` tuple type in `checkIfNewMonomerCouldEstablishConnections` excluded `undefined`, forcing a non-null assertion (`!`) when reading the optional `R1`/`R2` attachment-point bonds. Widened the tuple element type to `PolymerBond | MonomerToAtomBond | null | undefined` so the existing `!bond` guard inside the `.every()` callback narrows the value safely, letting the two non-null assertions and their `eslint-disable-next-line @typescript-eslint/no-non-null-assertion` comments be removed without changing runtime behavior.

Fixes #10563

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
