### PR TITLE
#10562 Refactor: Non-null assertion clean up from \packages\ketcher-core\src\application\ketcher.ts` file

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -103,9 +103,16 @@ export class Ketcher {
   libraryUpdateEvent: Subscription;
 
   get editor(): Editor {
-    // we should assign editor exactly after ketcher creation
-    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
-    return this.#editor!;
+    // we should assign editor exactly after ketcher creation, so #editor
+    // being null here would indicate a programming error (accessing the
+    // editor before Ketcher has finished initializing), not a normal
+    // runtime case
+    if (!this.#editor) {
+      throw new Error(
+        'Editor is not initialized yet. It should be assigned right after Ketcher creation.',
+      );
+    }
+    return this.#editor;
   }
 
   get eventBus(): EventEmitter {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The `editor` getter used a non-null assertion since `#editor` is only assigned right after `Ketcher` construction. Replaced it with an explicit guard clause that throws a descriptive error if the editor is accessed before initialization, documenting the invariant instead of silently suppressing the type check.

Fixes #10562

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
