### PR TITLE
#10559 Refactor: Non-null assertion clean up from \packages\ketcher-react\src\script\editor\shared\closest.ts` file

### DIFF
--- a/packages/ketcher-core/src/utilities/__tests__/errorMessages.test.ts
+++ b/packages/ketcher-core/src/utilities/__tests__/errorMessages.test.ts
@@ -1,0 +1,22 @@
+import {
+  atomsForBondNotFoundMessage,
+  entityNotFoundMessage,
+} from '../errorMessages';
+
+describe('entityNotFoundMessage', () => {
+  it('builds a message from the entity name and id', () => {
+    expect(entityNotFoundMessage('Atom', 5)).toBe('Atom 5 not found');
+  });
+
+  it('builds a message for a different entity name', () => {
+    expect(entityNotFoundMessage('Bond', 1)).toBe('Bond 1 not found');
+  });
+});
+
+describe('atomsForBondNotFoundMessage', () => {
+  it('builds a message including the bond id and both atom ids', () => {
+    expect(atomsForBondNotFoundMessage(3, 1, 2)).toBe(
+      'Atom(s) for bond 3 not found: begin=1, end=2',
+    );
+  });
+});

--- a/packages/ketcher-core/src/utilities/__tests__/getOrThrow.test.ts
+++ b/packages/ketcher-core/src/utilities/__tests__/getOrThrow.test.ts
@@ -1,0 +1,23 @@
+import { getOrThrow } from '../getOrThrow';
+
+describe('getOrThrow', () => {
+  it('returns the value when the key is present', () => {
+    const map = new Map<string, number>([['a', 1]]);
+
+    expect(getOrThrow(map, 'a', 'not found')).toBe(1);
+  });
+
+  it('throws with the given message when the key is missing', () => {
+    const map = new Map<string, number>();
+
+    expect(() => getOrThrow(map, 'missing', 'value missing')).toThrow(
+      'value missing',
+    );
+  });
+
+  it('returns falsy values without throwing', () => {
+    const map = new Map<string, number>([['zero', 0]]);
+
+    expect(getOrThrow(map, 'zero', 'not found')).toBe(0);
+  });
+});

--- a/packages/ketcher-core/src/utilities/errorMessages.ts
+++ b/packages/ketcher-core/src/utilities/errorMessages.ts
@@ -1,0 +1,11 @@
+export function entityNotFoundMessage(entityName: string, id: number): string {
+  return `${entityName} ${id} not found`;
+}
+
+export function atomsForBondNotFoundMessage(
+  bondId: number,
+  beginAtomId: number,
+  endAtomId: number,
+): string {
+  return `Atom(s) for bond ${bondId} not found: begin=${beginAtomId}, end=${endAtomId}`;
+}

--- a/packages/ketcher-core/src/utilities/getOrThrow.ts
+++ b/packages/ketcher-core/src/utilities/getOrThrow.ts
@@ -1,0 +1,7 @@
+import assert from 'assert';
+
+export function getOrThrow<K, V>(map: Map<K, V>, key: K, message: string): V {
+  const value = map.get(key);
+  assert(value !== undefined, message);
+  return value;
+}

--- a/packages/ketcher-core/src/utilities/index.ts
+++ b/packages/ketcher-core/src/utilities/index.ts
@@ -29,3 +29,5 @@ export * from './ensureString';
 export * from './normalizeError';
 export * from './monomers';
 export * from './dom';
+export * from './getOrThrow';
+export * from './errorMessages';

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -23,6 +23,9 @@ import {
   IMAGE_KEY,
   MULTITAIL_ARROW_KEY,
   FunctionalGroup,
+  getOrThrow,
+  atomsForBondNotFoundMessage,
+  entityNotFoundMessage,
 } from 'ketcher-core';
 import type { ClosestItem, ClosestItemWithMap } from './closest.types';
 
@@ -189,15 +192,16 @@ function findClosestBond(
       return;
     }
 
-    const beginAtom = restruct.atoms.get(bond.b.begin);
-    const endAtom = restruct.atoms.get(bond.b.end);
-    if (!beginAtom || !endAtom) {
-      // A bond's begin/end atoms are always present in the same restruct;
-      // their absence would indicate a corrupted structure.
-      throw new Error(
-        `Atom(s) for bond ${bid} not found: begin=${bond.b.begin}, end=${bond.b.end}`,
-      );
-    }
+    const beginAtom = getOrThrow(
+      restruct.atoms,
+      bond.b.begin,
+      atomsForBondNotFoundMessage(bid, bond.b.begin, bond.b.end),
+    );
+    const endAtom = getOrThrow(
+      restruct.atoms,
+      bond.b.end,
+      atomsForBondNotFoundMessage(bid, bond.b.begin, bond.b.end),
+    );
     const p1 = beginAtom.a.pp;
     const p2 = endAtom.a.pp;
 
@@ -215,12 +219,11 @@ function findClosestBond(
       closestBondCenter = bid;
     }
 
-    const hb = restruct.molecule.halfBonds.get(bond.b.hb1 as number);
-    if (!hb) {
-      // Every bond has a corresponding half-bond created alongside it;
-      // its absence would indicate a corrupted structure.
-      throw new Error(`Half-bond ${bond.b.hb1} for bond ${bid} not found`);
-    }
+    const hb = getOrThrow(
+      restruct.molecule.halfBonds,
+      bond.b.hb1 as number,
+      `Half-bond ${bond.b.hb1} for bond ${bid} not found`,
+    );
     const dir = hb.dir;
     const norm = hb.norm;
 
@@ -332,11 +335,11 @@ function findClosestFrag(
   const closestAtom = findClosestAtom(restruct, pos, skip, minDist);
 
   if (closestAtom) {
-    const atom = struct.atoms.get(closestAtom.id);
-    if (!atom) {
-      // closestAtom.id always comes from an atom present in the same struct.
-      throw new Error(`Atom ${closestAtom.id} not found`);
-    }
+    const atom = getOrThrow(
+      struct.atoms,
+      closestAtom.id,
+      entityNotFoundMessage('Atom', closestAtom.id),
+    );
     return {
       id: atom.fragment,
       dist: closestAtom.dist,
@@ -346,17 +349,17 @@ function findClosestFrag(
   const closestBond = findClosestBond(restruct, pos, skip, minDist, options);
 
   if (closestBond) {
-    const bond = struct.bonds.get(closestBond.id);
-    if (!bond) {
-      // closestBond.id always comes from a bond present in the same struct.
-      throw new Error(`Bond ${closestBond.id} not found`);
-    }
+    const bond = getOrThrow(
+      struct.bonds,
+      closestBond.id,
+      entityNotFoundMessage('Bond', closestBond.id),
+    );
     const atomId = bond.begin;
-    const atom = struct.atoms.get(atomId);
-    if (!atom) {
-      // A bond's begin atom is always present in the same struct.
-      throw new Error(`Atom ${atomId} not found`);
-    }
+    const atom = getOrThrow(
+      struct.atoms,
+      atomId,
+      entityNotFoundMessage('Atom', atomId),
+    );
     return {
       id: atom.fragment,
       dist: closestBond.dist,
@@ -614,14 +617,16 @@ function findCloseMerge(
   selected.bonds.forEach((bid) => {
     const bond = struct.bonds.get(bid);
     if (bond) {
-      const beginAtom = struct.atoms.get(bond.begin);
-      const endAtom = struct.atoms.get(bond.end);
-      if (!beginAtom || !endAtom) {
-        // A bond's begin/end atoms are always present in the same struct.
-        throw new Error(
-          `Atom(s) for bond ${bid} not found: begin=${bond.begin}, end=${bond.end}`,
-        );
-      }
+      const beginAtom = getOrThrow(
+        struct.atoms,
+        bond.begin,
+        atomsForBondNotFoundMessage(bid, bond.begin, bond.end),
+      );
+      const endAtom = getOrThrow(
+        struct.atoms,
+        bond.end,
+        atomsForBondNotFoundMessage(bid, bond.begin, bond.end),
+      );
       pos.bonds.set(bid, Vec2.lc2(beginAtom.pp, 0.5, endAtom.pp, 0.5));
     }
   });

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -189,10 +189,17 @@ function findClosestBond(
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const p1 = restruct.atoms.get(bond.b.begin)!.a.pp;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const p2 = restruct.atoms.get(bond.b.end)!.a.pp;
+    const beginAtom = restruct.atoms.get(bond.b.begin);
+    const endAtom = restruct.atoms.get(bond.b.end);
+    if (!beginAtom || !endAtom) {
+      // A bond's begin/end atoms are always present in the same restruct;
+      // their absence would indicate a corrupted structure.
+      throw new Error(
+        `Atom(s) for bond ${bid} not found: begin=${bond.b.begin}, end=${bond.b.end}`,
+      );
+    }
+    const p1 = beginAtom.a.pp;
+    const p2 = endAtom.a.pp;
 
     const mid = Vec2.lc2(p1, 0.5, p2, 0.5);
     const cdist = Vec2.dist(pos, mid);
@@ -208,8 +215,12 @@ function findClosestBond(
       closestBondCenter = bid;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const hb = restruct.molecule.halfBonds.get(bond.b.hb1 as number)!;
+    const hb = restruct.molecule.halfBonds.get(bond.b.hb1 as number);
+    if (!hb) {
+      // Every bond has a corresponding half-bond created alongside it;
+      // its absence would indicate a corrupted structure.
+      throw new Error(`Half-bond ${bond.b.hb1} for bond ${bid} not found`);
+    }
     const dir = hb.dir;
     const norm = hb.norm;
 
@@ -321,9 +332,13 @@ function findClosestFrag(
   const closestAtom = findClosestAtom(restruct, pos, skip, minDist);
 
   if (closestAtom) {
+    const atom = struct.atoms.get(closestAtom.id);
+    if (!atom) {
+      // closestAtom.id always comes from an atom present in the same struct.
+      throw new Error(`Atom ${closestAtom.id} not found`);
+    }
     return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      id: struct.atoms.get(closestAtom.id)!.fragment,
+      id: atom.fragment,
       dist: closestAtom.dist,
     };
   }
@@ -331,11 +346,19 @@ function findClosestFrag(
   const closestBond = findClosestBond(restruct, pos, skip, minDist, options);
 
   if (closestBond) {
-    // eslint-disable-next-line
-    const atomId = struct.bonds.get(closestBond.id)!.begin;
+    const bond = struct.bonds.get(closestBond.id);
+    if (!bond) {
+      // closestBond.id always comes from a bond present in the same struct.
+      throw new Error(`Bond ${closestBond.id} not found`);
+    }
+    const atomId = bond.begin;
+    const atom = struct.atoms.get(atomId);
+    if (!atom) {
+      // A bond's begin atom is always present in the same struct.
+      throw new Error(`Atom ${atomId} not found`);
+    }
     return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      id: struct.atoms.get(atomId)!.fragment,
+      id: atom.fragment,
       dist: closestBond.dist,
     };
   }
@@ -510,8 +533,12 @@ function findClosestFG(restruct: ReStruct, pos: Vec2, skip) {
       const cursorPosition = new Vec2(x, y);
 
       const dist = Vec2.dist(rectangleCenter, cursorPosition);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const { id } = reSGroup.item!;
+      const sGroupItem = reSGroup.item;
+      if (!sGroupItem) {
+        // A ReSGroup is always constructed with its underlying SGroup item.
+        throw new Error(`ReSGroup ${reSGroupId} has no item`);
+      }
+      const { id } = sGroupItem;
       return { id, dist };
     }
   }
@@ -587,17 +614,15 @@ function findCloseMerge(
   selected.bonds.forEach((bid) => {
     const bond = struct.bonds.get(bid);
     if (bond) {
-      pos.bonds.set(
-        bid,
-        Vec2.lc2(
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          struct.atoms.get(bond.begin)!.pp,
-          0.5,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          struct.atoms.get(bond.end)!.pp,
-          0.5,
-        ),
-      );
+      const beginAtom = struct.atoms.get(bond.begin);
+      const endAtom = struct.atoms.get(bond.end);
+      if (!beginAtom || !endAtom) {
+        // A bond's begin/end atoms are always present in the same struct.
+        throw new Error(
+          `Atom(s) for bond ${bid} not found: begin=${bond.begin}, end=${bond.end}`,
+        );
+      }
+      pos.bonds.set(bid, Vec2.lc2(beginAtom.pp, 0.5, endAtom.pp, 0.5));
     }
   });
 

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  ***************************************************************************/
 
+import assert from 'assert';
+
 import {
   type ReStruct,
   type ImageReferencePositionInfo,
@@ -537,10 +539,7 @@ function findClosestFG(restruct: ReStruct, pos: Vec2, skip) {
 
       const dist = Vec2.dist(rectangleCenter, cursorPosition);
       const sGroupItem = reSGroup.item;
-      if (!sGroupItem) {
-        // A ReSGroup is always constructed with its underlying SGroup item.
-        throw new Error(`ReSGroup ${reSGroupId} has no item`);
-      }
+      assert(sGroupItem, `ReSGroup ${reSGroupId} has no item`);
       const { id } = sGroupItem;
       return { id, dist };
     }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
All assertions guarded lookups that are true structural invariants (a bond's begin/end atoms, its half-bond, an ReSGroup's item). Replaced them with explicit guard clauses that throw a descriptive error if the invariant is ever violated, which both narrows the type via control flow and documents the assumption instead of silently asserting non-null.

Fixes #10559

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request
