### PR TITLE
#5149 - Only elements are moving with the cursor while adding User Template to the Canvas

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -43,7 +43,7 @@ import { fromRGroupAttachmentPointAddition } from './rgroupAttachmentPoint';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import type { Image } from 'domain/entities/image';
 
-type CreatedItems = {
+export type CreatedItems = {
   atoms: number[];
   bonds: number[];
   rxnArrows: number[];

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -28,7 +28,7 @@ import { fromBondStereoUpdate } from './bondStereo';
 import { Action } from './action';
 import closest from '../shared/closest';
 import { fromAromaticTemplateOnBond } from './aromaticFusing';
-import { fromPaste } from './paste';
+import { fromPaste, type CreatedItems } from './paste';
 import utils from '../shared/utils';
 import { fromSgroupAddition } from './sgroup';
 import type { ReStruct } from 'application/render';
@@ -45,8 +45,8 @@ export function fromTemplateOnCanvas(
   pos: Vec2,
   angle = 0,
   isPreview = true,
-): [Action, { atoms: number[]; bonds: number[] }] {
-  const [action, pasteItems] = fromPaste(
+): [Action, { atoms: number[]; bonds: number[] }, CreatedItems] {
+  const [action, pasteItems, items] = fromPaste(
     restruct,
     template.molecule,
     pos,
@@ -56,7 +56,7 @@ export function fromTemplateOnCanvas(
 
   action.addOp(new CalcImplicitH(pasteItems.atoms).perform(restruct));
 
-  return [action, pasteItems];
+  return [action, pasteItems, items];
 }
 
 function extraBondAction(

--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -48,6 +48,12 @@ class TemplatePreview {
   private floatingPreview: {
     atoms: number[];
     bonds: number[];
+    rxnArrows: number[];
+    rxnPluses: number[];
+    texts: number[];
+    images: number[];
+    simpleObjects: number[];
+    multitailArrows: number[];
   } | null;
 
   private position: Vec2;
@@ -164,7 +170,7 @@ class TemplatePreview {
   }
 
   private showFloatingPreview(position: Vec2) {
-    [this.floatingPreviewAction, this.floatingPreview] = fromTemplateOnCanvas(
+    [this.floatingPreviewAction, , this.floatingPreview] = fromTemplateOnCanvas(
       this.restruct,
       this.template,
       position,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
### Problem
 When adding a user template with mixed content (atoms + reaction arrows +
  text + shapes), only atoms/bonds moved with the cursor. Other entities stayed at the
  origin.

  ### Root Cause:
  - fromPaste creates all entity types (atoms, bonds, rxnArrows, texts, images,
  simpleObjects, multitailArrows)
  - But only pasteItems (atoms/bonds) was being returned and tracked
  - The full items object with all entities was being discarded

  ### The Fix:
  1. paste.ts - Return the full items as 3rd value: [action, pasteItems, items]
  2. template.ts - fromTemplateOnCanvas passes through items from fromPaste
  3. templatePreview.ts - The actual fix:
    - Expanded floatingPreview type to include all 8 entity types
    - Captured 3rd return value: [this.floatingPreviewAction, , this.floatingPreview] = 
  fromTemplateOnCanvas(...)

Now all entities created by fromPaste are tracked and moved together
  with the cursor.


<img width="1350" height="910" alt="20260721-0714-41 0517301" src="https://github.com/user-attachments/assets/567749ac-d9bc-4dba-9b7b-1d59dcc27299" />

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request