### PR TITLE
#7455 - Support monomer replacement with drag-and-drop from library

### DIFF
--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -1187,7 +1187,31 @@ export class CoreEditor {
     );
 
     this.events.setLibraryItemDragState.add((state: LibraryItemDragState) => {
+      // Clear previous replacement target highlight
+      if (this.libraryItemDragState?.hoveredMonomer) {
+        const previousRenderer =
+          this.libraryItemDragState.hoveredMonomer.renderer;
+        if (
+          previousRenderer &&
+          'removeReplacementTargetHighlight' in previousRenderer
+        ) {
+          previousRenderer.removeReplacementTargetHighlight();
+        }
+      }
+
       this.libraryItemDragState = state;
+
+      // Show replacement target highlight for newly hovered monomer
+      if (state?.hoveredMonomer) {
+        const renderer = state.hoveredMonomer.renderer;
+        if (renderer && 'showReplacementTargetValid' in renderer) {
+          if (state.isValidReplacement) {
+            renderer.showReplacementTargetValid();
+          } else if ('showReplacementTargetInvalid' in renderer) {
+            renderer.showReplacementTargetInvalid();
+          }
+        }
+      }
     });
 
     this.events.placeLibraryItemOnCanvas.add(

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -64,6 +64,7 @@ import {
   MONOMER_START_X_POSITION,
   MONOMER_START_Y_POSITION,
 } from 'domain/entities/DrawingEntitiesManager';
+import { replaceMonomer } from 'domain/entities/DrawingEntitiesManager.replaceMonomer';
 import { getStructureBbox } from 'domain/entities/structureBbox';
 import type { PolymerBond } from 'domain/entities/PolymerBond';
 import {
@@ -1238,6 +1239,18 @@ export class CoreEditor {
         this.calculateAndStoreNextAutochainPosition(
           monomersAddResult.lastMonomer,
         );
+      },
+    );
+    this.events.replaceMonomerOnCanvas.add(
+      (targetMonomer: BaseMonomer, replacementItem: MonomerOrAmbiguousType) => {
+        const command = replaceMonomer(
+          this.drawingEntitiesManager,
+          targetMonomer,
+          replacementItem,
+        );
+        const history = EditorHistory.getInstance(this);
+        history.update(command);
+        this.renderersContainer.update(command);
       },
     );
     this.events.autochain.add((monomerItem) => this.onAutochain(monomerItem));

--- a/packages/ketcher-core/src/application/editor/editor.types.ts
+++ b/packages/ketcher-core/src/application/editor/editor.types.ts
@@ -20,6 +20,7 @@ import type { Struct } from 'domain/entities/struct';
 import type { selectionKeys } from './shared/constants';
 import type { PipelineSubscription, Subscription } from 'subscription';
 import type { IRnaPreset } from './tools/Tool';
+import type { BaseMonomer } from 'domain/entities/BaseMonomer';
 
 export type EditorSelection = {
   [key in typeof selectionKeys[number]]?: number[];
@@ -110,4 +111,8 @@ export type LibraryItemDragState = {
     x: number;
     y: number;
   };
+  // Monomer drag-and-replace feature: track hovered monomer for replacement
+  hoveredMonomer?: BaseMonomer | null;
+  // Monomer drag-and-replace feature: validation result for replacement compatibility
+  isValidReplacement?: boolean;
 } | null;

--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -71,6 +71,7 @@ export interface IEditorEvents {
   toggleLineLengthHighlighting: Subscription;
   setLibraryItemDragState: Subscription;
   placeLibraryItemOnCanvas: Subscription;
+  replaceMonomerOnCanvas: Subscription;
   autochain: Subscription;
   previewAutochain: Subscription;
   removeAutochainPreview: Subscription;
@@ -147,6 +148,7 @@ export const editorEvents: IEditorEvents = {
   toggleLineLengthHighlighting: new Subscription(),
   setLibraryItemDragState: new Subscription(),
   placeLibraryItemOnCanvas: new Subscription(),
+  replaceMonomerOnCanvas: new Subscription(),
   autochain: new Subscription(),
   previewAutochain: new Subscription(),
   removeAutochainPreview: new Subscription(),

--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -3,7 +3,11 @@ import type { CoreEditor } from 'application/editor/Editor';
 import { provideEditorInstance } from 'application/editor/editorSingleton';
 import { Coordinates } from 'application/editor/shared/coordinates';
 import type { D3SvgElementSelection } from 'application/render/types';
-import { SELECTION_COLOR } from 'application/render/renderers/constants';
+import {
+  SELECTION_COLOR,
+  REPLACEMENT_TARGET_VALID_COLOR,
+  REPLACEMENT_TARGET_INVALID_COLOR,
+} from 'application/render/renderers/constants';
 import assert from 'assert';
 import { AttachmentPoint } from 'domain/AttachmentPoint';
 import type { BaseMonomer } from 'domain/entities/BaseMonomer';
@@ -487,6 +491,52 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
     this.selectionBorder = undefined;
   }
 
+  private replacementTargetCircle?: D3SvgElementSelection<
+    SVGCircleElement,
+    void
+  >;
+
+  public showReplacementTargetValid() {
+    if (this.replacementTargetCircle) {
+      this.replacementTargetCircle
+        .attr('fill', REPLACEMENT_TARGET_VALID_COLOR)
+        .attr('cx', this.center.x)
+        .attr('cy', this.center.y);
+    } else {
+      this.replacementTargetCircle = this.canvas
+        ?.insert('circle', ':first-child')
+        .attr('r', `${BaseMonomerRenderer.selectionCircleRadius}px`)
+        .attr('opacity', '0.6')
+        .attr('cx', this.center.x)
+        .attr('cy', this.center.y)
+        .attr('fill', REPLACEMENT_TARGET_VALID_COLOR)
+        .attr('class', 'dynamic-element replacement-target-highlight');
+    }
+  }
+
+  public showReplacementTargetInvalid() {
+    if (this.replacementTargetCircle) {
+      this.replacementTargetCircle
+        .attr('fill', REPLACEMENT_TARGET_INVALID_COLOR)
+        .attr('cx', this.center.x)
+        .attr('cy', this.center.y);
+    } else {
+      this.replacementTargetCircle = this.canvas
+        ?.insert('circle', ':first-child')
+        .attr('r', `${BaseMonomerRenderer.selectionCircleRadius}px`)
+        .attr('opacity', '0.6')
+        .attr('cx', this.center.x)
+        .attr('cy', this.center.y)
+        .attr('fill', REPLACEMENT_TARGET_INVALID_COLOR)
+        .attr('class', 'dynamic-element replacement-target-highlight');
+    }
+  }
+
+  public removeReplacementTargetHighlight() {
+    this.replacementTargetCircle?.remove();
+    this.replacementTargetCircle = undefined;
+  }
+
   protected abstract appendBody(
     rootElement: D3SvgElementSelection<SVGGElement, void>,
     theme?,
@@ -680,6 +730,7 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
     this.rootElement?.remove();
     this.rootElement = undefined;
     this.removeSelection();
+    this.removeReplacementTargetHighlight();
     if (this.monomer.hovered) {
       this.editorEvents.mouseLeaveMonomer.dispatch();
     }

--- a/packages/ketcher-core/src/application/render/renderers/constants.ts
+++ b/packages/ketcher-core/src/application/render/renderers/constants.ts
@@ -8,6 +8,9 @@ export const BAD_VALENCE_LINE_OFFSET = 2;
 export const SELECTION_COLOR = '#57FF8F';
 export const SELECTION_HOVERED_COLOR = '#CCFFDD';
 
+export const REPLACEMENT_TARGET_VALID_COLOR = '#4A90E2';
+export const REPLACEMENT_TARGET_INVALID_COLOR = '#FF6B6B';
+
 export const MONOMER_SYMBOLS_IDS = {
   [KetMonomerClass.AminoAcid]: {
     hover: '#peptide-hover',

--- a/packages/ketcher-core/src/domain/helpers/index.ts
+++ b/packages/ketcher-core/src/domain/helpers/index.ts
@@ -25,3 +25,7 @@ export {
   isSingleRGroupAttachmentPoint,
   getAttachmentPointLabelWithBinaryShift,
 } from './attachmentPointCalculations';
+export {
+  canReplaceMonomer,
+  getAttachmentPointNames,
+} from './monomerValidation';

--- a/packages/ketcher-core/src/domain/helpers/monomerValidation.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomerValidation.ts
@@ -80,7 +80,7 @@ export function getAttachmentPointNames(
         typeof rgroups.forEach === 'function'
       ) {
         // rgroups is a Map with keys like 1, 2, 3 corresponding to R1, R2, R3
-        rgroups.forEach((_value: any, key: number) => {
+        rgroups.forEach((_value: unknown, key: number) => {
           const pointName = `R${key}` as AttachmentPointName;
           if (!attachmentPoints.includes(pointName)) {
             attachmentPoints.push(pointName);

--- a/packages/ketcher-core/src/domain/helpers/monomerValidation.ts
+++ b/packages/ketcher-core/src/domain/helpers/monomerValidation.ts
@@ -1,0 +1,161 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import type { BaseMonomer } from 'domain/entities/BaseMonomer';
+import type { AttachmentPointName, MonomerOrAmbiguousType } from 'domain/types';
+
+/**
+ * Extracts attachment point names from a monomer library item.
+ *
+ * @param item - The library monomer item to extract attachment points from
+ * @returns Array of attachment point names (e.g., ['R1', 'R2', 'R3'])
+ */
+export function getAttachmentPointNames(
+  item: MonomerOrAmbiguousType,
+): AttachmentPointName[] {
+  if (!item) {
+    return [];
+  }
+
+  const attachmentPoints: AttachmentPointName[] = [];
+
+  // Method 1: Check top-level attachmentPoints array
+  // Use same logic as BaseMonomer.getAttachmentPointDictFromMonomerDefinition
+  if (
+    'attachmentPoints' in item &&
+    item.attachmentPoints &&
+    Array.isArray(item.attachmentPoints)
+  ) {
+    const attachmentPointDictionary = {};
+    item.attachmentPoints.forEach((attachmentPoint, attachmentPointIndex) => {
+      const attachmentPointNumber = attachmentPointIndex + 1;
+      let calculatedAttachmentPointNumber: number;
+
+      if (attachmentPoint.type) {
+        if (attachmentPoint.type === 'left') {
+          calculatedAttachmentPointNumber = 1;
+        } else if (attachmentPoint.type === 'right') {
+          calculatedAttachmentPointNumber = 2;
+        } else if (attachmentPoint.type === 'side') {
+          calculatedAttachmentPointNumber =
+            attachmentPointNumber +
+            ('R1' in attachmentPointDictionary ? 0 : 1) +
+            ('R2' in attachmentPointDictionary ? 0 : 1);
+        } else {
+          calculatedAttachmentPointNumber = attachmentPointNumber;
+        }
+      } else {
+        calculatedAttachmentPointNumber = attachmentPointNumber;
+      }
+
+      const pointName =
+        `R${calculatedAttachmentPointNumber}` as AttachmentPointName;
+      attachmentPointDictionary[pointName] = null;
+      if (!attachmentPoints.includes(pointName)) {
+        attachmentPoints.push(pointName);
+      }
+    });
+  }
+
+  // Method 2: Check struct.rgroups (fallback for monomers without attachmentPoints array)
+  if ('struct' in item && item.struct && 'rgroups' in item.struct) {
+    const rgroups = item.struct.rgroups;
+    if (rgroups) {
+      // Handle both Map and plain object structures
+      if (
+        typeof rgroups.size === 'number' &&
+        typeof rgroups.forEach === 'function'
+      ) {
+        // rgroups is a Map with keys like 1, 2, 3 corresponding to R1, R2, R3
+        rgroups.forEach((_value: any, key: number) => {
+          const pointName = `R${key}` as AttachmentPointName;
+          if (!attachmentPoints.includes(pointName)) {
+            attachmentPoints.push(pointName);
+          }
+        });
+      } else if (typeof rgroups === 'object') {
+        // rgroups is a plain object
+        Object.keys(rgroups).forEach((key) => {
+          const pointName = `R${key}` as AttachmentPointName;
+          if (!attachmentPoints.includes(pointName)) {
+            attachmentPoints.push(pointName);
+          }
+        });
+      }
+    }
+  }
+
+  return attachmentPoints;
+}
+
+/**
+ * Validates whether a target monomer on the canvas can be replaced
+ * by a library monomer item based on connection point compatibility.
+ *
+ * A replacement is valid if the replacement monomer has all the
+ * attachment points that are currently connected (active) on the
+ * target monomer. Unconnected attachment points on the target are ignored.
+ *
+ * @param targetMonomer - The existing monomer on canvas to be replaced
+ * @param replacementItem - The library item to replace it with
+ * @returns true if replacement is valid (all active attachment points match), false otherwise
+ *
+ * @example
+ * // Target has R1, R2 active (connected), R3 unconnected
+ * // Replacement has R1, R2, R4 available
+ * // Result: true (all active points R1, R2 are available)
+ *
+ * @example
+ * // Target has R1, R2 active
+ * // Replacement has only R1 available
+ * // Result: false (R2 is missing)
+ *
+ * @example
+ * // Target has no active bonds (isolated monomer)
+ * // Replacement has any attachment points
+ * // Result: true (no constraints to validate)
+ */
+export function canReplaceMonomer(
+  targetMonomer: BaseMonomer,
+  replacementItem: MonomerOrAmbiguousType,
+): boolean {
+  // Step 1: Get active attachment points from target monomer
+  // Active = attachment points that currently have bonds (not null)
+  const activeAttachmentPoints = Object.entries(
+    targetMonomer.attachmentPointsToBonds,
+  )
+    .filter(([_name, bond]) => bond !== null)
+    .map(([name]) => name as AttachmentPointName);
+
+  // Step 2: If no active bonds, any replacement is valid
+  if (activeAttachmentPoints.length === 0) {
+    return true;
+  }
+
+  // Step 3: Get available attachment points from replacement item
+  const availableAttachmentPoints = getAttachmentPointNames(replacementItem);
+
+  // Step 4: If we couldn't determine available attachment points,
+  // REJECT the replacement (fail-safe: don't allow potentially invalid replacements)
+  if (availableAttachmentPoints.length === 0) {
+    return false;
+  }
+
+  // Step 5: Check that all active points are available in replacement
+  return activeAttachmentPoints.every((point) =>
+    availableAttachmentPoints.includes(point),
+  );
+}

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag.tsx
@@ -64,10 +64,11 @@ export const useLibraryItemDrag = (
           const monomers = Array.from(
             editor.drawingEntitiesManager.monomers.values(),
           );
-          const HIT_RADIUS = 1.5; // angstroms
+          const HIT_RADIUS = 0.5; // angstroms
           let closestDistance = Infinity;
 
           for (const monomer of monomers) {
+            // Calculate Euclidean distance between cursor and monomer position
             const distance = Math.sqrt(
               Math.pow(monomer.position.x - modelPosition.x, 2) +
                 Math.pow(monomer.position.y - modelPosition.y, 2),
@@ -75,6 +76,8 @@ export const useLibraryItemDrag = (
             if (distance < HIT_RADIUS && distance < closestDistance) {
               closestDistance = distance;
               hoveredMonomer = monomer;
+              // Validate replacement: check if library item has all active attachment points
+              // that the target monomer currently uses for bonds
               if (!Array.isArray(item) && 'label' in item) {
                 isValidReplacement = canReplaceMonomer(
                   monomer,
@@ -124,7 +127,7 @@ export const useLibraryItemDrag = (
               const monomers = Array.from(
                 editor.drawingEntitiesManager.monomers.values(),
               );
-              const HIT_RADIUS = 1.5; // angstroms
+              const HIT_RADIUS = 0.5; // angstroms
               let closestDistance = Infinity;
 
               for (const monomer of monomers) {

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useLibraryItemDrag.tsx
@@ -1,7 +1,15 @@
 import { RefObject, useEffect } from 'react';
 import { D3DragEvent, drag, select } from 'd3';
 import { selectEditor, setIsDragging } from 'state/common';
-import { IRnaPreset, MonomerOrAmbiguousType, ZoomTool } from 'ketcher-core';
+import {
+  IRnaPreset,
+  MonomerOrAmbiguousType,
+  ZoomTool,
+  BaseMonomer,
+  canReplaceMonomer,
+  Vec2,
+  Coordinates,
+} from 'ketcher-core';
 import { useDispatch, useSelector } from 'react-redux';
 
 export const useLibraryItemDrag = (
@@ -35,12 +43,56 @@ export const useLibraryItemDrag = (
         dispatch(setIsDragging(true));
 
         const { clientX: x, clientY: y } = event.sourceEvent;
+        const canvasWrapperBoundingClientRect = ZoomTool.instance.canvasWrapper
+          .node()
+          ?.getBoundingClientRect();
+
+        let hoveredMonomer: BaseMonomer | null = null;
+        let isValidReplacement = false;
+
+        if (canvasWrapperBoundingClientRect) {
+          const { top, left } = canvasWrapperBoundingClientRect;
+          const transform = ZoomTool.instance.zoomTransform;
+          const adjustedX = x - left;
+          const adjustedY = y - top;
+          const [scaledX, scaledY] = transform.invert([adjustedX, adjustedY]);
+          const modelPosition = Coordinates.canvasToModel(
+            new Vec2(scaledX, scaledY),
+          );
+
+          // Find CLOSEST monomer within 1.5 angstrom radius
+          const monomers = Array.from(
+            editor.drawingEntitiesManager.monomers.values(),
+          );
+          const HIT_RADIUS = 1.5; // angstroms
+          let closestDistance = Infinity;
+
+          for (const monomer of monomers) {
+            const distance = Math.sqrt(
+              Math.pow(monomer.position.x - modelPosition.x, 2) +
+                Math.pow(monomer.position.y - modelPosition.y, 2),
+            );
+            if (distance < HIT_RADIUS && distance < closestDistance) {
+              closestDistance = distance;
+              hoveredMonomer = monomer;
+              if (!Array.isArray(item) && 'label' in item) {
+                isValidReplacement = canReplaceMonomer(
+                  monomer,
+                  item as MonomerOrAmbiguousType,
+                );
+              }
+            }
+          }
+        }
+
         editor.events.setLibraryItemDragState.dispatch({
           item,
           position: {
             x: x - (editor.ketcherRootElementBoundingClientRect?.left || 0),
             y: y - (editor.ketcherRootElementBoundingClientRect?.top || 0),
           },
+          hoveredMonomer,
+          isValidReplacement,
         });
       })
       .on('end', (event: D3DragEvent<HTMLElement, unknown, unknown>) => {
@@ -48,20 +100,68 @@ export const useLibraryItemDrag = (
           const { clientX: x, clientY: y } = event.sourceEvent;
           const canvasWrapperBoundingClientRect =
             ZoomTool.instance.canvasWrapper.node()?.getBoundingClientRect();
+
           if (canvasWrapperBoundingClientRect) {
             const { top, left, right, bottom } =
               canvasWrapperBoundingClientRect;
             const transform = ZoomTool.instance.zoomTransform;
-            const adjustedX = x - left + transform.k * 15;
-            const adjustedY = y - top + transform.k * 15;
-            const [scaledX, scaledY] = transform.invert([adjustedX, adjustedY]);
             const mouseWithinCanvas =
               x >= left && x <= right && y >= top && y <= bottom;
+
             if (mouseWithinCanvas) {
-              editor.events.placeLibraryItemOnCanvas.dispatch(item, {
-                x: scaledX,
-                y: scaledY,
-              });
+              const adjustedX = x - left;
+              const adjustedY = y - top;
+              const [scaledX, scaledY] = transform.invert([
+                adjustedX,
+                adjustedY,
+              ]);
+              const modelPosition = Coordinates.canvasToModel(
+                new Vec2(scaledX, scaledY),
+              );
+
+              // Find CLOSEST monomer within 1.5 angstrom radius
+              let hoveredMonomer: BaseMonomer | null = null;
+              const monomers = Array.from(
+                editor.drawingEntitiesManager.monomers.values(),
+              );
+              const HIT_RADIUS = 1.5; // angstroms
+              let closestDistance = Infinity;
+
+              for (const monomer of monomers) {
+                const distance = Math.sqrt(
+                  Math.pow(monomer.position.x - modelPosition.x, 2) +
+                    Math.pow(monomer.position.y - modelPosition.y, 2),
+                );
+                if (distance < HIT_RADIUS && distance < closestDistance) {
+                  closestDistance = distance;
+                  hoveredMonomer = monomer;
+                }
+              }
+
+              if (hoveredMonomer && !Array.isArray(item) && 'label' in item) {
+                const isValid = canReplaceMonomer(
+                  hoveredMonomer,
+                  item as MonomerOrAmbiguousType,
+                );
+                if (isValid) {
+                  editor.events.replaceMonomerOnCanvas.dispatch(
+                    hoveredMonomer,
+                    item as MonomerOrAmbiguousType,
+                  );
+                }
+              } else {
+                // Dropping on empty canvas - add new monomer (existing behavior)
+                const adjustedXForPlacement = x - left + transform.k * 15;
+                const adjustedYForPlacement = y - top + transform.k * 15;
+                const [scaledXPlacement, scaledYPlacement] = transform.invert([
+                  adjustedXForPlacement,
+                  adjustedYForPlacement,
+                ]);
+                editor.events.placeLibraryItemOnCanvas.dispatch(item, {
+                  x: scaledXPlacement,
+                  y: scaledYPlacement,
+                });
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- Enable users to replace an existing canvas monomer by dragging a library monomer onto it, preserving all bond connections
- Add visual feedback (blue/red highlight circle) during drag to indicate valid/invalid replacement targets
- Validate attachment point compatibility before allowing replacement (replacement monomer must have all currently-bonded attachment points of the target)

## Details

- Hit-testing uses 0.5 angstrom radius to find closest monomer under cursor during drag
- Replacement is executed via the existing `replaceMonomer` command, supporting undo/redo out of the box
- Original placement behavior (drop on empty canvas) is preserved
- Highlight cleanup happens automatically on drag end and monomer removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)