### PR TITLE
#2818 – Periodic Table: P, F, Cs atoms weight is out of the box

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/PeriodTable/components/AtomInfo/AtomInfo.module.less
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/PeriodTable/components/AtomInfo/AtomInfo.module.less
@@ -23,6 +23,7 @@
   top: 2em;
   width: 60px;
   font-size: 10px;
+  overflow-wrap: break-word;
   .highlight-shadow(black);
 
   opacity: 1;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The element-detail card shown when clicking a cell in the Periodic Table dialog
(`AtomInfo.tsx`) renders the atomic weight as a single unbroken numeric string inside a
fixed `width: 60px` box (`AtomInfo.module.less`, `.ket_atom_info`). There was no
word-wrap rule, so elements with long high-precision mass values — Caesium
(`132.905451966`), Phosphorus (`30.9737619985`), Fluorine (`18.9984031636`) — couldn't
wrap and spilled past the card's border. Shorter mass values (e.g. Hydrogen's `1.00794`)
fit within the box and never triggered the bug.

Fix: added `overflow-wrap: break-word;` to `.ket_atom_info`, letting long numbers wrap
onto a second line within the existing box instead of overflowing it.

Verified in a real browser: reproduced the bug on the unpatched CSS (confirmed
`132.905451966` visibly overflowing the card's border for Cs), then confirmed the fix
resolves it for all three reported elements (Cs, P, F), with no regression on short
values (checked Hydrogen).

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request