### PR TITLE
10515 – Change the pI tooltip

### DIFF
--- a/ketcher-autotests/tests/specs/Templates/Custom-Templates/custom-templates.spec.ts
+++ b/ketcher-autotests/tests/specs/Templates/Custom-Templates/custom-templates.spec.ts
@@ -15,6 +15,7 @@ import { StructureLibraryDialog } from '@tests/pages/molecules/canvas/StructureL
 import {
   AromaticsTemplate,
   FunctionalGroupsTabItems,
+  SaltsAndSolventsTabItems,
   TabSection,
   TemplateLibraryTab,
 } from '@tests/pages/constants/structureLibraryDialog/Constants';
@@ -67,6 +68,9 @@ test.describe('Open Ketcher', () => {
     await StructureLibraryDialog(page).openTab(TabSection.SaltsAndSolvents);
     await PasteFromClipboardDialog(page).closeWindowButton.click();
     await BottomToolbar(page).structureLibrary();
+    await expect(
+      page.getByTestId(SaltsAndSolventsTabItems.TwoEthylhexanol).locator('svg'),
+    ).toBeVisible();
     await takeEditorScreenshot(page);
   });
 

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -756,7 +756,14 @@ const PeptideProperties = (props: PeptidePropertiesProps) => {
                 ? _round(props.macromoleculesProperties.pKa, 2)
                 : '–'
             }
-            hint="The isoelectric point is calculated as the median of all pKa values for the structure."
+            hint={
+              <div>
+                The isoelectric point is calculated as the median of all pKa
+                values for amino acids (values from{' '}
+                <i>Miclotte et. al. (2020)</i>. Only amino acid natural
+                analogues are used in the calculation.
+              </div>
+            }
           />
           <BasicProperty
             name="Extinction Coef.(1/Mcm)"


### PR DESCRIPTION
Updated the isoelectric-point tooltip in macromolecules mode to describe the revised calculation method, natural-analogue handling, and Miclotte et al. reference.

Closes #10515