### PR TITLE
#2947 - After entering zero or deleting the previous value, zero is not deleted in the "Repeat count" field 

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx
@@ -89,7 +89,12 @@ GenericInput.val = function (ev, schema) {
   const value = isNumber ? input.value.replace(/,/g, '.') : input.value;
 
   if (isInteger) {
-    return Number(value) || 0;
+    if (value.trim() === '') {
+      return undefined;
+    }
+
+    const parsedValue = Number(value);
+    return Number.isNaN(parsedValue) ? value : parsedValue;
   }
 
   // When the value can be a float the validation is passed to the parent component

--- a/packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx
@@ -88,14 +88,14 @@ GenericInput.val = function (ev, schema) {
 
   const value = isNumber ? input.value.replace(/,/g, '.') : input.value;
 
-  if (isInteger) {
-    if (value.trim() === '') {
-      return undefined;
-    }
-
-    const parsedValue = Number(value);
-    return Number.isNaN(parsedValue) ? value : parsedValue;
+  if (isNumber && value.trim() === '') {
+    return;
   }
+
+if (isInteger) {
+  const parsedValue = Number(value);
+  return Number.isNaN(parsedValue) ? value : parsedValue;
+}
 
   // When the value can be a float the validation is passed to the parent component
   // because it's more complicated

--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -187,12 +187,19 @@ class Form extends Component<FormProps> {
       value,
       extraValue,
       onChange: (val: unknown) => {
-        const newState = { ...this.props.result, [name]: val };
+        const newState =
+          val === undefined
+            ? omit(this.props.result, [name])
+            : { ...this.props.result, [name]: val };
         this.updateState(newState);
         if (onChange) onChange(val);
       },
       onExtraChange: (val: unknown) => {
-        const newState = { ...this.props.result, [extraName ?? '']: val };
+        const extraFieldName = extraName ?? '';
+        const newState =
+          val === undefined
+            ? omit(this.props.result, [extraFieldName])
+            : { ...this.props.result, [extraFieldName]: val };
         this.updateState(newState);
       },
     };

--- a/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/form/form.tsx
@@ -135,6 +135,15 @@ type FormValidationError = ValidationError & {
   schema: KetcherSchema;
 };
 
+const updateFieldValue = (
+  result: Record<string, unknown>,
+  fieldName: string,
+  val: unknown,
+) =>
+  val === undefined
+    ? omit(result, [fieldName])
+    : { ...result, [fieldName]: val };
+
 class Form extends Component<FormProps> {
   schema: ReturnType<typeof propSchema>;
   private _cachedSchema: FormSchema;
@@ -187,19 +196,17 @@ class Form extends Component<FormProps> {
       value,
       extraValue,
       onChange: (val: unknown) => {
-        const newState =
-          val === undefined
-            ? omit(this.props.result, [name])
-            : { ...this.props.result, [name]: val };
+        const newState = updateFieldValue(this.props.result, name, val);
         this.updateState(newState);
         if (onChange) onChange(val);
       },
       onExtraChange: (val: unknown) => {
         const extraFieldName = extraName ?? '';
-        const newState =
-          val === undefined
-            ? omit(this.props.result, [extraFieldName])
-            : { ...this.props.result, [extraFieldName]: val };
+        const newState = updateFieldValue(
+          this.props.result,
+          extraFieldName,
+          val,
+        );
         this.updateState(newState);
       },
     };

--- a/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.test.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/toolbox/sgroup.test.tsx
@@ -40,6 +40,27 @@ describe('Multiple repeating S-groups limitations should be in [1, 200]', () => 
       screen.queryByText('must be greater than or equal to 1'),
     ).not.toBeInTheDocument();
   });
+
+  it('should keep Repeat count empty and disable Apply when input is cleared', () => {
+    const { input, store } = setup();
+
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect((input as HTMLInputElement).value).toBe('');
+    expect(screen.getByTestId('OK')).toBeDisabled();
+    const modalState = store?.getState?.().modal;
+    expect(modalState).not.toBeNull();
+    if (!modalState) {
+      throw new Error('Modal state is null');
+    }
+    const formState = modalState.form;
+    expect(formState).not.toBeNull();
+    if (!formState) {
+      throw new Error('Modal form state is null');
+    }
+    expect(formState.errors?.mul).toBeUndefined();
+  });
 });
 
 describe('Copolymer S-Group type availability', () => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

https://github.com/user-attachments/assets/68955eb2-899d-478c-888c-5341e21ca58c

Fix S-Group Repeat count snapping to 0 when cleared

- Updated Input.tsx to treat empty fields as undefined instead of coercing to 0.
- Updated form.tsx to omit undefined values from form state.
- Added regression unit tests in sgroup.test.tsx.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request