### PR TITLE
#2388 - Stereochemistry button isn't disabled when user selects structure without stereocenters

### DIFF
--- a/packages/ketcher-react/src/script/ui/action/tools.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.ts
@@ -82,12 +82,16 @@ const toolActions: Record<string, ToolActionEntry> = {
     shortcut: 'Alt+e',
     title: 'Stereochemistry',
     action: { tool: 'enhancedStereo' },
-    disabled: (editor) =>
-      editor.isMonomerCreationWizardActive ||
-      findStereoAtoms(
-        editor?.struct(),
-        Array.from(editor?.struct().atoms.keys()),
-      ).length === 0,
+    disabled: (editor) => {
+      if (editor.isMonomerCreationWizardActive) return true;
+      const struct = editor?.struct();
+      const selection = editor?.selection?.();
+      const atomIds =
+        selection && selection.atoms
+          ? selection.atoms
+          : Array.from(struct.atoms.keys());
+      return findStereoAtoms(struct, atomIds).length === 0;
+    },
     hidden: (options) => isHidden(options, 'enhanced-stereo'),
   },
   'charge-plus': {

--- a/packages/ketcher-react/src/script/ui/action/tools.ts
+++ b/packages/ketcher-react/src/script/ui/action/tools.ts
@@ -83,13 +83,12 @@ const toolActions: Record<string, ToolActionEntry> = {
     title: 'Stereochemistry',
     action: { tool: 'enhancedStereo' },
     disabled: (editor) => {
-      if (editor.isMonomerCreationWizardActive) return true;
-      const struct = editor?.struct();
-      const selection = editor?.selection?.();
+      if (editor.isMonomerCreationWizardActive) {
+        return true;
+      }
+      const struct = editor?.struct?.();
       const atomIds =
-        selection && selection.atoms
-          ? selection.atoms
-          : Array.from(struct.atoms.keys());
+        editor?.selection?.()?.atoms ?? Array.from(struct.atoms.keys());
       return findStereoAtoms(struct, atomIds).length === 0;
     },
     hidden: (options) => isHidden(options, 'enhanced-stereo'),


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [x] unit-tests written
- [x] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request