### PR TITLE
#3705 – Change bond type using keyboard shortcuts while hovering on bond

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
+++ b/packages/ketcher-react/src/script/ui/state/handleHotkeysOverItem.ts
@@ -9,6 +9,7 @@ import {
   Atom,
   Action,
   KetcherLogger,
+  bondChangingAction,
 } from 'ketcher-core';
 import { STRUCT_TYPE } from 'src/constants';
 import { openDialog } from './modal';
@@ -261,6 +262,9 @@ function getToolHandler(itemType: string, toolName = '') {
       hand: ({ dispatch }: HandlersProps) =>
         dispatch(onAction({ tool: 'hand' })),
     },
+    bonds: {
+      bond: (props: HandlersProps) => handleBondTypeChangeTool(props),
+    },
     sgroups: {
       atom: (props: HandlersProps) => handleSgroupsTool(props),
     },
@@ -318,6 +322,21 @@ function handleBondTool({ hoveredItemId, newAction, editor }: HandlersProps) {
     { label: 'C' },
   )[0];
   editor.update(newBond);
+}
+
+function handleBondTypeChangeTool({
+  hoveredItemId,
+  newAction,
+  editor,
+}: HandlersProps) {
+  const restruct = editor.render.ctab;
+  const bond = restruct.bonds.get(hoveredItemId)?.b;
+  if (!bond) return;
+
+  const action = bondChangingAction(restruct, hoveredItemId, bond, {
+    ...newAction.opts,
+  });
+  editor.update(action);
 }
 
 function handleChargeTool({ hoveredItemId, newAction, editor }: HandlersProps) {

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -201,6 +201,25 @@ function handleSelectTool(newAction, key: string, index: number) {
   return newAction;
 }
 
+// While hovering a bond, cycling through a shared shortcut (e.g. '1' for
+// single/up/down/updown) must advance from the bond's own current type/stereo,
+// not from the active toolbar tool (which doesn't change just from hovering,
+// so re-pressing the key would otherwise always land on the same entry) (#3705).
+function getNextBondTypeAction(hoveredItem, group, render) {
+  const hoveredBondId = hoveredItem.bonds;
+  if (hoveredBondId === undefined) return null;
+
+  const bond = render.ctab.bonds.get(hoveredBondId)?.b;
+  if (!bond) return null;
+
+  const currentIndex = group.findIndex((actName) => {
+    const opts = actions[actName]?.action?.opts;
+    return opts?.type === bond.type && opts?.stereo === bond.stereo;
+  });
+
+  return getNextAction(group[(currentIndex + 1) % group.length]);
+}
+
 function handleHotkeyGroup(
   group,
   actionTool,
@@ -233,7 +252,10 @@ function handleHotkeyGroup(
     if (actName === 'erase' && hasSelection) {
       dispatch(onAction(newAction));
     } else if (shouldHandleItemDirectly(hoveredItem, newAction)) {
-      newAction = getCurrentAction(group[index]) || newAction;
+      newAction =
+        getNextBondTypeAction(hoveredItem, group, render) ||
+        getCurrentAction(group[index]) ||
+        newAction;
       handleHotkeyOverItem({
         hoveredItem,
         newAction,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Two gaps combined to make this shortcut silently do nothing:

1. `handleHotkeysOverItem.ts`'s `getToolHandler` had an `atoms.bond` handler (hovering an
   atom + bond shortcut adds a new bond), but no `bonds.bond` handler — so hovering an
   existing bond and pressing a bond-type shortcut had no handler to dispatch to at all.
2. The shared shortcut-group cycling logic (`checkGroupOnTool`) determines "current
   position in the cycle" from the active toolbar tool, which doesn't change just from
   hovering — so even with a handler wired up, repeated presses on the same bond wouldn't
   actually cycle single → up → down → single as expected.

Fix:
- Added a `bonds.bond` handler (`handleBondTypeChangeTool`) using `bondChangingAction` —
  the same primitive the bond context menu's "Single"/"Double"/etc. items already use, so
  bond-flip and stereo-toggle behavior stays consistent with the existing, tested UI path.
- Added `getNextBondTypeAction`, which computes the cycle position from the *hovered
  bond's own current type/stereo* instead of the toolbar tool, only when hovering a bond,
  reusing the same shortcut-group structure already shared with the toolbar/context menu
  (including "Single Up/Down" as a real 4th member of the `'1'` group).

Verified in a real browser: drew a bond, hovered it, and pressed `1,1,1,1,2,2,0,3,4` in
sequence, confirming the same bond transitions correctly through
Single → Up → Down → Either → Single → Double → Double Cis/Trans → Any → Triple → Aromatic,
with no duplicate bonds created. Reproduced the bug on the unpatched code first (bond
correctly detected as hovered, but nothing changed across all 9 presses), then confirmed
the fix resolves it.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request