### PR TITLE
7211 - Keep the ruler input visible after reload

### DIFF
--- a/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+
+import { RootSizeContext } from '../../contexts';
+
+import { RulerArea } from './RulerArea';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('hooks', () => ({
+  useLayoutMode: () => 'sequence-layout-mode',
+}));
+
+jest.mock('../../hooks/useZoomTransform', () => ({
+  useZoomTransform: () => ({
+    applyX: (value: number) => value,
+    invertX: (value: number) => value,
+  }),
+}));
+
+jest.mock('./RulerInput', () => ({
+  __esModule: true,
+  default: ({ offsetX }: { offsetX: number }) => (
+    <input data-testid="ruler-input" data-offset-x={offsetX} />
+  ),
+}));
+
+jest.mock('./RulerHandle', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./RulerScale', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('RulerArea', () => {
+  it('moves a persisted ruler input into view when the editor becomes visible', () => {
+    let canvasContainerWidth = 0;
+    const canvasContainer = document.createElement('div');
+    Object.defineProperty(canvasContainer, 'clientWidth', {
+      get: () => canvasContainerWidth,
+    });
+    const canvas = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'svg',
+    );
+    canvasContainer.appendChild(canvas);
+
+    const editor = {
+      canvas,
+      events: {
+        setEditorLineLength: { dispatch: jest.fn() },
+        toggleLineLengthHighlighting: { dispatch: jest.fn() },
+      },
+    };
+
+    (useSelector as unknown as jest.Mock).mockImplementation((selector) => {
+      const selectorName = selector.name;
+
+      if (selectorName === 'selectEditorLineLength') {
+        return {
+          'sequence-layout-mode': 210,
+          'snake-layout-mode': 30,
+          'flex-layout-mode': 30,
+        };
+      }
+
+      return editor;
+    });
+
+    const { rerender } = render(
+      <RootSizeContext.Provider value={{ width: 0, height: 0 }}>
+        <RulerArea />
+      </RootSizeContext.Provider>,
+    );
+
+    expect(screen.getByTestId('ruler-input')).toHaveAttribute(
+      'data-offset-x',
+      '4460',
+    );
+
+    canvasContainerWidth = 900;
+    rerender(
+      <RootSizeContext.Provider value={{ width: 1200, height: 800 }}>
+        <RulerArea />
+      </RootSizeContext.Provider>,
+    );
+
+    expect(screen.getByTestId('ruler-input')).toHaveAttribute(
+      'data-offset-x',
+      '865',
+    );
+  });
+});

--- a/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.tsx
+++ b/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { D3DragEvent } from 'd3';
 import { useSelector } from 'react-redux';
 import { selectEditor, selectEditorLineLength } from 'state/common';
 import { useLayoutMode } from 'hooks';
 import clsx from 'clsx';
+import { RootSizeContext } from '../../contexts';
 
 import RulerInput from './RulerInput';
 import RulerScale from './RulerScale';
@@ -21,6 +22,7 @@ import { useZoomTransform } from '../../hooks/useZoomTransform';
 
 export const RulerArea = () => {
   const layoutMode = useLayoutMode();
+  const { width: rootWidth } = useContext(RootSizeContext);
   const editorLineLength = useSelector(selectEditorLineLength);
   const lineLengthValue = editorLineLength[layoutMode];
 
@@ -54,16 +56,15 @@ export const RulerArea = () => {
     const handlePosition = translateValueWithZoomAndDrag - 8;
     let inputPosition = translateValueWithZoomAndDrag + 10;
 
-    const canvasWidth = editor?.canvas.width.baseVal.value;
-    if (!canvasWidth) {
+    const canvasContainer = editor?.canvas.parentElement;
+    const visibleWidth = canvasContainer?.clientWidth || rootWidth;
+    if (!visibleWidth) {
       return [inputPosition, handlePosition];
     }
 
-    const canvasContainer = editor?.canvas.parentElement;
     const scrollLeft = canvasContainer?.scrollLeft || 0;
     const visibleLeftEdge = scrollLeft;
-    const visibleRightEdge =
-      scrollLeft + (canvasContainer?.clientWidth || canvasWidth);
+    const visibleRightEdge = scrollLeft + visibleWidth;
 
     // If input would go beyond right visible edge, cap it, take into account input width (35px)
     if (inputPosition + 35 > visibleRightEdge) {
@@ -77,8 +78,8 @@ export const RulerArea = () => {
 
     return [inputPosition, handlePosition];
   }, [
-    editor?.canvas.width.baseVal.value,
     editor?.canvas.parentElement,
+    rootWidth,
     transform,
     translateValue,
     dragDelta,


### PR DESCRIPTION
The persisted ruler value could be restored while the Macromolecules editor was still hidden, when its canvas width was zero. The ruler input therefore retained an off-screen position after switching back to Macromolecules mode.

The ruler now responds to editor root-size changes and recalculates its position using the visible canvas width. This keeps the input accessible after reloading with a large value such as 210.

Closes #7211