### PR TITLE
#10405 - Hovering over a data S-group should give the tooltip preview…

### DIFF
--- a/packages/ketcher-core/src/application/editor/editorEvents.ts
+++ b/packages/ketcher-core/src/application/editor/editorEvents.ts
@@ -31,6 +31,8 @@ export interface IEditorEvents {
   mouseDownAttachmentPoint: Subscription;
   mouseOverDrawingEntity: Subscription;
   mouseLeaveDrawingEntity: Subscription;
+  mouseOverDataSGroup: Subscription;
+  mouseLeaveDataSGroup: Subscription;
   mouseUpMonomer: Subscription;
   rightClickSequence: Subscription;
   rightClickCanvas: Subscription;
@@ -108,6 +110,8 @@ export function createEditorEvents(): IEditorEvents {
     mouseDownAttachmentPoint: new Subscription(),
     mouseOverDrawingEntity: new Subscription(),
     mouseLeaveDrawingEntity: new Subscription(),
+    mouseOverDataSGroup: new Subscription(),
+    mouseLeaveDataSGroup: new Subscription(),
     mouseUpMonomer: new Subscription(),
     rightClickSequence: new Subscription(),
     rightClickCanvas: new Subscription(),

--- a/packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts
+++ b/packages/ketcher-core/src/application/editor/tools/select/SelectBase.ts
@@ -46,6 +46,13 @@ import {
 import { getStructureBbox } from 'domain/entities/structureBbox';
 import { RotationView } from 'application/render/renderers/TransientView/RotationView';
 import { Atom } from 'domain/entities/CoreAtom';
+import type { Bond } from 'domain/entities/CoreBond';
+import type { SGroupDrawingEntity } from 'domain/entities/SGroupDrawingEntity';
+
+type RendererWithAtomOrBond = BaseRenderer & {
+  atom?: Atom;
+  bond?: Bond;
+};
 
 type EmptySnapResult = {
   snapPosition: null;
@@ -1191,6 +1198,7 @@ abstract class SelectBase implements BaseTool {
         renderer.drawingEntity,
       );
     this.editor.renderersContainer.update(modelChanges);
+    this.dispatchDataSGroupMouseOver(event);
   }
 
   mouseLeaveDrawingEntity(event: MouseEvent): void {
@@ -1204,6 +1212,72 @@ abstract class SelectBase implements BaseTool {
         renderer.drawingEntity,
       );
     this.editor.renderersContainer.update(modelChanges);
+    this.dispatchDataSGroupMouseLeave(event);
+  }
+
+  private findDataSGroupForRenderer(
+    renderer: RendererWithAtomOrBond | undefined,
+  ): SGroupDrawingEntity | undefined {
+    if (!renderer) return undefined;
+
+    const atom = renderer.atom;
+    const bond = renderer.bond;
+
+    for (const [, sgroupEntity] of this.editor.drawingEntitiesManager.sgroups) {
+      if (sgroupEntity.sgroup.type !== 'DAT') continue;
+
+      const sgroupAtomIds = sgroupEntity.sgroup.atoms;
+      const monomer = sgroupEntity.monomer;
+
+      if (
+        atom?.monomer === monomer &&
+        sgroupAtomIds.includes(atom.atomIdInMicroMode)
+      ) {
+        return sgroupEntity;
+      }
+
+      if (bond?.firstAtom?.monomer === monomer) {
+        if (
+          sgroupAtomIds.includes(bond.firstAtom.atomIdInMicroMode) ||
+          sgroupAtomIds.includes(bond.secondAtom.atomIdInMicroMode)
+        ) {
+          return sgroupEntity;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  protected dispatchDataSGroupMouseOver(event: MouseEvent): void {
+    const renderer = (
+      event.target as Element & { __data__?: RendererWithAtomOrBond }
+    ).__data__;
+    const sgroup = this.findDataSGroupForRenderer(renderer);
+    if (sgroup) {
+      this.editor.events.mouseOverDataSGroup.dispatch({
+        event,
+        sgroup: sgroup.sgroup,
+        targetElement: sgroup.renderer?.rootNode,
+      });
+    }
+  }
+
+  protected dispatchDataSGroupMouseLeave(event: MouseEvent): void {
+    const renderer = (
+      event.target as Element & { __data__?: RendererWithAtomOrBond }
+    ).__data__;
+    const currentGroup = this.findDataSGroupForRenderer(renderer);
+    if (!currentGroup) return;
+
+    const nextRenderer = (
+      event.relatedTarget as Element & { __data__?: RendererWithAtomOrBond }
+    )?.__data__;
+    const nextGroup = this.findDataSGroupForRenderer(nextRenderer);
+
+    if (currentGroup !== nextGroup) {
+      this.editor.events.mouseLeaveDataSGroup.dispatch(event);
+    }
   }
 
   public mouseOverPolymerBond(event: MouseEvent): void {

--- a/packages/ketcher-core/src/application/editor/tools/select/SelectFragment.ts
+++ b/packages/ketcher-core/src/application/editor/tools/select/SelectFragment.ts
@@ -43,6 +43,7 @@ export class SelectFragment extends SelectBase {
         renderer.drawingEntity,
       );
     this.editor.renderersContainer.update(modelChanges);
+    this.dispatchDataSGroupMouseOver(event);
   }
 
   mouseLeaveDrawingEntity(event) {
@@ -52,5 +53,6 @@ export class SelectFragment extends SelectBase {
         renderer.drawingEntity,
       );
     this.editor.renderersContainer.update(modelChanges);
+    this.dispatchDataSGroupMouseLeave(event);
   }
 }

--- a/packages/ketcher-core/src/application/render/renderers/BaseRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseRenderer.ts
@@ -69,6 +69,10 @@ export abstract class BaseRenderer implements IBaseRenderer {
     return rootNode.getBoundingClientRect();
   }
 
+  public get rootNode(): SVGGElement | undefined {
+    return this.rootElement?.node() ?? undefined;
+  }
+
   public get width() {
     return this.rootBBox?.width ?? 0;
   }

--- a/packages/ketcher-core/src/application/render/renderers/SGroupRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/SGroupRenderer.ts
@@ -678,6 +678,11 @@ export class SGroupRenderer extends BaseRenderer {
       return;
     }
 
+    // Capture the editor now (during rendering context) so event handlers
+    // always dispatch on the correct editor, not whatever provideEditorInstance()
+    // returns at mouse-event time (which may be the wrong editor).
+    const capturedEditor = provideEditorInstance();
+
     this.hoverAreaElement = this.rootElement
       .insert('rect', ':first-child')
       .data([this])
@@ -693,11 +698,20 @@ export class SGroupRenderer extends BaseRenderer {
 
     this.hoverAreaElement
       .on('mouseover', (event) => {
-        provideEditorInstance().events.mouseOverDrawingEntity.dispatch(event);
+        capturedEditor.events.mouseOverDrawingEntity.dispatch(event);
+        if (this.sgroup.type === SGroup.TYPES.DAT) {
+          capturedEditor.events.mouseOverDataSGroup.dispatch({
+            event,
+            sgroup: this.sgroup,
+          });
+        }
         this.appendHover();
       })
       .on('mouseleave', (event) => {
-        provideEditorInstance().events.mouseLeaveDrawingEntity.dispatch(event);
+        capturedEditor.events.mouseLeaveDrawingEntity.dispatch(event);
+        if (this.sgroup.type === SGroup.TYPES.DAT) {
+          capturedEditor.events.mouseLeaveDataSGroup.dispatch(event);
+        }
         this.removeHover();
       });
   }

--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -47,6 +47,7 @@ import { selectAllPresets } from 'state/rna-builder';
 import {
   AmbiguousMonomerPreviewState,
   BondPreviewState,
+  DataSGroupPreviewState,
   MonomerPreviewState,
   PresetPosition,
   PresetPreviewState,
@@ -318,6 +319,27 @@ export const EditorEvents = () => {
     [handleOpenBondPreview, debouncedShowPreview, presets, isContextMenuActive],
   );
 
+  const handleOpenDataSGroupPreview = useCallback(
+    ({
+      event,
+      sgroup,
+      targetElement,
+    }: {
+      event: MouseEvent;
+      sgroup: { data: { fieldName: string; fieldValue: string } };
+      targetElement?: Element;
+    }) => {
+      const previewData: DataSGroupPreviewState = {
+        type: PreviewType.DataSGroup,
+        fieldName: sgroup.data.fieldName,
+        fieldValue: sgroup.data.fieldValue,
+        target: targetElement ?? (event.target as Element),
+      };
+      debouncedShowPreview(previewData);
+    },
+    [debouncedShowPreview],
+  );
+
   const handleClosePreview = useCallback(() => {
     debouncedShowPreview.cancel();
     dispatch(showPreview(undefined));
@@ -354,6 +376,8 @@ export const EditorEvents = () => {
     editor?.events.mouseLeaveSequenceItem.add(handleClosePreview);
     editor?.events.mouseOverPolymerBond.add(handleOpenPreview);
     editor?.events.mouseLeavePolymerBond.add(handleClosePreview);
+    editor?.events.mouseOverDataSGroup.add(handleOpenDataSGroupPreview);
+    editor?.events.mouseLeaveDataSGroup.add(handleClosePreview);
     editor?.events.mouseOverDrawingEntity.add(handleOpenAtomLabelTooltip);
     editor?.events.mouseLeaveDrawingEntity.add(handleClosePreview);
 
@@ -381,6 +405,8 @@ export const EditorEvents = () => {
       editor?.events.mouseLeavePolymerBond.remove(handleClosePreview);
       editor?.events.mouseOverDrawingEntity.remove(handleOpenAtomLabelTooltip);
       editor?.events.mouseLeaveDrawingEntity.remove(handleClosePreview);
+      editor?.events.mouseOverDataSGroup.remove(handleOpenDataSGroupPreview);
+      editor?.events.mouseLeaveDataSGroup.remove(handleClosePreview);
 
       editor?.events.mouseOnMoveMonomer.remove(onMoveHandler);
       editor?.events.mouseMoveAttachmentPoint.remove(onMoveHandler);
@@ -389,7 +415,13 @@ export const EditorEvents = () => {
 
       window.removeEventListener('hidePreview', handleClosePreview);
     };
-  }, [editor, activeTool, handleOpenPreview, handleClosePreview]);
+  }, [
+    editor,
+    activeTool,
+    handleOpenPreview,
+    handleClosePreview,
+    handleOpenDataSGroupPreview,
+  ]);
 
   useEffect(() => {
     if (!hasAtLeastOneAntisense) {

--- a/packages/ketcher-macromolecules/src/components/preview/Preview.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/Preview.tsx
@@ -26,6 +26,7 @@ import MonomerPreview from './components/MonomerPreview/MonomerPreview';
 import PresetPreview from './components/PresetPreview/PresetPreview';
 import BondPreview from './components/BondPreview/BondPreview';
 import TextPreview from './components/TextPreview/TextPreview';
+import DataSGroupPreview from './components/SGroupPreview/DataSGroupPreview';
 
 const PreviewContainer = styled.div`
   display: inline-block;
@@ -115,6 +116,10 @@ export const Preview = () => {
 
   if (!preview) {
     return null;
+  }
+
+  if (preview.type === PreviewType.DataSGroup) {
+    return <DataSGroupPreview />;
   }
 
   return (

--- a/packages/ketcher-macromolecules/src/components/preview/components/SGroupPreview/DataSGroupPreview.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/SGroupPreview/DataSGroupPreview.test.tsx
@@ -1,0 +1,56 @@
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+import DataSGroupPreview from './DataSGroupPreview';
+import { configureAppStore } from 'state';
+import { showPreview } from 'state/common';
+import { PreviewType } from 'state/types';
+
+jest.mock('ketcher-react', () => ({
+  SGroupDataRender: ({
+    sGroupData,
+    'data-testid': testId,
+  }: {
+    sGroupData: string | null;
+    'data-testid'?: string;
+  }) => <div data-testid={testId}>{sGroupData}</div>,
+}));
+
+describe('DataSGroupPreview', () => {
+  it('renders fieldName=fieldValue for a Data S-group', () => {
+    const store = configureAppStore();
+    const fakeTarget = document.createElement('div');
+    document.body.appendChild(fakeTarget);
+
+    store.dispatch(
+      showPreview({
+        type: PreviewType.DataSGroup,
+        fieldName: 'TestField',
+        fieldValue: 'TestValue',
+        target: fakeTarget,
+      }),
+    );
+
+    render(
+      <Provider store={store}>
+        <DataSGroupPreview />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('data-sgroup-preview')).toBeInTheDocument();
+    expect(screen.getByText('TestField=TestValue')).toBeInTheDocument();
+
+    document.body.removeChild(fakeTarget);
+  });
+
+  it('renders nothing when preview is not a DataSGroup type', () => {
+    const store = configureAppStore();
+
+    render(
+      <Provider store={store}>
+        <DataSGroupPreview />
+      </Provider>,
+    );
+
+    expect(screen.queryByTestId('data-sgroup-preview')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ketcher-macromolecules/src/components/preview/components/SGroupPreview/DataSGroupPreview.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/SGroupPreview/DataSGroupPreview.tsx
@@ -1,0 +1,34 @@
+import type { FC } from 'react';
+import { useSelector } from 'react-redux';
+import { SGroupDataRender } from 'ketcher-react';
+import { useAppSelector } from 'hooks';
+import { selectShowPreview, selectEditor } from 'state/common';
+import { PreviewType } from 'state/types';
+
+const DataSGroupPreview: FC = () => {
+  const preview = useAppSelector(selectShowPreview);
+  const editor = useSelector(selectEditor);
+
+  if (!preview || preview.type !== PreviewType.DataSGroup) {
+    return null;
+  }
+
+  const target = preview.target;
+  const hoverRect = target?.getBoundingClientRect() ?? new DOMRect();
+  const ketcherRootElement = editor?.ketcherRootElement;
+  const canvasRect =
+    ketcherRootElement?.getBoundingClientRect() ?? new DOMRect();
+
+  const sGroupData = `${preview.fieldName}=${preview.fieldValue}`;
+
+  return (
+    <SGroupDataRender
+      hoverRect={hoverRect}
+      canvasRect={canvasRect}
+      sGroupData={sGroupData}
+      data-testid="data-sgroup-preview"
+    />
+  );
+};
+
+export default DataSGroupPreview;

--- a/packages/ketcher-macromolecules/src/state/types.ts
+++ b/packages/ketcher-macromolecules/src/state/types.ts
@@ -13,6 +13,7 @@ export enum PreviewType {
   Bond = 'bond',
   AmbiguousMonomer = 'ambiguousMonomer',
   Text = 'text',
+  DataSGroup = 'dataSGroup',
 }
 
 export interface PreviewStyle {
@@ -62,6 +63,12 @@ export interface AmbiguousMonomerPreviewState extends BasePreviewState {
   readonly presetMonomers?: ReadonlyArray<MonomerItemType | undefined>;
 }
 
+export interface DataSGroupPreviewState extends BasePreviewState {
+  readonly type: PreviewType.DataSGroup;
+  readonly fieldName: string;
+  readonly fieldValue: string;
+}
+
 export interface TextPreviewState extends BasePreviewState {
   readonly type: PreviewType.Text;
   readonly text: string;
@@ -71,5 +78,6 @@ export type EditorStatePreview =
   | MonomerPreviewState
   | PresetPreviewState
   | BondPreviewState
+  | DataSGroupPreviewState
   | AmbiguousMonomerPreviewState
   | TextPreviewState;

--- a/packages/ketcher-react/src/components/MonomerPreview/AmbiguousMonomerPreview/types.ts
+++ b/packages/ketcher-react/src/components/MonomerPreview/AmbiguousMonomerPreview/types.ts
@@ -11,6 +11,7 @@ export enum PreviewType {
   Preset = 'preset',
   Bond = 'bond',
   AmbiguousMonomer = 'ambiguousMonomer',
+  DataSGroup = 'dataSGroup',
   Text = 'text',
 }
 

--- a/packages/ketcher-react/src/components/index.ts
+++ b/packages/ketcher-react/src/components/index.ts
@@ -22,3 +22,4 @@ export * from './Accordion';
 export * from './InfoModal';
 export * from './Dialog';
 export * from './MonomerPreview';
+export { default as SGroupDataRender } from '../script/ui/views/components/StructEditor/SGroupDataRender';

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
@@ -75,17 +75,71 @@ function getPanelPositionRelativeToRect(
   return panelPositionInViewBox;
 }
 
-interface SGroupDataRenderProps {
+function getDomBasedPosition(
+  hoverRect: DOMRect,
+  canvasRect: DOMRect,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  const viewportLeftLimit = BAR_PANEL_SIZE * LEFT_PADDING_MULTIPLIER + width;
+  const viewportBottomLimit = canvasRect.height - BAR_PANEL_SIZE - height;
+  const viewportRightLimit = canvasRect.width - BAR_PANEL_SIZE - width;
+
+  const hoverCenterX = hoverRect.left + hoverRect.width / 2;
+  const relativeClientX = hoverCenterX - canvasRect.left;
+  const relativeClientY = hoverRect.bottom - canvasRect.top;
+
+  // Default: center below the hover rect
+  let x = hoverCenterX - width / 2 - canvasRect.left;
+  let y = hoverRect.bottom - canvasRect.top;
+
+  if (relativeClientY > viewportBottomLimit) {
+    y = hoverRect.top - height - canvasRect.top;
+  }
+
+  if (relativeClientX > viewportRightLimit) {
+    x = hoverRect.left - width - canvasRect.left;
+    y = hoverRect.top + hoverRect.height / 2 - height / 2 - canvasRect.top;
+  }
+
+  if (relativeClientX < viewportLeftLimit) {
+    x = hoverRect.right - canvasRect.left;
+    y = hoverRect.top + hoverRect.height / 2 - height / 2 - canvasRect.top;
+  }
+
+  return { x, y };
+}
+
+interface SGroupDataRenderBaseProps {
+  sGroupData: string | null;
+  className?: string;
+  'data-testid'?: string;
+}
+
+interface SGroupDataRenderRaphaelProps extends SGroupDataRenderBaseProps {
   clientX: number;
   clientY: number;
   render: Render;
   sGroup: SGroup;
-  sGroupData: string | null;
-  className?: string;
+  hoverRect?: undefined;
+  canvasRect?: undefined;
 }
 
+interface SGroupDataRenderDomProps extends SGroupDataRenderBaseProps {
+  hoverRect: DOMRect;
+  canvasRect: DOMRect;
+  clientX?: undefined;
+  clientY?: undefined;
+  render?: undefined;
+  sGroup?: undefined;
+}
+
+type SGroupDataRenderProps =
+  | SGroupDataRenderRaphaelProps
+  | SGroupDataRenderDomProps;
+
 const SGroupDataRender: FC<SGroupDataRenderProps> = (props) => {
-  const { clientX, clientY, render, className, sGroup, sGroupData } = props;
+  const { sGroupData, className } = props;
   const [wrapperHeight, setWrapperHeight] = useState(0);
   const [wrapperWidth, setWrapperWidth] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -97,24 +151,34 @@ const SGroupDataRender: FC<SGroupDataRenderProps> = (props) => {
     }
   });
 
-  const panelCoordinate = getPanelPositionRelativeToRect(
-    clientX,
-    clientY,
-    sGroup,
-    render,
-    wrapperWidth,
-    wrapperHeight,
-  );
+  const panelCoordinate =
+    'hoverRect' in props && props.hoverRect && props.canvasRect
+      ? getDomBasedPosition(
+          props.hoverRect,
+          props.canvasRect,
+          wrapperWidth,
+          wrapperHeight,
+        )
+      : getPanelPositionRelativeToRect(
+          props.clientX as number,
+          props.clientY as number,
+          props.sGroup as SGroup,
+          props.render as Render,
+          wrapperWidth,
+          wrapperHeight,
+        );
+  if (!panelCoordinate) return null;
 
-  return panelCoordinate ? (
+  return (
     <div
       ref={wrapperRef}
+      data-testid={props['data-testid']}
       style={{ left: panelCoordinate.x + 'px', top: panelCoordinate.y + 'px' }}
       className={clsx(classes.infoPanel, className)}
     >
       {sGroupData}
     </div>
-  ) : null;
+  );
 };
 
 export default SGroupDataRender;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Hovering over a data S-group should give the tooltip preview of FiledName=FiledValue with the atom/bond/structure

ketcher-core                                                                                                                                                                         
                                                                                                                                                                                       
 - editorEvents.ts — Added mouseOverDataSGroup and mouseLeaveDataSGroup events to the editor event bus.                                                                               
 - SelectBase.ts — Added findDataSGroupForRenderer, dispatchDataSGroupMouseOver, dispatchDataSGroupMouseLeave; both mouseOverDrawingEntity and mouseLeaveDrawingEntity now call these,
  so hovering any atom or bond inside a DAT S-group bracket triggers the tooltip. Types are clean (RendererWithAtomOrBond, no any). The dispatch includes targetElement:               
  sgroup.renderer?.rootNode so the tooltip always anchors to the S-group's bounding rect, not the hovered bond's thin line.                                                            
  - SelectFragment.ts — mouseOverDrawingEntity / mouseLeaveDrawingEntity call the same dispatch helpers (the override doesn't call super, so it needed them explicitly).               
  - BaseRenderer.ts — Added public get rootNode() to expose the SVG <g> node without breaking encapsulation of rootElement.                                                            
  - SGroupRenderer.ts — appendHoverAreaElement captures provideEditorInstance() at render time (fixes the wrong-editor bug) and dispatches mouseOverDataSGroup / mouseLeaveDataSGroup  
  on direct bracket hover.                                                                                                                                                             
                                                                                                                                                                                       
  ketcher-macromolecules   
- state/types.ts — Added DataSGroupPreviewState type with fieldName, fieldValue, target.                                                                                             
- Preview.tsx — Early-returns the DataSGroup preview type before the generic PreviewContainer, rendering DataSGroupPreview directly.                                                 
- EditorEvents.tsx — Subscribes to mouseOverDataSGroup / mouseLeaveDataSGroup; handleOpenDataSGroupPreview uses targetElement from the payload when provided (bond hover case), falls back to event.target (bracket hover case).                                                                                                                                           
- DataSGroupPreview.tsx — Reads the Redux preview state and renders SGroupDataRender with the DOM-based hover/canvas rects.      

 ketcher-react                                                                                                                                                                        
                                                                                                                                                                                       
 - SGroupDataRender.tsx — Extended with a discriminated-union props interface supporting both DOM-based (macro mode: hoverRect/canvasRect) and Raphael-based (micro mode:        render/sGroup/clientX/clientY) rendering paths.                                                                                                                                      
  - components/index.ts — Exports SGroupDataRender so ketcher-macromolecules can import it.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request