### PR TITLE
#3235 – When pressing "Ctrl+A", the "Lasso Selection" tool and the "Fragment Selection" tool automatically switch to the "Rectangle Selection" tool

### DIFF
--- a/ketcher-autotests/tests/fixtures/commonPageObjectFixtures.ts
+++ b/ketcher-autotests/tests/fixtures/commonPageObjectFixtures.ts
@@ -19,7 +19,7 @@ type CommonPageObjects = {
   CommonTopLeftToolbar: (page: Page) => CommonTopLeftToolbarType;
 };
 
-export const test = base.extend<Record<string, never>, CommonPageObjects>({
+export const test = base.extend<Record<never, never>, CommonPageObjects>({
   CommonTopRightToolbar: [
     async ({}, use) => {
       await use(CommonTopRightToolbar);

--- a/packages/ketcher-react/src/script/ui/action/action.types.ts
+++ b/packages/ketcher-react/src/script/ui/action/action.types.ts
@@ -136,6 +136,12 @@ type ActionThunkState = {
       select: ToolVariant;
     };
   };
+  actionState: {
+    activeTool?:
+      | { tool?: string }
+      | ((editor: ActionStateEditor) => void)
+      | null;
+  };
 };
 
 // todo: find out types

--- a/packages/ketcher-react/src/script/ui/action/index.ts
+++ b/packages/ketcher-react/src/script/ui/action/index.ts
@@ -239,8 +239,17 @@ const config: Record<string, UiAction> = {
     shortcut: 'Mod+a',
     action: {
       thunk: (dispatch, getState) => {
-        const selectionTool = getState().toolbar.visibleTools.select;
-        dispatch({ type: 'ACTION', action: tools[selectionTool].action });
+        const activeTool = getState().actionState?.activeTool;
+        const isSelectionToolActive =
+          typeof activeTool !== 'function' &&
+          (activeTool?.tool === 'select' ||
+            activeTool?.tool === 'fragmentSelection');
+        if (!isSelectionToolActive) {
+          dispatch({
+            type: 'ACTION',
+            action: tools['select-rectangle'].action,
+          });
+        }
         getState().editor.selection('all');
       },
     },


### PR DESCRIPTION
## How did you fix the issue?
Root cause: the `select-all` action's thunk (packages/ketcher-react/src/script/ui/action/index.ts)
decided which selection tool to re-apply after Ctrl+A by reading
`state.toolbar.visibleTools.select`. That value is only ever updated by the legacy
`toolInMenu()` DOM-lookup helper in `state/toolbar/index.js`, which locates the tool button
via `document.getElementById(tool)` plus a `.opened`/`overflow:hidden` ancestor search.
Since the toolbar was rewritten to use `ToolbarMultiToolItem`, that DOM shape no longer
exists, so `toolInMenu()` always returns `null` and `visibleTools.select` stays stuck at
its initial value `'select-rectangle'` forever, regardless of which select tool is
actually active. Every Ctrl+A therefore forced the tool back to Rectangle Selection.

Fix: read the actually active tool from `actionState.activeTool` instead. Only fall back
to Rectangle Selection when the current tool isn't already a selection-family tool
(`select` or `fragmentSelection`); otherwise leave the active tool untouched.

Verified in a live browser session (Playwright against the dev server): drew a Benzene
template, selected Lasso / Fragment / Structure Selection in turn, clicked empty canvas,
pressed Ctrl+A — the tool now correctly stays on the selected variant in all three cases,
and the structure is still fully selected. Also verified no regression: pressing Ctrl+A
while a non-select tool (e.g. Template) is active still correctly switches to Rectangle
Selection.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request

Additionally includes an unrelated one-line fix in `ketcher-autotests/tests/fixtures/commonPageObjectFixtures.ts`
(`Record<string, never>` → `Record<never, never>`), which was a pre-existing type-check breakage on `master`
blocking all pushes via the pre-push hook (TS 6.0.3 couldn't resolve Playwright's fixture-key typing against
an indexed-signature type). Verified full `npm run test` + `npm run test:types` pass across all workspaces.