### PR TITLE
#8176 – An IDT alias for one of the positions (5', internal, 3') must be unique in the whole library (another case)

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -1179,6 +1179,167 @@ describe('CoreEditor', () => {
       );
     });
 
+    it('should reject monomer group template (unsplit nucleotide) with an IDT alias that collides with another monomer group template', () => {
+      const nucleotide1 = {
+        root: {
+          templates: [{ $ref: 'monomerGroupTemplate-_Nucleotide1' }],
+        },
+        'monomerGroupTemplate-_Nucleotide1': {
+          type: 'monomerGroupTemplate',
+          id: '_Nucleotide1',
+          name: '_Nucleotide1',
+          class: 'RNA',
+          templates: [],
+          connections: [],
+          idtAliases: {
+            base: 'IdtNucleotideBase1',
+          },
+        },
+      };
+      const nucleotide2 = {
+        root: {
+          templates: [{ $ref: 'monomerGroupTemplate-_Nucleotide2' }],
+        },
+        'monomerGroupTemplate-_Nucleotide2': {
+          type: 'monomerGroupTemplate',
+          id: '_Nucleotide2',
+          name: '_Nucleotide2',
+          class: 'RNA',
+          templates: [],
+          connections: [],
+          idtAliases: {
+            base: 'IdtNucleotideBase1',
+          },
+        },
+      };
+
+      editor.updateMonomersLibrary(JSON.stringify(nucleotide1));
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+
+      expect(() =>
+        editor.updateMonomersLibrary(JSON.stringify(nucleotide2)),
+      ).toThrow(MonomerLibraryUpdateError);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Editor::updateMonomersLibrary',
+        expect.stringContaining('Duplicate IDT aliases detected'),
+      );
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
+      expect(
+        editor.monomersLibraryParsedJson?.['monomerGroupTemplate-_Nucleotide1'],
+      ).toBeDefined();
+    });
+
+    it('should reject the second of two colliding monomer group templates loaded in a single update payload', () => {
+      const nucleotidesInOneBatch = {
+        root: {
+          templates: [
+            { $ref: 'monomerGroupTemplate-_Nucleotide4' },
+            { $ref: 'monomerGroupTemplate-_Nucleotide5' },
+          ],
+        },
+        'monomerGroupTemplate-_Nucleotide4': {
+          type: 'monomerGroupTemplate',
+          id: '_Nucleotide4',
+          name: '_Nucleotide4',
+          class: 'RNA',
+          templates: [],
+          connections: [],
+          idtAliases: {
+            base: 'IdtBatchBase1',
+          },
+        },
+        'monomerGroupTemplate-_Nucleotide5': {
+          type: 'monomerGroupTemplate',
+          id: '_Nucleotide5',
+          name: '_Nucleotide5',
+          class: 'RNA',
+          templates: [],
+          connections: [],
+          idtAliases: {
+            base: 'IdtBatchBase1',
+          },
+        },
+      };
+
+      expect(() =>
+        editor.updateMonomersLibrary(JSON.stringify(nucleotidesInOneBatch)),
+      ).toThrow(MonomerLibraryUpdateError);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Editor::updateMonomersLibrary',
+        expect.stringContaining('Duplicate IDT aliases detected'),
+      );
+      expect(
+        editor.monomersLibraryParsedJson?.['monomerGroupTemplate-_Nucleotide4'],
+      ).toBeDefined();
+      expect(
+        editor.monomersLibraryParsedJson?.['monomerGroupTemplate-_Nucleotide5'],
+      ).toBeUndefined();
+    });
+
+    it('should reject monomer group template (unsplit nucleotide) with an IDT alias that collides with a regular monomer', () => {
+      const monomerWithIdtAlias = {
+        root: {
+          templates: [{ $ref: 'monomerTemplate-CHEM7' }],
+        },
+        'monomerTemplate-CHEM7': {
+          type: 'monomerTemplate',
+          id: 'CHEM7',
+          class: 'CHEM',
+          classHELM: 'CHEM',
+          fullName: 'Test Chem 7',
+          name: 'CHEM7',
+          naturalAnalogShort: 'X',
+          props: {
+            MonomerName: 'CHEM7',
+            MonomerClass: 'CHEM',
+            Name: 'CHEM7',
+            MonomerNaturalAnalogCode: 'X',
+          },
+          idtAliases: {
+            base: 'IdtShared1',
+          },
+        },
+      };
+      const nucleotideWithCollidingAlias = {
+        root: {
+          templates: [{ $ref: 'monomerGroupTemplate-_Nucleotide3' }],
+        },
+        'monomerGroupTemplate-_Nucleotide3': {
+          type: 'monomerGroupTemplate',
+          id: '_Nucleotide3',
+          name: '_Nucleotide3',
+          class: 'RNA',
+          templates: [],
+          connections: [],
+          idtAliases: {
+            base: 'IdtShared1',
+          },
+        },
+      };
+
+      editor.updateMonomersLibrary(JSON.stringify(monomerWithIdtAlias));
+
+      const initialTemplatesCount =
+        editor.monomersLibraryParsedJson?.root.templates.length ?? 0;
+
+      expect(() =>
+        editor.updateMonomersLibrary(
+          JSON.stringify(nucleotideWithCollidingAlias),
+        ),
+      ).toThrow(MonomerLibraryUpdateError);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Editor::updateMonomersLibrary',
+        expect.stringContaining('Duplicate IDT aliases detected'),
+      );
+      expect(editor.monomersLibraryParsedJson?.root.templates.length).toBe(
+        initialTemplatesCount,
+      );
+    });
+
     // In the KET format, modificationTypes is defined at the template level.
     // During parsing (via templateToMonomerProps) it gets moved to
     // props.modificationTypes, which the validation checks (#8133).

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -25,6 +25,7 @@ import {
   isBaseTool,
 } from 'application/editor/tools/Tool';
 import {
+  type IKetIdtAliases,
   type IKetMacromoleculesContent,
   type IKetMonomerGroupTemplate,
   KetMonomerGroupTemplateClass,
@@ -528,13 +529,29 @@ export class CoreEditor {
         firstMonomer.props.hidden === secondMonomer.props.hidden
       );
     };
-    const getIdtModificationAliases = (monomer?: MonomerItemType): string[] => {
-      const mods = monomer?.props?.idtAliases?.modifications;
-      const base = monomer?.props?.idtAliases?.base;
+    const getIdtAliasesList = (idtAliases?: IKetIdtAliases): string[] => {
+      const base = idtAliases?.base;
+      const mods = idtAliases?.modifications;
       return [base, mods?.internal, mods?.endpoint3, mods?.endpoint5].filter(
         (v): v is string => typeof v === 'string' && v.length > 0,
       );
     };
+    const getIdtModificationAliases = (monomer?: MonomerItemType): string[] =>
+      getIdtAliasesList(monomer?.props?.idtAliases);
+
+    const formatIdtAliasDetails = (idtAliases?: IKetIdtAliases): string[] =>
+      [
+        idtAliases?.base ? `IDT base alias "${idtAliases.base}"` : null,
+        idtAliases?.modifications?.endpoint3
+          ? `IDT 3' alias "${idtAliases.modifications.endpoint3}"`
+          : null,
+        idtAliases?.modifications?.endpoint5
+          ? `IDT 5' alias "${idtAliases.modifications.endpoint5}"`
+          : null,
+        idtAliases?.modifications?.internal
+          ? `IDT internal alias "${idtAliases.modifications.internal}"`
+          : null,
+      ].filter((value): value is string => Boolean(value));
 
     const formatAliasDetails = (monomer: MonomerItemType) =>
       [
@@ -544,18 +561,7 @@ export class CoreEditor {
         monomer.props?.aliasBILN
           ? `BILN alias "${monomer.props.aliasBILN}"`
           : null,
-        monomer.props?.idtAliases?.base
-          ? `IDT base alias "${monomer.props.idtAliases.base}"`
-          : null,
-        monomer.props?.idtAliases?.modifications?.endpoint3
-          ? `IDT 3' alias "${monomer.props.idtAliases.modifications.endpoint3}"`
-          : null,
-        monomer.props?.idtAliases?.modifications?.endpoint5
-          ? `IDT 5' alias "${monomer.props.idtAliases.modifications.endpoint5}"`
-          : null,
-        monomer.props?.idtAliases?.modifications?.internal
-          ? `IDT internal alias "${monomer.props.idtAliases.modifications.internal}"`
-          : null,
+        ...formatIdtAliasDetails(monomer.props?.idtAliases),
       ]
         .filter((value): value is string => Boolean(value))
         .join(', ');
@@ -801,6 +807,54 @@ export class CoreEditor {
               `Editor::updateMonomersLibrary: Load of monomer group template "${templateDefinition.name}" (template: ${templateRef.$ref}) has failed. Monomer group template name must consist only of letters, numbers, hyphens, underscores and asterisks. The template was not added to the library.`,
             );
             return;
+        }
+      }
+
+      const newTemplateIdtAliases = getIdtAliasesList(
+        templateDefinition.idtAliases,
+      );
+
+      if (newTemplateIdtAliases.length > 0) {
+        const conflictingMonomer = this._monomersLibrary.find((monomer) =>
+          getIdtModificationAliases(monomer).some((alias) =>
+            newTemplateIdtAliases.includes(alias),
+          ),
+        );
+
+        const conflictingTemplateRef =
+          monomersLibraryParsedJson.root.templates.find(
+            (existingTemplateRef) => {
+              if (existingTemplateRef.$ref === templateRef.$ref) {
+                return false;
+              }
+
+              const existingTemplate =
+                monomersLibraryParsedJson[existingTemplateRef.$ref];
+
+              if (
+                (existingTemplate as IKetMonomerGroupTemplate)?.type !==
+                KetTemplateType.MONOMER_GROUP_TEMPLATE
+              ) {
+                return false;
+              }
+
+              return getIdtAliasesList(
+                (existingTemplate as IKetMonomerGroupTemplate).idtAliases,
+              ).some((alias) => newTemplateIdtAliases.includes(alias));
+            },
+          );
+
+        if (conflictingMonomer || conflictingTemplateRef) {
+          const detail = formatIdtAliasDetails(
+            templateDefinition.idtAliases,
+          ).join(', ');
+          reportValidationError(
+            templateDefinition.name,
+            `Duplicate IDT aliases detected${
+              detail ? ` (${detail})` : ''
+            }. IDT aliases for 5', 3', internal and base positions must be unique.`,
+          );
+          return;
         }
       }
 


### PR DESCRIPTION
## How did you fix the issue?
#8174 already enforced global IDT-alias uniqueness (5'/3'/internal/base), but only for the
`updateMonomersLibrary` code path that handles individual monomers. `updateMonomersLibrary`
has a second, separate loop that handles monomer group templates (`class: "RNA"`) — these are
the "unsplit nucleotide" presets shown under the library's "Nucleotides" category. That loop
validated template class and name, but never checked `idtAliases` at all, so two unsplit
nucleotides (or a nucleotide and a regular monomer) could be loaded with the same 5'/3'/internal/
base IDT alias with no validation and no console error — exactly the reported repro.

Fix: extracted the IDT-alias-list/formatting logic already used for monomers into shared
helpers (`getIdtAliasesList`, `formatIdtAliasDetails`) so the monomer-group-template loop can
reuse it without duplicating logic. Added a collision check there that rejects a new preset if
its IDT alias collides with either (a) any monomer already in the library, or (b) any other
group template already committed in the current library (including ones added earlier in the
same batch) — matching the "must be unique in the whole library" requirement. On collision the
item is skipped (not the whole batch) and an error is thrown naming the monomer and the
conflicting alias, per the ticket's requirement.

Verified:
- New unit tests: nucleotide-vs-nucleotide collision (two separate loads), nucleotide-vs-nucleotide
  collision within a single load payload, and nucleotide-vs-regular-monomer collision — all
  correctly rejected while the first/valid item stays committed.
- Full `ketcher-core` test suite (prettier/eslint/tsc/circular-deps/jest) passes.
- Rebuilt `ketcher-core` dist and re-ran full test suites for `ketcher-macromolecules`,
  `ketcher-react`, `ketcher-standalone` against it — all pass.
- Reproduced live in the running app via `ketcher.updateMonomersLibrary(...)` exactly per the
  ticket's console-command steps: first nucleotide loads, second (colliding) is rejected with
  `"Duplicate IDT aliases detected (IDT base alias "...")"`, matching the ticket's expected
  behavior and screenshot.

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request