### PR TITLE
#3733 - can't use ketcher-standalone with vite because process.env is not set in the browser

### DIFF
--- a/packages/ketcher-core/.eslintrc.json
+++ b/packages/ketcher-core/.eslintrc.json
@@ -10,6 +10,17 @@
         "prefer": "type-imports",
         "fixStyle": "separate-type-imports"
       }
+    ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "assert",
+            "message": "Node's 'assert' module breaks browser bundlers (see issue #3733). Use `import { assert } from 'utilities'` instead."
+          }
+        ]
+      }
     ]
   },
   "overrides": [

--- a/packages/ketcher-core/src/application/editor/EditorHistory.ts
+++ b/packages/ketcher-core/src/application/editor/EditorHistory.ts
@@ -16,7 +16,7 @@
 
 import type { Command } from 'domain/entities/Command';
 import type { CoreEditor } from './Editor';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { ketcherProvider } from 'application/ketcherProvider';
 const HISTORY_SIZE = 32; // put me to options
 

--- a/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
+++ b/packages/ketcher-core/src/application/editor/MacromoleculesConverter.ts
@@ -25,7 +25,7 @@ import type { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import { Command } from 'domain/entities/Command';
 import type { PolymerBond } from 'domain/entities/PolymerBond';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { AttachmentPointName } from 'domain/types';
 import {
   getAttachmentPointLabel,

--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -34,7 +34,7 @@ import { fromBondStereoUpdate } from './bondStereo';
 import { Action } from './action';
 import { without } from 'lodash/fp';
 import type ReStruct from 'application/render/restruct/restruct';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 export function fromAtomAddition(restruct, pos, atom) {
   atom = { ...(atom || {}) };

--- a/packages/ketcher-core/src/application/editor/actions/erase.ts
+++ b/packages/ketcher-core/src/application/editor/actions/erase.ts
@@ -31,7 +31,7 @@ import { RGroup } from 'domain/entities/rgroup';
 import { removeAtomFromSgroupIfNeeded, removeSgroupIfNeeded } from './sgroup';
 
 import { Action } from './action';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { atomGetDegree, formatSelection } from './utils';
 import { removeAttachmentPointFromSuperatom } from '../actions/bond';
 import { fromBondStereoUpdate } from './bondStereo';

--- a/packages/ketcher-core/src/application/editor/actions/rgroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rgroupAttachmentPoint.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { ReStruct } from 'application/render';
 import { AttachmentPoints } from 'domain/entities/atom';
 import type { Struct } from 'domain/entities/struct';

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -49,7 +49,7 @@ import {
   SGroupAttachmentPointRemove,
 } from 'application/editor/operations/sgroup/sgroupAttachmentPoints';
 import type Restruct from 'application/render/restruct/restruct';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import { isNumber } from 'lodash';
 import { getAttachmentPointStereoBond } from 'domain/helpers/getAttachmentPointStereoBond';

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -29,7 +29,7 @@ import {
   ReinitializeModeOperation,
   RestoreSequenceCaretPositionOperation,
 } from 'application/editor/operations/modes';
-import assert from 'assert';
+import { assert } from 'utilities';
 import {
   getPeptideLibraryItem,
   getRnaPartLibraryItem,

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignAttachmentAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignAttachmentAtomOperation.ts
@@ -2,7 +2,7 @@ import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import type { MonomerCreationState, ReStruct } from 'application/render';
 import { OperationType } from 'application/editor/operations/OperationType';
 import { RemoveAttachmentPointOperation } from './RemoveAttachmentPointOperation';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { AttachmentPointName } from 'domain/types';
 import { getNextFreeAttachmentPoint } from 'domain/helpers';
 

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/AssignLeavingGroupAtomOperation.ts
@@ -1,7 +1,7 @@
 import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import type { MonomerCreationState, ReStruct } from 'application/render';
 import { OperationType } from 'application/editor/operations/OperationType';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { getNextFreeAttachmentPoint } from 'domain/helpers';
 import type { AttachmentPointName } from 'domain/types';
 import type Restruct from 'application/render/restruct/restruct';

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/MarkAsRnaComponentOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/MarkAsRnaComponentOperation.ts
@@ -10,7 +10,7 @@ import {
   type RnaPresetComponentKey,
   MonomerCreationComponentStructureUpdateEvent,
 } from 'application/editor/shared/customEvents';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 export class MarkAsRnaComponentOperation extends BaseOperation {
   constructor(

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignAttachmentPointOperation.ts
@@ -17,7 +17,7 @@
 import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import type { MonomerCreationState } from 'application/render';
 import { OperationType } from 'application/editor/operations/OperationType';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { AttachmentPointName } from 'domain/types';
 import type Restruct from 'application/render/restruct/restruct';
 

--- a/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
+++ b/packages/ketcher-core/src/application/editor/operations/monomerCreation/ReassignLeavingAtomOperation.ts
@@ -1,7 +1,7 @@
 import { BaseOperation } from 'application/editor/operations/BaseOperation';
 import { OperationType } from 'application/editor/operations/OperationType';
 import type { MonomerCreationState, ReStruct } from 'application/render';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { AttachmentPointName } from 'domain/types';
 
 export class ReassignLeavingAtomOperation extends BaseOperation {

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointAdd.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointAdd.ts
@@ -1,5 +1,5 @@
 import { type ReStruct, ReRGroupAttachmentPoint } from 'application/render';
-import assert from 'assert';
+import { assert } from 'utilities';
 import {
   type RGroupAttachmentPointType,
   RGroupAttachmentPoint,

--- a/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rgroupAttachmentPoint/RGroupAttachmentPointRemove.ts
@@ -1,5 +1,5 @@
 import type { ReStruct } from 'application/render';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { OperationPriority, OperationType } from '../OperationType';
 import BaseOperation from '../BaseOperation';
 

--- a/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowResize.ts
+++ b/packages/ketcher-core/src/application/editor/operations/rxn/RxnArrowResize.ts
@@ -15,11 +15,10 @@
  ***************************************************************************/
 
 import type { ReStruct } from 'application/render';
-import assert from 'assert';
 import { RxnArrow } from 'domain/entities/rxnArrow';
 import { Vec2 } from 'domain/entities/vec2';
 import { Scale } from 'domain/helpers';
-import { toFixed } from 'utilities';
+import { assert, toFixed } from 'utilities';
 import { OperationType } from '../OperationType';
 import Base from '../BaseOperation';
 

--- a/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAttachmentPoints.ts
+++ b/packages/ketcher-core/src/application/editor/operations/sgroup/sgroupAttachmentPoints.ts
@@ -2,7 +2,7 @@ import { BaseOperation } from '../BaseOperation';
 import { OperationPriority, OperationType } from '../OperationType';
 import type { ReStruct } from '../../../render';
 import type { SGroupAttachmentPoint } from 'domain/entities/sGroupAttachmentPoint';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 type Data = {
   sGroupId: number;

--- a/packages/ketcher-core/src/application/editor/tools/Bond.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Bond.ts
@@ -19,7 +19,7 @@ import type { BaseTool } from 'application/editor/tools/Tool';
 import { BaseMonomerRenderer } from 'application/render/renderers/BaseMonomerRenderer';
 import type { FlexModePolymerBondRenderer } from 'application/render/renderers/PolymerBondRenderer/FlexModePolymerBondRenderer';
 import type { SnakeModePolymerBondRenderer } from 'application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { AttachmentPoint } from 'domain/AttachmentPoint';
 import type { BaseMonomer } from 'domain/entities/BaseMonomer';
 import { Command } from 'domain/entities/Command';

--- a/packages/ketcher-core/src/application/editor/tools/Monomer.ts
+++ b/packages/ketcher-core/src/application/editor/tools/Monomer.ts
@@ -24,7 +24,7 @@ import {
 import type { MonomerOrAmbiguousType } from 'domain/types';
 import type { Command } from 'domain/entities/Command';
 import { monomerFactory } from '../operations/monomer/monomerFactory';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { Coordinates } from '../shared/coordinates';
 import { isAmbiguousMonomerLibraryItem } from 'domain/helpers/monomers';
 

--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -40,7 +40,6 @@ import { KetSerializer } from 'domain/serializers/ket/ketSerializer';
 import type { MolfileFormat } from 'domain/serializers/mol/mol.types';
 import { SGroup } from 'domain/entities/sgroup';
 import { Struct } from 'domain/entities/struct';
-import assert from 'assert';
 import { EventEmitter } from 'events';
 import {
   type LogSettings,
@@ -50,6 +49,7 @@ import {
   getSvgFromDrawnStructures,
   KetcherLogger,
   ensureString,
+  assert,
 } from 'utilities';
 import { ketcherProvider } from './ketcherProvider';
 import {

--- a/packages/ketcher-core/src/application/ketcherBuilder.ts
+++ b/packages/ketcher-core/src/application/ketcherBuilder.ts
@@ -22,7 +22,7 @@ import type {
 
 import { FormatterFactory } from 'application/formatters';
 import { Ketcher } from './ketcher';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { ketcherProvider } from './ketcherProvider';
 import {
   SettingsService,

--- a/packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/AtomRenderer.ts
@@ -13,7 +13,7 @@ import { StereoLabelStyleType } from 'application/render/restruct/generalEnumTyp
 import { StereoFlag } from 'domain/entities/fragment';
 import type { Settings } from 'application/settings';
 import util from '../util';
-import assert from 'assert';
+import { assert } from 'utilities';
 import {
   BAD_VALENCE_WARNING_COLOR,
   BAD_VALENCE_LINE_OFFSET,

--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -3,7 +3,7 @@ import { provideEditorInstance } from 'application/editor/editorSingleton';
 import { Coordinates } from 'application/editor/shared/coordinates';
 import type { D3SvgElementSelection } from 'application/render/types';
 import { SELECTION_COLOR } from 'application/render/renderers/constants';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { AttachmentPoint } from 'domain/AttachmentPoint';
 import type { BaseMonomer } from 'domain/entities/BaseMonomer';
 import type { DrawingEntity } from 'domain/entities/DrawingEntity';

--- a/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/FlexModePolymerBondRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/FlexModePolymerBondRenderer.ts
@@ -6,7 +6,7 @@ import {
 import { Coordinates } from 'application/editor/shared/coordinates';
 import type { PolymerBondRendererStartAndEndPositions } from 'application/render/renderers/PolymerBondRenderer/PolymerBondRenderer.types';
 import type { D3SvgElementSelection } from 'application/render/types';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { MonomerSize } from 'domain/constants';
 import { Vec2 } from 'domain/entities/vec2';
 import { getStructureBbox } from 'domain/entities/structureBbox';

--- a/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer.ts
@@ -5,7 +5,7 @@ import type { PolymerBondRendererStartAndEndPositions } from 'application/render
 import { SideChainConnectionBondRendererUtility } from 'application/render/renderers/PolymerBondRenderer/SideChainConnectionBondRendererUtility';
 import { SVGPathDAttributeUtility } from 'application/render/renderers/PolymerBondRenderer/SVGPathDAttributeUtility';
 import type { D3SvgElementSelection } from 'application/render/types';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { BaseMonomer, Vec2 } from 'domain/entities';
 import type { Cell } from 'domain/entities/canvas-matrix/Cell';
 import {

--- a/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
+++ b/packages/ketcher-core/src/application/render/renderers/RenderersManager.ts
@@ -9,7 +9,7 @@ import type { BaseMonomerRenderer } from 'application/render/renderers/BaseMonom
 import type { FlexModePolymerBondRenderer } from 'application/render/renderers/PolymerBondRenderer/FlexModePolymerBondRenderer';
 import { PolymerBondRendererFactory } from 'application/render/renderers/PolymerBondRenderer/PolymerBondRendererFactory';
 import type { SnakeModePolymerBondRenderer } from 'application/render/renderers/PolymerBondRenderer/SnakeModePolymerBondRenderer';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { HydrogenBond } from 'domain/entities/HydrogenBond';
 import { LinkerSequenceNode } from 'domain/entities/LinkerSequenceNode';
 import { MonomerSequenceNode } from 'domain/entities/MonomerSequenceNode';

--- a/packages/ketcher-core/src/application/render/renderers/sequence/MonomerToAtomBondSequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/MonomerToAtomBondSequenceRenderer.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { assert } from 'utilities';
 import { BaseSequenceRenderer } from 'application/render/renderers/sequence/BaseSequenceRenderer';
 import type { D3SvgElementSelection } from 'application/render/types';
 import type { MonomerToAtomBond } from 'domain/entities/MonomerToAtomBond';

--- a/packages/ketcher-core/src/application/render/renderers/sequence/PolymerBondSequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/PolymerBondSequenceRenderer.ts
@@ -1,5 +1,5 @@
 import type { PolymerBond } from 'domain/entities/PolymerBond';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { BaseSequenceRenderer } from 'application/render/renderers/sequence/BaseSequenceRenderer';
 import type { D3SvgElementSelection } from 'application/render/types';
 import type { SubChainNode } from 'domain/entities/monomer-chains/types';

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -34,7 +34,6 @@ import type {
 } from 'domain/entities/monomer-chains/types';
 import type { CoreEditor } from 'application/editor/Editor';
 import { RestoreSequenceCaretPositionOperation } from 'application/editor/operations/modes';
-import assert from 'assert';
 import { Command } from 'domain/entities/Command';
 import { NewSequenceButton } from 'application/render/renderers/sequence/ui-controls/NewSequenceButton';
 import { isNumber } from 'lodash';
@@ -43,7 +42,7 @@ import { SequenceViewModel } from 'application/render/renderers/sequence/Sequenc
 import { sequenceRendererStore } from 'application/render/renderers/sequence/SequenceRendererStore';
 import { BackBoneSequenceNode } from 'domain/entities/BackBoneSequenceNode';
 import type { SequenceViewModelChain } from 'application/render/renderers/sequence/SequenceViewModel/SequenceViewModelChain';
-import { SettingsManager } from 'utilities';
+import { assert, SettingsManager } from 'utilities';
 import { SequenceEventDelegationManager } from './SequenceEventDelegationManager';
 import ZoomTool from 'application/editor/tools/Zoom';
 import { select } from 'd3';

--- a/packages/ketcher-core/src/application/render/renderers/utils.ts
+++ b/packages/ketcher-core/src/application/render/renderers/utils.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { assert } from 'utilities';
 import { provideEditorInstance } from 'application/editor/editorSingleton';
 import { BaseMonomerRenderer } from 'application/render/renderers/BaseMonomerRenderer';
 import { BaseSequenceItemRenderer } from 'application/render/renderers/sequence/BaseSequenceItemRenderer';

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -35,7 +35,7 @@ import type { Render } from '../raphaelRender';
 import { Scale } from 'domain/helpers';
 import draw from '../draw';
 import util from '../util';
-import { toFixed } from 'utilities';
+import { assert, toFixed } from 'utilities';
 import type {
   RenderOptions,
   RenderOptionStyles,
@@ -46,7 +46,6 @@ import { type AttachmentPointName, attachmentPointNames } from 'domain/types';
 import { getAttachmentPointLabel } from 'domain/helpers/attachmentPointCalculations';
 import { VALENCE_MAP } from 'application/render/restruct/constants';
 import { SUPERATOM_CLASS_TEXT } from 'application/render/restruct/resgroup';
-import assert from 'assert';
 import { getAttachmentPointTooltip } from 'domain/helpers/attachmentPointTooltips';
 import { ShowHydrogenLabels } from './showHydrogenLabels';
 

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -24,7 +24,7 @@ import { Pile } from 'domain/entities/pile';
 import { Pool } from 'domain/entities/pool';
 import type { RGroupAttachmentPoint } from 'domain/entities/rgroupAttachmentPoint';
 import type { Vec2 } from 'domain/entities/vec2';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { LayerMap } from './generalEnumTypes';
 import ReAtom from './reatom';
 import ReBond from './rebond';

--- a/packages/ketcher-core/src/application/render/util.ts
+++ b/packages/ketcher-core/src/application/render/util.ts
@@ -20,7 +20,7 @@ import type { Bond } from 'domain/entities/bond';
 import type { Box2Abs } from 'domain/entities/box2Abs';
 import type { HalfBond } from 'domain/entities/halfBond';
 import { Vec2 } from 'domain/entities/vec2';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { LayerMap } from './restruct/generalEnumTypes';
 import type ReStruct from './restruct/restruct';
 import type Visel from './restruct/visel';

--- a/packages/ketcher-core/src/application/utils.ts
+++ b/packages/ketcher-core/src/application/utils.ts
@@ -10,7 +10,7 @@ import type { StructService } from 'domain/services';
 import { ChemicalMimeType } from 'domain/services/struct/structService.types';
 import { EditorHistory } from './editor/internal';
 import { KetSerializer } from 'domain/serializers';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 export async function prepareStructToRender(
   structStr: string,

--- a/packages/ketcher-core/src/domain/AttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/AttachmentPoint.ts
@@ -4,7 +4,7 @@ import type { PolymerBond } from 'domain/entities/PolymerBond';
 import type { D3SvgElementSelection } from 'application/render/types';
 import { type Selection, line } from 'd3';
 import type { BaseMonomer } from './entities/BaseMonomer';
-import assert from 'assert';
+import { assert } from 'utilities';
 import {
   type Coordinates,
   canvasToMonomerCoordinates,

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.replaceMonomer.ts
@@ -8,7 +8,7 @@ import { Command } from 'domain/entities/Command';
 import type { PolymerBond } from 'domain/entities/PolymerBond';
 import type { Atom } from 'domain/entities/CoreAtom';
 import type { MonomerToAtomBond } from 'domain/entities/MonomerToAtomBond';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 import type { DrawingEntitiesManager } from './DrawingEntitiesManager';
 

--- a/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntitiesManager.ts
@@ -10,7 +10,6 @@ import { Command } from 'domain/entities/Command';
 import type { DrawingEntity } from 'domain/entities/DrawingEntity';
 import { getStructureBbox } from 'domain/entities/structureBbox';
 import { PolymerBond } from 'domain/entities/PolymerBond';
-import assert from 'assert';
 import {
   type KetFileMultitailArrowNode,
   type LinkerSequenceNode,
@@ -114,7 +113,7 @@ import {
 import { SugarWithBaseSnakeLayoutNode } from 'domain/entities/snake-layout-model/SugarWithBaseSnakeLayoutNode';
 import { SingleMonomerSnakeLayoutNode } from 'domain/entities/snake-layout-model/SingleMonomerSnakeLayoutNode';
 import { getRnaPartLibraryItem } from 'domain/helpers/rna';
-import { KetcherLogger, SettingsManager } from 'utilities';
+import { assert, KetcherLogger, SettingsManager } from 'utilities';
 import { EmptyMonomer } from 'domain/entities/EmptyMonomer';
 import {
   RxnArrowAddOperation,

--- a/packages/ketcher-core/src/domain/entities/DrawingEntity.ts
+++ b/packages/ketcher-core/src/domain/entities/DrawingEntity.ts
@@ -1,6 +1,6 @@
 import { Vec2 } from 'domain/entities/vec2';
 import type { BaseRenderer } from 'application/render/renderers/BaseRenderer';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { Coordinates } from 'application/editor/shared/coordinates';
 let id = 0;
 

--- a/packages/ketcher-core/src/domain/entities/Nucleoside.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleoside.ts
@@ -1,6 +1,6 @@
 import type { RNABase } from 'domain/entities/RNABase';
 import type { Sugar } from 'domain/entities/Sugar';
-import assert from 'assert';
+import { assert } from 'utilities';
 import {
   getNextMonomerInChain,
   getRnaBaseFromSugar,

--- a/packages/ketcher-core/src/domain/entities/Nucleotide.ts
+++ b/packages/ketcher-core/src/domain/entities/Nucleotide.ts
@@ -2,7 +2,7 @@ import { provideEditorInstance } from 'application/editor/editorSingleton';
 import type { RNABase } from 'domain/entities/RNABase';
 import type { Phosphate } from 'domain/entities/Phosphate';
 import { Sugar } from 'domain/entities/Sugar';
-import assert from 'assert';
+import { assert } from 'utilities';
 import {
   getPhosphateFromSugar,
   getRnaBaseFromSugar,

--- a/packages/ketcher-core/src/domain/entities/box2Abs.ts
+++ b/packages/ketcher-core/src/domain/entities/box2Abs.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import { Vec2 } from './vec2';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 export class Box2Abs {
   readonly p0: Vec2;

--- a/packages/ketcher-core/src/domain/entities/functionalGroup.ts
+++ b/packages/ketcher-core/src/domain/entities/functionalGroup.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 import type { ReSGroup } from 'application/render';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { FunctionalGroupsProvider, SaltsAndSolventsProvider } from '../helpers';
 import type { Atom } from './atom';
 import type { Bond } from './bond';

--- a/packages/ketcher-core/src/domain/entities/halfBond.ts
+++ b/packages/ketcher-core/src/domain/entities/halfBond.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import { Vec2 } from './vec2';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 /** @internal */
 export class HalfBond {

--- a/packages/ketcher-core/src/domain/entities/monomerMicromolecule.ts
+++ b/packages/ketcher-core/src/domain/entities/monomerMicromolecule.ts
@@ -15,7 +15,7 @@
  ***************************************************************************/
 import { SGroup } from 'domain/entities/sgroup';
 import type { Struct } from 'domain/entities/struct';
-import assert from 'assert';
+import { assert } from 'utilities';
 import type { BaseMonomer } from 'domain/entities/BaseMonomer';
 
 export class MonomerMicromolecule extends SGroup {

--- a/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/domain/entities/sGroupAttachmentPoint.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { assert } from 'utilities';
 import { RGroupAttachmentPoint } from './rgroupAttachmentPoint';
 
 /**

--- a/packages/ketcher-core/src/domain/entities/sgroup.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroup.ts
@@ -26,7 +26,7 @@ import type { Pool } from 'domain/entities/pool';
 import type { SGroupAttachmentPoint } from 'domain/entities/sGroupAttachmentPoint';
 import type { ReSGroup } from 'application/render';
 import { SgContexts } from 'application/editor/shared/constants';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { isNumber } from 'lodash';
 import { geometricCenter, getAtomPositions } from 'domain/entities/geometry';
 

--- a/packages/ketcher-core/src/domain/entities/sgroupForest.ts
+++ b/packages/ketcher-core/src/domain/entities/sgroupForest.ts
@@ -16,9 +16,8 @@
 
 import { Pile } from './pile';
 import { SGroup } from './sgroup';
-import assert from 'assert';
 import type { Struct } from './struct';
-import { KetcherLogger } from 'utilities';
+import { assert, KetcherLogger } from 'utilities';
 
 export class SGroupForest {
   /** node id -> parent id */

--- a/packages/ketcher-core/src/domain/entities/struct.ts
+++ b/packages/ketcher-core/src/domain/entities/struct.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import assert from 'assert';
+import { assert } from 'utilities';
 import { Atom, radicalElectrons } from './atom';
 import type { EditorSelection } from 'application/editor/editor.types';
 import { Bond } from './bond';

--- a/packages/ketcher-core/src/domain/entities/vec2.ts
+++ b/packages/ketcher-core/src/domain/entities/vec2.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import assert from 'assert';
-import { toFixed } from 'utilities';
+import { assert, toFixed } from 'utilities';
 
 export interface Point {
   x?: number;

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerTemplateUtils.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/monomerTemplateUtils.ts
@@ -6,7 +6,7 @@ import { Struct, Vec2, BaseMonomer } from 'domain/entities';
 import { type MonomerItemType, AttachmentPointName } from 'domain/types';
 import { getAttachmentPointLabelWithBinaryShift } from 'domain/helpers/attachmentPointCalculations';
 import { isNumber } from 'lodash';
-import assert from 'assert';
+import { assert } from 'utilities';
 import { moleculeToStruct } from './moleculeToStruct';
 import { rxnToStruct } from './rxnToStruct';
 import { simpleObjectToStruct } from './simpleObjectToStruct';

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -63,7 +63,6 @@ import {
   templateToMonomerProps,
   variantMonomerToDrawingEntity,
 } from 'domain/serializers/ket/fromKet/monomerToDrawingEntity';
-import assert from 'assert';
 import { polymerBondToDrawingEntity } from 'domain/serializers/ket/fromKet/polymerBondToDrawingEntity';
 import { getMonomerUniqueKey } from 'domain/helpers/monomers';
 import {
@@ -71,7 +70,7 @@ import {
   fillStructRgLabelsByMonomerTemplate,
   getTemplateAttachmentPoints,
 } from 'domain/serializers/ket/fromKet/monomerTemplateUtils';
-import { KetcherLogger } from 'utilities';
+import { assert, KetcherLogger } from 'utilities';
 import { Chem } from 'domain/entities/Chem';
 import { DrawingEntitiesManager } from 'domain/entities/DrawingEntitiesManager';
 import {

--- a/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/parseSGroup.ts
@@ -22,7 +22,7 @@ import type { Struct } from 'domain/entities/struct';
 
 import type { SGroupMap, AtomMap, PostLoadHandler } from './mol.types';
 import utils from './utils';
-import assert from 'assert';
+import { assert } from 'utilities';
 
 function readKeyValuePairs(
   str: string,

--- a/packages/ketcher-core/src/utilities/assert.ts
+++ b/packages/ketcher-core/src/utilities/assert.ts
@@ -1,0 +1,18 @@
+/**
+ * Browser-safe replacement for Node.js's built-in `assert` module.
+ *
+ * `ketcher-core` is consumed by bundlers (e.g. Vite) that build for the
+ * browser. Importing the Node.js `assert` module directly pulls in a
+ * dependency chain (`assert` -> `util` -> `process`) that relies on Node.js
+ * globals and crashes with `ReferenceError: process is not defined` unless
+ * the consumer manually configures Node polyfills.
+ *
+ * This function mirrors the subset of Node's `assert(value, message)` API
+ * used across the codebase: it throws when `value` is falsy and otherwise
+ * acts as a TypeScript assertion function so callers keep type narrowing.
+ */
+export function assert(value: unknown, message?: string): asserts value {
+  if (!value) {
+    throw new Error(message ?? 'Assertion failed');
+  }
+}

--- a/packages/ketcher-core/src/utilities/index.ts
+++ b/packages/ketcher-core/src/utilities/index.ts
@@ -31,3 +31,4 @@ export * from './monomers';
 export * from './dom';
 export * from './getOrThrow';
 export * from './errorMessages';
+export * from './assert';

--- a/packages/ketcher-react/.eslintrc.json
+++ b/packages/ketcher-react/.eslintrc.json
@@ -23,6 +23,17 @@
         "prefer": "type-imports",
         "fixStyle": "separate-type-imports"
       }
+    ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "assert",
+            "message": "Node's 'assert' module breaks browser bundlers (see issue #3733). Use `import { assert } from 'ketcher-core'` instead."
+          }
+        ]
+      }
     ]
   },
   "overrides": [

--- a/packages/ketcher-react/src/components/MonomerPreview/calculatePreviewPosition.ts
+++ b/packages/ketcher-react/src/components/MonomerPreview/calculatePreviewPosition.ts
@@ -17,10 +17,10 @@ import {
   type AmbiguousMonomerType,
   type PolymerBond,
   ZoomTool,
+  assert,
 } from 'ketcher-core';
 import { preview } from './constants';
 import type { PreviewStyle } from './AmbiguousMonomerPreview/types';
-import assert from 'assert';
 import { KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR } from 'src/constants';
 
 export const calculateMonomerPreviewTop = createCalculatePreviewTopFunction(

--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -85,6 +85,7 @@ import {
   Visel,
   paperPathFromSVGElement,
   fromFragmentDeletion,
+  assert,
 } from 'ketcher-core';
 import {
   DOMSubscription,
@@ -109,7 +110,6 @@ import type {
   ToolEventHandlerName,
 } from './tool/Tool';
 import { getSelectionMap, getStructCenter } from './utils/structLayout';
-import assert from 'assert';
 import { isNumber } from 'lodash';
 import paperjs from 'paper';
 

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  ***************************************************************************/
 
-import assert from 'assert';
-
 import {
   type ReStruct,
   type ImageReferencePositionInfo,
@@ -29,6 +27,7 @@ import {
   getOrThrow,
   atomsForBondNotFoundMessage,
   entityNotFoundMessage,
+  assert,
 } from 'ketcher-core';
 import type {
   ClosestItem,

--- a/packages/ketcher-react/src/script/editor/tool/apoint.ts
+++ b/packages/ketcher-react/src/script/editor/tool/apoint.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import assert from 'assert';
-import { Atom, FunctionalGroup } from 'ketcher-core';
+import { Atom, FunctionalGroup, assert } from 'ketcher-core';
 import type Editor from '../Editor';
 import type { Tool } from './Tool';
 import { editRGroupAttachmentPoint } from './apoint.utils';

--- a/packages/ketcher-react/src/script/editor/tool/arrow/reactionArrowAdd.ts
+++ b/packages/ketcher-react/src/script/editor/tool/arrow/reactionArrowAdd.ts
@@ -6,9 +6,9 @@ import {
   fromArrowAddition,
   fromArrowDeletion,
   fromArrowResizing,
+  assert,
 } from 'ketcher-core';
 import type { Editor } from '../../Editor';
-import assert from 'assert';
 import type { ArrowAddTool } from './arrow.types';
 
 interface BaseDragContext {

--- a/packages/ketcher-react/src/script/editor/tool/arrow/reactionArrowMoveTool.ts
+++ b/packages/ketcher-react/src/script/editor/tool/arrow/reactionArrowMoveTool.ts
@@ -7,8 +7,8 @@ import {
   CoordinateTransformation,
   fromArrowResizing,
   fromMultipleMove,
+  assert,
 } from 'ketcher-core';
-import assert from 'assert';
 import { ArrowTool } from './arrowTool';
 
 export class ReactionArrowMoveTool

--- a/packages/ketcher-react/src/script/editor/tool/helper/locate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/helper/locate.ts
@@ -21,8 +21,8 @@ import {
   IMAGE_KEY,
   Vec2,
   MULTITAIL_ARROW_KEY,
+  assert,
 } from 'ketcher-core';
-import assert from 'assert';
 
 function getElementsInRectangle(restruct: ReStruct, p0, p1) {
   const bondList: Array<number> = [];

--- a/packages/ketcher-react/src/script/editor/tool/rotate.ts
+++ b/packages/ketcher-react/src/script/editor/tool/rotate.ts
@@ -32,8 +32,8 @@ import {
   MonomerMicromolecule,
   RotateMonomerOperation,
   CoordinateTransformation,
+  assert,
 } from 'ketcher-core';
-import assert from 'assert';
 import { intersection, throttle } from 'lodash';
 import type { Editor, Selection } from '../Editor';
 import type { Tool } from './Tool';

--- a/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
+++ b/packages/ketcher-react/src/script/editor/utils/functionalGroupsTooltip.ts
@@ -1,5 +1,4 @@
-import assert from 'assert';
-import { MonomerMicromolecule, SGroup, Struct } from 'ketcher-core';
+import { MonomerMicromolecule, SGroup, Struct, assert } from 'ketcher-core';
 import type Editor from '../Editor';
 
 let showTooltipTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/ketcher-react/src/script/ui/dialog/AbbreviationLookup/AbbreviationLookup.tsx
+++ b/packages/ketcher-react/src/script/ui/dialog/AbbreviationLookup/AbbreviationLookup.tsx
@@ -26,7 +26,7 @@ import {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import assert from 'assert';
+import { assert } from 'ketcher-core';
 import { Icon } from 'components';
 import MuiAutocomplete, {
   type AutocompleteChangeReason,

--- a/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/AttachmentPointEditPopup/AttachmentPointEditPopup.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from 'react';
 import clsx from 'clsx';
-import type {
-  AtomLabel,
-  AttachmentPointClickData,
-  AttachmentPointName,
+import {
+  type AtomLabel,
+  type AttachmentPointClickData,
+  type AttachmentPointName,
+  assert,
 } from 'ketcher-core';
 import AttachmentPointControls from '../MonomerCreationWizard/components/AttachmentPointControls/AttachmentPointControls';
 import { useAttachmentPointSelectsData } from '../MonomerCreationWizard/hooks/useAttachmentPointSelectsData';
@@ -11,7 +12,6 @@ import { useAttachmentPointSelectsData } from '../MonomerCreationWizard/hooks/us
 import styles from './AttachmentPointEditPopup.module.less';
 import selectStyles from '../../../component/form/Select/Select.module.less';
 import type { Editor } from '../../../../editor';
-import assert from 'assert';
 
 type Props = {
   data: AttachmentPointClickData;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeAttachmentPointMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useMakeAttachmentPointMenuItems.tsx
@@ -3,11 +3,11 @@ import type {
   MenuItemsProps,
 } from '../contextMenu.types';
 import type { Editor } from 'src/script/editor';
-import assert from 'assert';
 import { Item } from 'react-contexify';
 import { Icon } from '../../../../../../components';
 import styles from '../ContextMenu.module.less';
 import type { ReactNode } from 'react';
+import { assert } from 'ketcher-core';
 
 type Props = {
   props: MenuItemsProps<AtomContextMenuProps>;

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRGroupAttachmentPointEdit.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRGroupAttachmentPointEdit.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import assert from 'assert';
 import { useAppContext } from 'src/hooks';
 import type Editor from 'src/script/editor';
 import type {
@@ -7,7 +6,7 @@ import type {
   RGroupAttachmentPointContextMenuProps,
 } from '../contextMenu.types';
 import { editRGroupAttachmentPoint } from 'src/script/editor/tool/apoint.utils';
-import { type Ketcher, ketcherProvider } from 'ketcher-core';
+import { type Ketcher, ketcherProvider, assert } from 'ketcher-core';
 
 type Params = ItemEventParams<RGroupAttachmentPointContextMenuProps>;
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AttachmentPointLabelMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/AttachmentPointLabelMenuItems.tsx
@@ -11,9 +11,9 @@ import {
   Coordinates,
   ketcherProvider,
   MonomerCreationAttachmentPointClickEvent,
+  assert,
 } from 'ketcher-core';
 import type Editor from '../../../../../editor';
-import assert from 'assert';
 
 const AttachmentPointLabelMenuItems = ({
   propsFromTrigger,


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

### Root cause
`ketcher-core` and `ketcher-react` imported Node.js's built-in `assert` module:
```
import assert from 'assert';
```
When consumed by Vite in a browser environment, the `assert` dependency resolved to a browser shim that internally depended on `util` and `process`.
Since `process` is not available in the browser, the application failed at runtime.

### Solution 

 - Replaced Node.js `assert` imports with an internal browser-safe assertion utility.
 - Added ESLint restrictions to prevent future imports from Node.js's `assert` module.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request