### PR TITLE
#10273 – RNA Builder: Inappropriate sugars are not disabled when the …

### DIFF
--- a/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
+++ b/packages/ketcher-macromolecules/src/helpers/rnaValidations.ts
@@ -35,7 +35,10 @@ export const getValidations = (
 
   if (
     !isEditMode ||
-    (!newPreset?.sugar && !newPreset?.phosphate && !newPreset?.base)
+    (!selectedPhosphatePosition &&
+      !newPreset?.sugar &&
+      !newPreset?.phosphate &&
+      !newPreset?.base)
   ) {
     return {
       sugarValidations,


### PR DESCRIPTION
## How the feature works / How did you fix the issue?

Updated the RNA Builder validation logic so that an explicitly selected phosphate position is taken into account even when no preset components have been added yet.

Previously, the validation logic returned early for an empty preset, so selecting a phosphate position before adding any components did not apply the required R1/R2 validation to sugars.

The early return condition was adjusted to preserve the existing behavior for an empty preset with no selected phosphate position while allowing the existing position-specific validation to run when a phosphate position is explicitly selected.

### Verification

https://github.com/user-attachments/assets/b778aa99-e049-491b-a9be-83f3bb4680f0

## Testing

- Existing `rnaValidations` tests: 4/4 passed
- Manually verified that sugars without R1 are disabled when phosphate is selected on the left
- Verified the right phosphate validation path


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request