### PR TITLE
#3268 – Incorrect display of Attachment points along with Atom Properties

### DIFF
--- a/packages/ketcher-core/__tests__/application/render/restruct/rergroupAttachmentPoint.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/restruct/rergroupAttachmentPoint.test.ts
@@ -1,5 +1,7 @@
 import { Render, ReStruct } from 'application/render';
+import draw from 'application/render/draw';
 import type { RenderOptions } from 'application/render/render.types';
+import { Box2Abs } from 'domain/entities/box2Abs';
 import {
   AttachmentPoints,
   Atom,
@@ -54,6 +56,121 @@ function mockSvgDomApi() {
 
   window.SVGElement.prototype.getBBox = () =>
     ({ x: 0, y: 0, width: 10, height: 10 } as DOMRect);
+}
+
+function createTwoNeighborAttachmentPointFixture(renderOptions: RenderOptions) {
+  const struct = new Struct();
+  const attachedAtomId = struct.atoms.add(
+    new Atom({
+      label: 'C',
+      pp: new Vec2(0, 0),
+      attachmentPoints: AttachmentPoints.FirstSideOnly,
+    }),
+  );
+  const upperNeighborAtomId = struct.atoms.add(
+    new Atom({
+      label: 'C',
+      pp: new Vec2(1, 1),
+    }),
+  );
+  const lowerNeighborAtomId = struct.atoms.add(
+    new Atom({
+      label: 'C',
+      pp: new Vec2(1, -1),
+    }),
+  );
+
+  const upperBond = new Bond({
+    begin: attachedAtomId,
+    end: upperNeighborAtomId,
+    type: Bond.PATTERN.TYPE.SINGLE,
+  });
+  const lowerBond = new Bond({
+    begin: attachedAtomId,
+    end: lowerNeighborAtomId,
+    type: Bond.PATTERN.TYPE.SINGLE,
+  });
+  const upperBondId = struct.bonds.add(upperBond);
+  const lowerBondId = struct.bonds.add(lowerBond);
+
+  struct.bondInitHalfBonds(upperBondId, upperBond);
+  struct.bondInitHalfBonds(lowerBondId, lowerBond);
+  struct.initNeighbors();
+  struct.setImplicitHydrogen();
+
+  const attachmentPointId = struct.rgroupAttachmentPoints.add(
+    new RGroupAttachmentPoint(attachedAtomId, 'primary'),
+  );
+
+  // Attachment-point numbers are rendered only when the structure contains an
+  // atom with a second-side or both-sides attachment-point flag.
+  struct.atoms.add(
+    new Atom({
+      label: 'C',
+      pp: new Vec2(5, 5),
+      attachmentPoints: AttachmentPoints.BothSides,
+    }),
+  );
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const render = new Render(container, renderOptions);
+  const restruct = new ReStruct(struct, render);
+
+  restruct.update(true);
+
+  const reAtom = restruct.atoms.get(attachedAtomId);
+  const reAttachmentPoint =
+    restruct.rgroupAttachmentPoints.get(attachmentPointId);
+
+  expect(reAtom).toBeDefined();
+  expect(reAttachmentPoint).toBeDefined();
+
+  if (!reAtom || !reAttachmentPoint) {
+    throw new Error('Test setup failed to create render objects');
+  }
+
+  return { render, restruct, reAtom, reAttachmentPoint, attachmentPointId };
+}
+
+function expectVec2CloseTo(actual: Vec2, expected: Vec2, precision = 6) {
+  expect(actual.x).toBeCloseTo(expected.x, precision);
+  expect(actual.y).toBeCloseTo(expected.y, precision);
+}
+
+function captureAttachmentPointRender({
+  restruct,
+  reAttachmentPoint,
+  attachmentPointId,
+}: ReturnType<typeof createTwoNeighborAttachmentPointFixture>) {
+  const shapeSpy = jest.spyOn(draw, 'rgroupAttachmentPoint');
+  const labelSpy = jest.spyOn(draw, 'rgroupAttachmentPointLabel');
+
+  reAttachmentPoint.visel.clear();
+  reAttachmentPoint.show(restruct, attachmentPointId);
+
+  const shapeCall = shapeSpy.mock.calls[0];
+  const labelCall = labelSpy.mock.calls[0];
+
+  shapeSpy.mockRestore();
+  labelSpy.mockRestore();
+
+  if (!shapeCall || !labelCall) {
+    throw new Error('Attachment point rendering was not captured');
+  }
+
+  return {
+    shape: {
+      shiftedStemStart: shapeCall[1],
+      attachmentPointEnd: shapeCall[2],
+      directionVector: shapeCall[3],
+    },
+    label: {
+      labelPosition: labelCall[1],
+      labelText: labelCall[2],
+    },
+  };
 }
 
 describe('ReRGroupAttachmentPoint', () => {
@@ -135,5 +252,73 @@ describe('ReRGroupAttachmentPoint', () => {
     expect(
       secondaryAttachmentPoint?.getAttribute('data-attached-to-atomid'),
     ).toBe(atomElement?.getAttribute('data-atom-id'));
+  });
+
+  it('keeps ordinary geometry unchanged and moves the rendered glyph outward when a wide atom-property label shifts the stem start', () => {
+    const wideLabelOptions = {
+      ...options,
+      microModeScale: 40,
+    } as RenderOptions;
+    const fixture = createTwoNeighborAttachmentPointFixture(wideLabelOptions);
+    const { render, reAtom, reAttachmentPoint } = fixture;
+    const ordinaryRender = captureAttachmentPointRender(fixture);
+    reAtom.visel.exts = [new Box2Abs(new Vec2(-60, -7), new Vec2(18, 7))];
+    const shiftedRender = captureAttachmentPointRender(fixture);
+
+    expectVec2CloseTo(reAttachmentPoint.lineDirectionVector, new Vec2(-1, 0));
+    expectVec2CloseTo(ordinaryRender.shape.directionVector, new Vec2(-1, 0));
+    expectVec2CloseTo(ordinaryRender.shape.shiftedStemStart, new Vec2(0, 0));
+    expectVec2CloseTo(
+      ordinaryRender.shape.attachmentPointEnd,
+      new Vec2(-34, 0),
+    );
+    expectVec2CloseTo(ordinaryRender.label.labelPosition, new Vec2(-28, -6.8));
+    expect(ordinaryRender.label.labelText).toBe('1');
+    expectVec2CloseTo(shiftedRender.shape.directionVector, new Vec2(-1, 0));
+    expectVec2CloseTo(shiftedRender.shape.shiftedStemStart, new Vec2(-66, 0));
+    expectVec2CloseTo(
+      shiftedRender.shape.attachmentPointEnd,
+      new Vec2(-100, 0),
+    );
+    expectVec2CloseTo(shiftedRender.label.labelPosition, new Vec2(-94, -6.8));
+    expect(shiftedRender.label.labelText).toBe('1');
+    expectVec2CloseTo(
+      shiftedRender.label.labelPosition.sub(ordinaryRender.label.labelPosition),
+      shiftedRender.shape.shiftedStemStart.sub(
+        ordinaryRender.shape.shiftedStemStart,
+      ),
+    );
+    expect(
+      Vec2.dot(
+        shiftedRender.shape.attachmentPointEnd.sub(
+          shiftedRender.shape.shiftedStemStart,
+        ),
+        reAttachmentPoint.lineDirectionVector,
+      ),
+    ).toBeCloseTo(render.options.microModeScale * 0.85, 6);
+    expect(
+      Vec2.dot(
+        shiftedRender.label.labelPosition.sub(
+          shiftedRender.shape.shiftedStemStart,
+        ),
+        reAttachmentPoint.lineDirectionVector,
+      ),
+    ).toBeGreaterThan(0);
+    expect(
+      Vec2.dot(
+        shiftedRender.shape.attachmentPointEnd.sub(
+          shiftedRender.label.labelPosition,
+        ),
+        reAttachmentPoint.lineDirectionVector,
+      ),
+    ).toBeGreaterThan(0);
+    expect(
+      Vec2.dot(
+        shiftedRender.shape.shiftedStemStart.sub(
+          ordinaryRender.shape.attachmentPointEnd,
+        ),
+        reAttachmentPoint.lineDirectionVector,
+      ),
+    ).toBeGreaterThan(0);
   });
 });

--- a/packages/ketcher-core/__tests__/application/render/restruct/rergroupAttachmentPoint.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/restruct/rergroupAttachmentPoint.test.ts
@@ -134,6 +134,74 @@ function createTwoNeighborAttachmentPointFixture(renderOptions: RenderOptions) {
   return { render, restruct, reAtom, reAttachmentPoint, attachmentPointId };
 }
 
+/**
+ * Fixture for the #3268 regression: atom at (0,0) with attachment point and
+ * query properties (rb3;s2), two symmetric neighbors that force the bisect
+ * direction to coincide with the AP direction (both go left, i.e. (−1, 0)).
+ * A separate detached BothSides atom activates AP number rendering.
+ * update() is NOT called inside the fixture so callers can install spies first.
+ */
+function createQueryPropertyFixture(renderOptions: RenderOptions) {
+  const struct = new Struct();
+
+  const attachedAtomId = struct.atoms.add(
+    new Atom({
+      label: 'C',
+      pp: new Vec2(0, 0),
+      attachmentPoints: AttachmentPoints.FirstSideOnly,
+      ringBondCount: 3,
+      substitutionCount: 2,
+    }),
+  );
+  const upperNeighborId = struct.atoms.add(
+    new Atom({ label: 'C', pp: new Vec2(1, 1) }),
+  );
+  const lowerNeighborId = struct.atoms.add(
+    new Atom({ label: 'C', pp: new Vec2(1, -1) }),
+  );
+
+  const upperBond = new Bond({
+    begin: attachedAtomId,
+    end: upperNeighborId,
+    type: Bond.PATTERN.TYPE.SINGLE,
+  });
+  const lowerBond = new Bond({
+    begin: attachedAtomId,
+    end: lowerNeighborId,
+    type: Bond.PATTERN.TYPE.SINGLE,
+  });
+  const upperBondId = struct.bonds.add(upperBond);
+  const lowerBondId = struct.bonds.add(lowerBond);
+
+  struct.bondInitHalfBonds(upperBondId, upperBond);
+  struct.bondInitHalfBonds(lowerBondId, lowerBond);
+  struct.initNeighbors();
+  struct.setImplicitHydrogen();
+
+  struct.rgroupAttachmentPoints.add(
+    new RGroupAttachmentPoint(attachedAtomId, 'primary'),
+  );
+
+  // Smallest detached setup atom that activates AP number rendering without
+  // adding any neighbours to the main atom.
+  struct.atoms.add(
+    new Atom({
+      label: 'C',
+      pp: new Vec2(5, 5),
+      attachmentPoints: AttachmentPoints.BothSides,
+    }),
+  );
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const render = new Render(container, renderOptions);
+  const restruct = new ReStruct(struct, render);
+
+  // Intentionally not calling restruct.update(true) — callers install spies first.
+  return { render, restruct };
+}
+
 function expectVec2CloseTo(actual: Vec2, expected: Vec2, precision = 6) {
   expect(actual.x).toBeCloseTo(expected.x, precision);
   expect(actual.y).toBeCloseTo(expected.y, precision);
@@ -254,27 +322,33 @@ describe('ReRGroupAttachmentPoint', () => {
     ).toBe(atomElement?.getAttribute('data-atom-id'));
   });
 
-  it('preserves nominal geometry when the stem start does not reach the endpoint, and restores it when it does', () => {
+  it('preserves nominal endpoint and number position; clamps extreme stem start to maintain a minimum visible stem', () => {
+    // microModeScale=40, lineWidth=2 (=40/20).
+    // nominalLength = 40*0.85 = 34 px.
+    // minimumStemLength = OUTLINE_PADDING * microModeScale = 0.15*40 = 6 px.
+    // maximumStartProjection = 34-6 = 28 px.
     const fixture = createTwoNeighborAttachmentPointFixture({
       ...options,
       microModeScale: 40,
     } as RenderOptions);
     const { render, reAtom, reAttachmentPoint } = fixture;
 
-    // Case 1 – no label extent: shiftedStemStart at the atom position; all
-    // geometry is at the nominal position derived from the atom centre.
+    // Case 1 – no label extent: stem start at the atom centre; all geometry
+    // is at the nominal position.
     reAtom.visel.exts = [];
     const noShiftRender = captureAttachmentPointRender(fixture);
+    // Direction is determined by the structural bisection, not the label.
     expectVec2CloseTo(reAttachmentPoint.lineDirectionVector, new Vec2(-1, 0));
+    expectVec2CloseTo(noShiftRender.shape.directionVector, new Vec2(-1, 0));
     expectVec2CloseTo(noShiftRender.shape.shiftedStemStart, new Vec2(0, 0));
     expectVec2CloseTo(noShiftRender.shape.attachmentPointEnd, new Vec2(-34, 0));
     expectVec2CloseTo(noShiftRender.label.labelPosition, new Vec2(-28, -6.8));
     expect(noShiftRender.label.labelText).toBe('1');
 
-    // Case 2 – moderate label extent: stem start shifts to (-16, 0) but has
-    // not yet reached the nominal endpoint at (-34, 0); nominal geometry is
-    // preserved exactly.
-    // Box2Abs((-10,-5),(8,5)) → shiftRayBox = 10; with lineWidth=2 → shift=16.
+    // Case 2 – moderate label: stem start shifts to (-16, 0) but stays within
+    // maximumStartProjection=28; nominal endpoint and number are preserved.
+    // Box2Abs((-10,-5),(8,5)) → shiftRayBox=10; atomSymbolShift=10;
+    // return = 10+3*2=16, rawProjection=16 < 28 → no clamp.
     reAtom.visel.exts = [new Box2Abs(new Vec2(-10, -5), new Vec2(8, 5))];
     const moderateRender = captureAttachmentPointRender(fixture);
     expectVec2CloseTo(moderateRender.shape.shiftedStemStart, new Vec2(-16, 0));
@@ -284,23 +358,115 @@ describe('ReRGroupAttachmentPoint', () => {
     );
     expectVec2CloseTo(moderateRender.label.labelPosition, new Vec2(-28, -6.8));
 
-    // Case 3 – wide label extent: stem start shifts to (-66, 0), past the
-    // nominal endpoint; endpoint and number move outward to keep a valid stem.
-    // Box2Abs((-60,-7),(18,7)) → shiftRayBox = 60; with lineWidth=2 → shift=66.
+    // Case 3 – extreme label: raw stem start would be at projection 66
+    // (rawProjection=66 > 28), so it is clamped to maxStartProjection=28
+    // → shiftedStemStart=(-28, 0).  Endpoint and number remain at their nominal
+    // positions; the visible stem is exactly minimumStemLength=6 px.
+    // Box2Abs((-60,-7),(18,7)) → shiftRayBox=60; atomSymbolShift=60;
+    // return = 60+3*2=66.
     reAtom.visel.exts = [new Box2Abs(new Vec2(-60, -7), new Vec2(18, 7))];
     const wideRender = captureAttachmentPointRender(fixture);
-    expectVec2CloseTo(wideRender.shape.shiftedStemStart, new Vec2(-66, 0));
-    expectVec2CloseTo(wideRender.shape.attachmentPointEnd, new Vec2(-100, 0));
-    expectVec2CloseTo(wideRender.label.labelPosition, new Vec2(-94, -6.8));
+
+    // Nominal endpoint is preserved (was incorrectly displaced to (-100,0) before fix).
+    expectVec2CloseTo(wideRender.shape.attachmentPointEnd, new Vec2(-34, 0));
+    // Number position is preserved (was incorrectly displaced to (-94,-6.8) before fix).
+    expectVec2CloseTo(wideRender.label.labelPosition, new Vec2(-28, -6.8));
     expect(wideRender.label.labelText).toBe('1');
-    // The stem must remain outward with the full nominal length.
-    expect(
-      Vec2.dot(
-        wideRender.shape.attachmentPointEnd.sub(
-          wideRender.shape.shiftedStemStart,
-        ),
-        reAttachmentPoint.lineDirectionVector,
+    // Stem start is clamped to maxStartProjection=28.
+    expectVec2CloseTo(wideRender.shape.shiftedStemStart, new Vec2(-28, 0));
+    // Direction is unaffected by the label width.
+    expectVec2CloseTo(wideRender.shape.directionVector, new Vec2(-1, 0));
+
+    // The clamped start is strictly before the nominal endpoint along the direction.
+    const startProj = Vec2.dot(
+      wideRender.shape.shiftedStemStart.sub(new Vec2(0, 0)),
+      reAttachmentPoint.lineDirectionVector,
+    );
+    const endProj = Vec2.dot(
+      wideRender.shape.attachmentPointEnd.sub(new Vec2(0, 0)),
+      reAttachmentPoint.lineDirectionVector,
+    );
+    expect(startProj).toBeLessThan(endProj);
+
+    // The visible stem is at least minimumStemLength = OUTLINE_PADDING * microModeScale = 6 px.
+    const stemLength = Vec2.dot(
+      wideRender.shape.attachmentPointEnd.sub(
+        wideRender.shape.shiftedStemStart,
       ),
-    ).toBeCloseTo(render.options.microModeScale * 0.85, 6);
+      reAttachmentPoint.lineDirectionVector,
+    );
+    expect(stemLength).toBeGreaterThanOrEqual(
+      0.15 * render.options.microModeScale,
+    );
+  });
+
+  it('displaces rb3;s2 query-property label laterally so it does not overlap the AP number', () => {
+    // The main atom at (0,0) has FirstSideOnly AP and query properties
+    // rb3;s2.  Two symmetric neighbors at (1,±1) make bisectLargestSector
+    // return (−1,0), which is the same direction as the AP → without lateral
+    // displacement the query label would land on the wave glyph.
+    //
+    // getBBox is mocked by mockSvgDomApi (returns {x:0,y:0,width:10,height:10}),
+    // so the test validates rendered translateAbs offsets and AABB separation
+    // logic under deterministic mocked dimensions, not real browser font geometry.
+    const { render, restruct } = createQueryPropertyFixture(options);
+
+    const apLabelSpy = jest.spyOn(draw, 'rgroupAttachmentPointLabel');
+    const paperTextSpy = jest.spyOn(render.paper, 'text');
+
+    restruct.update(true);
+
+    // --- AP number ---
+    // The AP number label is '1' (primary AP, BothSides atom present).
+    const apLabelCallIdx = apLabelSpy.mock.calls.findIndex((c) => c[2] === '1');
+    expect(apLabelCallIdx).toBeGreaterThanOrEqual(0);
+
+    const apLabelPos = apLabelSpy.mock.calls[apLabelCallIdx][1] as Vec2;
+    const apLabelEl = apLabelSpy.mock.results[apLabelCallIdx].value as {
+      getBBox(): DOMRect;
+      delta?: { x: number; y: number };
+    };
+    const apBb = apLabelEl.getBBox();
+    const apDelta = apLabelEl.delta ?? { x: 0, y: 0 };
+    const apRect = {
+      left: apLabelPos.x + apDelta.x + apBb.x,
+      right: apLabelPos.x + apDelta.x + apBb.x + apBb.width,
+      top: apLabelPos.y + apDelta.y + apBb.y,
+      bottom: apLabelPos.y + apDelta.y + apBb.y + apBb.height,
+    };
+
+    // --- Query-property aamPath ---
+    // paper.text is called with the combined text; for this atom it is 'rb3;s2\n'.
+    const aamCallIdx = paperTextSpy.mock.calls.findIndex(
+      (c) => typeof c[2] === 'string' && (c[2] as string).includes('rb3'),
+    );
+    expect(aamCallIdx).toBeGreaterThanOrEqual(0);
+
+    const aamInitX = paperTextSpy.mock.calls[aamCallIdx][0] as number;
+    const aamInitY = paperTextSpy.mock.calls[aamCallIdx][1] as number;
+    const aamEl = paperTextSpy.mock.results[aamCallIdx].value as {
+      getBBox(): DOMRect;
+      delta?: { x: number; y: number };
+    };
+    const aamBb = aamEl.getBBox();
+    const aamDelta = aamEl.delta ?? { x: 0, y: 0 };
+    const aamRect = {
+      left: aamInitX + aamDelta.x + aamBb.x,
+      right: aamInitX + aamDelta.x + aamBb.x + aamBb.width,
+      top: aamInitY + aamDelta.y + aamBb.y,
+      bottom: aamInitY + aamDelta.y + aamBb.y + aamBb.height,
+    };
+
+    // The laterally-displaced query label must not intersect the AP number.
+    const separated =
+      aamRect.right <= apRect.left ||
+      aamRect.left >= apRect.right ||
+      aamRect.bottom <= apRect.top ||
+      aamRect.top >= apRect.bottom;
+
+    expect(separated).toBe(true);
+
+    apLabelSpy.mockRestore();
+    paperTextSpy.mockRestore();
   });
 });

--- a/packages/ketcher-core/__tests__/application/render/restruct/rergroupAttachmentPoint.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/restruct/rergroupAttachmentPoint.test.ts
@@ -254,71 +254,53 @@ describe('ReRGroupAttachmentPoint', () => {
     ).toBe(atomElement?.getAttribute('data-atom-id'));
   });
 
-  it('keeps ordinary geometry unchanged and moves the rendered glyph outward when a wide atom-property label shifts the stem start', () => {
-    const wideLabelOptions = {
+  it('preserves nominal geometry when the stem start does not reach the endpoint, and restores it when it does', () => {
+    const fixture = createTwoNeighborAttachmentPointFixture({
       ...options,
       microModeScale: 40,
-    } as RenderOptions;
-    const fixture = createTwoNeighborAttachmentPointFixture(wideLabelOptions);
+    } as RenderOptions);
     const { render, reAtom, reAttachmentPoint } = fixture;
-    const ordinaryRender = captureAttachmentPointRender(fixture);
-    reAtom.visel.exts = [new Box2Abs(new Vec2(-60, -7), new Vec2(18, 7))];
-    const shiftedRender = captureAttachmentPointRender(fixture);
 
+    // Case 1 – no label extent: shiftedStemStart at the atom position; all
+    // geometry is at the nominal position derived from the atom centre.
+    reAtom.visel.exts = [];
+    const noShiftRender = captureAttachmentPointRender(fixture);
     expectVec2CloseTo(reAttachmentPoint.lineDirectionVector, new Vec2(-1, 0));
-    expectVec2CloseTo(ordinaryRender.shape.directionVector, new Vec2(-1, 0));
-    expectVec2CloseTo(ordinaryRender.shape.shiftedStemStart, new Vec2(0, 0));
+    expectVec2CloseTo(noShiftRender.shape.shiftedStemStart, new Vec2(0, 0));
+    expectVec2CloseTo(noShiftRender.shape.attachmentPointEnd, new Vec2(-34, 0));
+    expectVec2CloseTo(noShiftRender.label.labelPosition, new Vec2(-28, -6.8));
+    expect(noShiftRender.label.labelText).toBe('1');
+
+    // Case 2 – moderate label extent: stem start shifts to (-16, 0) but has
+    // not yet reached the nominal endpoint at (-34, 0); nominal geometry is
+    // preserved exactly.
+    // Box2Abs((-10,-5),(8,5)) → shiftRayBox = 10; with lineWidth=2 → shift=16.
+    reAtom.visel.exts = [new Box2Abs(new Vec2(-10, -5), new Vec2(8, 5))];
+    const moderateRender = captureAttachmentPointRender(fixture);
+    expectVec2CloseTo(moderateRender.shape.shiftedStemStart, new Vec2(-16, 0));
     expectVec2CloseTo(
-      ordinaryRender.shape.attachmentPointEnd,
+      moderateRender.shape.attachmentPointEnd,
       new Vec2(-34, 0),
     );
-    expectVec2CloseTo(ordinaryRender.label.labelPosition, new Vec2(-28, -6.8));
-    expect(ordinaryRender.label.labelText).toBe('1');
-    expectVec2CloseTo(shiftedRender.shape.directionVector, new Vec2(-1, 0));
-    expectVec2CloseTo(shiftedRender.shape.shiftedStemStart, new Vec2(-66, 0));
-    expectVec2CloseTo(
-      shiftedRender.shape.attachmentPointEnd,
-      new Vec2(-100, 0),
-    );
-    expectVec2CloseTo(shiftedRender.label.labelPosition, new Vec2(-94, -6.8));
-    expect(shiftedRender.label.labelText).toBe('1');
-    expectVec2CloseTo(
-      shiftedRender.label.labelPosition.sub(ordinaryRender.label.labelPosition),
-      shiftedRender.shape.shiftedStemStart.sub(
-        ordinaryRender.shape.shiftedStemStart,
-      ),
-    );
+    expectVec2CloseTo(moderateRender.label.labelPosition, new Vec2(-28, -6.8));
+
+    // Case 3 – wide label extent: stem start shifts to (-66, 0), past the
+    // nominal endpoint; endpoint and number move outward to keep a valid stem.
+    // Box2Abs((-60,-7),(18,7)) → shiftRayBox = 60; with lineWidth=2 → shift=66.
+    reAtom.visel.exts = [new Box2Abs(new Vec2(-60, -7), new Vec2(18, 7))];
+    const wideRender = captureAttachmentPointRender(fixture);
+    expectVec2CloseTo(wideRender.shape.shiftedStemStart, new Vec2(-66, 0));
+    expectVec2CloseTo(wideRender.shape.attachmentPointEnd, new Vec2(-100, 0));
+    expectVec2CloseTo(wideRender.label.labelPosition, new Vec2(-94, -6.8));
+    expect(wideRender.label.labelText).toBe('1');
+    // The stem must remain outward with the full nominal length.
     expect(
       Vec2.dot(
-        shiftedRender.shape.attachmentPointEnd.sub(
-          shiftedRender.shape.shiftedStemStart,
+        wideRender.shape.attachmentPointEnd.sub(
+          wideRender.shape.shiftedStemStart,
         ),
         reAttachmentPoint.lineDirectionVector,
       ),
     ).toBeCloseTo(render.options.microModeScale * 0.85, 6);
-    expect(
-      Vec2.dot(
-        shiftedRender.label.labelPosition.sub(
-          shiftedRender.shape.shiftedStemStart,
-        ),
-        reAttachmentPoint.lineDirectionVector,
-      ),
-    ).toBeGreaterThan(0);
-    expect(
-      Vec2.dot(
-        shiftedRender.shape.attachmentPointEnd.sub(
-          shiftedRender.label.labelPosition,
-        ),
-        reAttachmentPoint.lineDirectionVector,
-      ),
-    ).toBeGreaterThan(0);
-    expect(
-      Vec2.dot(
-        shiftedRender.shape.shiftedStemStart.sub(
-          ordinaryRender.shape.attachmentPointEnd,
-        ),
-        reAttachmentPoint.lineDirectionVector,
-      ),
-    ).toBeGreaterThan(0);
   });
 });

--- a/packages/ketcher-core/src/application/render/draw.ts
+++ b/packages/ketcher-core/src/application/render/draw.ts
@@ -1735,6 +1735,12 @@ function rgroupAttachmentPoint(
   return resultShape;
 }
 
+// Wave glyph dimensions in path-local units (derived from attachmentPointSvgPathString).
+// x spans +13 to −13.1 → perpendicular half-extent 13.1; y max = 5.2 → far-along extent.
+export const AP_PATH_SCALE = 39.8;
+export const AP_WAVE_HALF_PERP = 13.1;
+export const AP_WAVE_FAR_ALONG = 5.2;
+
 function getSvgCurveShapeAttachmentPoint(
   centerPosition: Vec2,
   directionVector: Vec2,
@@ -1743,9 +1749,8 @@ function getSvgCurveShapeAttachmentPoint(
   // declared here https://github.com/epam/ketcher/issues/2165
   // this path has (0,0) in the position of attachment point atom
   const attachmentPointSvgPathString = `M13 1.5l-1.5 3.7c-0.3 0.8-1.5 0.8-1.9 0l-1.7-4.4c-0.3-0.8-1.5-0.8-1.9 0l-1.7 4.4c-0.3 0.8-1.5 0.8-1.8 0l-1.8-4.4c-0.3-0.8-1.5-0.8-1.9 0l-1.7 4.4c-0.3 0.8-1.5 0.8-1.9 0l-1.7-4.4c-0.3-0.8-1.5-0.8-1.9 0l-1.6 4.2c-0.3 0.9-1.6 0.8-1.9 0l-1.2-3.5`;
-  const attachmentPointSvgPathSize = 39.8;
 
-  const shapeScale = basicSize / attachmentPointSvgPathSize;
+  const shapeScale = basicSize / AP_PATH_SCALE;
   const angleDegrees =
     (Math.atan2(directionVector.y, directionVector.x) * 180) / Math.PI - 90;
 

--- a/packages/ketcher-core/src/application/render/restruct/reatom.ts
+++ b/packages/ketcher-core/src/application/render/restruct/reatom.ts
@@ -16,6 +16,7 @@
 
 import {
   Atom,
+  AttachmentPoints,
   type AtomQueryProperties,
   StereoLabel,
 } from 'domain/entities/atom';
@@ -38,7 +39,11 @@ import type ReStruct from './restruct';
 import type { Render } from '../raphaelRender';
 import type { Element, RaphaelSet } from 'raphael';
 import { Scale } from 'domain/helpers';
-import draw from '../draw';
+import draw, {
+  AP_PATH_SCALE,
+  AP_WAVE_HALF_PERP,
+  AP_WAVE_FAR_ALONG,
+} from '../draw';
 import util from '../util';
 import { assert, toFixed } from 'utilities';
 import type {
@@ -1114,8 +1119,32 @@ class ReAtom extends ReObject {
       }
       // estimate the shift backwards to account for the size of the aam/query text box itself
       t += util.shiftRayBox(ps, dir.negated(), Box2Abs.fromRelBox(aamBox));
+
+      let perpShift = new Vec2(0, 0);
+
+      if (
+        this.hasAttachmentPoint() &&
+        this.a.attachmentPoints !== AttachmentPoints.BothSides &&
+        this.a.neighbors.length > 1
+      ) {
+        perpShift = computeLateralApLabelShift(
+          ps,
+          dir,
+          8 + t,
+          aamBox.width,
+          aamBox.height,
+          options.microModeScale,
+          visel.exts,
+        );
+      }
+
       dir = dir.scaled(8 + t);
-      pathAndRBoxTranslate(aamPath, aamBox, dir.x, dir.y);
+      pathAndRBoxTranslate(
+        aamPath,
+        aamBox,
+        dir.x + perpShift.x,
+        dir.y + perpShift.y,
+      );
       restruct.addReObjectPath(LayerMap.data, this.visel, aamPath, ps, true);
 
       if (customQueryTooltipText) {
@@ -2320,6 +2349,101 @@ function pathAndRBoxTranslate(
 
 function newVectorFromAngle(angle: number): Vec2 {
   return new Vec2(Math.cos(angle), Math.sin(angle));
+}
+
+/** Project an axis-aligned box onto AP-local along/perp axes. */
+function projectBoxOnApAxes(
+  W: number,
+  H: number,
+  apDir: Vec2,
+): { halfAlong: number; halfPerp: number } {
+  const ax = Math.abs(apDir.x);
+  const ay = Math.abs(apDir.y);
+  return {
+    halfAlong: (W / 2) * ax + (H / 2) * ay,
+    halfPerp: (W / 2) * ay + (H / 2) * ax,
+  };
+}
+
+/** Count atom-relative visel extents that overlap the candidate canvas-space box. */
+function countExtOverlaps(
+  exts: Box2Abs[],
+  atomPos: Vec2,
+  centerX: number,
+  centerY: number,
+  W: number,
+  H: number,
+): number {
+  const box = new Box2Abs(
+    centerX - W / 2,
+    centerY - H / 2,
+    centerX + W / 2,
+    centerY + H / 2,
+  );
+  let count = 0;
+  for (const ext of exts) {
+    const ab = ext.translate(atomPos);
+    if (
+      !(
+        box.p1.x <= ab.p0.x ||
+        box.p0.x >= ab.p1.x ||
+        box.p1.y <= ab.p0.y ||
+        box.p0.y >= ab.p1.y
+      )
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Returns the perpendicular shift that moves a property label clear of the AP
+ * wave glyph when the label's proposed placement overlaps the nominal AP area
+ * (#3268).  Returns Vec2(0,0) when no shift is needed.
+ */
+function computeLateralApLabelShift(
+  atomPos: Vec2,
+  apDir: Vec2,
+  proposedAlongDist: number,
+  boxWidth: number,
+  boxHeight: number,
+  microModeScale: number,
+  viselExts: Box2Abs[],
+): Vec2 {
+  const waveHalfPerp = (AP_WAVE_HALF_PERP / AP_PATH_SCALE) * microModeScale;
+  const waveFarAlong = (AP_WAVE_FAR_ALONG / AP_PATH_SCALE) * microModeScale;
+  const nominalLength = 0.85 * microModeScale;
+
+  const { halfAlong, halfPerp } = projectBoxOnApAxes(
+    boxWidth,
+    boxHeight,
+    apDir,
+  );
+
+  const intersectsAlong =
+    proposedAlongDist - halfAlong < nominalLength + waveFarAlong &&
+    proposedAlongDist + halfAlong > 0;
+
+  if (!intersectsAlong || halfPerp === 0) return new Vec2(0, 0);
+
+  const shiftMag = waveHalfPerp + halfPerp + 2;
+  const perpDir = new Vec2(-apDir.y, apDir.x);
+
+  const score = (sign: 1 | -1): number =>
+    countExtOverlaps(
+      viselExts,
+      atomPos,
+      atomPos.x + apDir.x * proposedAlongDist + perpDir.x * sign * shiftMag,
+      atomPos.y + apDir.y * proposedAlongDist + perpDir.y * sign * shiftMag,
+      boxWidth,
+      boxHeight,
+    );
+
+  const posScore = score(1);
+  const negScore = score(-1);
+  const sign = negScore < posScore ? -1 : 1;
+  return perpDir.scaled(sign * shiftMag);
 }
 
 export default ReAtom;

--- a/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
@@ -450,49 +450,37 @@ function getAttachmentPointGeometry(
   directionVector: Vec2,
 ): AttachmentPointGeometry {
   const atomPositionVector = Scale.modelToCanvas(atom.a.pp, options);
-  const nominalEnd = atomPositionVector.addScaled(
+  const nominalLength = options.microModeScale * 0.85;
+
+  // Endpoint and number are always at their nominal distance from the atom
+  // centre. A wide atom symbol shifts only the stem start, never the endpoint
+  // (#3268).
+  const attachmentPointEnd = atomPositionVector.addScaled(
     directionVector,
-    options.microModeScale * 0.85,
+    nominalLength,
   );
-  const nominalLabelPosition = getLabelPositionForAttachmentPoint(
+  const labelPosition = getLabelPositionForAttachmentPoint(
     atomPositionVector,
     directionVector,
     options.microModeScale,
   );
-  const shiftedStemStart = atom.getShiftedSegmentPosition(
-    options,
+
+  const rawStemStart = atom.getShiftedSegmentPosition(options, directionVector);
+
+  // Safety cap: preserve at least OUTLINE_PADDING × microModeScale of visible
+  // stem so the wave cannot collapse onto or past the endpoint.
+  // Ordinary geometry is unchanged whenever rawProjection ≤ maxStartProjection.
+  const minStemLength =
+    ReRGroupAttachmentPoint.OUTLINE_PADDING * options.microModeScale;
+  const maxStartProjection = Math.max(nominalLength - minStemLength, 0);
+  const rawProjection = Vec2.dot(
+    rawStemStart.sub(atomPositionVector),
     directionVector,
   );
-
-  // Project the shift along the direction to determine whether the shifted stem
-  // start has reached or passed the nominal endpoint.  The nominal projection
-  // simplifies to `microModeScale * 0.85` because the direction vector is unit.
-  const shiftProjection = Vec2.dot(
-    shiftedStemStart.sub(atomPositionVector),
-    directionVector,
-  );
-  const nominalEndProjection = options.microModeScale * 0.85;
-
-  if (shiftProjection < nominalEndProjection) {
-    // Ordinary case: stem start is within the nominal glyph – preserve the
-    // original endpoint and number position exactly.
-    return {
-      atomPositionVector,
-      shiftedStemStart,
-      attachmentPointEnd: nominalEnd,
-      labelPosition: nominalLabelPosition,
-    };
-  }
-
-  // Overrun case: shifted start reaches or passes the nominal endpoint.
-  // Push the endpoint and number outward from the final start so the stem
-  // retains its full length and the number follows the displaced glyph.
-  const displacement = shiftedStemStart.sub(atomPositionVector);
-  const attachmentPointEnd = shiftedStemStart.addScaled(
-    directionVector,
-    options.microModeScale * 0.85,
-  );
-  const labelPosition = nominalLabelPosition.add(displacement);
+  const shiftedStemStart =
+    rawProjection > maxStartProjection
+      ? atomPositionVector.addScaled(directionVector, maxStartProjection)
+      : rawStemStart;
 
   return {
     atomPositionVector,

--- a/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
@@ -22,6 +22,13 @@ type AttachmentPointShape = {
   node?: SVGElement | null;
 };
 
+type AttachmentPointGeometry = {
+  atomPositionVector: Vec2;
+  shiftedStemStart: Vec2;
+  attachmentPointEnd: Vec2;
+  labelPosition: Vec2;
+};
+
 class ReRGroupAttachmentPoint extends ReObject {
   item: RGroupAttachmentPoint;
   reAtom: ReAtom;
@@ -178,11 +185,16 @@ class ReRGroupAttachmentPoint extends ReObject {
     if (!directionVector) {
       return;
     }
+    const geometry = getAttachmentPointGeometry(
+      this.reAtom,
+      restruct.render.options,
+      directionVector,
+    );
     this.lineDirectionVector = directionVector;
 
     const attachmentPointShape = showAttachmentPointShape(
-      this.reAtom,
       restruct.render,
+      geometry,
       directionVector,
       restruct.addReObjectPath.bind(restruct),
       this.visel,
@@ -194,11 +206,11 @@ class ReRGroupAttachmentPoint extends ReObject {
       // in case of isTrisectionRequired (trisection case) we should show labels '1' and '2' for those separated vectors
       const labelText = this.item.type === 'primary' ? '1' : '2';
       showAttachmentPointLabel(
-        this.reAtom,
         restruct.render,
-        directionVector,
+        geometry,
         restruct.addReObjectPath.bind(restruct),
         labelText,
+        this.reAtom.color,
         this.visel,
       );
     }
@@ -320,26 +332,16 @@ class ReRGroupAttachmentPoint extends ReObject {
 }
 
 function showAttachmentPointShape(
-  atom: ReAtom,
   { options, paper }: Render,
+  geometry: AttachmentPointGeometry,
   directionVector: Vec2,
   addReObjectPath: InstanceType<typeof ReStruct>['addReObjectPath'],
   visel: Visel,
 ): AttachmentPointShape {
-  const atomPositionVector = Scale.modelToCanvas(atom.a.pp, options);
-  const shiftedAtomPositionVector = atom.getShiftedSegmentPosition(
-    options,
-    directionVector,
-  );
-  const attachmentPointEnd = atomPositionVector.addScaled(
-    directionVector,
-    options.microModeScale * 0.85,
-  );
-
   const resultShape = draw.rgroupAttachmentPoint(
     paper,
-    shiftedAtomPositionVector,
-    attachmentPointEnd,
+    geometry.shiftedStemStart,
+    geometry.attachmentPointEnd,
     directionVector,
     options,
   );
@@ -348,7 +350,7 @@ function showAttachmentPointShape(
     LayerMap.indices,
     visel,
     resultShape,
-    atomPositionVector,
+    geometry.atomPositionVector,
     true,
   );
 
@@ -408,38 +410,66 @@ function getAttachmentDirectionForOnlyOneBond(
 }
 
 function showAttachmentPointLabel(
-  atom: ReAtom,
   { options, paper }: Render,
-  directionVector: Vec2,
+  geometry: AttachmentPointGeometry,
   addReObjectPath: InstanceType<typeof ReStruct>['addReObjectPath'],
   labelText: string,
+  atomColor: string,
   visel: Visel,
 ): void {
-  const atomPositionVector = Scale.modelToCanvas(atom.a.pp, options);
-  const labelPosition = getLabelPositionForAttachmentPoint(
-    atomPositionVector,
-    directionVector,
-    options.microModeScale,
-  );
   const labelPath = draw.rgroupAttachmentPointLabel(
     paper,
-    labelPosition,
+    geometry.labelPosition,
     labelText,
     options,
-    atom.color,
+    atomColor,
   );
-  addReObjectPath(LayerMap.indices, visel, labelPath, atomPositionVector, true);
+  addReObjectPath(
+    LayerMap.indices,
+    visel,
+    labelPath,
+    geometry.atomPositionVector,
+    true,
+  );
 }
 
 function getLabelPositionForAttachmentPoint(
-  atomPositionVector: Vec2,
+  shiftedStemStart: Vec2,
   directionVector: Vec2,
   shapeHeight: number,
 ): Vec2 {
   const normal = directionVector.rotateSC(1, 0);
-  return atomPositionVector
+  return shiftedStemStart
     .addScaled(normal, 0.17 * shapeHeight)
     .addScaled(directionVector, shapeHeight * 0.7);
+}
+
+function getAttachmentPointGeometry(
+  atom: ReAtom,
+  options: RenderOptions,
+  directionVector: Vec2,
+): AttachmentPointGeometry {
+  const atomPositionVector = Scale.modelToCanvas(atom.a.pp, options);
+  const shiftedStemStart = atom.getShiftedSegmentPosition(
+    options,
+    directionVector,
+  );
+  const attachmentPointEnd = shiftedStemStart.addScaled(
+    directionVector,
+    options.microModeScale * 0.85,
+  );
+  const labelPosition = getLabelPositionForAttachmentPoint(
+    shiftedStemStart,
+    directionVector,
+    options.microModeScale,
+  );
+
+  return {
+    atomPositionVector,
+    shiftedStemStart,
+    attachmentPointEnd,
+    labelPosition,
+  };
 }
 
 export { ReRGroupAttachmentPoint };

--- a/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rergroupAttachmentPoint.ts
@@ -434,12 +434,12 @@ function showAttachmentPointLabel(
 }
 
 function getLabelPositionForAttachmentPoint(
-  shiftedStemStart: Vec2,
+  atomPositionVector: Vec2,
   directionVector: Vec2,
   shapeHeight: number,
 ): Vec2 {
   const normal = directionVector.rotateSC(1, 0);
-  return shiftedStemStart
+  return atomPositionVector
     .addScaled(normal, 0.17 * shapeHeight)
     .addScaled(directionVector, shapeHeight * 0.7);
 }
@@ -450,19 +450,49 @@ function getAttachmentPointGeometry(
   directionVector: Vec2,
 ): AttachmentPointGeometry {
   const atomPositionVector = Scale.modelToCanvas(atom.a.pp, options);
+  const nominalEnd = atomPositionVector.addScaled(
+    directionVector,
+    options.microModeScale * 0.85,
+  );
+  const nominalLabelPosition = getLabelPositionForAttachmentPoint(
+    atomPositionVector,
+    directionVector,
+    options.microModeScale,
+  );
   const shiftedStemStart = atom.getShiftedSegmentPosition(
     options,
     directionVector,
   );
+
+  // Project the shift along the direction to determine whether the shifted stem
+  // start has reached or passed the nominal endpoint.  The nominal projection
+  // simplifies to `microModeScale * 0.85` because the direction vector is unit.
+  const shiftProjection = Vec2.dot(
+    shiftedStemStart.sub(atomPositionVector),
+    directionVector,
+  );
+  const nominalEndProjection = options.microModeScale * 0.85;
+
+  if (shiftProjection < nominalEndProjection) {
+    // Ordinary case: stem start is within the nominal glyph – preserve the
+    // original endpoint and number position exactly.
+    return {
+      atomPositionVector,
+      shiftedStemStart,
+      attachmentPointEnd: nominalEnd,
+      labelPosition: nominalLabelPosition,
+    };
+  }
+
+  // Overrun case: shifted start reaches or passes the nominal endpoint.
+  // Push the endpoint and number outward from the final start so the stem
+  // retains its full length and the number follows the displaced glyph.
+  const displacement = shiftedStemStart.sub(atomPositionVector);
   const attachmentPointEnd = shiftedStemStart.addScaled(
     directionVector,
     options.microModeScale * 0.85,
   );
-  const labelPosition = getLabelPositionForAttachmentPoint(
-    shiftedStemStart,
-    directionVector,
-    options.microModeScale,
-  );
+  const labelPosition = nominalLabelPosition.add(displacement);
 
   return {
     atomPositionVector,


### PR DESCRIPTION
### How the feature works? / How did you fix the issue?

Fixed attachment-point rendering when an atom also displays query-property labels.

Previously, atom/query-property labels and attachment points could be placed in
the same open sector, causing the attachment-point stem, wave, or number to
overlap the property label. An earlier approach moved the attachment-point
endpoint outward, which made the attachment-point bond visually too long.

The updated solution keeps the attachment-point endpoint and number at their
nominal positions. When a property label intersects the nominal attachment-point
area, the label is displaced laterally. The stem start is also capped to preserve
a visible, outward-facing stem.

Closes #3268

### Verification
Added focused unit regression coverage for nominal, moderate, and extreme
attachment-point geometry.
Verified that query-property labels and attachment-point numbers do not
overlap under deterministic rendered geometry.
Loaded the SMILES from #3268 in standalone mode and confirmed that all six
attachment points remain visible without elongated bonds or property-label
overlap.

### Screenshot

<img width="1916" height="1082" alt="Screenshot 2026-08-20 095212" src="https://github.com/user-attachments/assets/34b958b9-47ff-4ba6-aa6f-f1719adbcf98" />

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request