### PR TITLE
#10323 - Hydrogen bonds disappears after user expands monomer on Mole…

### DIFF
--- a/packages/ketcher-core/src/application/render/restruct/rebond.ts
+++ b/packages/ketcher-core/src/application/render/restruct/rebond.ts
@@ -332,6 +332,26 @@ class ReBond extends ReObject {
     const bond = this.b;
     const sgroups = restruct.render.ctab.sgroups;
     const functionalGroups = restruct.render.ctab.molecule.functionalGroups;
+
+    // Hide hydrogen bonds if either connected monomer is expanded
+    if (bond.type === Bond.PATTERN.TYPE.HYDROGEN) {
+      const beginSgroup = restruct.molecule.getGroupFromAtomId(bond.begin);
+      const endSgroup = restruct.molecule.getGroupFromAtomId(bond.end);
+
+      if (
+        beginSgroup instanceof MonomerMicromolecule &&
+        beginSgroup.monomer.monomerItem.expanded
+      ) {
+        return true;
+      }
+      if (
+        endSgroup instanceof MonomerMicromolecule &&
+        endSgroup.monomer.monomerItem.expanded
+      ) {
+        return true;
+      }
+    }
+
     return (
       FunctionalGroup.isBondInContractedFunctionalGroup(
         bond,


### PR DESCRIPTION
**Problem**
When a user expanded a monomer on the molecules canvas, hydrogen bonds connected to that monomer remained visible. This caused visua lconfusion because:
  - Hydrogen bonds represent connections at the monomer level
  - When a monomer is expanded, its internal structure (micromolecule) is shown
  - The hydrogen bonds should not be visible in the expanded state, as they are conceptually replaced by the detailed atomic structure

**Solution**
Added logic to the ReBond.isHidden() method in packages/ketcher-core/src/application/render/restruct/rebond.ts to check if a hydrogen bond should be hidden based on the expansion state of connected monomers.

The fix works by:
  1. Detecting when the bond is a hydrogen bond (Bond.PATTERN.TYPE.HYDROGEN)
  2. Checking if either the begin or end atom belongs to a MonomerMicromolecule S-group
  3. Verifying if that monomer is in an expanded state (monomerItem.expanded)
  4. Hiding the hydrogen bond if either connected monomer is expanded

**Why This Solution Works**
This approach correctly handles the visual hierarchy:
  - At the monomer level: hydrogen bonds are visible, showing inter-monomer connections
  - At the expanded micromolecule level: hydrogen bonds are hidden, as the detailed atomic structure takes precedence

The fix is minimal and follows the existing pattern in isHidden(), which already handles visibility logic for functional groups and S-groups. By checking both the begin and end atoms, we ensure hydrogen bonds are hidden regardless of which monomer (or both) is expanded.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request