### PR TITLE
#5462 - Using the RemoteStructServiceProvider will result in an error message

### DIFF
--- a/packages/ketcher-core/src/infrastructure/services/struct/__tests__/remoteStructService.customHeaders.test.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/__tests__/remoteStructService.customHeaders.test.ts
@@ -1,0 +1,35 @@
+import { RemoteStructService } from '../remoteStructService';
+
+describe('RemoteStructService custom headers error handling', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('rejects the returned promise instead of throwing synchronously when fetch throws (e.g. invalid custom headers)', () => {
+    global.fetch = jest.fn(() => {
+      throw new TypeError('Invalid value');
+    }) as unknown as typeof fetch;
+
+    const service = new RemoteStructService(
+      'http://localhost:8002/v2/',
+      {},
+      { 'Invalid Header': 'oops' },
+    );
+
+    let thrownSynchronously = false;
+    let result: Promise<unknown> | undefined;
+    try {
+      result = service.check({ struct: 'C', types: [] }, undefined);
+    } catch {
+      thrownSynchronously = true;
+    }
+
+    expect(thrownSynchronously).toBe(false);
+    expect(result).toBeInstanceOf(Promise);
+    return expect(result).rejects.toThrow(
+      /Invalid custom headers passed to RemoteStructServiceProvider/,
+    );
+  });
+});

--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -83,15 +83,28 @@ function request(
 ) {
   let requestUrl = url;
   if (data && method === 'GET') requestUrl = parametrizeUrl(url, data);
-  let response: any = fetch(requestUrl, {
-    method,
-    headers: {
-      Accept: 'application/json',
-      ...(headers ?? {}),
-    },
-    body: method !== 'GET' ? data : undefined,
-    credentials: 'same-origin',
-  });
+
+  const mergedHeaders = {
+    Accept: 'application/json',
+    ...(headers ?? {}),
+  };
+
+  let response: any;
+  try {
+    response = fetch(requestUrl, {
+      method,
+      headers: mergedHeaders,
+      body: method !== 'GET' ? data : undefined,
+      credentials: 'same-origin',
+    });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    return Promise.reject(
+      new Error(
+        `Invalid custom headers passed to RemoteStructServiceProvider: ${details}`,
+      ),
+    );
+  }
 
   if (responseHandler) {
     response = responseHandler(response);


### PR DESCRIPTION
… message

## How the feature works? / How did you fix the issue?
`Request()` in `remoteStructService.ts` calls `fetch()` outside a `try/catch`. When `customHeaders` contains something `fetch/Headers` rejects (invalid header name/value), the browser throws a TypeError synchronously, before any Promise is created.

Neither `request()` nor the calling chain (`RemoteStructService.convert/check/...() → Indigo.convert()`) is async. They just return the result of `fetch()`. So that synchronous throw propagates straight out of `convert()/check()/etc`. as an uncaught exception, instead of surfacing as a rejected Promise. Callers throughout the codebase expect a Promise and attach `.then()/.catch()`, which never even gets attached — hence #5462: passing customHeaders "results in an error message" instead of a normal rejected promise consumers can handle.

Wrap the `fetch()` call in `try/catch` and turn the caught error into `Promise.reject(new Error(...))` with a clear message ("Invalid custom headers passed to RemoteStructServiceProvider: ..."), so the failure is delivered through the normal `async/Promise` path like every other error from this service.

Testing: added a regression test that mocks fetch to throw synchronously and asserts `RemoteStructService.check()` returns a rejected Promise rather than throwing. Verified the test fails against the old throw-based version and passes with the fix.


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

Fixes #5462 