### PR TITLE
fix: null guard for RxnPlusAdd.data.plid in paste action

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/paste.ts
+++ b/packages/ketcher-core/src/application/editor/actions/paste.ts
@@ -273,7 +273,9 @@ export function fromPaste(
   pstruct.rxnPluses.forEach((plus) => {
     const operation = new RxnPlusAdd(plus.pp.add(offset)).perform(restruct);
     action.addOp(operation);
-    items.rxnPluses.push(operation.data.plid);
+    if (operation.data.plid !== null) {
+      items.rxnPluses.push(operation.data.plid);
+    }
   });
 
   pstruct.simpleObjects.forEach((simpleObject) => {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

**Root cause:** Commit c0f11ad1a2 (#10768 — `BaseOperation.ts` any-type cleanup) gave `BaseOperation` proper generic data types, making `operation.data.plid` correctly typed as `number | null` instead of the previous implicit `any`. This exposed a latent bug in `paste.ts:276` where `items.rxnPluses.push(operation.data.plid)` passes a `number | null` into a `number[]` array — a TypeScript error.

**Fix:** Added a null guard before the push so only a confirmed `number` value is added to the array:

```ts
// before
items.rxnPluses.push(operation.data.plid); // TS error: number | null not assignable to number

// after
if (operation.data.plid !== null) {
  items.rxnPluses.push(operation.data.plid);
}
```

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)