### PR TITLE
#6170 - TypeError: Cannot read properties of undefined (reading pp)

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/__tests__/rotate.test.ts
+++ b/packages/ketcher-core/src/application/editor/actions/__tests__/rotate.test.ts
@@ -1,0 +1,136 @@
+import { fromRotate } from '../rotate';
+import { Struct } from 'domain/entities/struct';
+import { Vec2 } from 'domain/entities/vec2';
+import { RxnPlus } from 'domain/entities/rxnPlus';
+import { Text } from 'domain/entities/text';
+import { SGroup } from 'domain/entities/sgroup';
+import { Fragment } from 'domain/entities/fragment';
+
+/**
+ * Regression tests for https://github.com/epam/ketcher/issues/6170
+ *
+ * `fromRotate` used to dereference `.pp`/`.position` on pool entries looked
+ * up by id from the (possibly stale) editor selection without checking
+ * whether the entry still exists in the current Struct. If the selection
+ * held on to an id of an item that no longer exists (deleted, replaced,
+ * or a race between struct mutation and selection state), this threw:
+ * `TypeError: Cannot read properties of undefined (reading 'pp')`.
+ *
+ * `fromRotate` itself takes untyped params (see the `// eslint-disable-line`
+ * on its declaration), so plain duck-typed fixtures are passed directly
+ * without needing type casts.
+ */
+describe('fromRotate: stale selection ids', () => {
+  const center = new Vec2(0, 0);
+  const angle = Math.PI / 4;
+
+  it('does not throw when selection.rxnPluses references a non-existent id', () => {
+    const struct = new Struct();
+    const restruct = { molecule: struct };
+    const selection = { rxnPluses: [999] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+  });
+
+  it('does not throw when selection.texts references a non-existent id', () => {
+    const struct = new Struct();
+    const restruct = { molecule: struct };
+    const selection = { texts: [999] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+  });
+
+  it('does not throw when selection.sgroupData references a non-existent id', () => {
+    const struct = new Struct();
+    const restruct = { molecule: struct };
+    const selection = { sgroupData: [999] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+  });
+
+  it('does not throw when selection.sgroupData references an sgroup with no position', () => {
+    const struct = new Struct();
+    const sgroup = new SGroup('DAT');
+    // sgroup.pp is null by default (not yet positioned)
+    const sgid = struct.sgroups.add(sgroup);
+    const restruct = { molecule: struct };
+    const selection = { sgroupData: [sgid] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+  });
+
+  it('does not throw when selection.enhancedFlags references a non-existent fragment id', () => {
+    const struct = new Struct();
+    const restruct = { molecule: struct };
+    const selection = { enhancedFlags: [999] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+  });
+
+  it('does not throw when selection.atoms references a non-existent id (already-fixed case)', () => {
+    const struct = new Struct();
+    const restruct = { molecule: struct };
+    const selection = { atoms: [999] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+  });
+
+  // These exercise the full `action.perform(restruct)` path (not just the
+  // guard), so they need just enough of a ReStruct-shaped render layer for
+  // the operations' `execute()` to run. This confirms the guard only skips
+  // missing entries and doesn't swallow legitimate ones.
+  const renderOptions = { microModeScale: 1 };
+  const fakeVisel = () => ({ translate: () => undefined });
+
+  it('still moves a valid rxnPlus (guard does not swallow real entries)', () => {
+    const struct = new Struct();
+    const rxnPlus = new RxnPlus({ pp: new Vec2(1, 1) });
+    const plusId = struct.rxnPluses.add(rxnPlus);
+    const restruct = {
+      molecule: struct,
+      rxnPluses: new Map([[plusId, { visel: fakeVisel() }]]),
+      render: { options: renderOptions },
+      markItem: () => undefined,
+    };
+    const selection = { rxnPluses: [plusId] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+    expect(rxnPlus.pp).not.toEqual(new Vec2(1, 1));
+  });
+
+  it('still moves a valid text', () => {
+    const struct = new Struct();
+    const text = new Text({
+      content: '',
+      position: new Vec2(1, 1),
+      pos: [new Vec2(0, 1), new Vec2(1, 1), new Vec2(1, 0), new Vec2(0, 0)],
+    });
+    const textId = struct.texts.add(text);
+    const restruct = {
+      molecule: struct,
+      texts: new Map([
+        [textId, { visel: fakeVisel(), getReferencePoints: () => [] }],
+      ]),
+      render: { options: renderOptions },
+      markItem: () => undefined,
+    };
+    const selection = { texts: [textId] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+    expect(text.position).not.toEqual(new Vec2(1, 1));
+  });
+
+  it('still moves a valid enhanced flag (fragment)', () => {
+    const struct = new Struct();
+    const fragment = new Fragment([], new Vec2(1, 1));
+    const fragId = struct.frags.add(fragment);
+    const restruct = {
+      molecule: struct,
+      markItem: () => undefined,
+    };
+    const selection = { enhancedFlags: [fragId] };
+
+    expect(() => fromRotate(restruct, selection, center, angle)).not.toThrow();
+    expect(fragment.stereoFlagPosition).not.toEqual(new Vec2(1, 1));
+  });
+});

--- a/packages/ketcher-core/src/application/editor/actions/rotate.ts
+++ b/packages/ketcher-core/src/application/editor/actions/rotate.ts
@@ -301,6 +301,8 @@ export function fromRotate(restruct, selection, center, angle: number) {
   if (selection.rxnPluses) {
     selection.rxnPluses.forEach((pid) => {
       const plus = struct.rxnPluses.get(pid);
+      if (!plus) return;
+
       action.addOp(new RxnPlusMove(pid, rotateDelta(plus.pp, center, angle)));
     });
   }
@@ -308,6 +310,8 @@ export function fromRotate(restruct, selection, center, angle: number) {
   if (selection.texts) {
     selection.texts.forEach((textId) => {
       const text = struct.texts.get(textId);
+      if (!text) return;
+
       action.addOp(
         new TextMove(textId, rotateDelta(text.position, center, angle)),
       );
@@ -317,6 +321,8 @@ export function fromRotate(restruct, selection, center, angle: number) {
   if (selection.sgroupData) {
     selection.sgroupData.forEach((did) => {
       const data = struct.sgroups.get(did);
+      if (!data || !data.pp) return;
+
       action.addOp(
         new SGroupDataMove(did, rotateDelta(data.pp, center, angle)),
       );
@@ -327,6 +333,8 @@ export function fromRotate(restruct, selection, center, angle: number) {
     selection.enhancedFlags.forEach((flagId) => {
       const frId = flagId;
       const frag = restruct.molecule.frags.get(frId);
+      if (!frag) return;
+
       action.addOp(
         new EnhancedFlagMove(
           flagId,


### PR DESCRIPTION
## How to reproduce easy?

1. Open Ketcher
2. Past any ring onto the canvas (e.g., COC1=NC=C(CN2C3CC2CN(C3)C4=NC=C(C5=CC(OCC(C)(O)C)=CN6N=CC(C#N)=C56)C=C4)C=C1) by clicking on the canvas.
3. Select it entirely (Ctrl+A).
4. Open DevTools → Console and execute:
```
const ed = window.ketcher.editor;
ed.selection({ ...ed.selection(), rxnPluses: [999999] });
```

## How the feature works? / How did you fix the issue?
`fromRotate `(in packages/ketcher-core/src/application/editor/actions/rotate.ts) rotates the current editor selection by looking up each selected entity from the Struct by id and immediately reading its position (.pp / .position). If the editor's selection object holds an id that no longer exists in the current Struct — e.g. the entity was deleted/replaced by a concurrent action while the selection state wasn't cleared — the lookup returns undefined, and the code crashed with:

`TypeError: Cannot read properties of undefined (reading 'pp')`

This is the root cause of #6170. The atoms branch of `fromRotate `already guarded against this (fixed earlier for #7887), but the sibling branches — rxnPluses, texts, sgroupData, and enhancedFlags — did not, so the same class of crash was still reachable when rotating a selection containing a reaction plus, a text object, an S-group data label, or a stereo flag with a stale id.

Fix: added the same if (!entity) return; guard already used for atoms to the rxnPluses, texts, sgroupData (also guarding a missing pp), and enhancedFlags branches, so a stale id is simply skipped instead of crashing.

Tests: added packages/ketcher-core/src/application/editor/actions/tests/rotate.test.ts — regression tests confirming fromRotate no longer throws for a stale id in each of the four branches (plus the already-fixed atoms case), and positive tests confirming valid entities are still correctly rotated (the guard doesn't swallow legitimate entries). Verified the regression tests fail with the exact reported error when the fix is reverted, and pass with it applied.


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

fixes #6170 