### PR TITLE
#3152 - The Abbreviation lookup appears when pressing the shortcut "0" several times

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/hotkeys.test.tsx
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.test.tsx
@@ -39,6 +39,22 @@ describe('Hot keys', () => {
     });
     expect(screen.getByTestId('select-lasso').className).toContain('selected');
   });
+
+  // Regression test for https://github.com/epam/ketcher/issues/3152:
+  // '0' (Any Bond) was missing from the shortcutKeys list used to tell a
+  // repeated shortcut press apart from the start of an abbreviation search,
+  // so pressing '0' a second time incorrectly opened the Abbreviation
+  // Lookup, unlike the equivalent '1'-'4' bond shortcuts.
+  it('should not open Abbreviation lookup when pressing "0" (Any Bond) several times', async () => {
+    const { store } = renderWithMockStore(<LeftToolbarContainer />);
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      fireEvent.keyDown(document, { code: 'Digit0', key: '0' });
+      fireEvent.keyDown(document, { code: 'Digit0', key: '0' });
+      fireEvent.keyDown(document, { code: 'Digit0', key: '0' });
+    });
+    expect(store.getState().abbreviationLookup.isOpen).toBe(false);
+  });
 });
 
 function renderWithMockStore(component) {

--- a/packages/ketcher-react/src/script/ui/state/hotkeys.ts
+++ b/packages/ketcher-react/src/script/ui/state/hotkeys.ts
@@ -79,6 +79,7 @@ function removeNotRenderedStruct(actionTool, group, dispatch) {
 let abbreviationLookupTimeoutId: number | undefined;
 const ABBREVIATION_LOOKUP_TYPING_TIMEOUT = 1000;
 const shortcutKeys = [
+  '0',
   '1',
   '2',
   '3',


### PR DESCRIPTION
…eral times

shortcutKeys (used to tell a repeated shortcut press apart from the start of an abbreviation search) listed '1'-'4' but not '0', even though '0' is the Any Bond shortcut. Re-pressing '0' was therefore treated as a non-shortcut key, incorrectly opening the Abbreviation Lookup instead of just re-activating Any Bond like '1'-'4' already do.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request