### PR TITLE
#10982 Refactor: Explicit/implicit Any type clean up from packages/ketcher-core/src/domain/entities/pool.ts file

### DIFF
--- a/packages/ketcher-core/__tests__/application/render/restruct/resgroup.test.ts
+++ b/packages/ketcher-core/__tests__/application/render/restruct/resgroup.test.ts
@@ -116,13 +116,13 @@ describe('resgroup should draw brackets with attachment points correctly', () =>
       render.ctab,
       'getRGroupAttachmentPointsVBoxByAtomIds',
     );
-    const bonds = new Pool();
+    const bonds = new Pool<Bond>();
     mockBonds.forEach((bond, i) => bonds.set(i, new Bond(bond)));
     restruct.molecule.bonds = bonds;
   });
 
   it('should draw brackets with attachment points with more than 2 cross bonds per atom with 1 attachment point', () => {
-    const bonds = new Pool();
+    const bonds = new Pool<Bond>();
     mockBonds.forEach((bond, i) => bonds.set(i, new Bond(bond)));
     restruct.molecule.bonds = bonds;
     reSgroup.draw(restruct as unknown as ReStruct, sGroup);

--- a/packages/ketcher-core/__tests__/mock-data.ts
+++ b/packages/ketcher-core/__tests__/mock-data.ts
@@ -8,8 +8,8 @@ import { PolymerBondRendererFactory } from 'application/render/renderers/Polymer
 import {
   type Loop,
   type RGroupAttachmentPoint,
-  Atom,
-  Bond,
+  type Atom,
+  type Bond,
   Box2Abs,
   Pool,
   Struct,

--- a/packages/ketcher-core/__tests__/mock-data.ts
+++ b/packages/ketcher-core/__tests__/mock-data.ts
@@ -8,6 +8,8 @@ import { PolymerBondRendererFactory } from 'application/render/renderers/Polymer
 import {
   type Loop,
   type RGroupAttachmentPoint,
+  Atom,
+  Bond,
   Box2Abs,
   Pool,
   Struct,
@@ -393,11 +395,11 @@ const mockBonds = [
   },
 ];
 
-const atoms = new Pool();
-mockAtoms.forEach((atom, key) => atoms.set(key, atom));
+const atoms = new Pool<Atom>();
+mockAtoms.forEach((atom, key) => atoms.set(key, atom as Atom));
 
-const bonds = new Pool();
-mockBonds.forEach((bond, key) => bonds.set(key, bond));
+const bonds = new Pool<Bond>();
+mockBonds.forEach((bond, key) => bonds.set(key, bond as Bond));
 
 const mockHalfBonds = [
   {

--- a/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
+++ b/packages/ketcher-core/src/application/editor/operations/atom/AtomDelete.ts
@@ -52,6 +52,7 @@ class AtomDelete extends BaseOperation {
     }
 
     const set = restruct.connectedComponents.get(restructedAtom.component);
+    if (!set) return;
     set.delete(aid);
     if (set.size === 0) {
       restruct.connectedComponents.delete(restructedAtom.component);

--- a/packages/ketcher-core/src/application/render/restruct/restruct.ts
+++ b/packages/ketcher-core/src/application/render/restruct/restruct.ts
@@ -75,8 +75,8 @@ class ReStruct {
   public reloops: Map<number, ReLoop> = new Map();
   public rxnPluses: Map<number, ReRxnPlus> = new Map();
   public rxnArrows: Map<number, ReRxnArrow> = new Map();
-  public frags: Pool = new Pool();
-  public rgroups: Pool = new Pool();
+  public frags: Pool<ReFrag> = new Pool();
+  public rgroups: Pool<ReRGroup> = new Pool();
   public rgroupAttachmentPoints: Pool<ReRGroupAttachmentPoint> = new Pool();
 
   public sgroups: Map<number, ReSGroup> = new Map();
@@ -93,8 +93,8 @@ class ReStruct {
     RaphaelPath
   >;
 
-  public connectedComponents: Pool = new Pool();
-  private readonly ccFragmentType: Pool = new Pool();
+  public connectedComponents: Pool<Pile> = new Pool();
+  private readonly ccFragmentType: Pool<number> = new Pool();
   private structChanged = false;
   public needRecalculateVisibleAtomsAndBonds = false;
 
@@ -210,6 +210,7 @@ class ReStruct {
     const atom = reAtom || this.atoms.get(aid);
     if (!atom || atom.component < 0) return;
     const cc = this.connectedComponents.get(atom.component);
+    if (!cc) return;
 
     cc.delete(aid);
     if (cc.size < 1) this.connectedComponents.delete(atom.component);
@@ -273,7 +274,7 @@ class ReStruct {
   }
 
   removeConnectedComponent(ccid: number): boolean {
-    this.connectedComponents.get(ccid).forEach((aid) => {
+    this.connectedComponents.get(ccid)?.forEach((aid) => {
       const atom = this.atoms.get(aid);
       if (atom) atom.component = -1;
     });
@@ -815,8 +816,8 @@ class ReStruct {
   }
 
   showFragments(): void {
-    this.frags.forEach((frag, id) => {
-      const path = frag.draw(this.render, id);
+    this.frags.forEach((frag) => {
+      const path = frag.draw(this.render);
       if (path) {
         this.addReObjectPath(LayerMap.data, frag.visel, path, null, true);
       }

--- a/packages/ketcher-core/src/domain/entities/pool.ts
+++ b/packages/ketcher-core/src/domain/entities/pool.ts
@@ -30,7 +30,7 @@ function hasResetInitiallySelected(
   );
 }
 
-export class Pool<TValue = any> extends Map<number, TValue> {
+export class Pool<TValue = unknown> extends Map<number, TValue> {
   private nextId = 0;
 
   add(item: TValue): number {

--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.ts
@@ -34,7 +34,7 @@ import type { AtomMap, SGroupMap } from './mol.types';
 const loadRGroupFragments = true; // TODO: set to load the fragments
 
 /** M-property block: string keys (CHG, alias, …) map to per-atom pools */
-type MPropertyProps = Map<string, Pool>;
+type MPropertyProps = Map<string, Pool<string | number | AtomList>>;
 
 function parseAtomLine(atomLine: string): Atom {
   /* reader */
@@ -202,7 +202,10 @@ function handleRGroupProperty(
 
   for (const a2r of a2rs) {
     const rg = Number(a2r[1]);
-    rglabels.set(a2r[0], (rglabels.get(a2r[0]) || 0) | (1 << (rg - 1)));
+    rglabels.set(
+      a2r[0],
+      ((rglabels.get(a2r[0]) as number) || 0) | (1 << (rg - 1)),
+    );
   }
 }
 
@@ -418,7 +421,7 @@ function parsePropertyLines(
   rLogic: Record<number, RGroupAttributes>,
 ): MPropertyProps {
   /* reader */
-  const props = new Map<string, Pool>();
+  const props = new Map<string, Pool<string | number | AtomList>>();
 
   while (shift < end) {
     const line = ctabLines[shift];
@@ -452,7 +455,11 @@ function parsePropertyLines(
  * @param values { Pool }
  * @param propId { string }
  */
-function applyAtomProp(atoms: Pool<Atom>, values: Pool, propId: string): void {
+function applyAtomProp(
+  atoms: Pool<Atom>,
+  values: Pool<string | number | AtomList>,
+  propId: string,
+): void {
   /* reader */
   values.forEach((propVal, aid) => {
     const atom = atoms.get(aid);
@@ -723,13 +730,16 @@ function labelsListToIds(labels: string[]): number[] {
  * @param lst
  * @returns { Pool }
  */
-function parsePropertyLineAtomList(hdr: string[], lst: string[]): Pool {
+function parsePropertyLineAtomList(
+  hdr: string[],
+  lst: string[],
+): Pool<AtomList> {
   /* reader */
   const aid = utils.parseDecimalInt(hdr[1]) - 1;
   const count = utils.parseDecimalInt(hdr[2]);
   const notList = hdr[4].trim() === 'T';
   const ids = labelsListToIds(lst.slice(0, count));
-  const ret = new Pool();
+  const ret = new Pool<AtomList>();
   ret.set(
     aid,
     new AtomList({

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -197,10 +197,12 @@ class SelectTool implements Tool {
       };
     } else if (ci.map === 'rgroups') {
       const rgroup = ctab.rgroups.get(ci.id);
-      sel = {
-        atoms: rgroup.getAtoms(rnd),
-        bonds: rgroup.getBonds(rnd),
-      };
+      if (rgroup) {
+        sel = {
+          atoms: rgroup.getAtoms(rnd),
+          bonds: rgroup.getBonds(rnd),
+        };
+      }
     } else if (ci.map === 'sgroupData') {
       if (isSelected(selection, ci)) return;
     }


### PR DESCRIPTION
Replace the unsafe `any` default generic parameter in Pool with `unknown`, and update all callers to use explicit type arguments. Also fixes two latent null-safety bugs in connectedComponents access exposed by the stricter typing.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request