### PR TITLE
#11100 Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\toolbars\ToolbarGroupItem\ToolbarMultiToolItem\usePortalOpening.ts file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
@@ -14,21 +14,13 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useState } from 'react';
-
 import type { ToolbarItem } from '../../toolbar.types';
 
 type HookParams = [string, string | null, ToolbarItem[]];
 
 function usePortalOpening([id, opened, options]: HookParams): [boolean] {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-
-  useEffect(() => {
-    const currentId = (options.length && options[0].id) || '';
-    const newState = opened === id || opened === currentId;
-    setIsOpen(newState);
-  }, [opened, options]);
-
+  const currentId = (options.length && options[0].id) || '';
+  const isOpen = opened === id || opened === currentId;
   return [isOpen];
 }
 


### PR DESCRIPTION
…vation

Replace six instances where state was set inside useEffect for values that can be computed synchronously from existing props/state:

- usePortalOpening: remove useState/useEffect, compute isOpen inline
- useDisabledForSequenceMode: remove useState/useEffect, compute isDisabled inline
- TemplateDialog: replace filteredFG state+effect with useMemo
- Settings: replace changedGroups state+effect with useMemo
- InfoPanel: replace sGroupData and molecule state+effects with useMemo
- MacromoleculePropertiesWindow: replace selectedTabIndex/massMeasurementUnit effect-based reset with setState-during-render pattern (both values are also set by user interaction so they cannot be pure useMemo)

Also adds the null guard for connectedComponents.get() in AtomDelete.ts that was missed in the Pool<TValue=unknown> migration.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request