### PR TITLE
#4445 – Macro: Context menu opened outside selection have to remove selection in the same manner as it works in Micro mode

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -1869,6 +1869,88 @@ describe('CoreEditor', () => {
         Reflect.deleteProperty(svgElementWithBBox, 'getBBox');
       }
     });
+
+    it('should dispatch rightClickSelectedMonomers via elementsFromPoint fallback when event.target has no __data__', () => {
+      editor.setMode(new FlexMode());
+
+      const svgElementWithBBox = SVGElement.prototype as SVGElement & {
+        getBBox?: () => DOMRect;
+      };
+      const initialGetBBox = svgElementWithBBox.getBBox;
+      svgElementWithBBox.getBBox = () =>
+        ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+      const addChanges = editor.drawingEntitiesManager.addMonomer(
+        peptideMonomerItem,
+        new Vec2(0, 0),
+      );
+      editor.renderersContainer.update(addChanges);
+      const monomer = Array.from(editor.drawingEntitiesManager.monomers)[0][1];
+      const selectChanges =
+        editor.drawingEntitiesManager.selectDrawingEntity(monomer);
+      editor.renderersContainer.update(selectChanges);
+
+      const unselectSpy = jest.spyOn(
+        editor.drawingEntitiesManager,
+        'unselectAllDrawingEntities',
+      );
+      const rightClickSelectedMonomersHandler = jest.fn();
+      const rightClickCanvasHandler = jest.fn();
+      const rightClickCanvasSequenceHandler = jest.fn();
+      editor.events.rightClickSelectedMonomers.add(
+        rightClickSelectedMonomersHandler,
+      );
+      editor.events.rightClickCanvas.add(rightClickCanvasHandler);
+      editor.events.rightClickCanvasSequence.add(
+        rightClickCanvasSequenceHandler,
+      );
+
+      const rendererEl = document.createElement('div');
+      (rendererEl as unknown as { __data__: unknown }).__data__ =
+        monomer.renderer;
+
+      const hasEFP = 'elementsFromPoint' in document;
+      const savedEFP = hasEFP ? document.elementsFromPoint : undefined;
+      (document as unknown as Record<string, unknown>).elementsFromPoint = jest
+        .fn()
+        .mockReturnValue([rendererEl]);
+
+      const noDataTarget = document.createElement('div');
+      rootElement.appendChild(noDataTarget);
+
+      try {
+        noDataTarget.dispatchEvent(
+          new MouseEvent('contextmenu', {
+            bubbles: true,
+            clientX: 0,
+            clientY: 0,
+          }),
+        );
+
+        expect(rightClickSelectedMonomersHandler).toHaveBeenCalledTimes(1);
+        expect(rightClickSelectedMonomersHandler.mock.calls[0][0][1]).toEqual([
+          monomer,
+        ]);
+        expect(unselectSpy).not.toHaveBeenCalled();
+        expect(rightClickCanvasHandler).not.toHaveBeenCalled();
+        expect(rightClickCanvasSequenceHandler).not.toHaveBeenCalled();
+      } finally {
+        noDataTarget.remove();
+        if (savedEFP !== undefined) {
+          (document as unknown as Record<string, unknown>).elementsFromPoint =
+            savedEFP;
+        } else {
+          delete (document as unknown as Record<string, unknown>)
+            .elementsFromPoint;
+        }
+        unselectSpy.mockRestore();
+        if (initialGetBBox) {
+          svgElementWithBBox.getBBox = initialGetBBox;
+        } else {
+          Reflect.deleteProperty(svgElementWithBBox, 'getBBox');
+        }
+      }
+    });
   });
 
   describe('remove autochain preview handling', () => {

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -24,6 +24,8 @@ import {
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH,
   MONOMER_GROUP_TEMPLATE_NAME_MAX_LENGTH_ERROR_MESSAGE,
 } from 'utilities';
+import { FlexMode, SnakeMode } from 'application/editor/modes';
+import { SequenceRenderer } from 'application/render/renderers/sequence/SequenceRenderer';
 
 type RescaleStructForModeTransitionContext = {
   micromoleculesEditor: {
@@ -1717,6 +1719,98 @@ describe('CoreEditor', () => {
       } else {
         Reflect.deleteProperty(svgElementWithBBox, 'getBBox');
       }
+    });
+
+    it('should clear selection and dispatch rightClickCanvas in flex mode on right-click on empty canvas', () => {
+      editor.setMode(new FlexMode());
+      const unselectSpy = jest.spyOn(
+        editor.drawingEntitiesManager,
+        'unselectAllDrawingEntities',
+      );
+      const rightClickCanvasHandler = jest.fn();
+      editor.events.rightClickCanvas.add(rightClickCanvasHandler);
+
+      const canvasElement = document.createElement('div');
+      rootElement.appendChild(canvasElement);
+      canvasElement.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          clientX: 0,
+          clientY: 0,
+        }),
+      );
+
+      expect(unselectSpy).toHaveBeenCalledTimes(1);
+      expect(rightClickCanvasHandler).toHaveBeenCalledWith([
+        expect.anything(),
+        [],
+      ]);
+
+      canvasElement.remove();
+    });
+
+    it('should clear selection and dispatch rightClickCanvas in snake mode on right-click on empty canvas', () => {
+      editor.setMode(new SnakeMode());
+      const unselectSpy = jest.spyOn(
+        editor.drawingEntitiesManager,
+        'unselectAllDrawingEntities',
+      );
+      const rightClickCanvasHandler = jest.fn();
+      editor.events.rightClickCanvas.add(rightClickCanvasHandler);
+
+      const canvasElement = document.createElement('div');
+      rootElement.appendChild(canvasElement);
+      canvasElement.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          clientX: 0,
+          clientY: 0,
+        }),
+      );
+
+      expect(unselectSpy).toHaveBeenCalledTimes(1);
+      expect(rightClickCanvasHandler).toHaveBeenCalledWith([
+        expect.anything(),
+        [],
+      ]);
+
+      canvasElement.remove();
+    });
+
+    it('should clear selection and dispatch rightClickCanvasSequence in sequence mode on right-click on empty canvas', () => {
+      // editor defaults to sequence-layout-mode (DEFAULT_LAYOUT_MODE)
+      const unselectSpy = jest.spyOn(
+        editor.drawingEntitiesManager,
+        'unselectAllDrawingEntities',
+      );
+      const unselectSequenceSpy = jest.spyOn(
+        SequenceRenderer,
+        'unselectEmptyAndBackboneSequenceNodes',
+      );
+      const rightClickCanvasSequenceHandler = jest.fn();
+      editor.events.rightClickCanvasSequence.add(
+        rightClickCanvasSequenceHandler,
+      );
+
+      const canvasElement = document.createElement('div');
+      rootElement.appendChild(canvasElement);
+      canvasElement.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          clientX: 0,
+          clientY: 0,
+        }),
+      );
+
+      expect(unselectSpy).toHaveBeenCalledTimes(1);
+      expect(unselectSequenceSpy).toHaveBeenCalledTimes(1);
+      expect(rightClickCanvasSequenceHandler).toHaveBeenCalledWith([
+        expect.anything(),
+        [],
+      ]);
+
+      unselectSequenceSpy.mockRestore();
+      canvasElement.remove();
     });
   });
 

--- a/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/Editor.test.ts
@@ -1812,6 +1812,63 @@ describe('CoreEditor', () => {
       unselectSequenceSpy.mockRestore();
       canvasElement.remove();
     });
+
+    it('should not clear selection when right-clicking a canvas-level element with __data__ set to a selected monomer renderer', () => {
+      editor.setMode(new FlexMode());
+
+      const svgElementWithBBox = SVGElement.prototype as SVGElement & {
+        getBBox?: () => DOMRect;
+      };
+      const initialGetBBox = svgElementWithBBox.getBBox;
+      svgElementWithBBox.getBBox = () =>
+        ({ x: 0, y: 0, width: 0, height: 0 } as DOMRect);
+
+      const addChanges = editor.drawingEntitiesManager.addMonomer(
+        peptideMonomerItem,
+        new Vec2(0, 0),
+      );
+      editor.renderersContainer.update(addChanges);
+      const monomer = Array.from(editor.drawingEntitiesManager.monomers)[0][1];
+      const selectChanges =
+        editor.drawingEntitiesManager.selectDrawingEntity(monomer);
+      editor.renderersContainer.update(selectChanges);
+
+      const unselectSpy = jest.spyOn(
+        editor.drawingEntitiesManager,
+        'unselectAllDrawingEntities',
+      );
+      const rightClickSelectedMonomersHandler = jest.fn();
+      const rightClickCanvasHandler = jest.fn();
+      editor.events.rightClickSelectedMonomers.add(
+        rightClickSelectedMonomersHandler,
+      );
+      editor.events.rightClickCanvas.add(rightClickCanvasHandler);
+
+      // Simulate the selection circle: a canvas-level element with __data__ = renderer
+      const selectionIndicator = document.createElement('circle');
+      (selectionIndicator as unknown as { __data__: unknown }).__data__ =
+        monomer.renderer;
+      rootElement.appendChild(selectionIndicator);
+
+      selectionIndicator.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          clientX: 0,
+          clientY: 0,
+        }),
+      );
+
+      expect(unselectSpy).not.toHaveBeenCalled();
+      expect(rightClickCanvasHandler).not.toHaveBeenCalled();
+      expect(rightClickSelectedMonomersHandler).toHaveBeenCalled();
+
+      selectionIndicator.remove();
+      if (initialGetBBox) {
+        svgElementWithBBox.getBBox = initialGetBBox;
+      } else {
+        Reflect.deleteProperty(svgElementWithBBox, 'getBBox');
+      }
+    });
   });
 
   describe('remove autochain preview handling', () => {

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -1153,10 +1153,15 @@ export class CoreEditor {
         ]);
       } else if (isClickOnCanvas) {
         if (this.mode.modeName === 'sequence-layout-mode') {
-          this.events.rightClickCanvasSequence.dispatch([
-            event,
-            sequenceSelections,
-          ]);
+          const modelChanges =
+            this.drawingEntitiesManager.unselectAllDrawingEntities();
+
+          modelChanges.merge(
+            SequenceRenderer.unselectEmptyAndBackboneSequenceNodes(),
+          );
+
+          this.renderersContainer.update(modelChanges);
+          this.events.rightClickCanvasSequence.dispatch([event, []]);
         } else {
           this.events.rightClickCanvas.dispatch([event, selectedMonomers]);
         }

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -1074,20 +1074,7 @@ export class CoreEditor {
         return;
       }
 
-      // Walk up from event.target: target may be a child SVG shape or a
-      // canvas-level selection indicator that doesn't carry __data__ directly.
-      let eventData = event.target?.__data__;
-      if (eventData === undefined) {
-        let el: Element | null =
-          event.target instanceof Element ? event.target.parentElement : null;
-        while (el && el !== this.canvas) {
-          if (el.__data__ !== undefined) {
-            eventData = el.__data__;
-            break;
-          }
-          el = el.parentElement;
-        }
-      }
+      const eventData = event.target?.__data__;
       const canvasBoundingClientRect = this.canvas.getBoundingClientRect();
       const isClickOnCanvas =
         event.clientX >= canvasBoundingClientRect.left &&
@@ -1165,6 +1152,19 @@ export class CoreEditor {
           selectedMonomers,
         ]);
       } else if (isClickOnCanvas) {
+        if (
+          typeof document.elementsFromPoint === 'function' &&
+          document
+            .elementsFromPoint(event.clientX, event.clientY)
+            .some((el) => el.__data__?.drawingEntity?.selected)
+        ) {
+          this.events.rightClickSelectedMonomers.dispatch([
+            event,
+            selectedMonomers,
+          ]);
+          return false;
+        }
+
         const modelChanges =
           this.drawingEntitiesManager.unselectAllDrawingEntities();
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -1152,18 +1152,21 @@ export class CoreEditor {
           selectedMonomers,
         ]);
       } else if (isClickOnCanvas) {
-        if (this.mode.modeName === 'sequence-layout-mode') {
-          const modelChanges =
-            this.drawingEntitiesManager.unselectAllDrawingEntities();
+        const modelChanges =
+          this.drawingEntitiesManager.unselectAllDrawingEntities();
 
+        if (this.mode.modeName === 'sequence-layout-mode') {
           modelChanges.merge(
             SequenceRenderer.unselectEmptyAndBackboneSequenceNodes(),
           );
+        }
 
-          this.renderersContainer.update(modelChanges);
+        this.renderersContainer.update(modelChanges);
+
+        if (this.mode.modeName === 'sequence-layout-mode') {
           this.events.rightClickCanvasSequence.dispatch([event, []]);
         } else {
-          this.events.rightClickCanvas.dispatch([event, selectedMonomers]);
+          this.events.rightClickCanvas.dispatch([event, []]);
         }
       }
 

--- a/packages/ketcher-core/src/application/editor/Editor.ts
+++ b/packages/ketcher-core/src/application/editor/Editor.ts
@@ -1074,7 +1074,20 @@ export class CoreEditor {
         return;
       }
 
-      const eventData = event.target?.__data__;
+      // Walk up from event.target: target may be a child SVG shape or a
+      // canvas-level selection indicator that doesn't carry __data__ directly.
+      let eventData = event.target?.__data__;
+      if (eventData === undefined) {
+        let el: Element | null =
+          event.target instanceof Element ? event.target.parentElement : null;
+        while (el && el !== this.canvas) {
+          if (el.__data__ !== undefined) {
+            eventData = el.__data__;
+            break;
+          }
+          el = el.parentElement;
+        }
+      }
       const canvasBoundingClientRect = this.canvas.getBoundingClientRect();
       const isClickOnCanvas =
         event.clientX >= canvasBoundingClientRect.left &&

--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -530,6 +530,17 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
         .attr('cy', this.center.y)
         .attr('fill', SELECTION_COLOR)
         .attr('class', 'dynamic-element');
+
+      // The circle is appended to the canvas root, not to the monomer <g>, so
+      // D3 datum propagation does not reach it. Bind the renderer manually so
+      // that right-click events on the circle are routed like monomer clicks.
+      const circleNode = this.selectionCircle?.node();
+      if (circleNode) {
+        type SelectionCircleNode = Omit<SVGCircleElement, '__data__'> & {
+          __data__?: unknown;
+        };
+        (circleNode as unknown as SelectionCircleNode).__data__ = this;
+      }
     }
   }
 

--- a/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/BaseMonomerRenderer.ts
@@ -530,17 +530,6 @@ export abstract class BaseMonomerRenderer extends BaseRenderer {
         .attr('cy', this.center.y)
         .attr('fill', SELECTION_COLOR)
         .attr('class', 'dynamic-element');
-
-      // The circle is appended to the canvas root, not to the monomer <g>, so
-      // D3 datum propagation does not reach it. Bind the renderer manually so
-      // that right-click events on the circle are routed like monomer clicks.
-      const circleNode = this.selectionCircle?.node();
-      if (circleNode) {
-        type SelectionCircleNode = Omit<SVGCircleElement, '__data__'> & {
-          __data__?: unknown;
-        };
-        (circleNode as unknown as SelectionCircleNode).__data__ = this;
-      }
     }
   }
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
When the context menu was opened on an empty area of the canvas in Macro Sequence mode, the existing nucleotide selection was passed to the context menu and remained visible.

The selection is now cleared before opening the canvas context menu. Both drawing entities and empty/backbone sequence nodes are unselected, and the context menu receives an empty selection.

Right-clicking a selected nucleotide still preserves the current selection.

### Result after the fix

Right-clicking an empty area of the canvas now clears the current selection in all macromolecule layout modes:

Sequence mode
Flex mode
Snake mode

Right-clicking a selected entity continues to preserve the current selection.

Manually verified in all three layout modes.
<img width="1896" height="1024" alt="Screenshot 2026-08-17 113134" src="https://github.com/user-attachments/assets/65416627-b4a9-4672-945c-f651c419988c" />


Validation:

Manually verified empty-canvas right-click behavior in Sequence, Flex, and Snake modes
Added unit regression tests for all three layout modes
Existing and new `Editor.test.ts` tests passed: 45/45
TypeScript check passed
ESLint check passed

Closes #4445

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request