### PR TITLE
#11101 - Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\modal\components\process\Check\Check.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -229,7 +228,13 @@ const CheckDialog: FC<CheckDialogProps> = (props) => {
   const handleSettingsChange = () => setIsCheckedWithNewSettings(false);
 
   useEffect(() => {
-    handleCheck();
+    // Intentionally omits setIsStructureChecking(false): on mount the loading
+    // state starts as false, so there is nothing to reset.
+    onCheck(result.checkOptions).then(() => {
+      setIsStructureChecking(true);
+      setLastCheckDate(new Date());
+      setIsCheckedWithNewSettings(true);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx
@@ -228,7 +228,11 @@ const CheckDialog: FC<CheckDialogProps> = (props) => {
   const handleSettingsChange = () => setIsCheckedWithNewSettings(false);
 
   useEffect(() => {
-    handleCheck();
+    onCheck(result.checkOptions).then(() => {
+      setIsStructureChecking(true);
+      setLastCheckDate(new Date());
+      setIsCheckedWithNewSettings(true);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
Removes the react-hooks/set-state-in-effect anti-pattern from packages/ketcher-react/src/script/ui/views/modal/components/process/Check/Check.tsx.

The mount effect previously called handleCheck(), which synchronously called setIsStructureChecking(false) inside a useEffect — the pattern the rule flags. The fix inlines only the async part of handleCheck directly into the effect (the setIsStructureChecking(false) reset is not needed on mount since the state already starts as false).

Also removes the now-dead file-level /* eslint-disable react-hooks/set-state-in-effect */ (added to master after this branch was cut) as part of the rebase.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request