### PR TITLE
#11102 Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\modal\components\meta\Settings\Settings.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/meta/Settings/Settings.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/meta/Settings/Settings.tsx
@@ -20,7 +20,7 @@ import {
   setDefaultSettings,
   updateFormState,
 } from '../../../../../state/modal/form';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import ColorPicker from '../../../../../component/form/colorPicker/ColorPicker';
 import { Dialog } from '../../../../components';
@@ -134,18 +134,14 @@ const SettingsDialog = (props: Props) => {
     ...prop
   } = props;
 
-  const [changedGroups, setChangedGroups] = useState(new Set());
-
-  useEffect(() => {
+  const changedGroups = useMemo(() => {
     const changed = new Set<string>();
-
     for (const key in initState) {
       if (initState[key] !== formState.result[key]) {
-        const group = fieldGroups[key];
-        changed.add(group);
+        changed.add(fieldGroups[key]);
       }
     }
-    setChangedGroups(changed);
+    return changed;
   }, [initState, formState.result]);
 
   const generalTab = {


### PR DESCRIPTION
changedGroups is derived synchronously from initState and formState.result, both available at render time — no need for state or a sync effect.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request