### PR TITLE
#11099 – Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-macromolecules\src\components\macromoleculeProperties\MacromoleculePropertiesWindow.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -945,6 +945,13 @@ const calculateMassMeasurementUnit = (mass?: number) => {
   return MassMeasurementUnit.MDa;
 };
 
+const calculateDefaultTabIndex = (
+  macromoleculesProperties: SingleChainMacromoleculeProperties | undefined,
+) =>
+  hasSpecificProperty(macromoleculesProperties, 'nucleotides')
+    ? PROPERTIES_TABS.RNA
+    : PROPERTIES_TABS.PEPTIDES;
+
 let recalculatePropertiesHandler: () => void;
 
 export const MacromoleculePropertiesWindow = () => {
@@ -966,10 +973,10 @@ export const MacromoleculePropertiesWindow = () => {
     | SingleChainMacromoleculeProperties
     | undefined = macromoleculesProperties?.[0];
 
-  const [selectedTabIndex, setSelectedTabIndex] = useState(
-    PROPERTIES_TABS.PEPTIDES,
+  const [selectedTabIndex, setSelectedTabIndex] = useState(() =>
+    calculateDefaultTabIndex(firstMacromoleculesProperties),
   );
-  const [massMeasurementUnit, setMassMeasurementUnit] = useState(
+  const [massMeasurementUnit, setMassMeasurementUnit] = useState(() =>
     calculateMassMeasurementUnit(firstMacromoleculesProperties?.mass),
   );
 
@@ -1049,16 +1056,24 @@ export const MacromoleculePropertiesWindow = () => {
     debouncedRecalculateMacromoleculeProperties,
   ]);
 
-  useEffect(() => {
+  // The properties object is re-parsed from the Indigo response on every
+  // recalculation, so a new identity means "new results arrived" and both
+  // selections fall back to their defaults. Adjusting during render (rather
+  // than in an effect) means React re-renders before committing, so the
+  // panel never paints with a stale tab.
+  const [previousProperties, setPreviousProperties] = useState(
+    firstMacromoleculesProperties,
+  );
+
+  if (previousProperties !== firstMacromoleculesProperties) {
+    setPreviousProperties(firstMacromoleculesProperties);
     setSelectedTabIndex(
-      hasSpecificProperty(firstMacromoleculesProperties, 'nucleotides')
-        ? PROPERTIES_TABS.RNA
-        : PROPERTIES_TABS.PEPTIDES,
+      calculateDefaultTabIndex(firstMacromoleculesProperties),
     );
     setMassMeasurementUnit(
       calculateMassMeasurementUnit(firstMacromoleculesProperties?.mass),
     );
-  }, [firstMacromoleculesProperties]);
+  }
 
   const onTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setSelectedTabIndex(newValue);


### PR DESCRIPTION
Closes #11099

## How did you fix the issue?

`MacromoleculePropertiesWindow` kept `selectedTabIndex` and `massMeasurementUnit` in state and resynced both from a `useEffect` whenever `firstMacromoleculesProperties` changed. Because the effect runs after commit, every recalculation rendered once with the stale tab/mass unit, then re-rendered — an extra commit/repaint, plus a duplicated "compute default" formula (once in the `useState` initializer, once in the effect).

Replaced the effect with a render-phase adjustment (the "adjust state when a prop changes" pattern from https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes, matching this repo's `react-you-might-not-need-an-effect/no-adjust-state-on-prop-change` lint rule):

- Extracted `calculateDefaultTabIndex` next to the existing `calculateMassMeasurementUnit` helper so the default-value logic isn't duplicated.
- Switched both `useState` calls to lazy initializers.
- Replaced the `useEffect` with a previous-value comparison done directly during render: if `firstMacromoleculesProperties` identity changed since the last render, both states are reset immediately (no extra effect pass, no stale-frame flicker).

Behavior is unchanged — this is a pure refactor per the issue's `refactor` label. In particular, since `firstMacromoleculesProperties` is a freshly `JSON.parse`d object on every recalculation, both selections still reset on every recalculation (identity-based trigger), same as before.

## Testing

- `eslint` on the changed file: same 3 pre-existing `react-hooks/exhaustive-deps` warnings (unrelated code), 0 new warnings/errors.
- `tsc --noEmit`: clean.
- E2E: `tests/specs/Macromolecule-editor/Calculate-Properties/calculate-properties.spec.ts` — 63/63 passed against a local standalone build, including the test covering default-tab selection (Case 7).

## Check list
- [x] unit-tests written (N/A — no unit test suite exists for this component; verified via existing E2E suite)
- [x] e2e-tests written (N/A — existing suite already covers this behavior; ran and confirmed no regressions)
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request