### PR TITLE
#11103 Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\modal\components\document\Open\components\CDXStructuresViewer\CDXStructuresViewer.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/CDXStructuresViewer/CDXStructuresViewer.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/components/CDXStructuresViewer/CDXStructuresViewer.tsx
@@ -48,7 +48,7 @@ export const CDXStructuresViewer = ({
   const editorOptions = useSelector(editorOptionsSelector);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [itemsMap, setItemsMap] = useState<itemsMapInterface>({});
-  const [loading, setLoading] = useState(false);
+  const loading = !!structList[selectedIndex] && !itemsMap[selectedIndex];
 
   useEffect(() => {
     if (!itemsMap[selectedIndex] || itemsMap[selectedIndex].error) {
@@ -59,24 +59,18 @@ export const CDXStructuresViewer = ({
   }, [inputHandler, itemsMap, selectedIndex]);
 
   const getImage = (str, index) => {
-    setLoading(true);
     parseStruct(str, server)
       .then((struct) => {
-        const object = {
-          base64struct: str,
-          struct,
-        };
-        setItemsMap((state) => ({ ...state, [index]: object }));
+        setItemsMap((state) => ({
+          ...state,
+          [index]: { base64struct: str, struct },
+        }));
       })
       .catch((error) => {
-        const object = {
-          base64struct: str,
-          error: error.message || error,
-        };
-        setItemsMap((state) => ({ ...state, [index]: object }));
-      })
-      .finally(() => {
-        setLoading(false);
+        setItemsMap((state) => ({
+          ...state,
+          [index]: { base64struct: str, error: error.message || error },
+        }));
       });
   };
 


### PR DESCRIPTION
loading was set synchronously via setLoading(true) at the start of getImage, called inside useEffect. It is fully derivable: loading is true when a struct exists at the current index but has not yet been fetched into itemsMap.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request