### PR TITLE
#11104 Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\components\StructEditor\InfoPanel.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/InfoPanel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { type FC, useState, useEffect } from 'react';
+import { type FC, useMemo } from 'react';
 import {
   type Render,
   type Struct,
@@ -89,23 +89,21 @@ interface InfoPanelProps {
 
 const InfoPanel: FC<InfoPanelProps> = (props) => {
   const { clientX, clientY, render, className, groupStruct, sGroup } = props;
-  const [molecule, setMolecule] = useState<Struct | null>(null);
-  const [sGroupData, setSGroupData] = useState<string | null>(null);
   const groupName = sGroup?.data?.name;
 
-  useEffect(() => {
+  const sGroupData = useMemo<string | null>(() => {
     if (sGroup && SGroup.isDataSGroup(sGroup)) {
-      setSGroupData(`${sGroup.data?.fieldName}=${sGroup.data?.fieldValue}`);
+      return `${sGroup.data?.fieldName}=${sGroup.data?.fieldValue}`;
     } else if (sGroup && SGroup.isQuerySGroup(sGroup)) {
-      setSGroupData('Query component');
-    } else {
-      setSGroupData(null);
+      return 'Query component';
     }
+    return null;
   }, [groupStruct, sGroup]);
 
-  useEffect(() => {
-    setMolecule(groupStruct ? groupStruct.clone() : null);
-  }, [groupName, groupStruct]);
+  const molecule = useMemo<Struct | null>(
+    () => (groupStruct ? groupStruct.clone() : null),
+    [groupName, groupStruct],
+  );
 
   // Ambiguous monomer tooltip uses marker coordinates, not mouse position,
   // so it must be checked before the clientX/clientY guard.


### PR DESCRIPTION
…useMemo

Both values are derived synchronously from props available at render time:
- sGroupData: computed from sGroup type checks and data fields
- molecule: groupStruct.clone() or null

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request