### PR TITLE
#11289 Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\components\monomerLibrary\monomerLibraryGroup\MonomerGroup.tsx file

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -46,7 +46,6 @@ import { SequenceSymbolOption } from '@tests/pages/constants/contextMenu/Constan
 import { MacromoleculesTopToolbar } from '@tests/pages/macromolecules/MacromoleculesTopToolbar';
 import { LayoutMode } from '@tests/pages/constants/macromoleculesTopToolbar/Constants';
 import { MonomerPreviewTooltip } from '@tests/pages/macromolecules/canvas/MonomerPreviewTooltip';
-import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 
 async function hoverMouseOverMonomer(page: Page, monomer: Monomer, nth = 0) {
   await CommonLeftToolbar(page).bondTool(MacroBondTool.Single);

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -90,28 +90,23 @@ const MonomerGroup = ({
     }
 
     const cardCoordinates = e.currentTarget.getBoundingClientRect();
-    let style: PreviewStyle;
-    let previewType: PreviewType;
-    let top: string;
 
     if (isAmbiguousMonomerLibraryItem(monomer)) {
-      top = calculateAmbiguousMonomerPreviewTop(monomer)(cardCoordinates);
+      const top = calculateAmbiguousMonomerPreviewTop(monomer)(cardCoordinates);
       const left = `${cardCoordinates.left + cardCoordinates.width / 2}px`;
-      previewType = PreviewType.AmbiguousMonomer;
-      style = { left, top, transform: 'translate(-50%, 0)' };
+      debouncedShowPreview({
+        type: PreviewType.AmbiguousMonomer,
+        monomer,
+        style: { left, top, transform: 'translate(-50%, 0)' },
+      });
     } else {
-      top = calculateMonomerPreviewTop(cardCoordinates);
-      style = { right: '-88px', top, transform: 'translate(-50%, 0)' };
-      previewType = PreviewType.Monomer;
+      const top = calculateMonomerPreviewTop(cardCoordinates);
+      debouncedShowPreview({
+        type: PreviewType.Monomer,
+        monomer,
+        style: { right: '-88px', top, transform: 'translate(-50%, 0)' },
+      });
     }
-
-    const previewData = {
-      type: previewType,
-      monomer,
-      style,
-    };
-
-    debouncedShowPreview(previewData);
   };
 
   const selectMonomer = (monomer: MonomerOrAmbiguousType) => {

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { EmptyFunction } from 'helpers';
 import { debounce } from 'lodash';
 import { MonomerItem } from '../monomerLibraryItem';
@@ -82,6 +82,8 @@ const MonomerGroup = ({
     () => debounce((p) => dispatchShowPreview(p), 500),
     [dispatchShowPreview],
   );
+
+  useEffect(() => () => debouncedShowPreview.cancel(), [debouncedShowPreview]);
 
   const closeLibraryPreview = useCallback(() => {
     debouncedShowPreview.cancel();

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -15,9 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback } from 'react';
 import { EmptyFunction } from 'helpers';
-import { debounce } from 'lodash';
 import { MonomerItem } from '../monomerLibraryItem';
 import { GroupContainerColumn, GroupTitle, ItemsContainer } from './styles';
 import { IMonomerGroupProps } from './types';
@@ -27,7 +26,7 @@ import {
   MonomerOrAmbiguousType,
   isAmbiguousMonomerLibraryItem,
 } from 'ketcher-core';
-import { useAppDispatch, useAppSelector } from 'hooks';
+import { useAppDispatch, useAppSelector, useDebouncedShowPreview } from 'hooks';
 import { selectEditor, showPreview } from 'state/common';
 import { selectGroupItemValidations } from 'state/rna-builder';
 import { PreviewStyle, PreviewType } from 'state';
@@ -73,17 +72,7 @@ const MonomerGroup = ({
     return false;
   };
 
-  const dispatchShowPreview = useCallback(
-    (payload) => dispatch(showPreview(payload)),
-    [dispatch],
-  );
-
-  const debouncedShowPreview = useMemo(
-    () => debounce((p) => dispatchShowPreview(p), 500),
-    [dispatchShowPreview],
-  );
-
-  useEffect(() => () => debouncedShowPreview.cancel(), [debouncedShowPreview]);
+  const debouncedShowPreview = useDebouncedShowPreview();
 
   const closeLibraryPreview = useCallback(() => {
     debouncedShowPreview.cancel();

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import { useCallback } from 'react';
 import { EmptyFunction } from 'helpers';
 import { MonomerItem } from '../monomerLibraryItem';
 import { GroupContainerColumn, GroupTitle, ItemsContainer } from './styles';
@@ -26,8 +25,8 @@ import {
   MonomerOrAmbiguousType,
   isAmbiguousMonomerLibraryItem,
 } from 'ketcher-core';
-import { useAppDispatch, useAppSelector, useDebouncedShowPreview } from 'hooks';
-import { selectEditor, showPreview } from 'state/common';
+import { useAppSelector, useDebouncedShowPreview } from 'hooks';
+import { selectEditor } from 'state/common';
 import { selectGroupItemValidations } from 'state/rna-builder';
 import { PreviewType } from 'state';
 import {
@@ -45,7 +44,6 @@ const MonomerGroup = ({
   disabled,
   onItemClick = EmptyFunction,
 }: IMonomerGroupProps) => {
-  const dispatch = useAppDispatch();
   const editor = useAppSelector(selectEditor);
   const activeGroupItemValidations = useAppSelector(selectGroupItemValidations);
   const isMonomerDisabled = (monomer: MonomerOrAmbiguousType) => {
@@ -72,12 +70,10 @@ const MonomerGroup = ({
     return false;
   };
 
-  const debouncedShowPreview = useDebouncedShowPreview();
-
-  const closeLibraryPreview = useCallback(() => {
-    debouncedShowPreview.cancel();
-    dispatch(showPreview(undefined));
-  }, [debouncedShowPreview, dispatch]);
+  const {
+    showPreview: debouncedShowPreview,
+    closePreview: closeLibraryPreview,
+  } = useDebouncedShowPreview();
 
   const handleItemMouseMove = (
     monomer: MonomerOrAmbiguousType,

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { EmptyFunction } from 'helpers';
 import { debounce } from 'lodash';
 import { MonomerItem } from '../monomerLibraryItem';
@@ -78,8 +78,8 @@ const MonomerGroup = ({
     [dispatch],
   );
 
-  const debouncedShowPreview = useCallback(
-    debounce((p) => dispatchShowPreview(p), 500),
+  const debouncedShowPreview = useMemo(
+    () => debounce((p) => dispatchShowPreview(p), 500),
     [dispatchShowPreview],
   );
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -29,7 +29,7 @@ import {
 import { useAppDispatch, useAppSelector, useDebouncedShowPreview } from 'hooks';
 import { selectEditor, showPreview } from 'state/common';
 import { selectGroupItemValidations } from 'state/rna-builder';
-import { PreviewStyle, PreviewType } from 'state';
+import { PreviewType } from 'state';
 import {
   calculateAmbiguousMonomerPreviewTop,
   calculateMonomerPreviewTop,

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
@@ -14,26 +14,31 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { debounce } from 'lodash';
 import { useAppDispatch } from './stateHooks';
-import { showPreview } from 'state/common';
+import { showPreview as showPreviewAction } from 'state/common';
 import type { EditorStatePreview } from 'state';
 
 export const useDebouncedShowPreview = () => {
   const dispatch = useAppDispatch();
 
-  const debouncedShowPreview = useMemo(
+  const showPreview = useMemo(
     () =>
       debounce(
         (payload: EditorStatePreview | undefined) =>
-          dispatch(showPreview(payload)),
+          dispatch(showPreviewAction(payload)),
         500,
       ),
     [dispatch],
   );
 
-  useEffect(() => () => debouncedShowPreview.cancel(), [debouncedShowPreview]);
+  const closePreview = useCallback(() => {
+    showPreview.cancel();
+    dispatch(showPreviewAction(undefined));
+  }, [showPreview, dispatch]);
 
-  return debouncedShowPreview;
+  useEffect(() => () => showPreview.cancel(), [showPreview]);
+
+  return { showPreview, closePreview };
 };

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
@@ -14,7 +14,26 @@
  * limitations under the License.
  ***************************************************************************/
 
-export * from './stateHooks';
-export * from './useIsCompactView';
-export * from './useDebouncedCallback';
-export * from './useDebouncedShowPreview';
+import { useEffect, useMemo } from 'react';
+import { debounce } from 'lodash';
+import { useAppDispatch } from './stateHooks';
+import { showPreview } from 'state/common';
+import type { EditorStatePreview } from 'state';
+
+export const useDebouncedShowPreview = () => {
+  const dispatch = useAppDispatch();
+
+  const debouncedShowPreview = useMemo(
+    () =>
+      debounce(
+        (payload: EditorStatePreview | undefined) =>
+          dispatch(showPreview(payload)),
+        500,
+      ),
+    [dispatch],
+  );
+
+  useEffect(() => () => debouncedShowPreview.cancel(), [debouncedShowPreview]);
+
+  return debouncedShowPreview;
+};


### PR DESCRIPTION
…erGroup to satisfy exhaustive-deps rule

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request