### PR TITLE
#11119 – Refactor: set-state-in-effect anti-pattern elimination from `packages\ketcher-macromolecules\src\components\LayoutModeButton\LayoutModeButton.tsx` file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/LayoutModeButton/LayoutModeButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/LayoutModeButton/LayoutModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Menu } from 'components/menu';
 import { MenuContext } from '../../contexts';
 import { useAppSelector, useLayoutMode } from 'hooks';
@@ -26,31 +26,25 @@ import {
 export const LayoutModeButton = () => {
   const editor = useAppSelector(selectEditor);
   const layoutMode = useLayoutMode();
-  const [activeMode, setActiveMode] = useState(layoutMode);
   const isSequenceEditInRNABuilderMode = useAppSelector(
     selectIsSequenceEditInRNABuilderMode,
   );
 
   const menuContext = useMemo(
     () => ({
-      isActive: (mode) => activeMode === mode,
+      isActive: (mode) => layoutMode === mode,
       activate: (mode) => {
-        if (mode === activeMode) {
+        if (mode === layoutMode) {
           return;
         }
-        setActiveMode(mode);
         // event to change active mode state in editor
         editor?.events.selectMode.dispatch(mode);
         // event to change active mode state in useLayoutMode hook
         editor?.events.layoutModeChange.dispatch(mode);
       },
     }),
-    [activeMode, editor],
+    [layoutMode, editor],
   );
-
-  useEffect(() => {
-    setActiveMode(layoutMode);
-  }, [layoutMode]);
 
   return (
     <MenuContext.Provider value={menuContext}>


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Removed the duplicated activeMode local state and the useEffect that synchronized it with the value returned by useLayoutMode().

The component now uses layoutMode directly as the single source of truth. The existing selectMode and layoutModeChange events are still dispatched when the user selects a different layout mode, so the existing behavior is preserved without effect-based state synchronization.

No screenshot is applicable because this is an internal refactoring with no intended visual or functional change.

Existing unit tests passed: 155 passed, 2 skipped. TypeScript and ESLint checks also passed.

Closes #11119

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request