### PR TITLE
#11110 Refactor: eliminate setState in MeasureInput during render to sync ex…

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
@@ -105,28 +105,25 @@ const MeasureInput = ({
   ...rest
 }: MeasureInputProps) => {
   const [internalValue, setInternalValue] = useState(String(value));
+  const [prevPropValue, setPrevPropValue] = useState(value);
   const {
     anchorEl,
     handleOpen: handlePopoverOpen,
     handleClose: handlePopoverClose,
   } = usePopoverAnchor();
 
-  // NOTE: onChange handler in the Input comopnent (packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx)
-  // is mapped to the internal function via constructor
-  // therefore the referencies to the MeasureInput's state are not updated
-  // so we need to sync the props and the internal value through useEffects and use callbacks with
-  // previous state to have the latest value
+  // Sync external value changes during render instead of in a useEffect to avoid
+  // the extra render cycle. React re-renders immediately when setState is called
+  // during render, skipping the intermediate paint.
+  if (prevPropValue !== value) {
+    setPrevPropValue(value);
+    setInternalValue(String(value));
+  }
 
-  useEffect(() => {
-    setInternalValue((prevValue) => {
-      if (prevValue !== String(value)) {
-        return String(value);
-      }
-
-      return prevValue;
-    });
-  }, [value]);
-
+  // NOTE: onChange handler in the Input component (packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx)
+  // is mapped to the internal function via constructor, so its closure does not
+  // capture updated MeasureInput state. Propagate internal changes via effect
+  // with a functional-update callback to always read the latest value.
   useEffect(() => {
     if (internalValue !== String(value)) {
       const isNewInternalValueValid = !isNaN(parseFloat(internalValue));

--- a/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
@@ -104,33 +104,27 @@ const MeasureInput = ({
   className,
   ...rest
 }: MeasureInputProps) => {
-  const [internalValue, setInternalValue] = useState(String(value));
-  const [prevPropValue, setPrevPropValue] = useState(value);
+  const stringifiedValue = String(value);
+  const [internalValue, setInternalValue] = useState(stringifiedValue);
+  const [prevPropValue, setPrevPropValue] = useState(stringifiedValue);
   const {
     anchorEl,
     handleOpen: handlePopoverOpen,
     handleClose: handlePopoverClose,
   } = usePopoverAnchor();
 
-  // Sync external value changes during render instead of in a useEffect to avoid
-  // the extra render cycle. React re-renders immediately when setState is called
-  // during render, skipping the intermediate paint.
-  if (prevPropValue !== value) {
-    setPrevPropValue(value);
-    setInternalValue(String(value));
+  if (prevPropValue !== stringifiedValue) {
+    setPrevPropValue(stringifiedValue);
+    setInternalValue(stringifiedValue);
   }
 
-  // NOTE: onChange handler in the Input component (packages/ketcher-react/src/script/ui/component/form/Input/Input.tsx)
-  // is mapped to the internal function via constructor, so its closure does not
-  // capture updated MeasureInput state. Propagate internal changes via effect
-  // with a functional-update callback to always read the latest value.
+  // Input binds onChange once in its constructor, so handleChange is stuck with
+  // the first render's closure and cannot call the current onChange. This effect
+  // is re-created every render, so it always holds the latest onChange/value —
+  // hence the deliberate single-dep list.
   useEffect(() => {
-    if (internalValue !== String(value)) {
-      const isNewInternalValueValid = !isNaN(parseFloat(internalValue));
-
-      if (isNewInternalValueValid) {
-        onChange(parseFloat(internalValue));
-      }
+    if (internalValue !== stringifiedValue) {
+      onChange(parseFloat(internalValue));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [internalValue]);


### PR DESCRIPTION


## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

## Problem

setState was called inside a useEffect to sync the prop into local state:

```
// ❌ Old code
useEffect(() => {
  setInternalValue(String(value)); // causes extra render cycle
}, [value]);
```

Every prop change triggered 2 renders:
1. Render with new prop
2. Effect runs → setState → render again

---
Fix

Replaced the useEffect with in-render state adjustment:

// ✅ New code
const [prevPropValue, setPrevPropValue] = useState(value);

```
if (prevPropValue !== value) {
  setPrevPropValue(value);
  setInternalValue(String(value)); // during render, not after
}
```

When React sees a setState call during render, it discards the current render output and immediately re-renders with the updated state — the intermediate state never reaches the DOM, so no flicker and no extra paint.

---
```
Why the second useEffect stays

useEffect(() => {
  if (internalValue !== String(value)) {
    onChange(parseFloat(internalValue));
  }
}, [internalValue]);
```

The Input component captures its onChange handler via constructor, so the closure never sees updated MeasureInput state. The effect is the only reliable way to propagate user-typed changes back to the parent — this one is legitimate.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request