### PR TITLE
#11105 - Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\components\MonomerCreationWizard\components\ReadonlyAttachmentPoint\ReadonlyAttachmentPoint.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/ReadonlyAttachmentPoint/ReadonlyAttachmentPoint.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/MonomerCreationWizard/components/ReadonlyAttachmentPoint/ReadonlyAttachmentPoint.tsx
@@ -33,14 +33,6 @@ const ReadonlyAttachmentPoint = ({
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [highlight, setHighlight] = useState(false);
-  // Track the currently selected leaving atom so the select reflects user changes.
-  const [currentLeavingAtomLabel, setCurrentLeavingAtomLabel] =
-    useState<AtomLabel>(leavingAtomLabel);
-
-  // Reset when the default label changes (e.g. component re-assigned).
-  useEffect(() => {
-    setCurrentLeavingAtomLabel(leavingAtomLabel);
-  }, [leavingAtomLabel]);
 
   // Panel hover → canvas highlight
   useEffect(() => {
@@ -49,12 +41,12 @@ const ReadonlyAttachmentPoint = ({
 
     const mouseOverHandler = () => {
       if (atomId !== undefined) {
-        // Use atom-specific highlighting to avoid AP name collisions between components.
         editor.highlightAtomById(atomId);
       } else {
         editor.highlightConnectionAttachmentPoint(name);
       }
     };
+
     const mouseLeaveHandler = () => {
       if (atomId !== undefined) {
         editor.highlightAtomById(null);
@@ -78,8 +70,10 @@ const ReadonlyAttachmentPoint = ({
       const apName = (event as CustomEvent<AttachmentPointName>).detail;
       setHighlight(apName === name);
     };
+
     const handleReset = (event: Event) => {
       const apName = (event as CustomEvent<AttachmentPointName>).detail;
+
       if (apName === name) {
         setHighlight(false);
       }
@@ -108,11 +102,10 @@ const ReadonlyAttachmentPoint = ({
 
   const selectsData = createReadonlyAttachmentPointSelectData(
     name,
-    currentLeavingAtomLabel,
+    leavingAtomLabel,
   );
 
   const handleLeavingAtomChange = (newLabel: AtomLabel) => {
-    setCurrentLeavingAtomLabel(newLabel);
     onLeavingAtomChange?.(name, newLabel);
   };
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Remove redundant local currentLeavingAtomLabel state and its synchronizing useEffect from ReadonlyAttachmentPoint.

The selected leaving atom is already owned by connectionLeavingAtoms in MonomerCreationWizardInternal. On change, the value is stored in this parent state and passed back down as leavingAtomLabel through RnaPresetTabs.

This removal is safe because ReadonlyAttachmentPoint is fully controlled by the parent state. It also avoids an unnecessary render cycle caused by syncing props to local state in useEffect, while preserving selected values across tab switches and using them during preset submission.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request