### PR TITLE
#5345 - Replacement of any monomer (side connected to another one) on monomer of different type works wrong - system keeps side chain bond (it shouldn't)

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -70,6 +70,7 @@ import { getNodeFromTwoStrandedNode } from 'domain/helpers/chains';
 import type { CoreEditor } from 'application/editor/Editor';
 import { MACROMOLECULES_BOND_TYPES } from 'application/editor/tools/types';
 import { KetMonomerClass } from 'application/formatters';
+import { monomerEntityFactory } from 'domain/helpers/monomerEntityFactory';
 import { registerMode } from './modesRegistry';
 
 const naturalAnalogues = uniq([
@@ -1921,6 +1922,35 @@ export class SequenceMode extends BaseMode {
     );
   }
 
+  private getMonomerClassForTypeComparison(
+    monomer: BaseMonomer | MonomerItemType,
+  ): KetMonomerClass {
+    if (!(monomer instanceof BaseMonomer)) {
+      const [, ketMonomerClass] = monomerEntityFactory(monomer);
+
+      return ketMonomerClass;
+    }
+
+    if (monomer instanceof AmbiguousMonomer) {
+      return monomer.monomerClass;
+    }
+
+    return this.getMonomerClassForTypeComparison(monomer.monomerItem);
+  }
+
+  // Side chain connections (Rn, n>2) are only preserved when the monomer
+  // being inserted is of the same type (peptide/chem/sugar/base/phosphate/
+  // nucleotide) as the monomer it replaces, per requirement 4.5.
+  private isSameMonomerTypeForSideChainConnection(
+    existingMonomer: BaseMonomer,
+    newMonomer: BaseMonomer | MonomerItemType,
+  ): boolean {
+    return (
+      this.getMonomerClassForTypeComparison(existingMonomer) ===
+      this.getMonomerClassForTypeComparison(newMonomer)
+    );
+  }
+
   isPasteAvailable(drawingEntitiesManager: DrawingEntitiesManager) {
     if (!this.isEditMode) {
       return true;
@@ -2111,11 +2141,16 @@ export class SequenceMode extends BaseMode {
 
     sideChainConnections?.forEach((sideConnectionData) => {
       const {
+        sourceMonomer,
         firstMonomerAttachmentPointName,
         secondMonomer,
         secondMonomerAttachmentPointName,
       } = sideConnectionData;
       if (
+        !this.isSameMonomerTypeForSideChainConnection(
+          sourceMonomer,
+          newMonomer,
+        ) ||
         !this.isConnectionPossible(
           newMonomer,
           firstMonomerAttachmentPointName,
@@ -2282,6 +2317,16 @@ export class SequenceMode extends BaseMode {
             : !bond.isBackBoneChainConnection))
       ) {
         return true;
+      }
+
+      if (
+        sideChainConnections &&
+        !this.isSameMonomerTypeForSideChainConnection(
+          selectedNode.monomer,
+          monomerItem,
+        )
+      ) {
+        return false;
       }
 
       return newMonomerAttachmentPoints.attachmentPointsList.includes(key);

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -1925,17 +1925,15 @@ export class SequenceMode extends BaseMode {
   private getMonomerClassForTypeComparison(
     monomer: BaseMonomer | MonomerItemType,
   ): KetMonomerClass {
-    if (!(monomer instanceof BaseMonomer)) {
-      const [, ketMonomerClass] = monomerEntityFactory(monomer);
-
-      return ketMonomerClass;
-    }
-
     if (monomer instanceof AmbiguousMonomer) {
       return monomer.monomerClass;
     }
 
-    return this.getMonomerClassForTypeComparison(monomer.monomerItem);
+    const [, ketMonomerClass] = monomerEntityFactory(
+      monomer instanceof BaseMonomer ? monomer.monomerItem : monomer,
+    );
+
+    return ketMonomerClass;
   }
 
   // Side chain connections (Rn, n>2) are only preserved when the monomer


### PR DESCRIPTION
…omer-of-different-type-works-wrong---system-keeps-side-chain-bond-it-shouldnt

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request