### PR TITLE
#11286 Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\components\monomerLibrary\RnaBuilder\RnaElementsView\RnaElements.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/RnaElements.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/RnaElements.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAppSelector } from 'hooks';
 import {
   createNewPreset,
@@ -45,8 +45,6 @@ export const RnaElements = ({
   const dispatch = useDispatch();
 
   const activeRnaBuilderItem = useAppSelector(selectActiveRnaBuilderItem);
-  const activeRnaBuilderItemRef = useRef(activeRnaBuilderItem);
-  activeRnaBuilderItemRef.current = activeRnaBuilderItem;
   const activePreset = useAppSelector(selectActivePreset);
   const isEditMode = useAppSelector(selectIsEditMode);
   const editor = useAppSelector(selectEditor);
@@ -58,17 +56,10 @@ export const RnaElements = ({
   const [newPreset, setNewPreset] = useState(activePreset);
 
   useEffect(() => {
-    dispatch(
-      setActiveRnaBuilderItem(
-        // activeRnaBuilderItemRef avoids adding activeRnaBuilderItem to deps:
-        // if it were a dep, user navigating between monomer groups while not
-        // in edit mode would re-trigger this effect and reset the selection.
-        isEditMode && activePreset
-          ? activeRnaBuilderItemRef.current
-          : RnaBuilderPresetsItem.Presets,
-      ),
-    );
-  }, [dispatch, isEditMode, activePreset]);
+    if (!isEditMode) {
+      dispatch(setActiveRnaBuilderItem(RnaBuilderPresetsItem.Presets));
+    }
+  }, [isEditMode, dispatch]);
 
   const groupsData = useGroupsData(libraryName);
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/RnaElements.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/RnaElements.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAppSelector } from 'hooks';
 import {
   createNewPreset,
@@ -45,6 +45,8 @@ export const RnaElements = ({
   const dispatch = useDispatch();
 
   const activeRnaBuilderItem = useAppSelector(selectActiveRnaBuilderItem);
+  const activeRnaBuilderItemRef = useRef(activeRnaBuilderItem);
+  activeRnaBuilderItemRef.current = activeRnaBuilderItem;
   const activePreset = useAppSelector(selectActivePreset);
   const isEditMode = useAppSelector(selectIsEditMode);
   const editor = useAppSelector(selectEditor);
@@ -58,12 +60,15 @@ export const RnaElements = ({
   useEffect(() => {
     dispatch(
       setActiveRnaBuilderItem(
+        // activeRnaBuilderItemRef avoids adding activeRnaBuilderItem to deps:
+        // if it were a dep, user navigating between monomer groups while not
+        // in edit mode would re-trigger this effect and reset the selection.
         isEditMode && activePreset
-          ? activeRnaBuilderItem
+          ? activeRnaBuilderItemRef.current
           : RnaBuilderPresetsItem.Presets,
       ),
     );
-  }, [isEditMode]);
+  }, [dispatch, isEditMode, activePreset]);
 
   const groupsData = useGroupsData(libraryName);
 


### PR DESCRIPTION
Add dispatch and activePreset to the useEffect dep array. Use activeRnaBuilderItemRef to read the current value without making it a dep — adding it directly would cause the effect to reset the builder item to Presets whenever the user navigates between monomer groups while not in edit mode.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request