### PR TITLE
#11285 Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\components\monomerLibrary\RnaPresetGroup\RnaPresetGroup.tsx file

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -46,7 +46,6 @@ import { SequenceSymbolOption } from '@tests/pages/constants/contextMenu/Constan
 import { MacromoleculesTopToolbar } from '@tests/pages/macromolecules/MacromoleculesTopToolbar';
 import { LayoutMode } from '@tests/pages/constants/macromoleculesTopToolbar/Constants';
 import { MonomerPreviewTooltip } from '@tests/pages/macromolecules/canvas/MonomerPreviewTooltip';
-import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 
 async function hoverMouseOverMonomer(page: Page, monomer: Monomer, nth = 0) {
   await CommonLeftToolbar(page).bondTool(MacroBondTool.Single);

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
@@ -23,7 +23,7 @@ import {
   MonomerItemType,
   RnaPresetWithOptionalFields,
 } from 'ketcher-core';
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement } from 'react';
 import {
   selectActivePreset,
   setActivePreset,
@@ -37,7 +37,7 @@ import {
   GroupContainerColumn,
   ItemsContainer,
 } from 'components/monomerLibrary/monomerLibraryGroup/styles';
-import { selectEditor, selectShowPreview, showPreview } from 'state/common';
+import { selectEditor, selectShowPreview } from 'state/common';
 import { RNAContextMenu } from 'components/contextMenu/RNAContextMenu';
 import { CONTEXT_MENU_ID } from 'components/contextMenu/types';
 import { useContextMenu } from 'react-contexify';
@@ -122,12 +122,10 @@ export const RnaPresetGroup = ({ presets, duplicatePreset, editPreset }) => {
   // region # Preview
   const preview = useAppSelector(selectShowPreview);
 
-  const debouncedShowPreview = useDebouncedShowPreview();
-
-  const closeLibraryPreview = useCallback((): void => {
-    debouncedShowPreview.cancel();
-    dispatch(showPreview(undefined));
-  }, [debouncedShowPreview, dispatch]);
+  const {
+    showPreview: debouncedShowPreview,
+    closePreview: closeLibraryPreview,
+  } = useDebouncedShowPreview();
 
   const handleItemMouseMove = (
     preset: IRnaPreset,

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
@@ -24,7 +24,7 @@ import {
   RnaPresetWithOptionalFields,
 } from 'ketcher-core';
 import { debounce } from 'lodash';
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useMemo } from 'react';
 import {
   selectActivePreset,
   setActivePreset,
@@ -128,8 +128,8 @@ export const RnaPresetGroup = ({ presets, duplicatePreset, editPreset }) => {
     [dispatch],
   );
 
-  const debouncedShowPreview = useCallback(
-    debounce((p) => dispatchShowPreview(p), 500),
+  const debouncedShowPreview = useMemo(
+    () => debounce((p) => dispatchShowPreview(p), 500),
     [dispatchShowPreview],
   );
 

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
@@ -16,15 +16,14 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useAppSelector } from 'hooks';
+import { useAppSelector, useDebouncedShowPreview } from 'hooks';
 import {
   getRnaPresetPhosphatePosition,
   isAmbiguousMonomerLibraryItem,
   MonomerItemType,
   RnaPresetWithOptionalFields,
 } from 'ketcher-core';
-import { debounce } from 'lodash';
-import React, { ReactElement, useCallback, useMemo } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import {
   selectActivePreset,
   setActivePreset,
@@ -123,15 +122,7 @@ export const RnaPresetGroup = ({ presets, duplicatePreset, editPreset }) => {
   // region # Preview
   const preview = useAppSelector(selectShowPreview);
 
-  const dispatchShowPreview = useCallback(
-    (payload: unknown) => dispatch(showPreview(payload)),
-    [dispatch],
-  );
-
-  const debouncedShowPreview = useMemo(
-    () => debounce((p) => dispatchShowPreview(p), 500),
-    [dispatchShowPreview],
-  );
+  const debouncedShowPreview = useDebouncedShowPreview();
 
   const closeLibraryPreview = useCallback((): void => {
     debouncedShowPreview.cancel();

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
@@ -14,26 +14,31 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { debounce } from 'lodash';
 import { useAppDispatch } from './stateHooks';
-import { showPreview } from 'state/common';
+import { showPreview as showPreviewAction } from 'state/common';
 import type { EditorStatePreview } from 'state';
 
 export const useDebouncedShowPreview = () => {
   const dispatch = useAppDispatch();
 
-  const debouncedShowPreview = useMemo(
+  const showPreview = useMemo(
     () =>
       debounce(
         (payload: EditorStatePreview | undefined) =>
-          dispatch(showPreview(payload)),
+          dispatch(showPreviewAction(payload)),
         500,
       ),
     [dispatch],
   );
 
-  useEffect(() => () => debouncedShowPreview.cancel(), [debouncedShowPreview]);
+  const closePreview = useCallback(() => {
+    showPreview.cancel();
+    dispatch(showPreviewAction(undefined));
+  }, [showPreview, dispatch]);
 
-  return debouncedShowPreview;
+  useEffect(() => () => showPreview.cancel(), [showPreview]);
+
+  return { showPreview, closePreview };
 };

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedShowPreview.ts
@@ -14,7 +14,26 @@
  * limitations under the License.
  ***************************************************************************/
 
-export * from './stateHooks';
-export * from './useIsCompactView';
-export * from './useDebouncedCallback';
-export * from './useDebouncedShowPreview';
+import { useEffect, useMemo } from 'react';
+import { debounce } from 'lodash';
+import { useAppDispatch } from './stateHooks';
+import { showPreview } from 'state/common';
+import type { EditorStatePreview } from 'state';
+
+export const useDebouncedShowPreview = () => {
+  const dispatch = useAppDispatch();
+
+  const debouncedShowPreview = useMemo(
+    () =>
+      debounce(
+        (payload: EditorStatePreview | undefined) =>
+          dispatch(showPreview(payload)),
+        500,
+      ),
+    [dispatch],
+  );
+
+  useEffect(() => () => debouncedShowPreview.cancel(), [debouncedShowPreview]);
+
+  return debouncedShowPreview;
+};


### PR DESCRIPTION
…setGroup

useCallback(debounce(...), deps) passes an opaque function reference as the callback, so the exhaustive-deps rule cannot statically analyse its captured dependencies. Replacing with useMemo(() => debounce(...), deps) wraps the call in an inline arrow function that the rule can inspect. Behaviour is unchanged: the debounced function is recreated only when dispatchShowPreview changes, and closeLibraryPreview already lists debouncedShowPreview in its own deps so it stays in sync.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request