### PR TITLE
refactor: #11111-eliminate set-state anti-pattern in SequenceTypeGroupButton

### DIFF
--- a/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
@@ -76,19 +76,14 @@ export const SequenceTypeGroupButton = () => {
   const [activeSequenceType, setActiveSequenceType] = useState<SequenceType>(
     editor?.events.changeSequenceTypeEnterMode,
   );
-  const [isSequenceMode, setIsSequenceMode] = useState(false);
   const isSequenceEditInRNABuilderMode = useAppSelector(
     selectIsSequenceEditInRNABuilderMode,
   );
   const layoutMode = useLayoutMode();
+  const isSequenceMode = layoutMode === 'sequence-layout-mode';
   const isDisabled = !!isSequenceEditInRNABuilderMode;
 
   const dispatch = useAppDispatch();
-
-  const onToggleSequenceMode = (data) => {
-    const mode = typeof data === 'object' ? data.mode : data;
-    setIsSequenceMode(mode === 'sequence-layout-mode');
-  };
 
   useEffect(() => {
     const onChangeSequenceType = (mode: SequenceType) => {
@@ -102,21 +97,15 @@ export const SequenceTypeGroupButton = () => {
       setActiveSequenceType(mode);
       persistSequenceType(mode);
     };
-    editor?.events.selectMode.add(onToggleSequenceMode);
     editor?.events.changeSequenceTypeEnterMode.add(onChangeSequenceType);
     editor?.events.changeSequenceTypeEnterMode.dispatch(
       getPersistedSequenceType(),
     );
 
     return () => {
-      editor?.events.selectMode.remove(onToggleSequenceMode);
       editor?.events.changeSequenceTypeEnterMode.remove(onChangeSequenceType);
     };
   }, [editor]);
-
-  useEffect(() => {
-    onToggleSequenceMode(layoutMode);
-  }, [layoutMode]);
 
   const handleSelectSequenceType = (sequenceType: string) => {
     editor?.events.changeSequenceTypeEnterMode.dispatch(sequenceType);


### PR DESCRIPTION


## How the feature works? / How did you fix the issue?
SequenceTypeGroupButton renders RNA/DNA/PEP toggle buttons only when the editor is in sequence layout mode. It also tracks the active sequence type (RNA/DNA/Peptide) to highlight the selected button.

How the fix works:
isSequenceMode was stored in useState and synced via a useEffect that called setIsSequenceMode whenever layoutMode changed — a classic derived-state anti-pattern causing an extra render cycle. Since layoutMode already comes from useLayoutMode() (a reactive hook backed by editor.events.layoutModeChange), isSequenceMode can be computed directly during render:

`const isSequenceMode = layoutMode === 'sequence-layout-mode';`

This removes the useState, the onToggleSequenceMode helper, the selectMode event subscriptions, and the redundant useEffect entirely.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request