### PR TITLE
#11284 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\components\SequenceSyncEditModeButton\SequenceSyncEditModeButton.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 
@@ -138,6 +138,44 @@ describe('SequenceSyncEditModeButton', () => {
     expect(
       screen.queryByTestId('sync_sequence_edit_mode'),
     ).not.toBeInTheDocument();
+  });
+
+  it('dispatches toggleIsSequenceSyncEditMode exactly once with the toggled value on click', () => {
+    hasAntisenseChains = true;
+    renderComponents();
+
+    const dispatchSpy = jest.spyOn(
+      fakeEditor.events.toggleIsSequenceSyncEditMode,
+      'dispatch',
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('sync_sequence_edit_mode'));
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('dispatches the current sync mode value when modelChange fires after a toggle', () => {
+    hasAntisenseChains = true;
+    renderComponents();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('sync_sequence_edit_mode'));
+    });
+
+    const dispatchSpy = jest.spyOn(
+      fakeEditor.events.toggleIsSequenceSyncEditMode,
+      'dispatch',
+    );
+
+    act(() => {
+      fakeEditor.events.modelChange.dispatch();
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(false);
   });
 
   it('becomes visible immediately after an antisense chain is created, without any extra mouse/keyboard/hover interaction', () => {

--- a/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
@@ -61,6 +61,7 @@ export const SequenceSyncEditModeButton = () => {
   const handleClick = () => {
     const isSequenceSyncEditModeNewState = !isSequenceSyncEditMode;
 
+    isSequenceSyncEditModeRef.current = isSequenceSyncEditModeNewState;
     setIsSequenceSyncEditMode(isSequenceSyncEditModeNewState);
     editor?.events.toggleIsSequenceSyncEditMode.dispatch(
       isSequenceSyncEditModeNewState,

--- a/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppSelector, useLayoutMode } from 'hooks';
 import { selectEditor } from 'state/common';
 import styled from '@emotion/styled';
@@ -55,9 +55,12 @@ export const SequenceSyncEditModeButton = () => {
     Boolean(editor?.drawingEntitiesManager?.hasAntisenseChains),
   );
 
+  const isSequenceSyncEditModeRef = useRef(isSequenceSyncEditMode);
+
   const handleClick = () => {
     const isSequenceSyncEditModeNewState = !isSequenceSyncEditMode;
 
+    isSequenceSyncEditModeRef.current = isSequenceSyncEditModeNewState;
     setIsSequenceSyncEditMode(isSequenceSyncEditModeNewState);
     editor?.events.toggleIsSequenceSyncEditMode.dispatch(
       isSequenceSyncEditModeNewState,
@@ -75,7 +78,7 @@ export const SequenceSyncEditModeButton = () => {
 
       if (isSequenceMode && hasAntisenseChains) {
         editor?.events.toggleIsSequenceSyncEditMode.dispatch(
-          isSequenceSyncEditMode,
+          isSequenceSyncEditModeRef.current,
         );
       }
     };
@@ -86,7 +89,7 @@ export const SequenceSyncEditModeButton = () => {
     return () => {
       editor?.events.modelChange.remove(updateHasAntisenseChains);
     };
-  }, [editor, isSequenceMode, isSequenceSyncEditMode]);
+  }, [editor, isSequenceMode]);
 
   return isSequenceMode && hasAtLeastOneAntisense ? (
     <StyledButton

--- a/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppSelector, useLayoutMode } from 'hooks';
 import { selectEditor } from 'state/common';
 import styled from '@emotion/styled';
@@ -55,6 +55,9 @@ export const SequenceSyncEditModeButton = () => {
     Boolean(editor?.drawingEntitiesManager?.hasAntisenseChains),
   );
 
+  const isSequenceSyncEditModeRef = useRef(isSequenceSyncEditMode);
+  isSequenceSyncEditModeRef.current = isSequenceSyncEditMode;
+
   const handleClick = () => {
     const isSequenceSyncEditModeNewState = !isSequenceSyncEditMode;
 
@@ -82,10 +85,10 @@ export const SequenceSyncEditModeButton = () => {
   useEffect(() => {
     if (isSequenceMode && hasAtLeastOneAntisense) {
       editor?.events.toggleIsSequenceSyncEditMode.dispatch(
-        isSequenceSyncEditMode,
+        isSequenceSyncEditModeRef.current,
       );
     }
-  }, [isSequenceMode, hasAtLeastOneAntisense]);
+  }, [isSequenceMode, hasAtLeastOneAntisense, editor]);
 
   return isSequenceMode && hasAtLeastOneAntisense ? (
     <StyledButton

--- a/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAppSelector, useLayoutMode } from 'hooks';
 import { selectEditor } from 'state/common';
 import styled from '@emotion/styled';
@@ -55,13 +55,9 @@ export const SequenceSyncEditModeButton = () => {
     Boolean(editor?.drawingEntitiesManager?.hasAntisenseChains),
   );
 
-  const isSequenceSyncEditModeRef = useRef(isSequenceSyncEditMode);
-  isSequenceSyncEditModeRef.current = isSequenceSyncEditMode;
-
   const handleClick = () => {
     const isSequenceSyncEditModeNewState = !isSequenceSyncEditMode;
 
-    isSequenceSyncEditModeRef.current = isSequenceSyncEditModeNewState;
     setIsSequenceSyncEditMode(isSequenceSyncEditModeNewState);
     editor?.events.toggleIsSequenceSyncEditMode.dispatch(
       isSequenceSyncEditModeNewState,
@@ -79,7 +75,7 @@ export const SequenceSyncEditModeButton = () => {
 
       if (isSequenceMode && hasAntisenseChains) {
         editor?.events.toggleIsSequenceSyncEditMode.dispatch(
-          isSequenceSyncEditModeRef.current,
+          isSequenceSyncEditMode,
         );
       }
     };
@@ -90,15 +86,7 @@ export const SequenceSyncEditModeButton = () => {
     return () => {
       editor?.events.modelChange.remove(updateHasAntisenseChains);
     };
-  }, [editor]);
-
-  useEffect(() => {
-    if (isSequenceMode && hasAtLeastOneAntisense) {
-      editor?.events.toggleIsSequenceSyncEditMode.dispatch(
-        isSequenceSyncEditModeRef.current,
-      );
-    }
-  }, [isSequenceMode, hasAtLeastOneAntisense, editor]);
+  }, [editor, isSequenceMode, isSequenceSyncEditMode]);
 
   return isSequenceMode && hasAtLeastOneAntisense ? (
     <StyledButton

--- a/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceSyncEditModeButton/SequenceSyncEditModeButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppSelector, useLayoutMode } from 'hooks';
 import { selectEditor } from 'state/common';
 import styled from '@emotion/styled';
@@ -55,6 +55,9 @@ export const SequenceSyncEditModeButton = () => {
     Boolean(editor?.drawingEntitiesManager?.hasAntisenseChains),
   );
 
+  const isSequenceSyncEditModeRef = useRef(isSequenceSyncEditMode);
+  isSequenceSyncEditModeRef.current = isSequenceSyncEditMode;
+
   const handleClick = () => {
     const isSequenceSyncEditModeNewState = !isSequenceSyncEditMode;
 
@@ -75,7 +78,7 @@ export const SequenceSyncEditModeButton = () => {
 
       if (isSequenceMode && hasAntisenseChains) {
         editor?.events.toggleIsSequenceSyncEditMode.dispatch(
-          isSequenceSyncEditMode,
+          isSequenceSyncEditModeRef.current,
         );
       }
     };
@@ -86,7 +89,15 @@ export const SequenceSyncEditModeButton = () => {
     return () => {
       editor?.events.modelChange.remove(updateHasAntisenseChains);
     };
-  }, [editor, isSequenceMode, isSequenceSyncEditMode]);
+  }, [editor]);
+
+  useEffect(() => {
+    if (isSequenceMode && hasAtLeastOneAntisense) {
+      editor?.events.toggleIsSequenceSyncEditMode.dispatch(
+        isSequenceSyncEditModeRef.current,
+      );
+    }
+  }, [isSequenceMode, hasAtLeastOneAntisense, editor]);
 
   return isSequenceMode && hasAtLeastOneAntisense ? (
     <StyledButton


### PR DESCRIPTION
…atisfy exhaustive-deps rule

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request