### PR TITLE
#11282 Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\components\shared\ConnectionOverview\components\MonomerMiniature\MonomerMiniature.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/shared/ConnectionOverview/components/MonomerMiniature/MonomerMiniature.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/ConnectionOverview/components/MonomerMiniature/MonomerMiniature.tsx
@@ -32,35 +32,35 @@ const MonomerMiniature = ({
 
   useLayoutEffect(() => {
     const svg = svgRef.current;
-    if (svg) {
-      const svgElement = select(svg) as unknown as Selection<
-        SVGSVGElement,
-        void,
-        HTMLElement,
-        never
-      >;
-      if (monomer instanceof AmbiguousMonomer) {
-        const centerX = (svg.width.baseVal.value - svg.x.baseVal.value) / 2;
-        const centerY = (svg.height.baseVal.value - svg.y.baseVal.value) / 2;
-        const position = new Vec2(centerX, centerY);
-        const positionInAngstrom = Coordinates.canvasToModel(position);
-        const variantMonomer = new AmbiguousMonomer(
-          monomer.variantMonomerItem,
-          positionInAngstrom,
-        );
-        const renderer = new AmbiguousMonomerRenderer(variantMonomer);
-        renderer.showExternal({
-          canvas: svgElement,
-          usage,
-          selectedAttachmentPoint,
-          connectedAttachmentPoints,
-        });
-        // TODO: Use factory here for any other monomer if it will be required (e.g. unresolved monomers)?
-        return () => {
-          renderer.remove();
-        };
-      }
+    if (!svg || !(monomer instanceof AmbiguousMonomer)) {
+      return;
     }
+
+    const svgElement = select(svg) as unknown as Selection<
+      SVGSVGElement,
+      void,
+      HTMLElement,
+      never
+    >;
+    const centerX = (svg.width.baseVal.value - svg.x.baseVal.value) / 2;
+    const centerY = (svg.height.baseVal.value - svg.y.baseVal.value) / 2;
+    const position = new Vec2(centerX, centerY);
+    const positionInAngstrom = Coordinates.canvasToModel(position);
+    const variantMonomer = new AmbiguousMonomer(
+      monomer.variantMonomerItem,
+      positionInAngstrom,
+    );
+    const renderer = new AmbiguousMonomerRenderer(variantMonomer);
+    renderer.showExternal({
+      canvas: svgElement,
+      usage,
+      selectedAttachmentPoint,
+      connectedAttachmentPoints,
+    });
+    // TODO: Use factory here for any other monomer if it will be required (e.g. unresolved monomers)?
+    return () => {
+      renderer.remove();
+    };
   }, [monomer, usage, selectedAttachmentPoint, connectedAttachmentPoints]);
 
   return (

--- a/packages/ketcher-macromolecules/src/components/shared/ConnectionOverview/components/MonomerMiniature/MonomerMiniature.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/ConnectionOverview/components/MonomerMiniature/MonomerMiniature.tsx
@@ -55,8 +55,11 @@ const MonomerMiniature = ({
           selectedAttachmentPoint,
           connectedAttachmentPoints,
         });
+        // TODO: Use factory here for any other monomer if it will be required (e.g. unresolved monomers)?
+        return () => {
+          renderer.remove();
+        };
       }
-      // TODO: Use factory here for any other monomer if it will be required (e.g. unresolved monomers)?
     }
   }, [monomer, usage, selectedAttachmentPoint, connectedAttachmentPoints]);
 

--- a/packages/ketcher-macromolecules/src/components/shared/ConnectionOverview/components/MonomerMiniature/MonomerMiniature.tsx
+++ b/packages/ketcher-macromolecules/src/components/shared/ConnectionOverview/components/MonomerMiniature/MonomerMiniature.tsx
@@ -58,7 +58,7 @@ const MonomerMiniature = ({
       }
       // TODO: Use factory here for any other monomer if it will be required (e.g. unresolved monomers)?
     }
-  }, [selectedAttachmentPoint, connectedAttachmentPoints]);
+  }, [monomer, usage, selectedAttachmentPoint, connectedAttachmentPoints]);
 
   return (
     <Container expanded={expanded} data-testid={testId}>


### PR DESCRIPTION
…fy exhaustive-deps rule

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request