### PR TITLE
#2524 - After appearance of EDIT ABBREVIATION modal, hotkey switching does not work until you click on the canvas #2524

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -3583,8 +3583,7 @@ class Editor implements KetcherEditor {
   }
 
   focusCliparea() {
-    const cliparea: HTMLElement | null = document.querySelector('.cliparea');
-    cliparea?.focus();
+    this.render.clientArea.focus();
   }
 }
 

--- a/packages/ketcher-react/src/script/ui/views/modal/Modal.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/Modal.tsx
@@ -46,11 +46,12 @@ function ModalContent({ modal, ketcherId, ...rest }: ModalContentProps) {
   });
 
   useLayoutEffect(() => {
-    if (modal.prop?.isNestedModal) {
-      return;
-    }
-
     return () => {
+      if (modal.prop?.isNestedModal) {
+        return;
+      }
+
+      // Defer focus restoration until modal unmount is fully processed.
       setTimeout(() => {
         try {
           ketcherProvider.getKetcher(ketcherId).editor.focusCliparea();

--- a/packages/ketcher-react/src/script/ui/views/modal/Modal.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/Modal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 import type { BaseCallProps, ModalContainerProps } from './modal.types';
 import classes from './Modal.module.less';
@@ -23,6 +23,7 @@ import clsx from 'clsx';
 import mediaSizes from './mediaSizes';
 import modals from '../../dialog';
 import useResizeObserver from 'use-resize-observer/polyfilled';
+import { ketcherProvider } from 'ketcher-core';
 
 interface ModalProps extends BaseCallProps {
   modal: {
@@ -38,11 +39,27 @@ type ModalContentProps = Omit<Props, 'modal'> & {
   modal: NonNullable<Props['modal']>;
 };
 
-function ModalContent({ modal, ...rest }: ModalContentProps) {
+function ModalContent({ modal, ketcherId, ...rest }: ModalContentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { height, width } = useResizeObserver<HTMLDivElement>({
     ref: containerRef as React.RefObject<HTMLDivElement>,
   });
+
+  useLayoutEffect(() => {
+    if (modal.prop?.isNestedModal) {
+      return;
+    }
+
+    return () => {
+      setTimeout(() => {
+        try {
+          ketcherProvider.getKetcher(ketcherId).editor.focusCliparea();
+        } catch {
+          // Do nothing if ketcher instance is already removed
+        }
+      }, 0);
+    };
+  }, [ketcherId, modal.prop?.isNestedModal]);
 
   const Component = modals[modal.name];
 
@@ -61,6 +78,7 @@ function ModalContent({ modal, ...rest }: ModalContentProps) {
             (height && height <= mediaSizes.smallHeight) ||
             (width && width <= mediaSizes.smallWidth),
         })}
+        ketcherId={ketcherId}
         {...rest}
       />
     </div>

--- a/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/FG/RemoveFG.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/FG/RemoveFG.tsx
@@ -14,13 +14,10 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useLayoutEffect } from 'react';
 import type { BaseCallProps, BaseProps } from '../../../modal.types';
 import classes from './RemoveFG.module.less';
 import { useAppContext } from '../../../../../../../hooks';
 import { fromSgroupDeletion, ketcherProvider } from 'ketcher-core';
-import { KETCHER_ROOT_NODE_CSS_SELECTOR } from 'src/constants';
-import { CLIP_AREA_BASE_CLASS } from '../../../../../component/cliparea/cliparea';
 
 interface RemoveFGProps extends BaseProps {
   fgIds: any;
@@ -45,16 +42,6 @@ const RemoveFG = (props: Props) => {
     props[key](res);
   };
 
-  useLayoutEffect(() => {
-    return () => {
-      (
-        document
-          .querySelector(KETCHER_ROOT_NODE_CSS_SELECTOR)
-          ?.getElementsByClassName(CLIP_AREA_BASE_CLASS)[0] as HTMLElement
-      )?.focus();
-    };
-  }, []);
-
   return (
     <div
       onSubmit={(event) => event.preventDefault()}
@@ -73,7 +60,10 @@ const RemoveFG = (props: Props) => {
           type="button"
           value={'Cancel'}
           className={classes.buttonCancel}
-          onClick={() => exit('onOk', false)}
+          onClick={() => {
+            exit('onOk', false);
+            editor.focusCliparea();
+          }}
           data-testid="Cancel"
         />
         <input
@@ -81,7 +71,10 @@ const RemoveFG = (props: Props) => {
           value={'Remove Abbreviation'}
           data-testid="remove-abbreviation-button"
           className={classes.buttonOk}
-          onClick={() => exit('onOk', remove())}
+          onClick={() => {
+            exit('onOk', remove());
+            editor.focusCliparea();
+          }}
         />
       </footer>
     </div>

--- a/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/FG/RemoveFG.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/FG/RemoveFG.tsx
@@ -14,10 +14,13 @@
  * limitations under the License.
  ***************************************************************************/
 
+import { useLayoutEffect } from 'react';
 import type { BaseCallProps, BaseProps } from '../../../modal.types';
 import classes from './RemoveFG.module.less';
 import { useAppContext } from '../../../../../../../hooks';
 import { fromSgroupDeletion, ketcherProvider } from 'ketcher-core';
+import { KETCHER_ROOT_NODE_CSS_SELECTOR } from 'src/constants';
+import { CLIP_AREA_BASE_CLASS } from '../../../../../component/cliparea/cliparea';
 
 interface RemoveFGProps extends BaseProps {
   fgIds: any;
@@ -41,6 +44,16 @@ const RemoveFG = (props: Props) => {
   const exit = (key, res) => {
     props[key](res);
   };
+
+  useLayoutEffect(() => {
+    return () => {
+      (
+        document
+          .querySelector(KETCHER_ROOT_NODE_CSS_SELECTOR)
+          ?.getElementsByClassName(CLIP_AREA_BASE_CLASS)[0] as HTMLElement
+      )?.focus();
+    };
+  }, []);
 
   return (
     <div

--- a/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/FG/RemoveFG.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/toolbox/FG/RemoveFG.tsx
@@ -60,10 +60,7 @@ const RemoveFG = (props: Props) => {
           type="button"
           value={'Cancel'}
           className={classes.buttonCancel}
-          onClick={() => {
-            exit('onOk', false);
-            editor.focusCliparea();
-          }}
+          onClick={() => exit('onOk', false)}
           data-testid="Cancel"
         />
         <input
@@ -71,10 +68,7 @@ const RemoveFG = (props: Props) => {
           value={'Remove Abbreviation'}
           data-testid="remove-abbreviation-button"
           className={classes.buttonOk}
-          onClick={() => {
-            exit('onOk', remove());
-            editor.focusCliparea();
-          }}
+          onClick={() => exit('onOk', remove())}
         />
       </footer>
     </div>


### PR DESCRIPTION
…s-not-work-until-you-click-on-the-canvas

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request