### PR TITLE
#11276 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\hooks\useSetRnaPresets.ts file

### DIFF
--- a/packages/ketcher-macromolecules/src/hooks/useSetRnaPresets.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useSetRnaPresets.ts
@@ -76,7 +76,7 @@ function useSetRnaPresets() {
       dispatch(loadMonomerLibrary([]));
       dispatch(clearFavorites());
     };
-  }, [editor, defaultRnaPresets]);
+  }, [editor, defaultRnaPresets, dispatch]);
 }
 
 export default useSetRnaPresets;


### PR DESCRIPTION
## Summary
- Add the (stable) `dispatch` reference to the `useEffect` dependency array in `useSetRnaPresets.ts` to satisfy `react-hooks/exhaustive-deps`
- No behavior change — `dispatch` from Redux never changes identity between renders

## Test plan
- [x] `eslint` no longer reports the warning for this file
- [x] `tsc --noEmit` passes for `ketcher-macromolecules`