### PR TITLE
#11117 - Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-macromolecules\src\components\monomerLibrary\monomerLibraryItem\hooks\useDisabledForSequenceMode.ts file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.test.tsx
@@ -149,4 +149,28 @@ describe('useDisabledForSequenceMode hook', () => {
       expect(result3.current).toBe(true);
     });
   });
+
+  describe('for groups without RNA builder restrictions', () => {
+    // The RNA builder renders ambiguous monomers through a MonomerGroup that
+    // passes no groupName, so this branch is reached while
+    // isSequenceEditInRNABuilderMode is true. Nothing may be disabled there,
+    // regardless of which caps the monomer happens to carry.
+    it('should return false if there is no groupName', () => {
+      mockUseAppSelector.mockReturnValue(true);
+      mockUseSelector.mockImplementation(() => true);
+      monomer.props.MonomerCaps = {};
+      const { result } = renderHook(() => useDisabledForSequenceMode(monomer));
+      expect(result.current).toBe(false);
+    });
+
+    it('should return false for a group the RNA builder does not restrict', () => {
+      mockUseAppSelector.mockReturnValue(true);
+      mockUseSelector.mockImplementation(() => true);
+      monomer.props.MonomerCaps = {};
+      const { result } = renderHook(() =>
+        useDisabledForSequenceMode(monomer, MonomerGroups.PEPTIDES),
+      );
+      expect(result.current).toBe(false);
+    });
+  });
 });

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.ts
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.ts
@@ -2,7 +2,6 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 import { MonomerGroups, MonomerItemType } from 'ketcher-core';
 import { useSelector } from 'react-redux';
-import { useEffect, useState } from 'react';
 import { selectIsSequenceFirstsOnlyNucleotidesSelected } from 'state/rna-builder';
 import { useAppSelector } from 'hooks';
 import { selectIsSequenceEditInRNABuilderMode } from 'state/common';
@@ -17,43 +16,26 @@ const useDisabledForSequenceMode = (
   const isSequenceFirstsOnlyNucleoelementsSelected = useSelector(
     selectIsSequenceFirstsOnlyNucleotidesSelected,
   );
-  const [isDisabled, setIsDisabled] = useState<boolean>(false);
 
-  useEffect(() => {
-    if (!isSequenceEditInRNABuilderMode) return setIsDisabled(false);
+  if (!isSequenceEditInRNABuilderMode) return false;
 
-    if (groupName === MonomerGroups.BASES) {
-      setIsDisabled(!item?.props?.MonomerCaps?.R1);
-    } else if (groupName === MonomerGroups.PHOSPHATES) {
-      setIsDisabled(
-        !(item?.props?.MonomerCaps?.R1 && item?.props?.MonomerCaps?.R2),
+  if (groupName === MonomerGroups.BASES) {
+    return !item?.props?.MonomerCaps?.R1;
+  } else if (groupName === MonomerGroups.PHOSPHATES) {
+    return !(item?.props?.MonomerCaps?.R1 && item?.props?.MonomerCaps?.R2);
+  } else if (groupName === MonomerGroups.SUGARS) {
+    if (isSequenceFirstsOnlyNucleoelementsSelected) {
+      return !(item?.props?.MonomerCaps?.R3 && item?.props?.MonomerCaps?.R2);
+    } else {
+      return !(
+        item?.props?.MonomerCaps?.R3 &&
+        item?.props?.MonomerCaps?.R2 &&
+        item?.props?.MonomerCaps?.R1
       );
-    } else if (groupName === MonomerGroups.SUGARS) {
-      if (isSequenceFirstsOnlyNucleoelementsSelected) {
-        setIsDisabled(
-          !(item?.props?.MonomerCaps?.R3 && item?.props?.MonomerCaps?.R2),
-        );
-      } else {
-        setIsDisabled(
-          !(
-            item?.props?.MonomerCaps?.R3 &&
-            item?.props?.MonomerCaps?.R2 &&
-            item?.props?.MonomerCaps?.R1
-          ),
-        );
-      }
     }
-  }, [
-    groupName,
-    isSequenceEditInRNABuilderMode,
-    isSequenceFirstsOnlyNucleoelementsSelected,
-    item?.props?.MonomerCaps?.R1,
-    item?.props?.MonomerCaps?.R2,
-    item?.props?.MonomerCaps?.R3,
-    setIsDisabled,
-  ]);
+  }
 
-  return isDisabled;
+  return false;
 };
 
 export default useDisabledForSequenceMode;

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.ts
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.ts
@@ -1,6 +1,5 @@
 import { MonomerGroups, MonomerItemType } from 'ketcher-core';
 import { useSelector } from 'react-redux';
-import { useEffect, useState } from 'react';
 import { selectIsSequenceFirstsOnlyNucleotidesSelected } from 'state/rna-builder';
 import { useAppSelector } from 'hooks';
 import { selectIsSequenceEditInRNABuilderMode } from 'state/common';
@@ -15,43 +14,26 @@ const useDisabledForSequenceMode = (
   const isSequenceFirstsOnlyNucleoelementsSelected = useSelector(
     selectIsSequenceFirstsOnlyNucleotidesSelected,
   );
-  const [isDisabled, setIsDisabled] = useState<boolean>(false);
 
-  useEffect(() => {
-    if (!isSequenceEditInRNABuilderMode) return setIsDisabled(false);
+  if (!isSequenceEditInRNABuilderMode) return false;
 
-    if (groupName === MonomerGroups.BASES) {
-      setIsDisabled(!item?.props?.MonomerCaps?.R1);
-    } else if (groupName === MonomerGroups.PHOSPHATES) {
-      setIsDisabled(
-        !(item?.props?.MonomerCaps?.R1 && item?.props?.MonomerCaps?.R2),
+  if (groupName === MonomerGroups.BASES) {
+    return !item?.props?.MonomerCaps?.R1;
+  } else if (groupName === MonomerGroups.PHOSPHATES) {
+    return !(item?.props?.MonomerCaps?.R1 && item?.props?.MonomerCaps?.R2);
+  } else if (groupName === MonomerGroups.SUGARS) {
+    if (isSequenceFirstsOnlyNucleoelementsSelected) {
+      return !(item?.props?.MonomerCaps?.R3 && item?.props?.MonomerCaps?.R2);
+    } else {
+      return !(
+        item?.props?.MonomerCaps?.R3 &&
+        item?.props?.MonomerCaps?.R2 &&
+        item?.props?.MonomerCaps?.R1
       );
-    } else if (groupName === MonomerGroups.SUGARS) {
-      if (isSequenceFirstsOnlyNucleoelementsSelected) {
-        setIsDisabled(
-          !(item?.props?.MonomerCaps?.R3 && item?.props?.MonomerCaps?.R2),
-        );
-      } else {
-        setIsDisabled(
-          !(
-            item?.props?.MonomerCaps?.R3 &&
-            item?.props?.MonomerCaps?.R2 &&
-            item?.props?.MonomerCaps?.R1
-          ),
-        );
-      }
     }
-  }, [
-    groupName,
-    isSequenceEditInRNABuilderMode,
-    isSequenceFirstsOnlyNucleoelementsSelected,
-    item?.props?.MonomerCaps?.R1,
-    item?.props?.MonomerCaps?.R2,
-    item?.props?.MonomerCaps?.R3,
-    setIsDisabled,
-  ]);
+  }
 
-  return isDisabled;
+  return false;
 };
 
 export default useDisabledForSequenceMode;

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.ts
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryItem/hooks/useDisabledForSequenceMode.ts
@@ -1,5 +1,3 @@
-/* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
-/* eslint-disable react-hooks/set-state-in-effect */
 import { MonomerGroups, MonomerItemType } from 'ketcher-core';
 import { useSelector } from 'react-redux';
 import { selectIsSequenceFirstsOnlyNucleotidesSelected } from 'state/rna-builder';


### PR DESCRIPTION
## Summary
- Closes #11117
- `useDisabledForSequenceMode` previously synced a purely derived boolean into `useState` via a `useEffect` that recomputed it on every dependency change. The value is 100% derivable from the hook's inputs (redux selectors + the `item`/`groupName` args) on every render, so this collapses into a plain derived value computed directly in the hook body — no `useState`/`useEffect` needed.
- Both selector hooks are still called unconditionally above the first early `return`, so hook order is unchanged.
- This removes the extra render that used to occur before `isDisabled` reflected the correct value (matching the anti-pattern elimination effort already applied elsewhere in this repo, e.g. `MeasureInput.tsx`, `RnaElementsAccordionView.tsx`).
- Also removes two now-dead `eslint-disable` comments (`react-hooks/set-state-in-effect`, `react-you-might-not-need-an-effect/no-event-handler`) that `e16cf3e` (#10806) added to this file on master. The rebase kept them silently; with no effect and no state left they were suppressions for the exact rules this PR exists to satisfy. `eslint` now passes on the file with none.

## Behavior
Same boolean logic per `MonomerGroups` branch. Two differences, both intended:

**1. First-render timing.** Consumers previously saw `false` on the first render in RNA-builder mode and the correct value one render later. They now get the correct value immediately — this is the "temporary incorrect state before effect syncs it" #11117 asks to remove.

**2. The fallthrough** (no matching group) went from silently keeping the previous state to an explicit `return false`.

An earlier version of this description called that branch "unreachable in practice". That was wrong. `groupName` is optional (`monomerLibraryItem/types.ts:20`) and is `undefined` on live paths: `MonomerList.tsx:82`/`:105` (the peptides/CHEM/favorites library), and `RnaElementsTabsView.tsx:164`, where the ambiguous-monomer `<MonomerGroup>` renders inside the RNA builder with no `groupName` — so the branch runs with `isSequenceEditInRNABuilderMode === true`.

There is still no regression, for a different reason: the old code's retained value on that path could only ever be the `useState<boolean>(false)` initial value, since `groupName` is a fixed prop per `MonomerItem` instance and no call site mutates it. So both versions yield `false`. That is now pinned by tests rather than argued in a PR body.

## Test plan
- [x] `eslint` on the hook — clean, with no suppressions
- [x] `tsc --noEmit` in `packages/ketcher-macromolecules` — clean
- [x] `prettier --check` — clean
- [x] Added 2 tests for the fallthrough: `groupName === undefined` and `MonomerGroups.PEPTIDES`, both with `MonomerCaps = {}` so they fail if either matches a restricted branch
- [x] Mutation-checked those tests — flipping the fallthrough to `return true` fails exactly the 2 new cases and none of the 9 existing ones, confirming the branch was previously uncovered
- [x] Full package unit suite: 36 suites, 160 passed, 2 pre-existing skips
- [x] Reviewed the only call site (`MonomerItem.tsx:66`) — usage is `useDisabledForSequenceMode(item, groupName) || disabled`, read inline
