### PR TITLE
#11107 - Refactor: set-state-in-effect anti-pattern elimination from packages\ketcher-react\src\script\ui\views\components\ContextMenu\menuItems\BondMenuItems.tsx file

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -46,7 +46,6 @@ import { SequenceSymbolOption } from '@tests/pages/constants/contextMenu/Constan
 import { MacromoleculesTopToolbar } from '@tests/pages/macromolecules/MacromoleculesTopToolbar';
 import { LayoutMode } from '@tests/pages/constants/macromoleculesTopToolbar/Constants';
 import { MonomerPreviewTooltip } from '@tests/pages/macromolecules/canvas/MonomerPreviewTooltip';
-import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 
 async function hoverMouseOverMonomer(page: Page, monomer: Monomer, nth = 0) {
   await CommonLeftToolbar(page).bondTool(MacroBondTool.Single);

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/BondMenuItems.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
-/* eslint-disable react-hooks/set-state-in-effect */
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useMemo } from 'react';
 import { Item, Submenu } from 'react-contexify';
 import type Editor from 'src/script/editor';
 import tools from '../../../../action/tools';
@@ -29,11 +27,6 @@ const nonQueryBondNames = getNonQueryBondNames(tools);
 
 const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
   const { ketcherId } = useAppContext();
-  const [bondData, setBondData] = useState<{
-    type: number;
-    stereo: number;
-  } | null>(null);
-  const [isBondBetweenMonomers, setIsBondBetweenMonomers] = useState(false);
   const [handleEdit] = useBondEdit();
   const [handleTypeChange, disabled] = useBondTypeChange();
   const [handleSGroupAttach, sGroupAttachHidden] = useBondSGroupAttach();
@@ -47,30 +40,31 @@ const BondMenuItems: FC<MenuItemsProps<BondsContextMenuProps>> = (props) => {
   const { changeDirection } = useChangeBondDirection(props as ItemEventParams);
   const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
 
-  useEffect(() => {
-    const editor = ketcherProvider.getKetcher(ketcherId)?.editor;
+  const bond = useMemo(() => {
     const bondIds = props.propsFromTrigger?.bondIds || [];
 
-    if (bondIds.length > 0 && editor) {
-      const bond = editor.render.ctab.molecule.bonds.get(bondIds[0]);
-      if (bond) {
-        setBondData({ type: bond.type, stereo: bond.stereo });
+    return bondIds.length > 0
+      ? editor.render.ctab.molecule.bonds.get(bondIds[0]) ?? null
+      : null;
+  }, [props.propsFromTrigger, editor]);
 
-        // Check if bond is between two monomers
-        const struct = editor.render.ctab.molecule;
-        const beginAtomSgroup = struct.getGroupFromAtomId(bond.begin);
-        const endAtomSgroup = struct.getGroupFromAtomId(bond.end);
-        const isBetweenMonomers =
-          beginAtomSgroup instanceof MonomerMicromolecule &&
-          endAtomSgroup instanceof MonomerMicromolecule &&
-          beginAtomSgroup !== endAtomSgroup;
-        setIsBondBetweenMonomers(isBetweenMonomers);
-      } else {
-        setBondData(null);
-        setIsBondBetweenMonomers(false);
-      }
+  const bondData = bond ? { type: bond.type, stereo: bond.stereo } : null;
+
+  const isBondBetweenMonomers = useMemo(() => {
+    if (!bond) {
+      return false;
     }
-  }, [props.propsFromTrigger, ketcherId]);
+
+    const struct = editor.render.ctab.molecule;
+    const beginAtomSgroup = struct.getGroupFromAtomId(bond.begin);
+    const endAtomSgroup = struct.getGroupFromAtomId(bond.end);
+
+    return (
+      beginAtomSgroup instanceof MonomerMicromolecule &&
+      endAtomSgroup instanceof MonomerMicromolecule &&
+      beginAtomSgroup !== endAtomSgroup
+    );
+  }, [bond, editor]);
 
   const highlightBondWithColor = (color: string) => {
     const bondIds = props.propsFromTrigger?.bondIds || [];


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
How it works: the bond context menu needs the clicked bond's type/stereo and whether it connects two different monomers, to  decide which menu items to show/enable.                                                                                          
Fix: those values were useState set only inside a useEffect watching props.propsFromTrigger — deriving state from props via an effect. Removed the state + effect, replaced with useMemo computing both directly from props.propsFromTrigger and editor during render. 5 lint warnings → 0. 

Issue - [#11107](https://github.com/epam/ketcher/issues/11107)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [X] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request