### PR TITLE
Backmerge: #11335 - Errors in console when Reaction Plus tool is active

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/bond.ts
+++ b/packages/ketcher-react/src/script/editor/tool/bond.ts
@@ -357,7 +357,7 @@ class BondTool implements Tool {
       );
       if (fgIds.length > 0) {
         this.editor.event.removeFG.dispatch({ fgIds });
-        delete this.dragCtx;
+        this.dragCtx = undefined;
         return { beginAtom, endAtom, beginPos, shouldReturn: true };
       }
     } else if (endAtom?.map === 'functionalGroups') {
@@ -523,7 +523,7 @@ class BondTool implements Tool {
           bondChangingAction(render.ctab, dragCtx.item.id, bond, bondProps),
         );
       }
-      delete this.dragCtx;
+      this.dragCtx = undefined;
     }
     this.editor.event.message.dispatch({
       info: false,

--- a/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionmap.ts
@@ -51,7 +51,7 @@ class ReactionMapTool implements Tool {
     const editor = this.editor;
     const rnd = editor.render;
 
-    if ('dragCtx' in this) {
+    if (this.dragCtx) {
       const closestItem = this.editor.findItem(
         event,
         ['atoms'],
@@ -93,7 +93,7 @@ class ReactionMapTool implements Tool {
   }
 
   mouseup(event) {
-    if ('dragCtx' in this) {
+    if (this.dragCtx) {
       const rnd = this.editor.render;
       const closestItem = this.editor.findItem(event, ['atoms']);
 
@@ -153,7 +153,7 @@ class ReactionMapTool implements Tool {
         }
       }
       this.updateLine(null, null);
-      delete this.dragCtx;
+      this.dragCtx = undefined;
     }
     this.editor.hover(this.editor.findItem(event, ['atoms']), null, event);
   }

--- a/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
+++ b/packages/ketcher-react/src/script/editor/tool/reactionplus.ts
@@ -47,7 +47,7 @@ class ReactionPlusTool implements Tool {
     const editor = this.editor;
     const rnd = editor.render;
 
-    if ('dragCtx' in this) {
+    if (this.dragCtx) {
       if (this.dragCtx.action) {
         this.dragCtx.action.perform(rnd.ctab);
       }
@@ -76,7 +76,7 @@ class ReactionPlusTool implements Tool {
         this.editor.update(this.dragCtx.action); // TODO investigate, subsequent undo/redo fails
       }
 
-      delete this.dragCtx;
+      this.dragCtx = undefined;
     }
 
     return true;


### PR DESCRIPTION
(cherry picked from commit 16fd54cf4c1decf9f02cd0b0447baf14a0b609c9)

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request