### PR TITLE
#3884 - System can't load molecule from clipboard if it ends with few carriage returns 

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.19.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.19.0-bugs.spec.ts
@@ -3,13 +3,19 @@
 /* eslint-disable @typescript-eslint/no-inferrable-types */
 /* eslint-disable no-magic-numbers */
 import { Page, test, expect } from '@fixtures';
-import { openFileAndAddToCanvasAsNewProjectMacro } from '@utils';
+import {
+  clickInTheMiddleOfTheCanvas,
+  openFileAndAddToCanvasAsNewProjectMacro,
+  pasteFromClipboardAndAddToCanvas,
+  pasteFromClipboardAndOpenAsNewProject,
+} from '@utils';
 
 import { CommonTopLeftToolbar } from '@tests/pages/common/CommonTopLeftToolbar';
 import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 import { SaveStructureDialog } from '@tests/pages/common/SaveStructureDialog';
 import { MoleculesFileFormatType } from '@tests/pages/constants/fileFormats/microFileFormats';
 import { ErrorMessageDialog } from '@tests/pages/common/ErrorMessageDialog';
+import { getAtomLocator } from '@utils/canvas/atoms/getAtomLocator/getAtomLocator';
 
 let page: Page;
 
@@ -57,5 +63,39 @@ test.describe('Ketcher bugs in 3.19.0', () => {
     expect(warnings).toContain('V3000');
 
     await SaveStructureDialog(page).cancel();
+  });
+
+  test('Case 2: Molecule pasted from clipboard loads when it ends with carriage returns', async () => {
+    /*
+     * Test case: https://github.com/epam/ketcher/issues/3884
+     * Description: SMILES is a single-line format, but trailing carriage returns left over
+     * by a copy-paste made Indigo read the input as a multi-line molfile/rxnfile, so it
+     * failed with "Convert error! ... 'RXN loader: bad header P'" instead of loading it.
+     * Scenario:
+     * 1. Go to Molecules mode (clean canvas)
+     * 2. Open... - Paste from clipboard - paste 'P' followed by several carriage returns
+     * 3. Press Open as New Project
+     * 4. Verify that the phosphorus atom is loaded and no error message is shown
+     * 5. Repeat for the Add to Canvas button
+     */
+    // a textarea normalizes pasted carriage returns to line feeds
+    const smilesWithTrailingCarriageReturns = 'P\n\n\n';
+
+    await pasteFromClipboardAndOpenAsNewProject(
+      page,
+      smilesWithTrailingCarriageReturns,
+    );
+    expect(await ErrorMessageDialog(page).isVisible()).toBe(false);
+    await expect(getAtomLocator(page, { atomLabel: 'P' })).toHaveCount(1);
+
+    await CommonTopLeftToolbar(page).clearCanvas();
+
+    await pasteFromClipboardAndAddToCanvas(
+      page,
+      smilesWithTrailingCarriageReturns,
+    );
+    await clickInTheMiddleOfTheCanvas(page);
+    expect(await ErrorMessageDialog(page).isVisible()).toBe(false);
+    await expect(getAtomLocator(page, { atomLabel: 'P' })).toHaveCount(1);
   });
 });

--- a/packages/ketcher-core/__tests__/application/formatters/serverFormatter.test.ts
+++ b/packages/ketcher-core/__tests__/application/formatters/serverFormatter.test.ts
@@ -19,4 +19,49 @@ describe('ServerFormatter', () => {
     expect(result.method).toBe(convert);
     expect(result.struct).toBe('A*C*G*T');
   });
+
+  it.each([
+    ['trailing CRLF', 'P\r\n\r\n'],
+    ['trailing LF', 'P\n\n\n'],
+    ['trailing CR', 'P\r\r\r'],
+    ['leading newlines', '\n\nP'],
+  ])('trims %s from SMILES input', (_caseName, stringifiedStruct) => {
+    const convert = jest.fn();
+    const layout = jest.fn();
+    const structService = { convert, layout } as unknown as StructService;
+    const formatter = new ServerFormatter(
+      structService,
+      {} as unknown as KetSerializer,
+      SupportedFormat.smiles,
+    );
+
+    const result = formatter.getCallingMethod(
+      stringifiedStruct,
+      SupportedFormat.smiles,
+    );
+
+    // Indigo re-detects the format from the content and reads a multi-line
+    // string as a molfile/rxnfile, failing with "RXN loader: bad header P"
+    expect(result.method).toBe(layout);
+    expect(result.struct).toBe('P');
+  });
+
+  it('keeps using convert for extended SMILES with coordinates', () => {
+    const convert = jest.fn();
+    const layout = jest.fn();
+    const structService = { convert, layout } as unknown as StructService;
+    const formatter = new ServerFormatter(
+      structService,
+      {} as unknown as KetSerializer,
+      SupportedFormat.smiles,
+    );
+
+    const result = formatter.getCallingMethod(
+      'CC |(0.0,0.0,0.0;1.0,0.0,0.0)|\n\n',
+      SupportedFormat.smiles,
+    );
+
+    expect(result.method).toBe(convert);
+    expect(result.struct).toBe('CC |(0.0,0.0,0.0;1.0,0.0,0.0)|');
+  });
 });

--- a/packages/ketcher-core/src/application/formatters/serverFormatter.ts
+++ b/packages/ketcher-core/src/application/formatters/serverFormatter.ts
@@ -104,7 +104,11 @@ export class ServerFormatter implements StructFormatter {
         method: SmilesFormatter.isContainsCoordinates(stringifiedStruct)
           ? this.#structService.convert
           : this.#structService.layout,
-        struct: stringifiedStruct,
+        // SMILES is a single-line format, so surrounding whitespace is never
+        // meaningful. Indigo re-detects the format from the content and treats
+        // trailing newlines (e.g. left over by a copy-paste) as a multi-line
+        // molfile/rxnfile, so it must be trimmed as the layout branch below does.
+        struct: stringifiedStruct.trim(),
       };
     }
     const withCoords = getPropertiesByFormat(format).supportsCoords;


### PR DESCRIPTION
**Root cause:** `ServerFormatter.getCallingMethod` trims the structure string on its fall-through layout branch, but the SMILES branch above it returned the string untouched. Ketcher never sends Indigo an input format on this path, so Indigo re-detects it from the content — a SMILES string with trailing carriage returns looks multi-line, so the molfile/rxnfile loaders ran instead of the SMILES one.

**Fix:** trim in the SMILES branch too. SMILES is a single-line format, so surrounding whitespace is never meaningful, and the trim stays scoped to that branch — molfiles keep their legitimately blank title line. Fixing it in `ketcher-core` rather than in the `ketcher-react` `parseStruct` also covers `ketcher.setMolecule` / `addFragment`, which use a separate `parseStruct` in `application/utils.ts`.

Verified against the shipped Indigo (1.46.0-rc.1): `"P"` and `"P\n"` load fine, `"P\r\n\r\n"` throws the reported error, `"P\n\n\n".trim()` loads fine.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request