### PR TITLE
Refactor: replace useCallback with useMemo for debouncedShowPreview i…

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
@@ -22,7 +22,7 @@ import {
   RnaPresetWithOptionalFields,
 } from 'ketcher-core';
 import { debounce } from 'lodash';
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback, useMemo } from 'react';
 import {
   selectActivePreset,
   setActivePreset,
@@ -126,8 +126,8 @@ export const RnaPresetGroup = ({ presets, duplicatePreset, editPreset }) => {
     [dispatch],
   );
 
-  const debouncedShowPreview = useCallback(
-    debounce((p) => dispatchShowPreview(p), 500),
+  const debouncedShowPreview = useMemo(
+    () => debounce((p) => dispatchShowPreview(p), 500),
     [dispatchShowPreview],
   );
 


### PR DESCRIPTION

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

How the feature works:
RnaPresetGroup renders a list of RNA preset cards in the monomer library. On hover, it shows a debounced preview tooltip. The debounce prevents the preview from firing on every mouse-move event — it waits 500ms of inactivity before dispatching.

How the fix works:
debouncedShowPreview was created with useCallback(debounce(...), deps). The problem: JavaScript evaluates arguments before calling a function, so debounce(...) ran on every render, creating a new debounce instance each time. useCallback then memoized only the reference — the freshly created (and immediately discarded) instance's internal timer was lost. This broke the debounce behavior silently.

Replacing it with useMemo(() => debounce(...), deps) moves the debounce(...) call inside the factory, so it only executes when dispatchShowPreview changes — preserving the debounce instance and its timer across renders.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request