### PR TITLE
Refactor: replace useCallback with useMemo for debouncedShowPreview i…

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/monomerLibraryGroup/MonomerGroup.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { EmptyFunction } from 'helpers';
 import { debounce } from 'lodash';
 import { MonomerItem } from '../monomerLibraryItem';
@@ -76,8 +76,8 @@ const MonomerGroup = ({
     [dispatch],
   );
 
-  const debouncedShowPreview = useCallback(
-    debounce((p) => dispatchShowPreview(p), 500),
+  const debouncedShowPreview = useMemo(
+    () => debounce((p) => dispatchShowPreview(p), 500),
     [dispatchShowPreview],
   );
 


### PR DESCRIPTION
…n MonomerGroup

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

How the feature works:
MonomerGroup renders a grid of monomer cards in the library panel. On hover, it shows a debounced preview tooltip — the 500ms debounce prevents the preview from firing on every mouse-move event as the user moves across cards.

How the fix works:
Same pattern as RnaPresetGroup: useCallback(debounce(...), deps) was evaluating debounce(...) on every render because JavaScript evaluates function arguments before the call. Each render created a new debounce instance whose internal timer was immediately discarded by useCallback. Replacing it with useMemo(() => debounce(...), deps) ensures the debounce instance is only created when dispatchShowPreview changes, preserving the timer between renders.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request