### PR TITLE
#11221 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-react\src\script\ui\views\toolbars\TopToolbar\ZoomControls.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/ZoomControls.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/ZoomControls.tsx
@@ -126,6 +126,7 @@ export const ZoomControls = ({
   shortcuts,
 }: ZoomProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -149,9 +150,11 @@ export const ZoomControls = ({
       onZoomSubmit();
     }
     setIsExpanded(false);
+    setAnchorEl(null);
   };
 
   const onExpand = () => {
+    setAnchorEl(containerRef.current);
     setIsExpanded(true);
   };
 
@@ -171,7 +174,7 @@ export const ZoomControls = ({
       <Dropdown
         open={isExpanded}
         onClose={onClose}
-        anchorEl={containerRef.current}
+        anchorEl={anchorEl}
         container={
           document.querySelector(KETCHER_ROOT_NODE_CSS_SELECTOR) ||
           document.querySelector(KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR)


### PR DESCRIPTION
Fixed the react-hooks violation caused by reading ref.current during render in ZoomControls.tsx (/packages/ketcher-react/src/script/ui/views/toolbars/TopToolbar/ZoomControls.tsx).

Root cause: ZoomControls passed containerRef.current directly to the Dropdown component during render via anchorEl={containerRef.current}. This reads mutable ref state during React's render phase, which can lead to inconsistent behavior with Strict Mode, concurrent rendering, and React Compiler optimizations.

Fix: introduced an anchorEl state to store the container DOM element. The ref is now accessed only inside the onExpand event handler, where containerRef.current is assigned to anchorEl. The dropdown then uses the state value via anchorEl={anchorEl}. The state is also cleared when the dropdown closes.

Verified: manually tested opening/closing the Zoom dropdown, changing the zoom value, Zoom In, Zoom Out, and resetting to 100%. The full ketcher-react test suite passes: 54 test suites passed, 371 tests passed. Prettier, Stylelint, ESLint, TypeScript, circular dependency checks, and git diff --check also pass.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request