### PR TITLE
#11241 - Refactor: react-you-might-not-need-an-effect/no-event-handler rule violation clean up from packages\ketcher-react\src\script\ui\views\modal\components\document\Open\Open.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/Open.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Open/Open.tsx
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 import type { BaseCallProps, BaseProps } from '../../../modal.types';
-import { type FC, useEffect, useMemo, useState } from 'react';
+import { type FC, useMemo, useState } from 'react';
 import { Dialog, LoadingCircles } from '../../../../components';
 import classes from './Open.module.less';
 import Recognize from '../../process/Recognize/Recognize';
@@ -94,7 +94,6 @@ const Open: FC<Props> = (props) => {
   const [structStr, setStructStr] = useState<string>('');
   const [structList, setStructList] = useState<string[]>([]);
   const [fileName, setFileName] = useState<string>('');
-  const [opener, setOpener] = useState<any>();
   const [currentState, setCurrentState] = useState(MODAL_STATES.idle);
   const [isLoading, setIsLoading] = useState(false);
   const { ketcherId } = useAppContext();
@@ -102,14 +101,6 @@ const Open: FC<Props> = (props) => {
     () => ketcherProvider.getKetcher(ketcherId),
     [ketcherId],
   );
-
-  useEffect(() => {
-    if (server) {
-      fileOpener(server).then((chosenOpener) => {
-        setOpener({ chosenOpener });
-      });
-    }
-  }, [server]);
 
   const onFileLoad = (files) => {
     if ((window as any).isKetcherFullscreenBeforeFilePicker) {
@@ -137,7 +128,9 @@ const Open: FC<Props> = (props) => {
     };
 
     setFileName(files[0].name);
-    opener.chosenOpener(files[0]).then(onLoad, onError);
+    fileOpener(server)
+      .then((chosenOpener) => chosenOpener(files[0]))
+      .then(onLoad, onError);
   };
 
   const onImageLoad = (files) => {


### PR DESCRIPTION
## Summary
Closes #11241.

- `Open.tsx` had a `useEffect` that reacted to the `server` prop by computing a `chosenOpener` function and storing it in local state (`opener`), which was later used inside the `onFileLoad` handler. This tripped the `react-you-might-not-need-an-effect/no-event-handler` ESLint rule, since the actual side effect (choosing/using the file opener) is only ever needed at the moment a file is selected — i.e. inside the event handler — not proactively on every render where `server` changes.
- Fix: removed the `opener` state and the `useEffect`, and call `fileOpener(server)` directly inside `onFileLoad`, chaining `.then(chosenOpener => chosenOpener(files[0]))` before the existing `onLoad`/`onError` handling.
- No observable behavior change: file opening, PPTX/text branching, loading spinner, and error handling all work exactly as before. The only incidental improvement is that computing the opener now also happens correctly even in edge cases where `server` becomes available only after mount (previously a race could leave `opener` unset when a file was chosen before the effect ran).

## Test plan
- `npx eslint src/script/ui/views/modal/components/document/Open/Open.tsx` (from `packages/ketcher-react`) — confirmed the `no-event-handler` warning no longer fires; remaining warnings are pre-existing and unrelated.
- `npx tsc --noEmit -p tsconfig.json` (from `packages/ketcher-react`) — no new type errors introduced by this change (pre-existing unrelated errors in other files remain).
- No existing unit tests target `Open.tsx`; manually reviewed the diff to confirm the file-open flow (fullscreen restore, filename tracking, PPTX vs text branching, loading state, error handling) is preserved.