### PR TITLE
#11245 - Refactor: react-you-might-not-need-an-effect/no-event-handler rule violation clean up from packages\ketcher-react\src\script\ui\dialog\template\useSaltsAndSolvets.ts file

### DIFF
--- a/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
+++ b/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
@@ -9,7 +9,7 @@ export default function useSaltsAndSolvents(
   saltsAndSolvents: Template[],
   filter: string,
 ) {
-  const [isFirstRender, setIsFirstRender] = useState(true);
+  const isFirstRenderRef = useRef(true);
   const timerId = useRef<null | ReturnType<typeof setTimeout>>(null);
   const [filteredSaltsAndSolvents, setFilteredSaltsAndSolvents] = useState(
     saltsAndSolvents[SALTS_AND_SOLVENTS],
@@ -36,8 +36,8 @@ export default function useSaltsAndSolvents(
   }, [saltsAndSolvents, addToSaSWithBatches]);
 
   useEffect(() => {
-    if (isFirstRender) {
-      setIsFirstRender(false);
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
       return;
     }
     clearTimeout(timerId.current as unknown as number);


### PR DESCRIPTION
## Summary
Closes #11245.

`useSaltsAndSolvets.ts` used a `useState`-backed `isFirstRender` flag purely to skip the first invocation of a `useEffect`, then flipped it back to `false` inside that same effect. This is the `react-you-might-not-need-an-effect/no-event-handler` anti-pattern: a state flag driving effect-only logic, which also tripped `no-adjust-state-on-prop-change` since the state update was really just gating behavior in response to prop changes (`saltsAndSolvents`, `filter`), not something that needs to trigger a re-render.

Fix: replaced the `isFirstRender` state with a `useRef<boolean>` (`isFirstRenderRef`). Mutating a ref does not cause a re-render and is not tracked by these lint rules, so the "skip on first render" bookkeeping is no longer flagged as event-handler-in-effect logic. The two flagged warnings (`no-event-handler`, `no-adjust-state-on-prop-change`) are gone; two pre-existing, unrelated warnings (`react-hooks/exhaustive-deps` on the other effect's deps, `no-derived-state` on storing `filteredSaltsAndSolvents`) are out of scope for this change and left untouched.

No observable behavior change: salts/solvents search/selection and the batched-loading behavior remain identical — this is a pure internal refactor of how the "skip first run" bookkeeping is implemented.

## Test plan
- `npx eslint src/script/ui/dialog/template/useSaltsAndSolvets.ts` (from `packages/ketcher-react`) — confirms the two `react-you-might-not-need-an-effect` warnings targeted by this issue no longer appear.
- `npx tsc --noEmit -p tsconfig.json` (from `packages/ketcher-react`) — no new type errors (pre-existing unrelated errors in the package are unaffected).
- No dedicated unit test exists for this hook (`TemplateDialog.test.tsx` mocks it out); manual review confirms identical runtime behavior since the ref-based first-render check is logically equivalent to the previous state-based one.