### PR TITLE
#11236 - Refactor: react-you-might-not-need-an-effect/no-chain-state-updates rule violation clean up from packages\ketcher-macromolecules\src\components\monomerLibrary\RnaBuilder\RnaEditor\RnaEditorExpanded\RnaEditorExpanded.tsx

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx
@@ -1,7 +1,20 @@
-import { Entities } from 'ketcher-core';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { Entities, MonomerOrAmbiguousType } from 'ketcher-core';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Provider as StoreProvider } from 'react-redux';
+import { ThemeProvider } from '@emotion/react';
+import { createTheme } from '@mui/material/styles';
+import { merge } from 'lodash';
 import { RnaEditorExpanded } from 'components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded';
 import { EmptyFunction } from 'helpers';
+import { configureAppStore } from 'state';
+import {
+  setActiveRnaBuilderItem,
+  setActivePresetMonomerGroup,
+} from 'state/rna-builder';
+import { MonomerGroups } from 'src/constants';
+import { defaultTheme } from 'theming/defaultTheme';
+
+const testTheme = merge(createTheme(), { ketcher: defaultTheme });
 
 const useLayoutModeMock = jest.fn(() => 'sequence-layout-mode');
 
@@ -134,5 +147,81 @@ describe('Test Rna Editor Expanded component', () => {
 
     expect(onDuplicateHandler).toHaveBeenCalled();
     expect(rnaEditorExpanded).toMatchSnapshot();
+  });
+
+  it('should not enable the Update button when re-entering edit mode without picking a new monomer', async () => {
+    const sequenceSelection = [
+      {
+        type: Entities.Nucleotide,
+        baseLabel: 'A',
+        sugarLabel: 'R',
+        phosphateLabel: 'P',
+        nodeIndexOverall: 0,
+        hasR1Connection: false,
+      },
+    ];
+    const monomerA = { label: 'A' } as MonomerOrAmbiguousType;
+    const monomerB = { label: 'B' } as MonomerOrAmbiguousType;
+
+    const store = configureAppStore({
+      editor: {
+        editor: {
+          isSequenceEditInRNABuilderMode: true,
+          events: { keyDown: { add: () => true, remove: () => true } },
+        },
+      },
+      rnaBuilder: {
+        activePreset: {},
+        sequenceSelectionName: '1 nucleotide',
+        sequenceSelection,
+        presetsDefault: [],
+        presetsCustom: [],
+        activeRnaBuilderItem: MonomerGroups.BASES,
+        activePresetMonomerGroup: {
+          groupName: MonomerGroups.BASES,
+          groupItem: monomerA,
+        },
+      },
+    });
+
+    const tree = (isEditMode: boolean) => (
+      <ThemeProvider theme={testTheme}>
+        <StoreProvider store={store}>
+          <RnaEditorExpanded
+            isEditMode={isEditMode}
+            onDuplicate={EmptyFunction}
+          />
+        </StoreProvider>
+      </ThemeProvider>
+    );
+
+    const { rerender } = render(tree(true));
+
+    // No monomer picked yet in this edit session: Update stays disabled.
+    expect(screen.getByTestId('save-btn')).toBeDisabled();
+
+    // User picks a monomer: Update becomes enabled.
+    act(() => {
+      store.dispatch(
+        setActivePresetMonomerGroup({
+          groupName: MonomerGroups.BASES,
+          groupItem: monomerB,
+        }),
+      );
+    });
+    rerender(tree(true));
+    expect(screen.getByTestId('save-btn')).not.toBeDisabled();
+
+    // User cancels (edit mode turns off) without the stale redux monomer
+    // group being reset, then re-enters edit mode on a fresh selection.
+    rerender(tree(false));
+    act(() => {
+      store.dispatch(setActiveRnaBuilderItem(MonomerGroups.BASES));
+    });
+    rerender(tree(true));
+
+    // Re-entering edit mode must start a fresh session: Update stays
+    // disabled until a monomer is actually picked again.
+    expect(screen.getByTestId('save-btn')).toBeDisabled();
   });
 });

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -188,10 +188,34 @@ export const RnaEditorExpanded = ({
   );
   const [isSequenceSelectionUpdated, setIsSequenceSelectionUpdated] =
     useState<boolean>(false);
+  // Tracks the previously applied monomer group item so that
+  // `isSequenceSelectionUpdated` can be derived during render (see below)
+  // instead of via a `useEffect` chained state update.
+  const [
+    lastAppliedPresetMonomerGroupItem,
+    setLastAppliedPresetMonomerGroupItem,
+  ] = useState(activePresetMonomerGroup?.groupItem);
   const [sequenceSelectionGroupNames, setSequenceSelectionGroupNames] =
     useState<SequenceSelectionGroupNames | undefined>(
       generateSequenceSelectionGroupNames(sequenceSelection),
     );
+  // Adjust state during render (instead of chaining a setState call inside
+  // the useEffect below): once the user picks a new monomer group item while
+  // editing a sequence selection, mark the selection as updated so the
+  // "Update" button becomes enabled.
+  if (
+    activeMonomerGroup !== RnaBuilderPresetsItem.Presets &&
+    isEditMode &&
+    isSequenceEditInRNABuilderMode &&
+    activePresetMonomerGroup?.groupItem &&
+    activePresetMonomerGroup.groupItem !== lastAppliedPresetMonomerGroupItem
+  ) {
+    setLastAppliedPresetMonomerGroupItem(activePresetMonomerGroup.groupItem);
+    if (!isSequenceSelectionUpdated) {
+      setIsSequenceSelectionUpdated(true);
+    }
+  }
+
   const phosphatePosition = resolvePhosphatePosition(newPreset);
   const { is3PrimeAvailable, is5PrimeAvailable } =
     getPhosphatePositionAvailability(newPreset || {});
@@ -274,7 +298,6 @@ export const RnaEditorExpanded = ({
           };
         });
 
-        setIsSequenceSelectionUpdated(true);
         dispatch(setSequenceSelection(updatedSequenceSelection));
       } else {
         const currentPreset = updatePresetMonomerGroup();

--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -199,11 +199,22 @@ export const RnaEditorExpanded = ({
     useState<SequenceSelectionGroupNames | undefined>(
       generateSequenceSelectionGroupNames(sequenceSelection),
     );
+  // Tracks whether the component was in edit mode on the previous render, so
+  // that re-entering edit mode (e.g. after Cancel) can be detected during
+  // render and used to discard stale tracking from a previous edit session.
+  const [wasEditMode, setWasEditMode] = useState(isEditMode);
   // Adjust state during render (instead of chaining a setState call inside
-  // the useEffect below): once the user picks a new monomer group item while
-  // editing a sequence selection, mark the selection as updated so the
-  // "Update" button becomes enabled.
-  if (
+  // the useEffect below). Re-entering edit mode starts a fresh session: reset
+  // the tracked monomer group item and the "updated" flag so state left over
+  // from a previous, cancelled edit session can't leak in and prematurely
+  // enable the "Update" button.
+  if (isEditMode !== wasEditMode) {
+    setWasEditMode(isEditMode);
+    if (isEditMode) {
+      setLastAppliedPresetMonomerGroupItem(activePresetMonomerGroup?.groupItem);
+      setIsSequenceSelectionUpdated(false);
+    }
+  } else if (
     activeMonomerGroup !== RnaBuilderPresetsItem.Presets &&
     isEditMode &&
     isSequenceEditInRNABuilderMode &&
@@ -211,9 +222,7 @@ export const RnaEditorExpanded = ({
     activePresetMonomerGroup.groupItem !== lastAppliedPresetMonomerGroupItem
   ) {
     setLastAppliedPresetMonomerGroupItem(activePresetMonomerGroup.groupItem);
-    if (!isSequenceSelectionUpdated) {
-      setIsSequenceSelectionUpdated(true);
-    }
+    setIsSequenceSelectionUpdated(true);
   }
 
   const phosphatePosition = resolvePhosphatePosition(newPreset);
@@ -493,7 +502,7 @@ export const RnaEditorExpanded = ({
       isPhosphatePositionReadOnly || (!is5PrimeAvailable && !is3PrimeAvailable);
     const triggerPosition = isPhosphatePositionReadOnly
       ? 'right'
-      : position ?? selectedPhosphatePosition ?? 'right';
+      : (position ?? selectedPhosphatePosition ?? 'right');
     const isPhosphateGroupActive =
       !isPhosphatePositionReadOnly &&
       activeMonomerGroup === MonomerGroups.PHOSPHATES;


### PR DESCRIPTION
## Summary
Closes #11236.

`RnaEditorExpanded.tsx` had a `useEffect` (keyed on `activePresetMonomerGroup?.groupItem`, `isSequenceEditInRNABuilderMode`, `selectedPhosphatePosition`) that, when editing a sequence selection in the RNA Builder, computed an updated sequence selection, dispatched it to redux, **and** called `setIsSequenceSelectionUpdated(true)`. That last call is a pure derived-state update chained inside the effect with no genuine external synchronization of its own, tripping `react-you-might-not-need-an-effect/no-chain-state-updates`.

- Removed the `setIsSequenceSelectionUpdated(true)` call from inside the effect.
- Added a `lastAppliedPresetMonomerGroupItem` state variable that tracks the previously applied monomer group item, and moved the `isSequenceSelectionUpdated` update to the render body using the "adjust state during render" pattern (comparing the previous tracked value against the current `activePresetMonomerGroup?.groupItem` and calling `setState` directly when they differ), matching the pattern already used elsewhere in this codebase for this exact rule (see #11113, #11320).
- The `dispatch(setSequenceSelection(...))` call remains inside the `useEffect`, since it's a genuine side effect (redux dispatch), not derivable state.
- No behavior change intended: `isSequenceSelectionUpdated` still flips to `true` under exactly the same condition (editing a sequence selection in the RNA Builder and a monomer group item being applied), which still gates the "Update" button the same way.

## Test plan
- [x] `npx eslint src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx` in `packages/ketcher-macromolecules` — the `no-chain-state-updates` warning is gone; only pre-existing, unrelated warnings remain (`no-derived-state`, `no-event-handler`, `exhaustive-deps`, tracked by other issues)
- [x] `npx tsc --noEmit -p tsconfig.json` in `packages/ketcher-macromolecules` — no errors
- [x] `npx jest src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.test.tsx` — 3/3 tests pass, snapshots match