### PR TITLE
#11229 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-macromolecules\src\components\Ruler\RulerArea.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.tsx
+++ b/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.tsx
@@ -127,12 +127,7 @@ export const RulerArea = () => {
     }
 
     return calculateLineLength(dragPosition);
-  }, [
-    isDragging,
-    dragPosition,
-    lineLengthValue,
-    calculateLineLength,
-  ]);
+  }, [isDragging, dragPosition, lineLengthValue, calculateLineLength]);
 
   const handleDragStart = useCallback(
     (event: D3DragEvent<SVGGElement, unknown, unknown>) => {

--- a/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.tsx
+++ b/packages/ketcher-macromolecules/src/components/Ruler/RulerArea.tsx
@@ -31,6 +31,7 @@ export const RulerArea = () => {
   const dragStartX = useRef(0);
   const [dragDelta, setDragDelta] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
+  const [dragPosition, setDragPosition] = useState<number | null>(null);
 
   const transform = useZoomTransform();
 
@@ -121,20 +122,15 @@ export const RulerArea = () => {
   );
 
   const previewValue = useMemo(() => {
-    if (!isDragging) {
+    if (!isDragging || dragPosition === null) {
       return lineLengthValue;
     }
 
-    const [, dragPosition] = calculateDragPosition(
-      dragStartX.current + dragDelta,
-    );
     return calculateLineLength(dragPosition);
   }, [
     isDragging,
+    dragPosition,
     lineLengthValue,
-    calculateDragPosition,
-    dragStartX,
-    dragDelta,
     calculateLineLength,
   ]);
 
@@ -156,6 +152,7 @@ export const RulerArea = () => {
         event.sourceEvent.clientX,
       );
       setDragDelta(dragDelta);
+      setDragPosition(dragPosition);
       editor?.events.toggleLineLengthHighlighting.dispatch(true, dragPosition);
     },
     [editor?.events?.toggleLineLengthHighlighting, calculateDragPosition],
@@ -173,6 +170,7 @@ export const RulerArea = () => {
       }
 
       setDragDelta(0);
+      setDragPosition(null);
       dragStartX.current = 0;
       editor?.events.toggleLineLengthHighlighting.dispatch(false);
     },


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request