### PR TITLE
#11205 - Refactor: useMemo anti-patterns clean up in packages\ketcher-macromolecules\src\contexts\RootSizeContext.tsx

### DIFF
--- a/packages/ketcher-macromolecules/src/contexts/RootSizeContext.tsx
+++ b/packages/ketcher-macromolecules/src/contexts/RootSizeContext.tsx
@@ -6,7 +6,7 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { debounce } from 'lodash';
+import { useDebouncedCallback } from '../hooks/useDebouncedCallback';
 
 export const RootSizeContext = createContext({ width: 0, height: 0 });
 
@@ -32,9 +32,7 @@ export const RootSizeProvider = ({
     setSize({ width, height });
   }, [rootRef]);
 
-  const debouncedHandleResize = useCallback(debounce(handleResize, 100), [
-    handleResize,
-  ]);
+  const debouncedHandleResize = useDebouncedCallback(handleResize, 100);
 
   useEffect(() => {
     handleResize();

--- a/packages/ketcher-macromolecules/src/hooks/index.ts
+++ b/packages/ketcher-macromolecules/src/hooks/index.ts
@@ -16,3 +16,4 @@
 
 export * from './stateHooks';
 export * from './useIsCompactView';
+export * from './useDebouncedCallback';

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+import { debounce, DebouncedFunc } from 'lodash';
+
+export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
+  callback: T,
+  delay: number,
+): DebouncedFunc<T> {
+  return useMemo(() => debounce(callback, delay), [callback, delay]);
+}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
How the feature works: RootSizeProvider tracks the root container's size (width/height) via RootSizeContext, updated on window resize, debounced so resize storms don't trigger excessive re-renders across the macromolecules editor.                            
Fix: debouncedHandleResize used useCallback(debounce(handleResize, 100), [handleResize]) — passing a call expression instead of a literal inline function, which is the wrong hook for memoizing a computed value (useCallback's first argument must be a literal function). Extracted a generic, reusable useDebouncedCallback(callback, delay) hook (built on useMemo, keyed on [callback, delay] — a literal array react-hooks/exhaustive-deps can fully verify, no disable comments needed) and used it here:  useDebouncedCallback(handleResize, 100). Same primitive now also backs useDebouncedShowPreview, so future debounced-callback needs across the codebase can build on it instead of repeating the anti-pattern. 


Issue - [11205](https://github.com/epam/ketcher/issues/11205)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [X] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request