### PR TITLE
#11277 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\hooks\useIndigoVersionToRedux.ts file

### DIFF
--- a/packages/ketcher-macromolecules/src/EditorEvents.tsx
+++ b/packages/ketcher-macromolecules/src/EditorEvents.tsx
@@ -57,6 +57,7 @@ import {
 } from 'state/types';
 import { calculateBondPreviewPosition } from 'ketcher-react';
 import { loadDefaultPresets, loadMonomerLibrary } from 'state/library';
+import { useIndigoVersionToRedux } from './hooks/useIndigoVersionToRedux';
 
 const noPreviewTools = [ToolName.bondSingle, ToolName.selectRectangle];
 
@@ -76,6 +77,8 @@ export const EditorEvents = () => {
     dispatch(loadDefaultPresets(editor?.defaultRnaPresetsLibraryItems));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
+
+  useIndigoVersionToRedux();
 
   useEffect(() => {
     editor?.events.updateMonomersLibrary.add(handleMonomersLibraryUpdate);

--- a/packages/ketcher-macromolecules/src/components/modal/About/About.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/About/About.tsx
@@ -17,7 +17,6 @@
 import Logo from './logo.svg';
 import { Modal } from '../../shared/modal/Modal';
 import { About as AboutStyled } from './About.styles';
-import { useIndigoVersionToRedux } from 'src/hooks/useIndigoVersionToRedux';
 import { selectAppMeta } from 'state/common/editorSlice';
 import { useAppDispatch, useAppSelector } from 'src/hooks/stateHooks';
 
@@ -42,7 +41,6 @@ export function About({
   onClose: () => void;
 }>) {
   const dispatch = useAppDispatch();
-  useIndigoVersionToRedux();
   const { buildDate, indigoVersion, version } = useAppSelector(selectAppMeta);
   const formattedDate = formatDate(buildDate);
 

--- a/packages/ketcher-macromolecules/src/hooks/useIndigoVersionToRedux.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useIndigoVersionToRedux.ts
@@ -1,30 +1,28 @@
 import { useEffect } from 'react';
 import { IndigoProvider } from 'ketcher-react';
-import { useAppDispatch, useAppSelector } from './stateHooks';
-import { setAppMeta, selectAppMeta } from 'state/common/editorSlice';
+import { useAppDispatch } from './stateHooks';
+import { setIndigoVersion } from 'state/common/editorSlice';
 
 export function useIndigoVersionToRedux() {
   const dispatch = useAppDispatch();
-  const app = useAppSelector(selectAppMeta);
 
   useEffect(() => {
     async function fetchIndigoInfo() {
       const indigo = IndigoProvider.getIndigo();
-      if (indigo?.info) {
-        try {
-          const info = await indigo.info();
-          dispatch(
-            setAppMeta({
-              ...app,
-              indigoVersion: info.indigoVersion ?? '',
-            }),
-          );
-        } catch (_e) {
-          // ignore
-        }
+
+      if (!indigo?.info) {
+        return;
+      }
+
+      try {
+        const info = await indigo.info();
+
+        dispatch(setIndigoVersion(info.indigoVersion ?? ''));
+      } catch (_e) {
+        // ignore
       }
     }
+
     fetchIndigoInfo();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 }

--- a/packages/ketcher-macromolecules/src/hooks/useIndigoVersionToRedux.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useIndigoVersionToRedux.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { IndigoProvider } from 'ketcher-react';
+import { KetcherLogger } from 'ketcher-core';
 import { useAppDispatch } from './stateHooks';
 import { setIndigoVersion } from 'state/common/editorSlice';
 
@@ -18,8 +19,11 @@ export function useIndigoVersionToRedux() {
         const info = await indigo.info();
 
         dispatch(setIndigoVersion(info.indigoVersion ?? ''));
-      } catch (_e) {
-        // ignore
+      } catch (error) {
+        KetcherLogger.error(
+          'useIndigoVersionToRedux::fetchIndigoInfo - Failed to fetch Indigo version',
+          error,
+        );
       }
     }
 

--- a/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
@@ -227,9 +227,6 @@ export const editorSlice: Slice<EditorState> = createSlice({
     setOligonucleotidesValue: (state, action: PayloadAction<number>) => {
       state.oligonucleotidesValue = action.payload;
     },
-    setAppMeta: (state, action: PayloadAction<AppMeta>) => {
-      state.app = action.payload;
-    },
     setIndigoVersion: (state, action: PayloadAction<string>) => {
       state.app.indigoVersion = action.payload;
     },
@@ -266,7 +263,6 @@ export const {
   setEditorLineLength,
   setUnipositiveIonsValue,
   setOligonucleotidesValue,
-  setAppMeta,
   setIndigoVersion,
   setSelectedMenuGroupItem,
 } = editorSlice.actions;

--- a/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/common/editorSlice.ts
@@ -230,6 +230,9 @@ export const editorSlice: Slice<EditorState> = createSlice({
     setAppMeta: (state, action: PayloadAction<AppMeta>) => {
       state.app = action.payload;
     },
+    setIndigoVersion: (state, action: PayloadAction<string>) => {
+      state.app.indigoVersion = action.payload;
+    },
     setSelectedMenuGroupItem: (
       state,
       action: PayloadAction<{ groupName: string; activeItemName: string }>,
@@ -264,6 +267,7 @@ export const {
   setUnipositiveIonsValue,
   setOligonucleotidesValue,
   setAppMeta,
+  setIndigoVersion,
   setSelectedMenuGroupItem,
 } = editorSlice.actions;
 


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request