### PR TITLE
#11217 – Refactor: Use memo rule violation clean up from RnaPresetGroup.tsx

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useAppSelector } from 'hooks';
+import { useAppSelector, useDebouncedCallback } from 'hooks';
 import {
   getRnaPresetPhosphatePosition,
   isAmbiguousMonomerLibraryItem,
   MonomerItemType,
   RnaPresetWithOptionalFields,
 } from 'ketcher-core';
-import { debounce } from 'lodash';
 import React, { ReactElement, useCallback } from 'react';
 import {
   selectActivePreset,
@@ -126,10 +125,7 @@ export const RnaPresetGroup = ({ presets, duplicatePreset, editPreset }) => {
     [dispatch],
   );
 
-  const debouncedShowPreview = useCallback(
-    debounce((p) => dispatchShowPreview(p), 500),
-    [dispatchShowPreview],
-  );
+  const debouncedShowPreview = useDebouncedCallback(dispatchShowPreview, 500);
 
   const closeLibraryPreview = useCallback((): void => {
     debouncedShowPreview.cancel();


### PR DESCRIPTION
Closes #11217

## How did you fix the issue?

`debouncedShowPreview` was built with `useCallback(debounce((p) => dispatchShowPreview(p), 500), [dispatchShowPreview])` — passing a *call expression* (`debounce(...)`, executed fresh on every render) as the memoized callback itself, instead of a literal inline function. That's the wrong hook shape for caching a computed value and is exactly the anti-pattern this issue's `useMemo` guidance targets (a memoization hook should derive/return a value, not be handed an already-invoked side-effecting expression); it also triggered a `react-hooks/exhaustive-deps` lint warning ("received a function whose dependencies are unknown").

Replaced it with the existing `useDebouncedCallback(callback, delay)` hook (`packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts`), which wraps `debounce` in a correctly-shaped `useMemo(() => debounce(callback, delay), [callback, delay])`. This is the same hook and fix already applied to `RootSizeContext.tsx` for the sibling issue #11205 (PR #11387), so this keeps the codebase consistent instead of introducing another one-off inline `useMemo`/`debounce` combination.

No behavior change: same 500ms debounce, same dispatched payload, `closeLibraryPreview`'s `debouncedShowPreview.cancel()` call keeps working identically.

## Testing

- `eslint` on the changed file: previously reported 1 `react-hooks/exhaustive-deps` warning, now 0 warnings/errors.
- `tsc --noEmit` for `ketcher-macromolecules`: no new errors introduced (pre-existing, unrelated `Cannot find type definition file for 'react-dom'` environment error reproduces identically on unmodified `master`).
- No unit test suite exists for this component (consistent with prior PRs on sibling components in this file's area).