### PR TITLE
#11259 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-react\src\script\ui\views\toolbars\ToolbarGroupItem\ToolbarMultiToolItem\usePortalOpening.ts file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/ToolbarGroupItem/ToolbarMultiToolItem/usePortalOpening.ts
@@ -1,5 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable react-hooks/set-state-in-effect */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *


### PR DESCRIPTION
The reported violation was `usePortalOpening`'s effect dependency array `[opened, options]`, which omitted `id`. **That effect no longer exists** — #11296 replaced the setState-in-useEffect anti-pattern with plain derived values, removing the hook and its dependency array altogether.

What remained were two file-level suppressions that #10806 (the ESLint 9 upgrade) added afterwards, generated against the pre-#11296 content:

```ts
/* eslint-disable react-hooks/exhaustive-deps */
/* eslint-disable react-hooks/set-state-in-effect */
```

`usePortalOpening` now contains no hooks at all, so neither rule can fire and both directives are dead. This PR removes them — which is why the diff is only two deleted lines.

Worth removing rather than leaving: a **file-level** disable silences the rule for the whole file, so any violation introduced by a hook added here later would go unreported — and `react-hooks/exhaustive-deps` is now configured as `error`.

The resulting file is byte-identical to what #11296 produced.

### Verification

- eslint reports **no problems** on the file
- a known-dirty control file (`ContextMenu.tsx`) still reports its `exhaustive-deps` violation, confirming the rule is loaded and enforced — so the clean result above is real, not a silent no-op
- prettier clean; `test:types` for ketcher-react passes with 0 errors
- no behavior change (comments only); single consumer `ToolbarMultiToolItem.tsx`, no tests affected



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request