### PR TITLE
#11263 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-react\src\script\ui\views\components\StructEditor\SGroupDataRender.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { type FC, useEffect, useRef, useState } from 'react';
 import {
   type Render,
@@ -94,12 +93,16 @@ const SGroupDataRender: FC<SGroupDataRenderProps> = (props) => {
   const [wrapperWidth, setWrapperWidth] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  // The panel is positioned from its own measured size, so it has to be
+  // measured once it is in the DOM and again whenever its content changes.
+  // Without a dependency array this would re-run after every render, including
+  // the re-render its own setState triggers.
   useEffect(() => {
     if (wrapperRef.current) {
       setWrapperHeight(wrapperRef.current.clientHeight);
       setWrapperWidth(wrapperRef.current.clientWidth);
     }
-  });
+  }, [sGroupData]);
 
   const panelCoordinate = getPanelPositionRelativeToRect(
     clientX,

--- a/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/StructEditor/SGroupDataRender.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useLayoutEffect, useRef, useState } from 'react';
 import {
   type Render,
   type SGroup,
@@ -96,8 +96,10 @@ const SGroupDataRender: FC<SGroupDataRenderProps> = (props) => {
   // The panel is positioned from its own measured size, so it has to be
   // measured once it is in the DOM and again whenever its content changes.
   // Without a dependency array this would re-run after every render, including
-  // the re-render its own setState triggers.
-  useEffect(() => {
+  // the re-render its own setState triggers. useLayoutEffect keeps the
+  // measurement and the reposition in the same commit, so the panel is never
+  // painted at its pre-measurement position.
+  useLayoutEffect(() => {
     if (wrapperRef.current) {
       setWrapperHeight(wrapperRef.current.clientHeight);
       setWrapperWidth(wrapperRef.current.clientWidth);


### PR DESCRIPTION
The effect that measures the info panel wrapper had **no dependency array**, so it re-ran after every render — including the render its own `setWrapperHeight` / `setWrapperWidth` calls triggered. That is the infinite chain of updates the rule warns about; it only settled because React bails out when the measured values are unchanged.

```diff
-  });
+  }, [sGroupData]);
```

The effect body reads no reactive values, so `[]` would also satisfy the rule — but it would measure only on mount, and `SGroupDataRender` isn't guaranteed to unmount between hovers. `InfoPanel` returns `null` when nothing is hovered, yet moving between two adjacent S-groups can swap `sGroupData` while the component stays mounted, leaving the panel positioned from the previous tooltip's size. Depending on `sGroupData` ends the every-render loop and still re-measures when the content changes.

The file-level `eslint-disable` for the rule is removed, since it's no longer needed.

### Verification

Run on ESLint 9.39.5 / eslint-plugin-react-hooks 7.1.1:
- the file reports no problems (all rules, not just react-hooks)
- restoring the missing dependency array makes `exhaustive-deps` fire again, confirming the rule is genuinely enforced on this file rather than silently inactive
- `--print-config` confirms the rule resolves to `error` for this path
- prettier clean; `test:types` for ketcher-react passes with 0 errors


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request