### PR TITLE
fix: refactor useSubscriptionOnEvents to improve event subscription h…

### DIFF
--- a/packages/ketcher-react/src/hooks/useSubscribtionOnEvents.ts
+++ b/packages/ketcher-react/src/hooks/useSubscribtionOnEvents.ts
@@ -27,54 +27,52 @@ import { useAppDispatch } from '../script/ui/state/hooks';
 
 export const useSubscriptionOnEvents = () => {
   const dispatch = useAppDispatch();
-
   const { ketcherId } = useAppContext();
 
-  const loadingHandler = () => {
-    dispatch(indigoVerification(true));
-  };
-  const actionResultHandler = () => {
-    dispatch(indigoVerification(false));
-  };
-
-  const subscribe = (ketcher: Ketcher) => {
-    ketcher.eventBus.addListener(KetcherAsyncEvents.LOADING, loadingHandler);
-    ketcher.eventBus.addListener(
-      KetcherAsyncEvents.SUCCESS,
-      actionResultHandler,
-    );
-    ketcher.eventBus.addListener(
-      KetcherAsyncEvents.FAILURE,
-      actionResultHandler,
-    );
-  };
-
-  const unsubscribe = (ketcher: Ketcher) => {
-    ketcher.eventBus.removeListener(KetcherAsyncEvents.LOADING, loadingHandler);
-    ketcher.eventBus.removeListener(
-      KetcherAsyncEvents.SUCCESS,
-      actionResultHandler,
-    );
-    ketcher.eventBus.removeListener(
-      KetcherAsyncEvents.FAILURE,
-      actionResultHandler,
-    );
-  };
-
   useEffect(() => {
-    const subscribeOnInit = () => {
-      subscribe(ketcherProvider.getKetcher(ketcherId));
+    const loadingHandler = () => {
+      dispatch(indigoVerification(true));
+    };
+    const actionResultHandler = () => {
+      dispatch(indigoVerification(false));
     };
 
-    const unsubscribeOnUnMount = () => {
-      unsubscribe(ketcherProvider.getKetcher(ketcherId));
+    const subscribe = (ketcher: Ketcher) => {
+      ketcher.eventBus.addListener(KetcherAsyncEvents.LOADING, loadingHandler);
+      ketcher.eventBus.addListener(
+        KetcherAsyncEvents.SUCCESS,
+        actionResultHandler,
+      );
+      ketcher.eventBus.addListener(
+        KetcherAsyncEvents.FAILURE,
+        actionResultHandler,
+      );
+    };
+
+    const unsubscribe = (ketcher: Ketcher) => {
+      ketcher.eventBus.removeListener(
+        KetcherAsyncEvents.LOADING,
+        loadingHandler,
+      );
+      ketcher.eventBus.removeListener(
+        KetcherAsyncEvents.SUCCESS,
+        actionResultHandler,
+      );
+      ketcher.eventBus.removeListener(
+        KetcherAsyncEvents.FAILURE,
+        actionResultHandler,
+      );
+    };
+
+    const subscribeOnInit = () => {
+      subscribe(ketcherProvider.getKetcher(ketcherId));
     };
 
     const initEventName = ketcherInitEventName(ketcherId);
     window.addEventListener(initEventName, subscribeOnInit);
     return () => {
-      unsubscribeOnUnMount();
+      unsubscribe(ketcherProvider.getKetcher(ketcherId));
       window.removeEventListener(initEventName, subscribeOnInit);
     };
-  }, []);
+  }, [ketcherId, dispatch]);
 };


### PR DESCRIPTION


## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

How the feature works:
useSubscriptionOnEvents subscribes to async Ketcher event bus events (LOADING, SUCCESS, FAILURE) and dispatches Redux actions to track indigo operation state. It listens for the ketcher init event on window, then attaches the listeners once the ketcher instance is ready. On unmount it cleans up both the window listener and the event bus subscriptions.

How the fix works:
loadingHandler, actionResultHandler, subscribe, and unsubscribe were defined outside the useEffect but used inside it, while the dep array was []. This meant the effect captured stale references to those functions — specifically stale dispatch and ketcherId closures — and would never re-subscribe if either changed.

The fix moves all helper functions inside the effect and adds [ketcherId, dispatch] to the dep array. Now the effect re-runs if ketcherId changes (re-subscribing to the correct instance), and the helpers always close over the current values.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request