### PR TITLE
#11227 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-macromolecules\src\components\ZoomControls\ZoomControls.tsx file  

### DIFF
--- a/packages/ketcher-macromolecules/src/components/ZoomControls/ZoomControls.tsx
+++ b/packages/ketcher-macromolecules/src/components/ZoomControls/ZoomControls.tsx
@@ -37,7 +37,8 @@ import {
 export const ZoomControls = () => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const [currentZoom, setCurrentZoom] = useState<number>(100);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerElement, setContainerElement] =
+    useState<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -80,7 +81,7 @@ export const ZoomControls = () => {
   };
 
   return (
-    <ElementAndDropdown ref={containerRef}>
+    <ElementAndDropdown ref={setContainerElement}>
       <DropDownButton onClick={onExpand} data-testid="zoom-selector">
         <ZoomLabel data-testid="zoom-input">{currentZoom}%</ZoomLabel>
         <Icon name="chevron" />
@@ -89,7 +90,7 @@ export const ZoomControls = () => {
       <Dropdown
         open={isExpanded}
         onClose={onClose}
-        anchorEl={containerRef.current}
+        anchorEl={containerElement}
         container={document.querySelector(
           KETCHER_MACROMOLECULES_ROOT_NODE_SELECTOR,
         )}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Related Issue - [11227](https://github.com/epam/ketcher/issues/11227)

Replaced the dropdown container ref in `ZoomControls` with state populated through a callback ref.

The `Dropdown` now receives its anchor element without reading `ref.current` during render. Access to the input ref remains inside the submit event handler.

The existing behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request