### PR TITLE
#11215 - Refactor: Preserve manual memoization rule violation problem clean up from packages\ketcher-macromolecules\src\components\preview\components\BondPreview\BondPreview.tsx file

### DIFF
--- a/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
+++ b/ketcher-autotests/tests/specs/Macromolecule-editor/Sequence-Mode/sequence-mode-edit.spec.ts
@@ -46,7 +46,6 @@ import { SequenceSymbolOption } from '@tests/pages/constants/contextMenu/Constan
 import { MacromoleculesTopToolbar } from '@tests/pages/macromolecules/MacromoleculesTopToolbar';
 import { LayoutMode } from '@tests/pages/constants/macromoleculesTopToolbar/Constants';
 import { MonomerPreviewTooltip } from '@tests/pages/macromolecules/canvas/MonomerPreviewTooltip';
-import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
 
 async function hoverMouseOverMonomer(page: Page, monomer: Monomer, nth = 0) {
   await CommonLeftToolbar(page).bondTool(MacroBondTool.Single);

--- a/packages/ketcher-macromolecules/src/components/preview/components/BondPreview/BondPreview.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/BondPreview/BondPreview.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable react-hooks/preserve-manual-memoization */
 import styled from '@emotion/styled';
-import { useMemo } from 'react';
 import { useAppSelector } from 'hooks';
 import { selectShowPreview } from 'state/common';
 import ConnectionOverview from 'components/shared/ConnectionOverview/ConnectionOverview';
@@ -20,18 +18,6 @@ const BondPreview = ({ className }: Props) => {
   const preview = useAppSelector(selectShowPreview) as BondPreviewState;
 
   const { polymerBond, style } = preview;
-
-  const ContainerDynamic = useMemo(() => {
-    if (!style) {
-      return styled(Container)``;
-    }
-
-    return styled(Container)`
-      top: ${style?.top ?? ''};
-      left: ${style?.left ?? ''};
-      right: ${style?.right ?? ''};
-    `;
-  }, [style]);
 
   const {
     firstMonomer,
@@ -61,9 +47,10 @@ const BondPreview = ({ className }: Props) => {
   }
 
   return (
-    <ContainerDynamic
+    <Container
       className={className}
       data-testid="polymer-library-preview"
+      style={style}
     >
       <ConnectionOverview
         firstMonomer={firstMonomer}
@@ -97,7 +84,7 @@ const BondPreview = ({ className }: Props) => {
           />
         }
       />
-    </ContainerDynamic>
+    </Container>
   );
 };
 

--- a/packages/ketcher-macromolecules/src/components/preview/components/BondPreview/BondPreview.tsx
+++ b/packages/ketcher-macromolecules/src/components/preview/components/BondPreview/BondPreview.tsx
@@ -50,7 +50,7 @@ const BondPreview = ({ className }: Props) => {
     <Container
       className={className}
       data-testid="polymer-library-preview"
-      style={style}
+      style={{ top: style?.top, left: style?.left, right: style?.right }}
     >
       <ConnectionOverview
         firstMonomer={firstMonomer}


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Issue - [11215](https://github.com/epam/ketcher/issues/11215)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [X] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request