### PR TITLE
#11217 - Refactor: Use memo rule violation clean up from packages\ketcher-macromolecules\src\components\monomerLibrary\RnaPresetGroup\RnaPresetGroup.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable react-hooks/use-memo */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *


### PR DESCRIPTION
Closes #11217

## Context

This file's `useMemo`/`exhaustive-deps` anti-pattern (a debounced preview callback built via `useCallback(debounce(...), [...])`, i.e. handing a hook a freshly-created call expression instead of a properly memoized value) had already been fixed on `master` by #11330, which extracted the logic into `useDebouncedShowPreview()` — a hook that correctly uses `useMemo(() => debounce(...), [dispatch])` to *return* the memoized debounced function.

What was left behind, and what this PR removes, are the two now-stale directives at the top of the file:

```ts
/* eslint-disable react-hooks/exhaustive-deps */
/* eslint-disable react-hooks/use-memo */
```

`eslint` reported both as `Unused eslint-disable directive (no problems were reported ...)` since the code they were silencing no longer exists in this file.

## Change

- Removed the two unused `eslint-disable` comments from `RnaPresetGroup.tsx`. No logic changes.

## Testing

- `npx eslint packages/ketcher-macromolecules/src/components/monomerLibrary/RnaPresetGroup/RnaPresetGroup.tsx` → 0 errors/warnings (previously 2 "unused directive" warnings).
- `tsc --noEmit` for `ketcher-macromolecules` → no errors.
- Full `npm run test` for the affected workspace (prettier, stylelint, eslint, types, jest) → all passing.

## Note

There is a stale, conflicting PR (#11392, branch `11217-refactor-usememo-rna-preset-group`) opened against an older `master` before #11330 landed; its diff is now superseded/conflicting with current `master`. That PR should be closed in favor of this one.