### PR TITLE
11260 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-react\src\script\ui\views\modal\components\Text\FontControl\FontControl.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/modal/components/Text/FontControl/FontControl.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Text/FontControl/FontControl.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -15,7 +14,14 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useEffect, useMemo, useState, useRef } from 'react';
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import { useClickOutside } from '../../../../../../../hooks/useClickOutside';
 import { type LexicalEditor, $getSelection, $isRangeSelection } from 'lexical';
 import {
@@ -27,27 +33,34 @@ import classes from './FontControl.module.less';
 
 import { range } from 'lodash/fp';
 
+const DEFAULT_FONT_SIZE = '13px';
+const MIN_FONT_SIZE = 4;
+const MAX_FONT_SIZE = 144;
+const fontSizes = range(MIN_FONT_SIZE, MAX_FONT_SIZE + 1);
+
 export const FontControl = ({ editor }: { editor: LexicalEditor }) => {
-  const defaultFontSize = '13px';
   const [isShowingFontSizeMenu, setIsShowingFontSizeMenu] = useState(false);
-  const [currentFontSize, setCurrentFontSize] = useState(defaultFontSize);
+  const [currentFontSize, setCurrentFontSize] = useState(DEFAULT_FONT_SIZE);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const onClickOutsideCloseDrowndown = (): void =>
     setIsShowingFontSizeMenu(false);
 
   useClickOutside(wrapperRef, onClickOutsideCloseDrowndown);
 
-  const setFontSize = (e, value: string) => {
-    e.preventDefault();
-    setCurrentFontSize(value);
-    editor.update(() => {
-      const selection = $getSelection();
-      if ($isRangeSelection(selection)) {
-        $patchStyleText(selection, { 'font-size': value });
-      }
-    });
-    setIsShowingFontSizeMenu(false);
-  };
+  const setFontSize = useCallback(
+    (e: MouseEvent, value: string) => {
+      e.preventDefault();
+      setCurrentFontSize(value);
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          $patchStyleText(selection, { 'font-size': value });
+        }
+      });
+      setIsShowingFontSizeMenu(false);
+    },
+    [editor],
+  );
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState }) => {
@@ -57,17 +70,13 @@ export const FontControl = ({ editor }: { editor: LexicalEditor }) => {
           const fontSize = $getSelectionStyleValueForProperty(
             selection,
             'font-size',
-            defaultFontSize,
+            DEFAULT_FONT_SIZE,
           );
           setCurrentFontSize(fontSize);
         }
       });
     });
   }, [editor]);
-
-  const MIN_FONT_SIZE = 4;
-  const MAX_FONT_SIZE = 144;
-  const fontSizes = range(MIN_FONT_SIZE, MAX_FONT_SIZE + 1);
 
   const fontSizeOptions = useMemo(
     () =>
@@ -82,7 +91,7 @@ export const FontControl = ({ editor }: { editor: LexicalEditor }) => {
           {fontSize}
         </button>
       )),
-    [isShowingFontSizeMenu],
+    [setFontSize],
   );
 
   return (


### PR DESCRIPTION
…m-packagesketcher-reactsrcscriptuiviewsmodalcomponentstextfontcontrolfontcontroltsx-file

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request