### PR TITLE
#11267 Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-react\src\script\ui\component\form\MeasureInput\measure-input.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
@@ -120,6 +120,10 @@ const MeasureInput = ({
     setInternalValue(stringifiedValue);
   }
 
+  // Input binds onChange once in its constructor, so handleChange is stuck with
+  // the first render's closure and cannot call the current onChange. This effect
+  // is re-created every render, so it always holds the latest onChange/value —
+  // hence the deliberate single-dep list.
   useEffect(() => {
     if (internalValue !== stringifiedValue) {
       onChange(parseFloat(internalValue));

--- a/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
+++ b/packages/ketcher-react/src/script/ui/component/form/MeasureInput/measure-input.tsx
@@ -120,16 +120,11 @@ const MeasureInput = ({
     setInternalValue(stringifiedValue);
   }
 
-  // Input binds onChange once in its constructor, so handleChange is stuck with
-  // the first render's closure and cannot call the current onChange. This effect
-  // is re-created every render, so it always holds the latest onChange/value —
-  // hence the deliberate single-dep list.
   useEffect(() => {
     if (internalValue !== stringifiedValue) {
       onChange(parseFloat(internalValue));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [internalValue]);
+  }, [internalValue, stringifiedValue, onChange]);
 
   const handleChange = (value: unknown) => {
     const stringifiedValue = String(value);


### PR DESCRIPTION
…p from packages\ketcher-react\src\script\ui\component\form\MeasureInput\measure-input.tsx file

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request