### PR TITLE
#11222 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-react\src\script\ui\views\toolbars\RightToolbar\RightToolbar.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable react-hooks/refs */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -16,7 +15,13 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { type FC, type PropsWithChildren, type RefObject, useRef } from 'react';
+import {
+  type FC,
+  type PropsWithChildren,
+  type RefObject,
+  useRef,
+  useState,
+} from 'react';
 import {
   type ToolbarGroupItemCallProps,
   type ToolbarGroupItemProps,
@@ -57,23 +62,25 @@ const RightToolbar = (props: Props) => {
   const { ref, height } = useResizeObserver<HTMLDivElement>();
   const [startRef, startInView] = useInView({ threshold: 1 });
   const [endRef, endInView] = useInView({ threshold: 1 });
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
   const sizeRef = useRef(null) as RefObject<HTMLDivElement | null>;
-  const scrollRef = useRef(null) as RefObject<HTMLDivElement | null>;
 
   const scrollUp = () => {
-    if (!scrollRef.current || !sizeRef.current) {
+    if (!scrollElement || !sizeRef.current) {
       return;
     }
 
-    scrollRef.current.scrollTop -= sizeRef.current.offsetHeight;
+    scrollElement.scrollTop -= sizeRef.current.offsetHeight;
   };
 
   const scrollDown = () => {
-    if (!scrollRef.current || !sizeRef.current) {
+    if (!scrollElement || !sizeRef.current) {
       return;
     }
 
-    scrollRef.current.scrollTop += sizeRef.current.offsetHeight;
+    scrollElement.scrollTop += sizeRef.current.offsetHeight;
   };
 
   return (
@@ -82,7 +89,7 @@ const RightToolbar = (props: Props) => {
       className={clsx(classes.root, className)}
       ref={ref}
     >
-      <div ref={scrollRef} className={classes.buttons}>
+      <div ref={setScrollElement} className={classes.buttons}>
         <div ref={startRef}>
           <Group
             className={clsx(
@@ -131,7 +138,7 @@ const RightToolbar = (props: Props) => {
           </Group>
         </div>
       </div>
-      {height && (scrollRef?.current?.scrollHeight || 0) > height && (
+      {height && (scrollElement?.scrollHeight || 0) > height && (
         <ArrowScroll
           startInView={startInView}
           endInView={endInView}

--- a/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/RightToolbar/RightToolbar.tsx
@@ -15,13 +15,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import {
-  type FC,
-  type PropsWithChildren,
-  type RefObject,
-  useRef,
-  useState,
-} from 'react';
+import { type FC, type PropsWithChildren } from 'react';
 import {
   type ToolbarGroupItemCallProps,
   type ToolbarGroupItemProps,
@@ -33,9 +27,9 @@ import { AtomsList } from './AtomsList';
 import { basicAtoms } from '../../../action/atoms';
 import classes from './RightToolbar.module.less';
 import clsx from 'clsx';
-import { useInView } from 'react-intersection-observer';
 import { useResizeObserver } from '../../../../../hooks';
 import { HorizontalDivider } from '../TopToolbar/Divider';
+import { useVerticalToolbarScroll } from '../useVerticalToolbarScroll';
 
 const Group: FC<{ className?: string } & PropsWithChildren> = ({
   children,
@@ -60,28 +54,17 @@ const RightToolbar = (props: Props) => {
   const { className, ...rest } = props;
   const { active, onAction, freqAtoms, status } = rest;
   const { ref, height } = useResizeObserver<HTMLDivElement>();
-  const [startRef, startInView] = useInView({ threshold: 1 });
-  const [endRef, endInView] = useInView({ threshold: 1 });
-  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
-    null,
-  );
-  const sizeRef = useRef(null) as RefObject<HTMLDivElement | null>;
-
-  const scrollUp = () => {
-    if (!scrollElement || !sizeRef.current) {
-      return;
-    }
-
-    scrollElement.scrollTop -= sizeRef.current.offsetHeight;
-  };
-
-  const scrollDown = () => {
-    if (!scrollElement || !sizeRef.current) {
-      return;
-    }
-
-    scrollElement.scrollTop += sizeRef.current.offsetHeight;
-  };
+  const {
+    scrollContainerRef,
+    scrollStepRef,
+    startRef,
+    endRef,
+    startInView,
+    endInView,
+    isOverflowing,
+    scrollBack,
+    scrollForward,
+  } = useVerticalToolbarScroll();
 
   return (
     <div
@@ -89,7 +72,7 @@ const RightToolbar = (props: Props) => {
       className={clsx(classes.root, className)}
       ref={ref}
     >
-      <div ref={setScrollElement} className={classes.buttons}>
+      <div ref={scrollContainerRef} className={classes.buttons}>
         <div ref={startRef}>
           <Group
             className={clsx(
@@ -129,7 +112,7 @@ const RightToolbar = (props: Props) => {
 
         <div ref={endRef}>
           <Group className={classes.groupItem}>
-            <div ref={sizeRef}>
+            <div ref={scrollStepRef}>
               <ToolbarGroupItem id="any-atom" {...rest} />
               <div className={classes.button}>
                 <ToolbarGroupItem id="extended-table" {...rest} />
@@ -138,12 +121,12 @@ const RightToolbar = (props: Props) => {
           </Group>
         </div>
       </div>
-      {height && (scrollElement?.scrollHeight || 0) > height && (
+      {height && isOverflowing && (
         <ArrowScroll
           startInView={startInView}
           endInView={endInView}
-          scrollForward={scrollDown}
-          scrollBack={scrollUp}
+          scrollForward={scrollForward}
+          scrollBack={scrollBack}
         />
       )}
     </div>

--- a/packages/ketcher-react/src/script/ui/views/toolbars/useVerticalToolbarScroll.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/useVerticalToolbarScroll.ts
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { useResizeObserver } from '../../../../hooks';
+
+const useVerticalToolbarScroll = () => {
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [startRef, startInView] = useInView({ threshold: 1 });
+  const [endRef, endInView] = useInView({ threshold: 1 });
+  const { ref: scrollStepRef, height: scrollStep } =
+    useResizeObserver<HTMLDivElement>();
+
+  const scrollBack = () => {
+    if (!scrollElement || !scrollStep) {
+      return;
+    }
+
+    scrollElement.scrollBy({ top: -scrollStep });
+  };
+
+  const scrollForward = () => {
+    if (!scrollElement || !scrollStep) {
+      return;
+    }
+
+    scrollElement.scrollBy({ top: scrollStep });
+  };
+
+  return {
+    scrollContainerRef: setScrollElement,
+    scrollStepRef,
+    startRef,
+    endRef,
+    startInView,
+    endInView,
+    isOverflowing: !startInView || !endInView,
+    scrollBack,
+    scrollForward,
+  };
+};
+
+export { useVerticalToolbarScroll };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Replaced the scroll container ref in RightToolbar with state populated through a callback ref.

The component no longer reads ref.current during render, and the obsolete react-hooks/refs ESLint suppression has been removed. The existing toolbar scrolling behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request