### PR TITLE
#11230 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-macromolecules\src\components\monomerLibrary\MonomerLibrary.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/MonomerLibrary.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-/* eslint-disable react-hooks/refs */
-
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef } from 'react';
+import { ChangeEvent, useCallback, useEffect, useMemo } from 'react';
 import { Tabs } from 'components/shared/Tabs';
 import { tabsContent } from 'components/monomerLibrary/tabsContent';
 import { useAppDispatch, useAppSelector } from 'hooks';
@@ -50,18 +48,13 @@ type Props = {
 };
 
 const MonomerLibrary = ({ toggleLibraryVisibility }: Props) => {
-  const presetsRef = useRef<IRnaPreset[]>([]);
   const dispatch = useAppDispatch();
   const selectedTabIndex = useAppSelector(selectCurrentTabIndex);
+  const presets = useAppSelector(selectAllPresets);
 
   useEffect(() => {
     dispatch(setSearchFilter(''));
   }, [dispatch]);
-
-  useAppSelector(selectAllPresets, (presets) => {
-    presetsRef.current = presets;
-    return true;
-  });
 
   const filterResults = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -76,9 +69,7 @@ const MonomerLibrary = ({ toggleLibraryVisibility }: Props) => {
       let presetWithSameName: IRnaPreset | undefined;
 
       do {
-        presetWithSameName = presetsRef.current.find(
-          (preset) => preset.name === name,
-        );
+        presetWithSameName = presets.find((preset) => preset.name === name);
         if (presetWithSameName) name += COPY;
       } while (presetWithSameName);
 
@@ -99,7 +90,7 @@ const MonomerLibrary = ({ toggleLibraryVisibility }: Props) => {
       dispatch(setIsEditMode(true));
       scrollToSelectedPreset(preset?.name);
     },
-    [dispatch],
+    [dispatch, presets],
   );
 
   const editPreset = useCallback(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Removed the presets ref and the custom useAppSelector equality function that mutated ref.current during render.

MonomerLibrary now uses the selected presets directly, and presets is included in the duplicatePreset callback dependencies. The obsolete react-hooks/refs ESLint suppression was also removed.

The existing preset duplication behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request