### PR TITLE
#11265 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-react\src\script\ui\views\components\ContextMenu\ContextMenu.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 /****************************************************************************
  * Copyright 2022 EPAM Systems
  *
@@ -36,6 +35,69 @@ import AttachmentPointLabelMenuItems from './menuItems/AttachmentPointLabelMenuI
 const props: Partial<MenuProps> = {
   animation: false,
   className: styles.contextMenu,
+};
+
+// Takes ketcherId as an argument instead of closing over it, so it stays out of
+// the render scope and callbacks using it do not have to depend on it.
+const resetMenuPosition = (menuElement: HTMLElement, ketcherId: string) => {
+  const contextMenuElement = menuElement;
+  const ketcherRootElement = document.querySelectorAll(
+    KETCHER_ROOT_NODE_CSS_SELECTOR,
+  )[ketcherProvider.getIndexById(ketcherId)];
+
+  if (!contextMenuElement || !ketcherRootElement) {
+    return;
+  }
+
+  const contextMenuElementBoundingBox =
+    contextMenuElement.getBoundingClientRect();
+  const ketcherRootElementBoundingBox =
+    ketcherRootElement.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  if (!contextMenuElementBoundingBox || !ketcherRootElementBoundingBox) {
+    return;
+  }
+
+  let left = contextMenuElementBoundingBox.left;
+  let top = contextMenuElementBoundingBox.top;
+
+  // Ensure the menu is within the Ketcher root element
+  if (
+    contextMenuElementBoundingBox.right > ketcherRootElementBoundingBox.right
+  ) {
+    left =
+      ketcherRootElementBoundingBox.right - contextMenuElementBoundingBox.width;
+  }
+
+  if (
+    contextMenuElementBoundingBox.bottom > ketcherRootElementBoundingBox.bottom
+  ) {
+    top =
+      ketcherRootElementBoundingBox.bottom -
+      contextMenuElementBoundingBox.height;
+  }
+
+  // Ensure the menu is within the viewport
+  if (left < 0) {
+    left = 0;
+  }
+
+  if (top < 0) {
+    top = 0;
+  }
+
+  if (contextMenuElementBoundingBox.right > viewportWidth) {
+    left = viewportWidth - contextMenuElementBoundingBox.width - 10;
+  }
+
+  if (contextMenuElementBoundingBox.bottom > viewportHeight) {
+    top = viewportHeight - contextMenuElementBoundingBox.height - 10;
+  }
+
+  contextMenuElement.style.left = `${left}px`;
+  contextMenuElement.style.top = `${top}px`;
 };
 
 const ContextMenu: FC = () => {
@@ -96,69 +158,6 @@ const ContextMenu: FC = () => {
     }
   };
 
-  const resetMenuPosition = (menuElement: HTMLElement) => {
-    const contextMenuElement = menuElement;
-    const ketcherRootElement = document.querySelectorAll(
-      KETCHER_ROOT_NODE_CSS_SELECTOR,
-    )[ketcherProvider.getIndexById(ketcherId)];
-
-    if (!contextMenuElement || !ketcherRootElement) {
-      return;
-    }
-
-    const contextMenuElementBoundingBox =
-      contextMenuElement.getBoundingClientRect();
-    const ketcherRootElementBoundingBox =
-      ketcherRootElement.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-
-    if (!contextMenuElementBoundingBox || !ketcherRootElementBoundingBox) {
-      return;
-    }
-
-    let left = contextMenuElementBoundingBox.left;
-    let top = contextMenuElementBoundingBox.top;
-
-    // Ensure the menu is within the Ketcher root element
-    if (
-      contextMenuElementBoundingBox.right > ketcherRootElementBoundingBox.right
-    ) {
-      left =
-        ketcherRootElementBoundingBox.right -
-        contextMenuElementBoundingBox.width;
-    }
-
-    if (
-      contextMenuElementBoundingBox.bottom >
-      ketcherRootElementBoundingBox.bottom
-    ) {
-      top =
-        ketcherRootElementBoundingBox.bottom -
-        contextMenuElementBoundingBox.height;
-    }
-
-    // Ensure the menu is within the viewport
-    if (left < 0) {
-      left = 0;
-    }
-
-    if (top < 0) {
-      top = 0;
-    }
-
-    if (contextMenuElementBoundingBox.right > viewportWidth) {
-      left = viewportWidth - contextMenuElementBoundingBox.width - 10;
-    }
-
-    if (contextMenuElementBoundingBox.bottom > viewportHeight) {
-      top = viewportHeight - contextMenuElementBoundingBox.height - 10;
-    }
-
-    contextMenuElement.style.left = `${left}px`;
-    contextMenuElement.style.top = `${top}px`;
-  };
-
   const trackVisibility = useCallback(
     (id: string, visible: boolean) => {
       const editor = ketcherProvider.getKetcher(ketcherId).editor as Editor;
@@ -172,7 +171,7 @@ const ContextMenu: FC = () => {
         if (contextMenuElement) {
           // Timeout is needed to ensure that the context menu is rendered by react-contexify library.
           // Without timeout library overrides the position of the context menu which we set.
-          setTimeout(() => resetMenuPosition(contextMenuElement), 0);
+          setTimeout(() => resetMenuPosition(contextMenuElement, ketcherId), 0);
         }
 
         if (submenuElements.length) {


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

`trackVisibility` is memoized on `[ketcherId]` but also calls `resetMenuPosition`, which was declared in the component body and closed over `ketcherId`. Being recreated on every render made it a reactive value the callback had to list:

```
185:5  error  React Hook useCallback has a missing dependency: 'resetMenuPosition'
```

Adding it to the dependency array would have defeated the memoization — a new function identity on every render rebuilds `trackVisibility` on every render too. Instead the reactivity is removed at its root: `resetMenuPosition` is moved to module scope and takes `ketcherId` as an argument, so it is no longer reactive and the callback keeps `[ketcherId]` as its only dependency.

The function body is unchanged — verified character-identical to the original after whitespace normalization, so the move is purely mechanical.

`adjustSubmenuPosition` is deliberately left alone: it closes over nothing reactive, so the rule already treats it as static and never reported it.

The file-level `eslint-disable` for the rule is removed, since it is no longer needed.

### Verification

On ESLint 9.39.5 / eslint-plugin-react-hooks 7.1.1:
- `--print-config` confirms `exhaustive-deps` resolves to `error` for this file
- removing the suppression **before** the fix reported exactly this one violation
- the fixed file reports no problems across all rules
- narrowing the dependency array makes the rule fire again, confirming it is still enforced on the refactored file
- prettier clean; `test:types` for ketcher-react passes with 0 errors


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request