### PR TITLE
#11444 – Refactor: Update `minimatch` package to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       ],
       "dependencies": {
         "@playwright/test": "^1.62.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.6",
         "playwright": "^1.62.1",
         "playwright-core": "^1.62.1",
         "react-router": "^8.3.0",
@@ -22592,12 +22592,12 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@playwright/test": "^1.62.1",
-    "minimatch": "^10.2.4",
+    "minimatch": "^10.2.6",
     "playwright": "^1.62.1",
     "playwright-core": "^1.62.1",
     "react-router": "^8.3.0",


### PR DESCRIPTION
Closes #11444

## How the feature works? / How did you fix the issue?
Updated minimatch from 10.2.4 to 10.2.6 and refreshed package-lock.json.

## Testing
- `npm run build:packages` — passed
- `git diff --check` — passed
- `npm ls minimatch --depth=0` — resolved to `minimatch@10.2.6`
- `npm test` — unrelated existing failures in `ketcher-react` and `ketcher-macromolecules`
- `npm run test:types` — unrelated existing error in `useRecalculateMacromoleculeProperties.ts`

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request