### PR TITLE
#11279 - Refactor: react-hooks/exhaustive-deps rule violation clean up from packages\ketcher-macromolecules\src\components\ZoomControls\ZoomInput.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/ZoomControls/ZoomInput.tsx
+++ b/packages/ketcher-macromolecules/src/components/ZoomControls/ZoomInput.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
@@ -58,7 +57,7 @@ export const ZoomInput = ({
         inputEl.select();
       }
     },
-    [onZoomSubmit, inputRef, hotkeysShortcuts],
+    [onZoomSubmit, inputRef],
   );
 
   const onFocusHandler = (event: FocusEvent<HTMLInputElement>) => {

--- a/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
+++ b/packages/ketcher-react/src/script/ui/dialog/template/useSaltsAndSolvets.ts
@@ -35,8 +35,7 @@ export default function useSaltsAndSolvents(
         batchDelay,
       );
     }
-  },
-  []);
+  }, []);
 
   useEffect(() => {
     const filteredSaS =


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

The `onKeyDown` callback listed `hotkeysShortcuts`, which the rule correctly reports as an unnecessary dependency:

```
59:5  error  React Hook useCallback has an unnecessary dependency: 'hotkeysShortcuts'
```

```diff
-    [onZoomSubmit, inputRef, hotkeysShortcuts],
+    [onZoomSubmit, inputRef],
```

`hotkeysShortcuts` is a module-level `const` in `components/ZoomControls/helpers`, computed once at import and only ever property-read (6 files, never reassigned). Its identity cannot change and it cannot trigger a re-render, so removing it is a no-op at runtime — the callback keeps exactly the same memoization behaviour, driven by `onZoomSubmit` and `inputRef`.

The file-level `eslint-disable` for `exhaustive-deps` is removed.

**The second suppression is deliberately kept.** `react-you-might-not-need-an-effect/no-event-handler` has been enabled as an error since #11420, and with both headers removed it still reports a real violation at line 70. Clearing it means moving the input handling up to the parent component, which is outside the scope of this task.

### Verification

On ESLint 10.9.0 / eslint-plugin-react-hooks 7.1.1 / Prettier 3.9.6:
- `--print-config` confirms `exhaustive-deps` resolves to `error` for this file
- removing the suppression **before** the fix reported exactly this violation
- the fixed file reports no problems across all rules
- restoring the dependency makes the rule fire again, confirming it's still enforced
- prettier clean; ketcher-macromolecules jest: 35 suites / 155 tests pass


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request