### PR TITLE
chore: add js-yaml as a dependency in package.json and package-lock.json

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.2",
+    "js-yaml": "^5.4.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-workspaces": "^0.7.0",
         "glob": "^13.0.6",
         "husky": "^8.0.3",
+        "js-yaml": "^5.4.0",
         "lint-staged": "^16.1.0",
         "npm-run-all2": "^9.0.3",
         "postcss": "^8.5.23",
@@ -227,6 +228,7 @@
         "eslint": "10.9.0",
         "git-revision-webpack-plugin": "^3.0.6",
         "html-replace-webpack-plugin": "^2.5.6",
+        "js-yaml": "^5.4.0",
         "less": "^4.2.0",
         "npm-run-all2": "^9.0.3",
         "prettier": "^3.9.6",
@@ -398,13 +400,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "example/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "example/node_modules/chalk": {
       "version": "4.1.2",
@@ -4137,11 +4132,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -9888,11 +9905,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -20896,16 +20912,26 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.0.tgz",
+      "integrity": "sha512-jE7vUJIebKzYQI5xu4co5CRBDlDEYnHrdzsxs4O2giCz4v2SbVMYKpmt1D9L38OKQAeCWmrOTRiCV93u0UkaJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {
@@ -26038,12 +26064,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/react-scripts/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
     "node_modules/react-scripts/node_modules/babel-jest": {
       "version": "27.5.1",
       "license": "MIT",
@@ -29206,6 +29226,8 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/stable": {
@@ -29935,6 +29957,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/svgo/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/svgo/node_modules/css-select": {
       "version": "2.1.0",
       "license": "BSD-2-Clause",
@@ -29974,6 +30005,19 @@
     "node_modules/svgo/node_modules/domutils/node_modules/domelementtype": {
       "version": "1.3.1",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/svgo/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/svgpath": {
       "version": "2.6.0",
@@ -31843,13 +31887,6 @@
       "version": "1.0.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vite-plugin-svgr/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/vite-plugin-svgr/node_modules/cosmiconfig": {
       "version": "8.3.6",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "js-yaml": "^5.4.0",
     "@typescript-eslint/eslint-plugin": "^8.66.0",
     "@typescript-eslint/parser": "^8.66.0",
     "color-alpha": "^1.1.3",


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)

Problem: js-yaml was only a transitive dependency (no workspace declared it directly), and overrides were not allowed.

Root cause: Two different old versions were installed across workspaces:
- node_modules/js-yaml@3.15.0 — pulled in by @istanbuljs/load-nyc-config (jest) and svgo
- example/node_modules/js-yaml@4.3.1 — pulled in by react-scripts's embedded eslint@8.x

Without overrides, the only way to bump a transitive dependency is to add it as a direct dependency. Added "js-yaml": "^5.4.0" to devDependencies in:
- package.json (root) → forces node_modules/js-yaml to 5.4.0
- example/package.json → forces example workspace's resolution to 5.4.0 (satisfied by the root's hoisted copy)

Why old nested copies remain: Packages that declare "js-yaml": "^3.13.1" or "^4.1.0" are incompatible with 5.x (major version boundary). npm installs nested copies for them:
- node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml@3.15.1
- node_modules/svgo/node_modules/js-yaml@3.15.1
- example/node_modules/js-yaml@4.3.1 (for react-scripts's eslint 8.x)

These cannot be updated without overrides or upgrading the packages that depend on them.



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request