### PR TITLE
Add ticket-handling skills and agents

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: code-review
+description: "Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes: Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/spec asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to \"review since X\"."
+---
+
+Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+- **Standards**: does the code conform to this repo's documented coding standards?
+- **Spec**: does the code faithfully implement the originating issue / spec?
+
+Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+The issue tracker should have been provided to you. If `docs/agents/issue-tracker.md` is missing, tell the user to run `/setup-matt-pocock-skills`.
+
+## Process
+
+### 1. Pin the fixed point
+
+Whatever the user said is the fixed point (a commit SHA, branch name, tag, `main`, `HEAD~5`, etc.). If they didn't specify one, ask for it.
+
+Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here, not inside two parallel sub-agents.
+
+### 2. Identify the spec source
+
+Look for the originating spec, in this order:
+
+1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.), fetched via the workflow in `docs/agents/issue-tracker.md`.
+2. A path the user passed as an argument.
+3. A spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
+
+### 3. Identify the standards sources
+
+Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+On top of whatever the repo documents, the Standards axis always carries the **smell baseline** below: a fixed set of Fowler code smells (_Refactoring_, ch.3) that applies even when a repo documents nothing. Two rules bind it:
+
+- **The repo overrides.** A documented repo standard always wins; where it endorses something the baseline would flag, suppress the smell.
+- **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation. Like any standard here, skip anything tooling already enforces.
+
+Each smell reads *what it is* → *how to fix*; match it against the diff:
+
+- **Mysterious Name**: a function, variable, or type whose name doesn't reveal what it does or holds. → rename it; if no honest name comes, the design's murky.
+- **Duplicated Code**: the same logic shape appears in more than one hunk or file in the change. → extract the shared shape, call it from both.
+- **Feature Envy**: a method that reaches into another object's data more than its own. → move the method onto the data it envies.
+- **Data Clumps**: the same few fields or params keep travelling together (a type wanting to be born). → bundle them into one type, pass that.
+- **Primitive Obsession**: a primitive or string standing in for a domain concept that deserves its own type. → give the concept its own small type.
+- **Repeated Switches**: the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, or one map both sites share.
+- **Shotgun Surgery**: one logical change forces scattered edits across many files in the diff. → gather what changes together into one module.
+- **Divergent Change**: one file or module is edited for several unrelated reasons. → split so each module changes for one reason.
+- **Speculative Generality**: abstraction, parameters, or hooks added for needs the spec doesn't have. → delete it; inline back until a real need shows.
+- **Message Chains**: long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+- **Middle Man**: a class or function that mostly just delegates onward. → cut it, call the real target direct.
+- **Refused Bequest**: a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
+
+### 4. Spawn both sub-agents in parallel
+
+**Standards sub-agent prompt** should include:
+
+- The full diff command and commit list.
+- The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full (the sub-agent has no other access to it).
+- The brief: "Report, per file/hunk where relevant, (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls: documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words."
+
+**Spec sub-agent prompt** should include:
+
+- The diff command and commit list.
+- The path or fetched contents of the spec.
+- The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+
+If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+### 5. Aggregate
+
+Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings, because the two axes are deliberately separate (see _Why two axes_).
+
+End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes: that's the reranking the separation exists to prevent.
+
+## Why two axes
+
+A change can pass one axis and fail the other:
+
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+Reporting them separately stops one axis from masking the other.

--- a/.agents/skills/code-review/agents/openai.yaml
+++ b/.agents/skills/code-review/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Code Review"
+  short_description: "Review a diff on standards and spec"

--- a/.agents/skills/implement-spec/SKILL.md
+++ b/.agents/skills/implement-spec/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: implement-spec
+description: "Implement a specification in code."
+disable-model-invocation: true
+---
+
+You have been provided a spec. This spec should have tickets associated with it, describing how to implement the spec.
+
+The goal is a PR which implements the entire spec on a single branch.
+
+The tickets are not a list of steps. They are a **task graph** with blocking relationships between them. This means there is always a **frontier** of tickets which are ready to be grabbed.
+
+Communication to and from subagents should be sparse. Communicate primarily through **context pointers**: to the spec, tickets, research notes, and previous commits. Don't duplicate information already available via pointers.
+
+**Implementer subagents** should be run in the background where possible for **maximum concurrency**.
+
+## Steps
+
+1. Read the spec and tickets. Read enough to understand the task graph.
+
+2. (optional) Use an **exploration subagent** to conduct any exploration required by the tickets - relevant codebase files or external documentation. Ensure the exploration subagent can save files - it should save its markdown notes in a directory outside the repo, accessible by all future subagents. This lets **implementer subagents** focus on implementation rather than exploration.
+
+3. Create a branch, and a draft PR. The PR should be marked as 'closing' the spec issue and tickets.
+
+4. Use **implementer subagents** to implement each ticket. Each implementer subagent should work in its own worktree, on its own branch.
+
+5. Once an **implementer subagent** completes, merge its work to the PR branch with a **merger subagent**.
+
+6. If this changes the **frontier** of available tickets, kick off more **implementer subagents** to work on the new tickets. This allows for maximum concurrency.
+
+7. Once all tickets are complete, run /code-review on the PR branch. Fix all issues raised by the code review in a single **implementer subagent**.
+
+8. Mark the PR as ready for review.
+
+9. Clean up all **implementer subagent** worktrees.

--- a/.agents/skills/implement-spec/agents/openai.yaml
+++ b/.agents/skills/implement-spec/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Implement Spec"
+  short_description: "Implement a whole spec as one PR"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: implement
+description: "Implement a piece of work based on a spec or set of tickets."
+disable-model-invocation: true
+---
+
+Implement the work described by the user in the spec or tickets.
+
+Use /tdd where possible, at pre-agreed seams.
+
+Run typechecking regularly, single test files regularly, and the full test suite once at the end.
+
+Once done, use /code-review to review the work.
+
+Commit your work to the current branch.

--- a/.agents/skills/implement/agents/openai.yaml
+++ b/.agents/skills/implement/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Implement"
+  short_description: "Build work from a spec or tickets"
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tdd
+description: Test-driven development. Use when the user wants to build features or fix bugs test-first, mentions "red-green-refactor", or wants integration tests.
+---
+
+# Test-Driven Development
+
+TDD is the red → green loop. This skill is the reference that makes that loop produce tests worth keeping: what a good test is, where tests go, the anti-patterns, and the rules of the loop. Every section applies on every cycle: consult them before and during the loop, not after.
+
+When exploring the codebase, read `CONTEXT.md` (if it exists) so test names and interface vocabulary match the project's domain language, and respect ADRs in the area you're touching.
+
+## What a good test is
+
+Tests verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't. A good test reads like a specification: "user can checkout with valid cart" tells you exactly what capability exists, and it survives refactors because it doesn't care about internal structure.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Seams: where tests go
+
+A **seam** is the public boundary you test at: the interface where you observe behavior without reaching inside. Tests live at seams, never against internals.
+
+**Test only at pre-agreed seams.** Before writing any test, write down the seams under test and confirm them with the user. No test is written at an unconfirmed seam. You can't test everything, so agreeing the seams up front is how testing effort lands on the critical paths and complex logic instead of every edge case.
+
+Ask: "What's the public interface, and which seams should we test?"
+
+When the shape of that interface is itself in question (how deep the module is, where the seam belongs, what the interface should expose), call the Skill tool with "codebase-design" for the vocabulary. It is the shared source of the module, interface, depth, seam, adapter, leverage and locality terms, and it is a reference to consult, not a session to run.
+
+## Anti-patterns
+
+- **Implementation-coupled**: mocks internal collaborators, tests private methods, or verifies through a side channel (querying the database instead of using the interface). The tell: the test breaks when you refactor but behavior hasn't changed.
+- **Tautological**: the assertion recomputes the expected value the way the code does (`expect(add(a, b)).toBe(a + b)`, a snapshot derived by hand the same way, a constant asserted equal to itself), so it passes by construction and can never disagree with the code. Expected values must come from an independent source of truth: a known-good literal, a worked example, the spec.
+- **Horizontal slicing**: writing all tests first, then all implementation. Bulk tests verify _imagined_ behavior: you test the _shape_ of things rather than user-facing behavior, the tests go insensitive to real changes, and you commit to test structure before understanding the implementation. Work in **vertical slices** instead: one test → one implementation → repeat, each test a **tracer bullet** that responds to what the last cycle taught you.
+
+## Rules of the loop
+
+- **Red before green.** Write the failing test first, then only enough code to pass it. Don't anticipate future tests or add speculative features.
+- **One slice at a time.** One seam, one test, one minimal implementation per cycle.
+- **Refactoring is not part of the loop.** It belongs to the review stage (see the `code-review` skill), not the red → green implementation cycle.

--- a/.agents/skills/tdd/agents/openai.yaml
+++ b/.agents/skills/tdd/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "TDD"
+  short_description: "Test-driven red-green-refactor"

--- a/.agents/skills/tdd/mocking.md
+++ b/.agents/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.agents/skills/tdd/tests.md
+++ b/.agents/skills/tdd/tests.md
@@ -1,0 +1,77 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+
+**Tautological tests**: Expected value restates the implementation, so the test passes by construction.
+
+```typescript
+// BAD: Expected value is recomputed the way the code computes it
+test("calculateTotal sums line items", () => {
+  const items = [{ price: 10 }, { price: 5 }];
+  const expected = items.reduce((sum, i) => sum + i.price, 0);
+  expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: Expected value is an independent, known literal
+test("calculateTotal sums line items", () => {
+  expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```

--- a/.claude/agents/ticket-implementer.md
+++ b/.claude/agents/ticket-implementer.md
@@ -1,0 +1,44 @@
+---
+name: ticket-implementer
+description: Deliver one unit of tickets — a single issue, or issues that meet in one diff — as one opened PR. Use for each unit of a ticket batch, one agent per unit.
+tools: Bash, Read, Write, Edit, Glob, Grep, Skill, TodoWrite
+model: inherit
+---
+
+# Ticket implementer
+
+You are given a **unit**: one issue number, or several that meet in one diff. You return one opened PR URL. Your spawn message carries the unit's issue numbers, the base branch, the notes path when exploration produced one, and any issue number this PR supersedes.
+
+You run unattended in an isolated worktree. Nothing you write is read until the PR is reviewed, so every finding, bypass, and open question rides in the PR body.
+
+## 1. Read the source
+
+Run `gh issue view <n>` for each of your issue numbers and work from what it returns — reading the issue beats any summary relayed to you. Read the notes file first when a path was given: it carries the shape this fix follows, and the issue text is not repeated there.
+
+Branch off the base branch you were given.
+
+**Done when:** you can state, per issue, the file(s) it names and the fix its body prescribes.
+
+## 2. Implement
+
+Read `.agents/skills/implement/SKILL.md` and follow it end to end, its review step included.
+
+Two discrepancies come up often, and both are yours to settle:
+
+- **The problem sits somewhere else than the issue says** — fix it where it actually is, and note the discrepancy in the PR body.
+- **The problem is already gone** — keep the PR to what remains of the unit and say so. A unit with nothing left produces no PR; report that instead.
+
+**Done when:** the implement skill's own bar is met and its review has run.
+
+## 3. Open the PR
+
+Act on every review finding you can before opening. The PR body carries the rest:
+
+- `Closes #N` for each issue in the unit, plus `Supersedes #N` when your spawn message named one.
+- **Open findings** — every review finding you did not act on.
+- **Bypassed checks** — every hook or check you bypassed, and why. A bypass travels with the diff so the reviewer sees it.
+- **Open questions** — a decision you could not settle alone. A PR carrying one is a draft (`gh pr create --draft`).
+
+Use `--body` or `--body-file` on `gh pr create` so nothing waits on an editor.
+
+**Done when:** you have returned the PR URL, or a named reason this unit produced none.

--- a/.claude/agents/ticket-sweep.md
+++ b/.claude/agents/ticket-sweep.md
@@ -1,0 +1,47 @@
+---
+name: ticket-sweep
+description: Run an unattended ticket sweep — cluster the repo's open tickets and deliver one cluster as opened PRs. Use when a schedule, cron job, or hook starts the run, or when a sweep is asked for with nobody watching it.
+tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Agent, TodoWrite
+model: inherit
+---
+
+# Ticket sweep
+
+One run of the pipeline: cluster the repo's open tickets, deliver the top cluster as opened PRs, report the URLs.
+
+Nobody is watching. The report at the end and the PR bodies are the only things a human ever reads, so anything that would have been a question becomes text in one of them.
+
+## 1. Preflight
+
+Confirm the run can finish before it starts anything: `gh auth status` succeeds, `gh repo view` resolves the repo, and the working tree is clean (`git status --porcelain` empty).
+
+Any of these failing ends the run at stage 3 with that command's output as the reason — no repair attempts, no workarounds.
+
+**Done when:** all three checks have passed, or one has failed and you are writing the report.
+
+## 2. Sweep
+
+Call the Skill tool with `find-ticket-clusters`, no arguments — the current repo and the `refactor` label are the defaults.
+
+This run is **schedule-started**: that skill's stage 3 takes the top-ranked cluster on its own, and its stage 4 hands off to `handle-tickets`, which delivers. Let both run end to end rather than re-deciding anything they decide.
+
+**Done when:** every unit `handle-tickets` delegated has an open PR URL or a named reason it produced none — or no cluster existed, and you have that sentence.
+
+## 3. Report
+
+Print, in this order:
+
+- **Repo and filter** — repo, label or view, base branch.
+- **Cluster** — the fix shape taken, and its issue numbers.
+- **PRs** — one line per unit: issue numbers → PR URL, marked `draft` where it is one.
+- **Skipped** — every unit with no PR, and the named reason.
+- **Left for tomorrow** — the clusters ranked below the one taken, by name and ticket count.
+
+**Done when:** all five sections are printed, each one either populated or explicitly empty.
+
+## Unattended run
+
+- **Decide, then park.** Every choice in the run is yours to make. A choice you genuinely cannot make travels as text: into the PR body via `handle-tickets` (which makes that PR a draft), or into the report's **Skipped** section when there is no PR to carry it.
+- **Every command returns on its own.** Run git and `gh` in non-interactive form — `--no-edit`, `--yes`, `GIT_EDITOR=true`, `--fill` or an explicit `--body` on `gh pr create`. A command that would open an editor or wait on a keypress is the one way this run hangs forever.
+- **One cluster per run.** The rest keep until the next sweep; a run that reaches for a second cluster lands more PRs than a human reviews in a day.
+- **Failure is a section, not a stop.** A unit that fails to deliver appears under **Skipped** with its reason while the other units finish. Only stage 1's preflight ends the whole run early.

--- a/.claude/skills/code-review
+++ b/.claude/skills/code-review
@@ -1,0 +1,1 @@
+../../.agents/skills/code-review

--- a/.claude/skills/find-ticket-clusters/SKILL.md
+++ b/.claude/skills/find-ticket-clusters/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: find-ticket-clusters
+description: 'Cluster a repo''s open tickets into batches one fix shape resolves, then hand a cluster to handle-tickets. Use when checking for work worth batching, on a scheduled sweep for refactor and lint tickets, or against a named label or tracker view.'
+argument-hint: '[tracker view | label] [repo]'
+---
+
+# Find ticket clusters
+
+Finds the **clusters** among a repo's open tickets — sets of tickets that one fix shape resolves, in several places — and hands one to `handle-tickets`.
+
+This skill reads; `handle-tickets` writes. Assignment, board moves, branches, and PRs all belong to `handle-tickets`.
+
+## 1. Read the tickets
+
+The current repository is the scope. Resolve it with `gh repo view` and search there; widen to an org-level tracker view only when an argument names one.
+
+The `refactor` label is the default filter. An argument naming a label or a tracker view replaces it — say which filter you applied either way.
+
+Send one **search sub-agent** to do the reading. It pulls every open, unassigned item in scope (`gh issue list --label <label>`, or `gh project item-list <number> --owner <org>` for a named view), opens each body, and returns one compact line per ticket: number, title, and the fix that body prescribes. The bodies stay in its context; only the lines come back — the fix a ticket prescribes lives in its body, and the title carries only the symptom.
+
+**Done when:** every open item in scope appears in your working list with its number, its title, and the fix its body prescribes.
+
+## 2. Cluster
+
+A **cluster** is two or more tickets that one fix shape resolves. Group stage 1's list by fix shape, reading for:
+
+- the same lint rule or check name quoted in the body
+- the same named anti-pattern or code smell
+- the same remedy sentence, repeated against a different path
+- the same package or subsystem
+
+A ticket whose fix shape no other ticket shares goes to `unclustered`, and stays there.
+
+**Done when:** every ticket from stage 1 sits in exactly one cluster or in `unclustered`, and each cluster is named by the fix shape its members share.
+
+## 3. Choose
+
+Rank clusters by how uniformly their members quote the same remedy — the most uniform cluster is the one a single sub-agent brief covers without per-ticket special-casing. Then, by how this run started:
+
+- **A human started it** — present the clusters (fix shape, ticket count, files touched) and ask which to take.
+- **A schedule started it** — take the top-ranked cluster, one per run. One cluster a day lands a reviewable number of PRs; the rest keep until tomorrow's sweep.
+
+**Done when:** exactly one cluster is chosen, or the column held no cluster at all — say so and stop.
+
+## 4. Hand off
+
+Call the Skill tool with `handle-tickets`, passing the chosen cluster's issue numbers and repo. Its stage 1 still runs — it resolves the base branch too — but the cluster *is* the resolved batch, so the open/unassigned filter needs no re-running.
+
+**Done when:** `handle-tickets` has been called with the cluster's issue numbers and repo.

--- a/.claude/skills/handle-tickets/SKILL.md
+++ b/.claude/skills/handle-tickets/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: handle-tickets
+description: 'Deliver a batch of tickets as opened PRs. Use when given a single issue to work, a cluster confirmed for delivery, a label, or a tracker view.'
+argument-hint: '[tracker view | label | issue numbers] [repo]'
+---
+
+# Handle tickets
+
+Turns a **batch** of tickets — one, or a cluster that shares a fix shape — into opened PRs. Those PRs are the whole output: every finding, bypass, and open question rides in a PR body, so an unattended run leaves nothing behind that needed a human watching it.
+
+**One ticket, one sub-agent, one PR** — unless tickets share a file, and then those tickets are one sub-agent and one PR together. Stage 3 settles which; nothing later revisits it. Every stage runs without asking — a decision that genuinely blocks becomes a draft PR carrying the question, so the run still ends in something reviewable.
+
+Each stage carries its own completion bar — advance once the bar is met for every ticket in the batch.
+
+## 1. Scope
+
+Resolve the batch to a concrete, numbered issue list, one repo, one base branch (default `master`). The current repository is the scope — resolve it with `gh repo view` and work there; use another repo only when an argument names one. The argument is either explicit issue numbers, a label, or a tracker view (`org/project number`) — resolve a label or view via `gh issue list` / `gh project item-list` and filter to open, unassigned-to-someone-else items. Issue numbers arriving pre-filtered (e.g. from `find-ticket-clusters`) satisfy this trivially — no need to re-run the open/unassigned filter.
+
+**Done when:** you can print a table of issue number → title, for every issue in the batch.
+
+## 2. Claim
+
+For every issue in the batch: assign it to `@me`, and move its tracker item to **In progress**. Look up the tracker's Status field id and option id with `gh project field-list` each run — they change per board.
+
+**Done when:** `gh issue view <n>` shows you as assignee, and the tracker item's Status reads "In progress", for every issue.
+
+## 3. Partition
+
+One ticket is one **unit** by default. Tickets naming the same file are one unit together, as are tickets whose files must change together — they meet in one diff, so one agent writes it and one PR carries it.
+
+The paths live in the issue bodies — a "Problem locations" field or equivalent. Send one **search sub-agent** to fetch them: it reads every issue in the batch and returns one line per ticket, number → the path(s) that ticket names. The bodies stay in its context; grouping needs only the paths.
+
+**Done when:** every ticket in the batch belongs to exactly one unit, and no file appears in two units.
+
+## 4. Dedupe
+
+Before delegating a unit, search for a PR that already targets its issue number(s) (`gh pr list --search "<issue> in:body"`, plus a search by branch-name pattern in case the body search misses it). A hit against the *current* base branch is a duplicate — reuse it, skip delegation for that unit. A hit whose diff no longer applies (opened before a since-merged fix landed) is stale — delegate anyway, and carry the old PR's number into stage 6 so the new PR names what it supersedes. Closing the old one belongs to the human.
+
+**Done when:** every unit carries one verdict — `new`, `reuse`, or `supersede` — before you spawn anything.
+
+## 5. Explore
+
+Exploration buys two different things. Across a cluster, the units share one fix shape, so the discovery is shared — run it once here rather than N times inside stage 6. On a single unit, it buys context isolation: the explorer spends the search tokens, and the implementer opens with notes instead of a cold codebase.
+
+Judge whether the shape is already settled by the issue bodies. A lint rule quoting its own remedy needs nothing. A shape that turns on a codebase convention, a rule's edge cases, or a util the fix should reuse needs one **exploration sub-agent**: it reads the issue bodies and the files the units name, then writes markdown notes to a directory outside the repo that every stage 6 agent can read.
+
+Notes carry what the issue bodies leave out — the convention to follow, the existing helper to reuse, the edge case that changes the fix. The issue text is already going to each agent verbatim, so notes that restate it cost tokens and add nothing.
+
+**Done when:** either you have recorded that the shape needs no exploration, or a notes file exists at a path you can hand to stage 6.
+
+## 6. Deliver
+
+Every `new`/`supersede` unit goes to its own **`ticket-implementer`** sub-agent (`isolation: "worktree"`), a lone unit included; launch them in a single message so they run in parallel. That agent definition carries the brief — how to work the unit and what the PR body must hold. Your spawn message carries only what is unit-specific:
+
+- the unit's issue numbers
+- the base branch to branch off and target
+- the stage 5 notes path, when there is one
+- the issue number this PR supersedes, when stage 4 named one
+
+**Done when:** every `new`/`supersede` unit has an open PR URL, or a named reason it produced none. That list of URLs is the run's output.

--- a/.claude/skills/implement
+++ b/.claude/skills/implement
@@ -1,0 +1,1 @@
+../../.agents/skills/implement

--- a/.claude/skills/implement-spec
+++ b/.claude/skills/implement-spec
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-spec

--- a/.claude/skills/tdd
+++ b/.claude/skills/tdd
@@ -1,0 +1,1 @@
+../../.agents/skills/tdd

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "implement-spec": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/implement-spec/SKILL.md",
+      "computedHash": "91670f6f5239fc64da91c2b2f6ada62a27d2f0e8e18215fefe53feeea7a43801"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ticket-implementer` and `ticket-sweep` agents for delivering ticket batches as PRs
- Add `code-review`, `find-ticket-clusters`, `handle-tickets`, `implement`, `implement-spec`, and `tdd` skills
- Add `skills-lock.json` tracking the external source of the `implement-spec` skill

## Test plan
- [ ] N/A — tooling/config only, no product code changed