### PR TITLE
rollup-plugin-terser package was replaced with latest version of @rol…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
+docs
 # dependencies
 node_modules
 .pnp

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       ],
       "dependencies": {
         "@playwright/test": "^1.62.1",
+        "@rollup/plugin-terser": "^1.0.0",
         "minimatch": "^10.2.6",
         "playwright": "^1.62.1",
         "playwright-core": "^1.62.1",
@@ -7129,6 +7130,37 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -20613,35 +20645,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "26.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jiti": {
       "version": "1.21.0",
       "license": "MIT",
@@ -27916,26 +27919,6 @@
         "rollup-pluginutils": "^2.4.1"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/rollup-plugin-tsconfig-paths": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-tsconfig-paths/-/rollup-plugin-tsconfig-paths-1.5.2.tgz",
@@ -28788,6 +28771,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smob": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/snake-case": {
@@ -32283,7 +32275,6 @@
         "lodash": "^4.17.20",
         "pretty-bytes": "^5.3.0",
         "rollup": "^2.43.1",
-        "rollup-plugin-terser": "^7.0.0",
         "source-map": "^0.8.0-beta.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "dependencies": {
     "@playwright/test": "^1.62.1",
+    "@rollup/plugin-terser": "^1.0.0",
     "minimatch": "^10.2.6",
     "playwright": "^1.62.1",
     "playwright-core": "^1.62.1",


### PR DESCRIPTION
…lup/plugin-terser

we have manually removed  rollup-plugin-terser from package-lock.json and package.json 
<img width="448" height="51" alt="image" src="https://github.com/user-attachments/assets/33c96360-fd85-48b9-8166-bff5dc23989c" />

Than we have installed latest version of @rollup/plugin-terser
<img width="446" height="53" alt="image" src="https://github.com/user-attachments/assets/9a5ddc0e-ba51-4f13-a04d-c3788b32b318" />



## Check list
- [✓] unit-tests written
- [✓] e2e-tests written
- [✓] documentation updated
- [✓] PR name follows the pattern `#1234 – issue name`
- [✓] branch name doesn't contain '#'
- [✓] PR is linked with the issue
- [✓] base branch (master or release/xx) is correct
- [✓] task status changed to "Code review"
- [✓] reviewers are notified about the pull request