### PR TITLE
#11224 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-react\src\script\ui\views\toolbars\LeftToolbar\LeftToolbar.tsx file

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-/* eslint-disable react-hooks/refs */
-
-import { type RefObject, useRef } from 'react';
+import { type RefObject, useRef, useState } from 'react';
 import { CREATE_MONOMER_TOOL_NAME, IMAGE_KEY } from 'ketcher-core';
 import {
   type ToolbarGroupItemCallProps,
@@ -119,25 +117,27 @@ const Group = ({ items, className, height, rest }: GroupProps) => {
 const LeftToolbar = (props: Props) => {
   const { className, ...rest } = props;
   const { ref, height } = useResizeObserver<HTMLDivElement>();
-  const scrollRef = useRef(null) as RefObject<HTMLDivElement | null>;
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
   const [startRef, startInView] = useInView({ threshold: 1 });
   const [endRef, endInView] = useInView({ threshold: 1 });
   const sizeRef = useRef(null) as RefObject<HTMLDivElement | null>;
 
   const scrollUp = () => {
-    if (!scrollRef.current || !sizeRef.current) {
+    if (!scrollElement || !sizeRef.current) {
       return;
     }
 
-    scrollRef.current.scrollTop -= sizeRef.current.offsetHeight;
+    scrollElement.scrollTop -= sizeRef.current.offsetHeight;
   };
 
   const scrollDown = () => {
-    if (!scrollRef.current || !sizeRef.current) {
+    if (!scrollElement || !sizeRef.current) {
       return;
     }
 
-    scrollRef.current.scrollTop += sizeRef.current.offsetHeight;
+    scrollElement.scrollTop += sizeRef.current.offsetHeight;
   };
 
   return (
@@ -148,7 +148,7 @@ const LeftToolbar = (props: Props) => {
     >
       <div
         className={classes.buttons}
-        ref={scrollRef}
+        ref={setScrollElement}
         data-testid="left-toolbar-buttons"
       >
         <div className={classes.listener} ref={startRef}>
@@ -224,7 +224,7 @@ const LeftToolbar = (props: Props) => {
           />
         </div>
       </div>
-      {height && (scrollRef?.current?.scrollHeight || 0) > height && (
+      {height && (scrollElement?.scrollHeight || 0) > height && (
         <ArrowScroll
           startInView={startInView}
           endInView={endInView}

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useState } from 'react';
 import { CREATE_MONOMER_TOOL_NAME, IMAGE_KEY } from 'ketcher-core';
 import {
   type ToolbarGroupItemCallProps,
@@ -40,8 +39,8 @@ import { RGroup } from './RGroup';
 import { Shape } from './Shape';
 import classes from './LeftToolbar.module.less';
 import clsx from 'clsx';
-import { useInView } from 'react-intersection-observer';
 import { useResizeObserver } from '../../../../../hooks';
+import { useVerticalToolbarScroll } from '../useVerticalToolbarScroll';
 
 interface LeftToolbarProps extends Omit<
   ToolbarGroupItemProps,
@@ -117,29 +116,17 @@ const Group = ({ items, className, height, rest }: GroupProps) => {
 const LeftToolbar = (props: Props) => {
   const { className, ...rest } = props;
   const { ref, height } = useResizeObserver<HTMLDivElement>();
-  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
-    null,
-  );
-  const [startRef, startInView] = useInView({ threshold: 1 });
-  const [endRef, endInView] = useInView({ threshold: 1 });
-  const { ref: sizeRef, height: scrollStep } =
-    useResizeObserver<HTMLDivElement>();
-
-  const scrollUp = () => {
-    if (!scrollElement || !scrollStep) {
-      return;
-    }
-
-    scrollElement.scrollBy({ top: -scrollStep });
-  };
-
-  const scrollDown = () => {
-    if (!scrollElement || !scrollStep) {
-      return;
-    }
-
-    scrollElement.scrollBy({ top: scrollStep });
-  };
+  const {
+    scrollContainerRef,
+    scrollStepRef,
+    startRef,
+    endRef,
+    startInView,
+    endInView,
+    isOverflowing,
+    scrollBack,
+    scrollForward,
+  } = useVerticalToolbarScroll();
 
   return (
     <div
@@ -149,7 +136,7 @@ const LeftToolbar = (props: Props) => {
     >
       <div
         className={classes.buttons}
-        ref={setScrollElement}
+        ref={scrollContainerRef}
         data-testid="left-toolbar-buttons"
       >
         <div className={classes.listener} ref={startRef}>
@@ -185,7 +172,7 @@ const LeftToolbar = (props: Props) => {
           height={height}
           rest={rest}
         />
-        <div className={classes.listener} ref={sizeRef}>
+        <div className={classes.listener} ref={scrollStepRef}>
           <Group
             className={classes.groupItem}
             items={[
@@ -225,12 +212,12 @@ const LeftToolbar = (props: Props) => {
           />
         </div>
       </div>
-      {height && (!startInView || !endInView) && (
+      {height && isOverflowing && (
         <ArrowScroll
           startInView={startInView}
           endInView={endInView}
-          scrollForward={scrollDown}
-          scrollBack={scrollUp}
+          scrollForward={scrollForward}
+          scrollBack={scrollBack}
         />
       )}
     </div>

--- a/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/LeftToolbar/LeftToolbar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { type RefObject, useRef, useState } from 'react';
+import { useState } from 'react';
 import { CREATE_MONOMER_TOOL_NAME, IMAGE_KEY } from 'ketcher-core';
 import {
   type ToolbarGroupItemCallProps,
@@ -122,22 +122,23 @@ const LeftToolbar = (props: Props) => {
   );
   const [startRef, startInView] = useInView({ threshold: 1 });
   const [endRef, endInView] = useInView({ threshold: 1 });
-  const sizeRef = useRef(null) as RefObject<HTMLDivElement | null>;
+  const { ref: sizeRef, height: scrollStep } =
+    useResizeObserver<HTMLDivElement>();
 
   const scrollUp = () => {
-    if (!scrollElement || !sizeRef.current) {
+    if (!scrollElement || !scrollStep) {
       return;
     }
 
-    scrollElement.scrollTop -= sizeRef.current.offsetHeight;
+    scrollElement.scrollBy({ top: -scrollStep });
   };
 
   const scrollDown = () => {
-    if (!scrollElement || !sizeRef.current) {
+    if (!scrollElement || !scrollStep) {
       return;
     }
 
-    scrollElement.scrollTop += sizeRef.current.offsetHeight;
+    scrollElement.scrollBy({ top: scrollStep });
   };
 
   return (
@@ -224,7 +225,7 @@ const LeftToolbar = (props: Props) => {
           />
         </div>
       </div>
-      {height && (scrollElement?.scrollHeight || 0) > height && (
+      {height && (!startInView || !endInView) && (
         <ArrowScroll
           startInView={startInView}
           endInView={endInView}

--- a/packages/ketcher-react/src/script/ui/views/toolbars/useVerticalToolbarScroll.ts
+++ b/packages/ketcher-react/src/script/ui/views/toolbars/useVerticalToolbarScroll.ts
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { useResizeObserver } from '../../../../hooks';
+
+const useVerticalToolbarScroll = () => {
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [startRef, startInView] = useInView({ threshold: 1 });
+  const [endRef, endInView] = useInView({ threshold: 1 });
+  const { ref: scrollStepRef, height: scrollStep } =
+    useResizeObserver<HTMLDivElement>();
+
+  const scrollBack = () => {
+    if (!scrollElement || !scrollStep) {
+      return;
+    }
+
+    scrollElement.scrollBy({ top: -scrollStep });
+  };
+
+  const scrollForward = () => {
+    if (!scrollElement || !scrollStep) {
+      return;
+    }
+
+    scrollElement.scrollBy({ top: scrollStep });
+  };
+
+  return {
+    scrollContainerRef: setScrollElement,
+    scrollStepRef,
+    startRef,
+    endRef,
+    startInView,
+    endInView,
+    isOverflowing: !startInView || !endInView,
+    scrollBack,
+    scrollForward,
+  };
+};
+
+export { useVerticalToolbarScroll };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Replaced the scroll container ref in LeftToolbar with state populated through a callback ref.

The component no longer reads ref.current during render, and the obsolete react-hooks/refs ESLint suppression has been removed. The existing toolbar scrolling and arrow visibility behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request