### PR TITLE
10987 refactor explicitimplicit any type clean up from packagesketcher coresrcdomainserializersketfromketrgrouptostructts file

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/rgroupToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/rgroupToStruct.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { RGroup } from 'domain/entities/rgroup';
-import type { RGroupAttributes } from 'domain/entities/rgroup';
+import { RGroup, RGroupAttributes } from 'domain/entities/rgroup';
 import type { Struct } from 'domain/entities/struct';
 import { ifDef } from 'utilities';
 import { moleculeToStruct } from './moleculeToStruct';

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/rgroupToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/rgroupToStruct.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -16,26 +15,27 @@
  ***************************************************************************/
 
 import { RGroup } from 'domain/entities/rgroup';
+import type { RGroupAttributes } from 'domain/entities/rgroup';
 import type { Struct } from 'domain/entities/struct';
-
 import { ifDef } from 'utilities';
 import { moleculeToStruct } from './moleculeToStruct';
+import type { KetRGroupLogic, KetRGroupNode } from '../types';
 
-export function rgroupToStruct(ketItem): Struct {
+export function rgroupToStruct(ketItem: KetRGroupNode): Struct {
   const struct = moleculeToStruct(ketItem);
   const rgroup = rgroupLogicToStruct(ketItem.rlogic);
-  struct.frags.forEach((_value: any, key) => {
+  struct.frags.forEach((_value, key) => {
     rgroup.frags.add(key);
   });
   if (ketItem.rlogic) struct.rgroups.set(ketItem.rlogic.number, rgroup);
   return struct;
 }
 
-export function rgroupLogicToStruct(rglogic) {
-  const params = {};
-  ifDef(params, 'range', rglogic.range);
-  ifDef(params, 'resth', rglogic.resth);
-  ifDef(params, 'ifthen', rglogic.ifthen);
+export function rgroupLogicToStruct(rglogic: KetRGroupLogic | undefined) {
+  const params: RGroupAttributes = {};
+  ifDef(params, 'range', rglogic?.range);
+  ifDef(params, 'resth', rglogic?.resth);
+  ifDef(params, 'ifthen', rglogic?.ifthen);
 
   return new RGroup(params);
 }

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/types.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/types.ts
@@ -1,1 +1,8 @@
-export type { KetAtomNode, KetBondNode, KetFragment, KetItem } from '../types';
+export type {
+  KetAtomNode,
+  KetBondNode,
+  KetFragment,
+  KetItem,
+  KetRGroupLogic,
+  KetRGroupNode,
+} from '../types';

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -34,6 +34,7 @@ import { moleculeToStruct } from './fromKet/moleculeToStruct';
 import { prepareStructForKet } from './toKet/prepare';
 import { rgroupToKet } from './toKet/rgroupToKet';
 import { rgroupToStruct } from './fromKet/rgroupToStruct';
+import type { KetRGroupNode } from './types';
 import { rxnToStruct } from './fromKet/rxnToStruct';
 import { simpleObjectToKet } from './toKet/simpleObjectToKet';
 import { simpleObjectToStruct } from './fromKet/simpleObjectToStruct';
@@ -156,7 +157,7 @@ function parseNode(node: KetMicromoleculeNode, struct: Struct) {
       break;
     }
     case 'rgroup': {
-      rgroupToStruct(node).mergeInto(struct);
+      rgroupToStruct(node as KetRGroupNode).mergeInto(struct);
       break;
     }
     case 'text': {

--- a/packages/ketcher-core/src/domain/serializers/ket/types.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/types.ts
@@ -108,9 +108,24 @@ export interface KetFragment {
   bonds?: KetBondNode[];
 }
 
+export interface KetRGroupLogic {
+  number: number;
+  range?: string;
+  resth?: boolean;
+  ifthen?: number;
+}
+
+export interface KetRGroupNode {
+  type: 'rgroup';
+  atoms?: (KetAtomNode | KetRgLabelNode)[];
+  bonds?: KetBondNode[];
+  sgroups?: KetSGroupNode[];
+  stereoFlagPosition?: Vec2;
+  properties?: Array<StructProperty>;
+  rlogic?: KetRGroupLogic;
+}
+
 export interface KetItem {
   fragments?: KetFragment[];
-  rlogic?: {
-    number: number;
-  };
+  rlogic?: KetRGroupLogic;
 }


### PR DESCRIPTION
Replaced all any types in
  packages/ketcher-core/src/domain/serializers/ket/fromKet/rgroupToStruct.ts:

  - Added KetRGroupLogic and KetRGroupNode interfaces to ket/types.ts; updated KetItem.rlogic to use
  KetRGroupLogic
  - Typed ketItem as KetRGroupNode, rglogic as KetRGroupLogic | undefined, params as RGroupAttributes
  - Removed implicit any from _value in forEach callback (inferred as Fragment | null)
  - Added optional chaining (rglogic?.range etc.) to match the | undefined parameter type
  - Removed /* eslint-disable @typescript-eslint/no-explicit-any */ banner
  - Re-exported new types from fromKet/types.ts


## Check list
- [✓] unit-tests written
- [✓] e2e-tests written
- [✓] documentation updated
- [✓] PR name follows the pattern `#1234 – issue name`
- [✓] branch name doesn't contain '#'
- [✓] PR is linked with the issue
- [✓] base branch (master or release/xx) is correct
- [✓] task status changed to "Code review"
- [✓] reviewers are notified about the pull request