### PR TITLE
#10988 - Refactor: Explicit/implicit Any type clean up from packages/ketcher-core/src/domain/serializers/ket/fromKet/rxnToStruct.ts file

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/rxnToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/rxnToStruct.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -19,8 +18,9 @@ import { RxnArrow } from 'domain/entities/rxnArrow';
 import { RxnPlus } from 'domain/entities/rxnPlus';
 import type { Struct } from 'domain/entities/struct';
 import { getNodeWithInvertedYCoord } from '../helpers';
+import type { KetRxnNode } from '../types';
 
-export function rxnToStruct(ketItem: any, struct: Struct): Struct {
+export function rxnToStruct(ketItem: KetRxnNode, struct: Struct): Struct {
   if (ketItem.type === 'arrow') {
     const arrow = new RxnArrow(getNodeWithInvertedYCoord(ketItem.data));
     arrow.setInitiallySelected(ketItem.selected);

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -108,6 +108,7 @@ import { MACROMOLECULES_BOND_TYPES } from 'application/editor/tools/types';
 import type { KetFileImageNode } from 'domain/entities/image';
 import type { KetFileMultitailArrowNode } from 'domain/entities/multitailArrow';
 import type { KetFileNode } from 'domain/serializers/serializers.types';
+import type { KetRxnNode } from './types';
 
 type KetMicromoleculeNode = {
   type?: string;
@@ -136,7 +137,9 @@ function parseNode(node: KetMicromoleculeNode, struct: Struct) {
   switch (type) {
     case 'arrow':
     case 'plus': {
-      rxnToStruct(node, struct);
+      // KetMicromoleculeNode only carries the discriminant, so the node has to
+      // be asserted to the shape the switch has already established here.
+      rxnToStruct(node as unknown as KetRxnNode, struct);
       break;
     }
     case 'simpleObject': {

--- a/packages/ketcher-core/src/domain/serializers/ket/types.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/types.ts
@@ -21,6 +21,7 @@ import type {
 import type { AtomCIP, BondCIP } from 'domain/entities/types';
 import type { StructProperty } from 'domain/entities/struct';
 import type { Vec2 } from 'domain/entities/vec2';
+import type { RxnArrowAttributes } from 'domain/entities/rxnArrow';
 
 export interface KetAtomNode {
   type?: 'atom-list';
@@ -114,3 +115,18 @@ export interface KetItem {
     number: number;
   };
 }
+
+export interface KetArrowNode {
+  type: 'arrow';
+  data: RxnArrowAttributes;
+  selected?: boolean;
+}
+
+export interface KetPlusNode {
+  type: 'plus';
+  // KET stores the position of a plus as [x, y, z]
+  location: [number, number, number];
+  selected?: boolean;
+}
+
+export type KetRxnNode = KetArrowNode | KetPlusNode;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

`rxnToStruct` took `ketItem` as `any`. It reads `type`/`data`/`selected` on an arrow node and `type`/`location`/`selected` on a plus node, so the parameter is now a discriminated union and the existing `ketItem.type === 'arrow'` check narrows the two branches by itself — no casts or guards inside the function.

```ts
export interface KetArrowNode { type: 'arrow'; data: RxnArrowAttributes; selected?: boolean }
export interface KetPlusNode  { type: 'plus'; location: [number, number, number]; selected?: boolean }
export type KetRxnNode = KetArrowNode | KetPlusNode;
```

Declared in the serializer's `types.ts` as the issue asks, reusing the existing `RxnArrowAttributes` for the arrow payload rather than restating it. The file's `eslint-disable @typescript-eslint/no-explicit-any` header is removed.

**Scope note.** This is deliberately limited to the two node shapes this function reads. The earlier attempt (#11013) modelled a repo-wide `KetNode` union across `types.ts` and `ketSerializer.ts` and collided with #11012 over ownership of the shared types, so the broader union is left to whoever owns it.

**The one assertion.** `parseNode` types its parameter as `KetMicromoleculeNode`, a local shape carrying only the discriminant and no payload, so the call needs an assertion — narrowing cannot recover fields the placeholder doesn't declare. It's the same unavoidable assertion this file already makes for `$ref` lookups, and it's commented at the call site.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request