### PR TITLE
#10989 - Refactor: Explicit/implicit Any type clean up from packages/ketcher-core/src/domain/serializers/ket/fromKet/simpleObjectToStruct.ts file

### DIFF
--- a/packages/ketcher-core/.eslintrc.json
+++ b/packages/ketcher-core/.eslintrc.json
@@ -137,7 +137,6 @@
         "src/domain/serializers/ket/fromKet/moleculeToStruct.ts",
         "src/domain/serializers/ket/fromKet/rgroupToStruct.ts",
         "src/domain/serializers/ket/fromKet/rxnToStruct.ts",
-        "src/domain/serializers/ket/fromKet/simpleObjectToStruct.ts",
         "src/domain/serializers/ket/fromKet/textToStruct.ts",
         "src/domain/serializers/ket/helpers.ts",
         "src/domain/serializers/ket/ketSerializer.ts",

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/simpleObjectToStruct.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/simpleObjectToStruct.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -18,8 +17,12 @@
 import { SimpleObject } from 'domain/entities/simpleObject';
 import type { Struct } from 'domain/entities/struct';
 import { getNodeWithInvertedYCoord } from '../helpers';
+import type { KetSimpleObjectNode } from './types';
 
-export function simpleObjectToStruct(ketItem: any, struct: Struct): Struct {
+export function simpleObjectToStruct(
+  ketItem: KetSimpleObjectNode,
+  struct: Struct,
+): Struct {
   const object = ketItem.data;
   const simpleObject = new SimpleObject(getNodeWithInvertedYCoord(object));
   simpleObject.setInitiallySelected(ketItem.selected);

--- a/packages/ketcher-core/src/domain/serializers/ket/fromKet/types.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/fromKet/types.ts
@@ -1,1 +1,7 @@
-export type { KetAtomNode, KetBondNode, KetFragment, KetItem } from '../types';
+export type {
+  KetAtomNode,
+  KetBondNode,
+  KetFragment,
+  KetItem,
+  KetSimpleObjectNode,
+} from '../types';

--- a/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/ketSerializer.ts
@@ -37,6 +37,7 @@ import { rgroupToStruct } from './fromKet/rgroupToStruct';
 import { rxnToStruct } from './fromKet/rxnToStruct';
 import { simpleObjectToKet } from './toKet/simpleObjectToKet';
 import { simpleObjectToStruct } from './fromKet/simpleObjectToStruct';
+import type { KetSimpleObjectNode } from './types';
 import { textToKet } from './toKet/textToKet';
 import { textToStruct } from './fromKet/textToStruct';
 import {
@@ -109,11 +110,20 @@ import type { KetFileImageNode } from 'domain/entities/image';
 import type { KetFileMultitailArrowNode } from 'domain/entities/multitailArrow';
 import type { KetFileNode } from 'domain/serializers/serializers.types';
 
-type KetMicromoleculeNode = {
-  type?: string;
-  $ref?: string;
-  stereoFlagPosition?: Point;
-};
+type KetMicromoleculeNode =
+  | KetSimpleObjectNode
+  | {
+      type?:
+        | 'arrow'
+        | 'plus'
+        | 'molecule'
+        | 'rgroup'
+        | 'text'
+        | typeof MULTITAIL_ARROW_SERIALIZE_KEY
+        | typeof IMAGE_SERIALIZE_KEY;
+      $ref?: string;
+      stereoFlagPosition?: Point;
+    };
 
 interface IKetMicromoleculeFile {
   header?: { moleculeName?: string };
@@ -125,7 +135,10 @@ interface IKetMicromoleculeFile {
 }
 
 interface IKetMicromoleculeSerializedResult {
-  root: { nodes: KetMicromoleculeNode[] };
+  // nodes is intentionally wider than KetMicromoleculeNode so that serializer
+  // functions (arrowToKet, plusToKet, etc.) whose type property is inferred as
+  // `string` can be pushed without casts.
+  root: { nodes: Array<{ type?: string; [key: string]: unknown }> };
   header?: unknown;
   // Allows dynamic property assignment for mol/rg sections: result[`mol${id}`], result[`rg${id}`]
   [key: string]: unknown;

--- a/packages/ketcher-core/src/domain/serializers/ket/types.ts
+++ b/packages/ketcher-core/src/domain/serializers/ket/types.ts
@@ -20,7 +20,8 @@ import type {
 } from 'domain/entities/atom';
 import type { AtomCIP, BondCIP } from 'domain/entities/types';
 import type { StructProperty } from 'domain/entities/struct';
-import type { Vec2 } from 'domain/entities/vec2';
+import type { Vec2, Point } from 'domain/entities/vec2';
+import type { SimpleObjectMode } from 'domain/entities/simpleObject';
 
 export interface KetAtomNode {
   type?: 'atom-list';
@@ -113,4 +114,13 @@ export interface KetItem {
   rlogic?: {
     number: number;
   };
+}
+
+export interface KetSimpleObjectNode {
+  type: 'simpleObject';
+  data: {
+    mode: SimpleObjectMode;
+    pos: [Point, Point];
+  };
+  selected?: boolean;
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

`simpleObjectToStruct` took `ketItem` as `any`. It now takes `KetSimpleObjectNode`.

This follows the shape reviewed and approved on #11014, which was closed before it could merge, so all four review points from there are implemented here:

**The type describes the KET wire shape, not the domain entity.** Reusing `SimpleObjectAttributes` would have been pragmatic but wrong in two ways: it carries `initiallySelected`, an internal serialization concept that never appears in a KET file, and it leaves `pos` optional where the KET spec requires two coordinate pairs — so a node missing `pos` would have typechecked.

```ts
export interface KetSimpleObjectNode {
  type: 'simpleObject';
  data: { mode: SimpleObjectMode; pos: [Point, Point] };
  selected?: boolean;
}
```

**No assertion at the call site.** `KetMicromoleculeNode` is now a union of this node and the remaining shapes, with `type` narrowed from `string` to the literals the switch actually matches. That makes `case 'simpleObject'` narrow on its own, so the call stays plain `simpleObjectToStruct(node, struct)`. An `as unknown as` there would have been weaker than the `any` being removed — it silences the call site permanently if the node shape later drifts. `IKetMicromoleculeSerializedResult` keeps a deliberately wider `nodes` type so the `toKet` functions, whose `type` infers as `string`, still push without casts.

**Both lint hatches closed.** The file-level `eslint-disable` and the `.eslintrc.json` entry that downgraded `no-explicit-any` to a warning for this file. Leaving either would let `any` walk back in with lint green.

**Import through the barrel.** `KetSimpleObjectNode` is re-exported from `fromKet/types.ts`, so the import matches sibling `mergeFragmentsToStruct.ts` rather than reaching past to `'../types'`.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request