### PR TITLE
#8138 - System should not add monomer to the library of empty value for type field is provided

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -821,6 +821,52 @@ export class Ketcher {
   }
 
   /**
+   * Extracts monomer name from SDF format for error messages.
+   * Tries multiple fallback strategies in order of reliability.
+   */
+  private extractMonomerNameFromSdf(sdf: string): string {
+    const DEFAULT_MONOMER_NAME = 'Unknown';
+    const SDF_TEMPLATE_NAME_REGEX = /TEMPLATE\s+\d+\s+[^/\s]+\/([^/\s]+)/;
+    const SDF_ALIAS_HELM_REGEX = /> {2}<aliasHELM>\s*\n([^\n]+)/;
+    const SDF_IDT_ALIASES_REGEX = /> {2}<idtAliases>\s*\n\w+=([^\n]+)/;
+
+    // Try TEMPLATE line first (most reliable)
+    const templateMatch = sdf.match(SDF_TEMPLATE_NAME_REGEX);
+    if (templateMatch) {
+      return templateMatch[1];
+    }
+
+    // Try metadata fields
+    const idtAliasesMatch = sdf.match(SDF_IDT_ALIASES_REGEX);
+    if (idtAliasesMatch && idtAliasesMatch[1].trim()) {
+      return idtAliasesMatch[1].trim();
+    }
+
+    const aliasHelmMatch = sdf.match(SDF_ALIAS_HELM_REGEX);
+    if (aliasHelmMatch && aliasHelmMatch[1].trim()) {
+      return aliasHelmMatch[1].trim();
+    }
+
+    return DEFAULT_MONOMER_NAME;
+  }
+
+  /**
+   * Validates that SDF monomer data has non-empty <type> field.
+   * @throws {Error} When <type> is empty
+   */
+  private validateSdfMonomerType(sdf: string): void {
+    const SDF_TYPE_FIELD_REGEX = /> {2}<type>\s*\n([^\n>]*)/;
+
+    const typeMatch = sdf.match(SDF_TYPE_FIELD_REGEX);
+    if (typeMatch && typeMatch[1].trim() === '') {
+      const monomerName = this.extractMonomerNameFromSdf(sdf);
+      throw new Error(
+        `Empty value for "type" is provided. "${monomerName}" monomer hasn't been added to the library.`,
+      );
+    }
+  }
+
+  /**
    * Converts raw monomer data to KET format before it is sent to the editor.
    *
    * @throws {Error} When conversion fails or the server rejects the payload.
@@ -841,6 +887,14 @@ export class Ketcher {
       dataInKetFormat = rawMonomersDataString;
     } else {
       try {
+        // Validate SDF BEFORE expensive conversion
+        if (
+          format === SupportedFormat.sdf ||
+          format === SupportedFormat.sdfV3000
+        ) {
+          this.validateSdfMonomerType(rawMonomersDataString);
+        }
+
         const convertResult = await this.structService.convert(
           {
             struct: rawMonomersDataString,


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                        
Fixes an issue where the system allowed adding monomers to the library even when the type field was empty in the SDF file, resulting in invalid monomer data being stored.

**Problem**
When users attempted to add monomers from SDF files that contained an empty <type> field, the system would accept and add these invalid monomers to the library. This could lead to:
  - Invalid monomer data in the library
  - Unexpected behavior when using these monomers
  - Inconsistent library state

**Solution**
Added validation to check the <type> field in SDF monomer data before the expensive conversion operation:
  - validateSdfMonomerType() - Validates that the <type> field is not empty
  - extractMonomerNameFromSdf() - Extracts the monomer name from SDF for descriptive error messages
  - Validation is performed in ensureMonomersLibraryDataInKetFormat() before calling the structure service converter

The validation uses multiple fallback strategies to extract the monomer name for clear error messages:
  1. TEMPLATE line (most reliable)
  2. idtAliases metadata field
  3. aliasHELM metadata field
  4. Falls back to "Unknown" if no name found

**Changes Made**
  - Type definitions fix: Simplified AllowedApiSetting and AllowedClientSetting type definitions
  - Added validation methods:
    - extractMonomerNameFromSdf() - Extracts monomer name from SDF using regex patterns
    - validateSdfMonomerType() - Validates non-empty <type> field
  - Integrated validation: Added validation call before SDF to KET conversion in ensureMonomersLibraryDataInKetFormat()

**Error Message**
When validation fails, users see:
Empty value for "type" is provided. "<MonomerName>" monomer hasn't been added to the library.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request