### PR TITLE
#5206 - Start new sequence between two side chains works wrong

### DIFF
--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -55,7 +55,8 @@ type BaseNodeSelection = {
 };
 
 type SequenceBondRenderer =
-  PolymerBondSequenceRenderer | MonomerToAtomBondSequenceRenderer;
+  | PolymerBondSequenceRenderer
+  | MonomerToAtomBondSequenceRenderer;
 
 export type NodeSelection = BaseNodeSelection & {
   node: SubChainNode;
@@ -284,14 +285,29 @@ export class SequenceRenderer {
       );
 
       if (!isEditInRnaBuilderMode) {
-        this.showNewSequenceButton(
-          chainIndex,
-          Math.max(
-            chain.lastRow.sequenceViewModelItems.length,
-            sequenceViewModel.chains[chainIndex + 1]?.firstRow
-              ?.sequenceViewModelItems.length ?? 0,
-          ),
-        );
+        const nextChain = sequenceViewModel.chains[chainIndex + 1];
+
+        // Extract actual Chain objects with type safety
+        const currentChain = chain.firstNode?.chain;
+        const nextChainObj = nextChain?.firstNode?.chain;
+
+        // Check if chains are connected via side-chain bonds
+        // If two sequences have at least one sidechain connection, the "plus" button between them should be absent
+        const hasSideChainConnection =
+          currentChain &&
+          nextChainObj &&
+          this.hasSideChainConnectionBetweenChains(currentChain, nextChainObj);
+
+        // Show PLUS button only if there are no side-chain connections between chains
+        if (!hasSideChainConnection) {
+          this.showNewSequenceButton(
+            chainIndex,
+            Math.max(
+              chain.lastRow.sequenceViewModelItems.length,
+              nextChain?.firstRow?.sequenceViewModelItems.length ?? 0,
+            ),
+          );
+        }
       }
     });
 
@@ -1421,6 +1437,49 @@ export class SequenceRenderer {
     });
 
     return rendererToReturn;
+  }
+
+  /**
+   * Checks if two chains have at least one side-chain connection between them.
+   *
+   * @param chain1 - First chain to check
+   * @param chain2 - Second chain to check
+   * @returns true if any monomer in chain1 has a side-chain bond to any monomer in chain2
+   *
+   * @example
+   * // Two chains connected by R3-R3 bond
+   * const hasConnection = hasSideChainConnectionBetweenChains(chainA, chainB);
+   * // Returns: true
+   *
+   * @remarks
+   * - Returns false if either chain is empty or undefined
+   * - Uses Set for O(1) lookup performance
+   * - Only checks connections from chain1 to chain2 (assumes bidirectional bonds)
+   */
+  private static hasSideChainConnectionBetweenChains(
+    chain1: Chain,
+    chain2: Chain,
+  ): boolean {
+    // Defensive programming - handle null/undefined/empty chains
+    if (!chain1?.monomers?.length || !chain2?.monomers?.length) {
+      return false;
+    }
+
+    const chain2Monomers = new Set(chain2.monomers);
+
+    for (const monomer of chain1.monomers) {
+      const sideConnections = monomer.sideConnections;
+      if (!sideConnections?.length) continue; // Skip if no connections
+
+      for (const sideConnection of sideConnections) {
+        const anotherMonomer = sideConnection.getAnotherMonomer(monomer);
+        if (anotherMonomer && chain2Monomers.has(anotherMonomer)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   public static showNewSequenceButton(indexOfRowBefore: number, width = 0) {

--- a/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
+++ b/packages/ketcher-core/src/application/render/renderers/sequence/SequenceRenderer.ts
@@ -55,8 +55,7 @@ type BaseNodeSelection = {
 };
 
 type SequenceBondRenderer =
-  | PolymerBondSequenceRenderer
-  | MonomerToAtomBondSequenceRenderer;
+  PolymerBondSequenceRenderer | MonomerToAtomBondSequenceRenderer;
 
 export type NodeSelection = BaseNodeSelection & {
   node: SubChainNode;


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                         
Fixes issue #5206 where the "plus" button (new sequence button) was incorrectly displayed between two sequences connected by side-chain bonds.                                                                  
                  
**Problem**
When two sequences are connected via side-chain bonds (e.g., R3-R3 connections), the "plus" button was still shown between them, allowing users to insert a new sequence. This behavior was incorrect because:
  - The button suggests inserting a new sequence between existing ones
  - Side-chain connected sequences should not have this button as they are already interconnected

**Solution**
Added logic to detect side-chain connections between adjacent chains:
  - Introduced hasSideChainConnectionBetweenChains() method that checks if two chains have any side-chain bonds between their monomers
  - Modified render() to skip showing the "plus" button when side-chain connections exist between adjacent chains
  - Uses Set-based lookup for O(1) performance when checking connections

**Technical Details**
The hasSideChainConnectionBetweenChains() method:
  - Iterates through all monomers in chain1
  - Checks their side connections against monomers in chain2
  - Returns true if any side-chain bond exists between the chains
  - Includes defensive null/undefined checks for robustness


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request