### PR TITLE
Update Ketcher to public version 3.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16726,9 +16726,9 @@
       }
     },
     "node_modules/indigo-ketcher": {
-      "version": "1.46.0-rc.2",
-      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.46.0-rc.2.tgz",
-      "integrity": "sha512-KzrnjE78gjxm9ONDwDncbhzE7VsOd3hnyNdKjpu8s9zptnjCZZNi2XBtZn8C5Zlo2qj40kvOogKh+lYoEfGNBg==",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/indigo-ketcher/-/indigo-ketcher-1.46.0.tgz",
+      "integrity": "sha512-BaYVFWMxcomiP/YJoLHqiLuh53digRfY7koIwH/S2L9Xan+n1dWthNROOEJh56bcbVqCbYhDEZdM1ATtKgRqLA==",
       "license": "Apache-2.0"
     },
     "node_modules/inflight": {
@@ -31972,7 +31972,7 @@
       }
     },
     "packages/ketcher-core": {
-      "version": "3.18.0-rc.4",
+      "version": "3.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -34056,7 +34056,7 @@
       }
     },
     "packages/ketcher-macromolecules": {
-      "version": "3.18.0-rc.4",
+      "version": "3.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -37137,7 +37137,7 @@
       }
     },
     "packages/ketcher-react": {
-      "version": "3.18.0-rc.4",
+      "version": "3.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -40335,11 +40335,11 @@
       }
     },
     "packages/ketcher-standalone": {
-      "version": "3.18.0-rc.4",
+      "version": "3.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
-        "indigo-ketcher": "1.46.0-rc.2",
+        "indigo-ketcher": "1.46.0",
         "ketcher-core": "*",
         "lodash": "^4.18.1"
       },

--- a/packages/ketcher-core/package.json
+++ b/packages/ketcher-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-core",
-  "version": "3.18.0-rc.4",
+  "version": "3.18.0",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-macromolecules/package.json
+++ b/packages/ketcher-macromolecules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-macromolecules",
-  "version": "3.18.0-rc.4",
+  "version": "3.18.0",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-react/package.json
+++ b/packages/ketcher-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-react",
-  "version": "3.18.0-rc.4",
+  "version": "3.18.0",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",

--- a/packages/ketcher-standalone/package.json
+++ b/packages/ketcher-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketcher-standalone",
-  "version": "3.18.0-rc.4",
+  "version": "3.18.0",
   "description": "Web-based molecule sketcher",
   "license": "Apache-2.0",
   "homepage": "http://lifescience.opensource.epam.com/ketcher",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.10",
-    "indigo-ketcher": "1.46.0-rc.2",
+    "indigo-ketcher": "1.46.0",
     "ketcher-core": "*",
     "lodash": "^4.18.1"
   },


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Bumps `indigo-ketcher` and the four Ketcher packages (`ketcher-core`, `ketcher-react`, `ketcher-macromolecules`, `ketcher-standalone`) from their `3.18.0-rc.4` / `1.46.0-rc.2` release-candidate versions to the public `3.18.0` / `1.46.0` versions, and updates `package-lock.json` accordingly.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request
