### PR TITLE
#10846 - RNA/DNA/PEP switcher on Macromolecules mode on Mac has Windows hotkey tooltips

### DIFF
--- a/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
+++ b/packages/ketcher-macromolecules/src/components/SequenceTypeGroupButton/SequenceTypeGroupButton.tsx
@@ -29,6 +29,7 @@ import {
   getPersistedSequenceType,
   persistSequenceType,
 } from 'helpers/sequenceTypeStorage';
+import { hotkeysShortcuts } from 'components/ZoomControls/helpers';
 
 const SequenceTypeButton = styled(Button)(({ theme, variant }) => ({
   color:
@@ -116,7 +117,7 @@ export const SequenceTypeGroupButton = () => {
       <ButtonGroup disabled={isDisabled}>
         <SequenceTypeButton
           data-testid={`${SequenceType.RNA}Btn`}
-          title="RNA (Ctrl+Alt+R)"
+          title={`RNA (${hotkeysShortcuts.RNASequenceType})`}
           variant={
             activeSequenceType === SequenceType.RNA ? 'contained' : 'outlined'
           }
@@ -126,7 +127,7 @@ export const SequenceTypeGroupButton = () => {
         </SequenceTypeButton>
         <SequenceTypeButton
           data-testid={`${SequenceType.DNA}Btn`}
-          title="DNA (Ctrl+Alt+D)"
+          title={`DNA (${hotkeysShortcuts.DNASequenceType})`}
           variant={
             activeSequenceType === SequenceType.DNA ? 'contained' : 'outlined'
           }
@@ -136,7 +137,7 @@ export const SequenceTypeGroupButton = () => {
         </SequenceTypeButton>
         <SequenceTypeButton
           data-testid={`${SequenceType.PEPTIDE}Btn`}
-          title="Peptides (Ctrl+Alt+P)"
+          title={`Peptides (${hotkeysShortcuts.PEPTIDESequenceTYpe})`}
           variant={
             activeSequenceType === SequenceType.PEPTIDE
               ? 'contained'


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

The three switcher tooltips hardcoded their shortcuts, so they always read `Ctrl+Alt` regardless of platform:

```diff
-title="RNA (Ctrl+Alt+R)"
+title={`RNA (${hotkeysShortcuts.RNASequenceType})`}
```

The shortcuts themselves were fine — they're declared as `Mod+Alt+r/d/p`, and `Mod` already resolves to ⌘ on Mac. Only the tooltips bypassed that. They now use `hotkeysShortcuts`, the same source the other toolbars already use, which renders `Ctrl+Alt+R` on Windows/Linux and `⌘+Option+R` on Mac.

Off Mac the text is unchanged, so the `title` assertions in `sequence-mode-switch.spec.ts` pass untouched — meaning CI shows no regression rather than proving the fix, since it runs on Linux.

`PEPTIDESequenceTYpe` is used verbatim; the capital `Y` is a typo in `hotkeysConfiguration` shared with the hotkey handler.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request