### PR TITLE
#11083 - In the Monomer Edit modal window, the Response option appears as OK instead of Yes

### DIFF
--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/MacromoleculeMenuItems.tsx
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/menuItems/MacromoleculeMenuItems.tsx
@@ -124,6 +124,7 @@ const MacromoleculeMenuItems = (
       await editor?.event.confirm.dispatch({
         title: 'Editing monomers',
         text: `You are going to edit ${totalMonomerCount} monomers. Are you sure?`,
+        okButtonLabel: 'Yes',
       });
       // Promise resolves when the user clicks OK; do nothing on Cancel (caught below).
       handleEdit(true);

--- a/packages/ketcher-react/src/script/ui/views/modal/components/Confirm/Confirm.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/Confirm/Confirm.tsx
@@ -5,9 +5,16 @@ type ConfirmProps = {
   onCancel: () => void;
   text?: string;
   title?: string;
+  okButtonLabel?: string;
 };
 
-export const Confirm = ({ onOk, onCancel, text, title }: ConfirmProps) => {
+export const Confirm = ({
+  onOk,
+  onCancel,
+  text,
+  title,
+  okButtonLabel,
+}: ConfirmProps) => {
   return (
     <div className={classes.window}>
       <header className={classes.header} data-testid="confirm-header">
@@ -27,7 +34,7 @@ export const Confirm = ({ onOk, onCancel, text, title }: ConfirmProps) => {
         />
         <input
           type="button"
-          value={'OK'}
+          value={okButtonLabel || 'OK'}
           className={classes.buttonOk}
           onClick={() => onOk()}
           data-testid="ok-button"


### PR DESCRIPTION

<img width="958" height="497" alt="qwq" src="https://github.com/user-attachments/assets/708d9e71-f08c-4480-8681-614237434300" />

## How the feature works? / How did you fix the issue?

The confirmation button label was hardcoded as `OK`, so the monomer edit dialog couldn't offer the "Yes" the requirement asks for.

```diff
 // Confirm.tsx
+  okButtonLabel?: string;
-          value={'OK'}
+          value={okButtonLabel || 'OK'}

 // MacromoleculeMenuItems.tsx
+        okButtonLabel: 'Yes',
```

Optional with an `OK` fallback, matching how the component already treats `title` and `text`. The dialog's other consumer — the unsupported S-group import (`shared.ts`) — dispatches without a payload, so it keeps `OK` unchanged.

No plumbing needed: `onConfirm` forwards the payload to `openDialog`, and the modal container spreads every key except `onResult`/`onCancel` into the dialog props, which is how `title` and `text` already arrive.

The button keeps its `ok-button` test id, so the e2e page objects that locate it are unaffected — nothing asserts the visible label.

Note on "Yes (default)" in the requirement: the button already carries `classes.buttonOk` and sits rightmost, so it was already the default action; only the label was wrong.

### Verification

eslint and prettier clean, `tsc` reports 0 errors, and the ketcher-react unit results are identical to master (the 6 failing suites are pre-existing).


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request