### PR TITLE
#11231 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-macromolecules\src\components\modal\monomerConnection\MonomerConnections.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable react-hooks/refs */
 import styled from '@emotion/styled';
 import { ActionButton } from 'components/shared/actionButton';
 import { Modal } from 'components/shared/modal';
 import { useAppSelector } from 'hooks';
 import { selectEditor } from 'state/common';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   AttachmentPoint,
   AttachmentPointName as AttachmentPointNameComponent,
@@ -70,14 +69,15 @@ const MonomerConnection = ({
   isReconnectionDialog,
 }: Readonly<MonomerConnectionProps>): React.ReactElement => {
   const editor = useAppSelector(selectEditor);
-  const initialFirstMonomerAttachmentPointRef = useRef(
-    polymerBond?.firstMonomerAttachmentPoint,
+  const [initialFirstMonomerAttachmentPoint] = useState(
+    () => polymerBond?.firstMonomerAttachmentPoint,
   );
-  const initialSecondMonomerAttachmentPointRef = useRef(
-    polymerBond?.secondMonomerAttachmentPoint,
+  const [initialSecondMonomerAttachmentPoint] = useState(
+    () => polymerBond?.secondMonomerAttachmentPoint,
   );
-  const hasFreeAttachmentPointsRef = useRef(
-    firstMonomer?.hasFreeAttachmentPoint ||
+  const [hasFreeAttachmentPoints] = useState(
+    () =>
+      firstMonomer?.hasFreeAttachmentPoint ||
       secondMonomer?.hasFreeAttachmentPoint,
   );
 
@@ -87,12 +87,12 @@ const MonomerConnection = ({
 
   const [firstSelectedAttachmentPoint, setFirstSelectedAttachmentPoint] =
     useState<string | null>(
-      initialFirstMonomerAttachmentPointRef.current ||
+      initialFirstMonomerAttachmentPoint ||
         getDefaultAttachmentPoint(firstMonomer),
     );
   const [secondSelectedAttachmentPoint, setSecondSelectedAttachmentPoint] =
     useState<string | null>(
-      initialSecondMonomerAttachmentPointRef.current ||
+      initialSecondMonomerAttachmentPoint ||
         getDefaultAttachmentPoint(secondMonomer),
     );
   const [modalExpanded, setModalExpanded] = useState(false);
@@ -100,11 +100,11 @@ const MonomerConnection = ({
   const cancelBondCreationAndClose = () => {
     if (isReconnectionDialog) {
       polymerBond?.firstMonomer.setBond(
-        initialFirstMonomerAttachmentPointRef.current as AttachmentPointName,
+        initialFirstMonomerAttachmentPoint as AttachmentPointName,
         polymerBond,
       );
       polymerBond?.secondMonomer?.setBond(
-        initialSecondMonomerAttachmentPointRef.current as AttachmentPointName,
+        initialSecondMonomerAttachmentPoint as AttachmentPointName,
         polymerBond,
       );
       onClose();
@@ -120,10 +120,8 @@ const MonomerConnection = ({
     }
 
     if (
-      firstSelectedAttachmentPoint ===
-        initialFirstMonomerAttachmentPointRef.current &&
-      secondSelectedAttachmentPoint ===
-        initialSecondMonomerAttachmentPointRef.current
+      firstSelectedAttachmentPoint === initialFirstMonomerAttachmentPoint &&
+      secondSelectedAttachmentPoint === initialSecondMonomerAttachmentPoint
     ) {
       cancelBondCreationAndClose();
 
@@ -137,10 +135,8 @@ const MonomerConnection = ({
       secondSelectedAttachmentPoint,
       polymerBond,
       isReconnection: isReconnectionDialog,
-      initialFirstMonomerAttachmentPoint:
-        initialFirstMonomerAttachmentPointRef.current,
-      initialSecondMonomerAttachmentPoint:
-        initialSecondMonomerAttachmentPointRef.current,
+      initialFirstMonomerAttachmentPoint,
+      initialSecondMonomerAttachmentPoint,
     });
 
     onClose();
@@ -204,7 +200,7 @@ const MonomerConnection = ({
           disabled={
             !firstSelectedAttachmentPoint ||
             !secondSelectedAttachmentPoint ||
-            !hasFreeAttachmentPointsRef.current
+            !hasFreeAttachmentPoints
           }
           clickHandler={connectMonomers}
         />

--- a/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
@@ -69,26 +69,29 @@ const MonomerConnection = ({
   isReconnectionDialog,
 }: Readonly<MonomerConnectionProps>): React.ReactElement => {
   const editor = useAppSelector(selectEditor);
-  const initialFirstMonomerAttachmentPoint =
-    polymerBond?.firstMonomerAttachmentPoint;
-  const initialSecondMonomerAttachmentPoint =
-    polymerBond?.secondMonomerAttachmentPoint;
+  // Selecting an attachment point mutates the bond and monomers. Preserve the
+  // values from the render that opened the dialog so Cancel and Reconnect can
+  // restore or compare against the original connection.
+  const [initialConnection] = useState(() => ({
+    firstAttachmentPoint: polymerBond?.firstMonomerAttachmentPoint,
+    secondAttachmentPoint: polymerBond?.secondMonomerAttachmentPoint,
+    hasFreeAttachmentPoints:
+      firstMonomer?.hasFreeAttachmentPoint ||
+      secondMonomer?.hasFreeAttachmentPoint,
+  }));
 
   if (!firstMonomer || !secondMonomer) {
     throw new Error('Monomers must exist!');
   }
 
-  const hasFreeAttachmentPoints =
-    firstMonomer.hasFreeAttachmentPoint || secondMonomer.hasFreeAttachmentPoint;
-
   const [firstSelectedAttachmentPoint, setFirstSelectedAttachmentPoint] =
     useState<string | null>(
-      initialFirstMonomerAttachmentPoint ||
+      initialConnection.firstAttachmentPoint ||
         getDefaultAttachmentPoint(firstMonomer),
     );
   const [secondSelectedAttachmentPoint, setSecondSelectedAttachmentPoint] =
     useState<string | null>(
-      initialSecondMonomerAttachmentPoint ||
+      initialConnection.secondAttachmentPoint ||
         getDefaultAttachmentPoint(secondMonomer),
     );
   const [modalExpanded, setModalExpanded] = useState(false);
@@ -96,11 +99,11 @@ const MonomerConnection = ({
   const cancelBondCreationAndClose = () => {
     if (isReconnectionDialog) {
       polymerBond?.firstMonomer.setBond(
-        initialFirstMonomerAttachmentPoint as AttachmentPointName,
+        initialConnection.firstAttachmentPoint as AttachmentPointName,
         polymerBond,
       );
       polymerBond?.secondMonomer?.setBond(
-        initialSecondMonomerAttachmentPoint as AttachmentPointName,
+        initialConnection.secondAttachmentPoint as AttachmentPointName,
         polymerBond,
       );
       onClose();
@@ -116,8 +119,8 @@ const MonomerConnection = ({
     }
 
     if (
-      firstSelectedAttachmentPoint === initialFirstMonomerAttachmentPoint &&
-      secondSelectedAttachmentPoint === initialSecondMonomerAttachmentPoint
+      firstSelectedAttachmentPoint === initialConnection.firstAttachmentPoint &&
+      secondSelectedAttachmentPoint === initialConnection.secondAttachmentPoint
     ) {
       cancelBondCreationAndClose();
 
@@ -131,8 +134,10 @@ const MonomerConnection = ({
       secondSelectedAttachmentPoint,
       polymerBond,
       isReconnection: isReconnectionDialog,
-      initialFirstMonomerAttachmentPoint,
-      initialSecondMonomerAttachmentPoint,
+      initialFirstMonomerAttachmentPoint:
+        initialConnection.firstAttachmentPoint,
+      initialSecondMonomerAttachmentPoint:
+        initialConnection.secondAttachmentPoint,
     });
 
     onClose();
@@ -196,7 +201,7 @@ const MonomerConnection = ({
           disabled={
             !firstSelectedAttachmentPoint ||
             !secondSelectedAttachmentPoint ||
-            !hasFreeAttachmentPoints
+            !initialConnection.hasFreeAttachmentPoints
           }
           clickHandler={connectMonomers}
         />

--- a/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
+++ b/packages/ketcher-macromolecules/src/components/modal/monomerConnection/MonomerConnections.tsx
@@ -69,21 +69,17 @@ const MonomerConnection = ({
   isReconnectionDialog,
 }: Readonly<MonomerConnectionProps>): React.ReactElement => {
   const editor = useAppSelector(selectEditor);
-  const [initialFirstMonomerAttachmentPoint] = useState(
-    () => polymerBond?.firstMonomerAttachmentPoint,
-  );
-  const [initialSecondMonomerAttachmentPoint] = useState(
-    () => polymerBond?.secondMonomerAttachmentPoint,
-  );
-  const [hasFreeAttachmentPoints] = useState(
-    () =>
-      firstMonomer?.hasFreeAttachmentPoint ||
-      secondMonomer?.hasFreeAttachmentPoint,
-  );
+  const initialFirstMonomerAttachmentPoint =
+    polymerBond?.firstMonomerAttachmentPoint;
+  const initialSecondMonomerAttachmentPoint =
+    polymerBond?.secondMonomerAttachmentPoint;
 
   if (!firstMonomer || !secondMonomer) {
     throw new Error('Monomers must exist!');
   }
+
+  const hasFreeAttachmentPoints =
+    firstMonomer.hasFreeAttachmentPoint || secondMonomer.hasFreeAttachmentPoint;
 
   const [firstSelectedAttachmentPoint, setFirstSelectedAttachmentPoint] =
     useState<string | null>(


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Replaced refs used for storing the initial monomer attachment points and attachment point availability with lazily initialized state.

MonomerConnections no longer reads ref.current during render. The obsolete react-hooks/refs ESLint suppression and unused useRef import were also removed.

The existing connection and reconnection behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request