### PR TITLE
#11232 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-macromolecules\src\components\macromoleculeProperties\MacromoleculePropertiesWindow.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -980,10 +980,10 @@ export const MacromoleculePropertiesWindow = () => {
   const recalculateMacromoleculeProperties =
     useRecalculateMacromoleculeProperties();
   const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
-  const debouncedRecalculateMacromoleculeProperties = useDebouncedCallback(
-    recalculateMacromoleculeProperties,
-    500,
-  );
+  const {
+    debouncedCallback: debouncedRecalculateMacromoleculeProperties,
+    cancel: cancelDebouncedRecalculateMacromoleculeProperties,
+  } = useDebouncedCallback(recalculateMacromoleculeProperties, 500);
 
   useEffect(() => {
     if (recalculatePropertiesHandler) {
@@ -1030,14 +1030,14 @@ export const MacromoleculePropertiesWindow = () => {
   // re-runs the effect above and schedules a debounced call; cancel it so
   // only this immediate calculation actually runs.
   useEffect(() => {
-    debouncedRecalculateMacromoleculeProperties.cancel();
+    cancelDebouncedRecalculateMacromoleculeProperties();
     recalculateMacromoleculeProperties(skipDataFetch);
   }, [
     unipositiveIonsMeasurementUnit,
     oligonucleotidesMeasurementUnit,
     skipDataFetch,
-    debouncedRecalculateMacromoleculeProperties,
     recalculateMacromoleculeProperties,
+    cancelDebouncedRecalculateMacromoleculeProperties,
   ]);
 
   // The properties object is re-parsed from the Indigo response on every

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable react-hooks/use-memo */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -15,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ***************************************************************************/
-
-/* eslint-disable react-hooks/refs */
 
 import { useAppDispatch, useAppSelector } from 'hooks';
 import {
@@ -993,12 +990,28 @@ export const MacromoleculePropertiesWindow = () => {
   const recalculateMacromoleculePropertiesRef = useRef<
     (shouldSkip?: boolean) => void
   >(recalculateMacromoleculeProperties);
+  const debouncedRecalculateMacromoleculePropertiesRef = useRef<
+    ReturnType<typeof debounce> | undefined
+  >(undefined);
   const debouncedRecalculateMacromoleculeProperties = useCallback(
-    debounce((shouldSkip?: boolean) => {
-      recalculateMacromoleculePropertiesRef.current(shouldSkip);
-    }, 500),
+    (shouldSkip?: boolean) => {
+      debouncedRecalculateMacromoleculePropertiesRef.current?.(shouldSkip);
+    },
     [],
   );
+
+  useEffect(() => {
+    debouncedRecalculateMacromoleculePropertiesRef.current = debounce(
+      (shouldSkip?: boolean) => {
+        recalculateMacromoleculePropertiesRef.current(shouldSkip);
+      },
+      500,
+    );
+
+    return () => {
+      debouncedRecalculateMacromoleculePropertiesRef.current?.cancel();
+    };
+  }, []);
 
   useEffect(() => {
     recalculateMacromoleculePropertiesRef.current = (shouldSkip?: boolean) => {
@@ -1051,7 +1064,7 @@ export const MacromoleculePropertiesWindow = () => {
   // re-runs the effect above and schedules a debounced call; cancel it so
   // only this immediate calculation actually runs.
   useEffect(() => {
-    debouncedRecalculateMacromoleculeProperties.cancel();
+    debouncedRecalculateMacromoleculePropertiesRef.current?.cancel();
     recalculateMacromoleculePropertiesRef.current(skipDataFetch);
   }, [
     unipositiveIonsMeasurementUnit,

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -982,6 +982,7 @@ export const MacromoleculePropertiesWindow = () => {
   const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
   const {
     debouncedCallback: debouncedRecalculateMacromoleculeProperties,
+    invokeImmediately: recalculateMacromoleculePropertiesImmediately,
     cancel: cancelDebouncedRecalculateMacromoleculeProperties,
   } = useDebouncedCallback(recalculateMacromoleculeProperties, 500);
 
@@ -1031,13 +1032,13 @@ export const MacromoleculePropertiesWindow = () => {
   // only this immediate calculation actually runs.
   useEffect(() => {
     cancelDebouncedRecalculateMacromoleculeProperties();
-    recalculateMacromoleculeProperties(skipDataFetch);
+    recalculateMacromoleculePropertiesImmediately(skipDataFetch);
   }, [
     unipositiveIonsMeasurementUnit,
     oligonucleotidesMeasurementUnit,
     skipDataFetch,
-    recalculateMacromoleculeProperties,
     cancelDebouncedRecalculateMacromoleculeProperties,
+    recalculateMacromoleculePropertiesImmediately,
   ]);
 
   // The properties object is re-parsed from the Indigo response on every

--- a/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
+++ b/packages/ketcher-macromolecules/src/components/macromoleculeProperties/MacromoleculePropertiesWindow.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { useAppDispatch, useAppSelector } from 'hooks';
+import { useAppDispatch, useAppSelector, useDebouncedCallback } from 'hooks';
 import {
   MolarMeasurementUnit,
   selectEditor,
@@ -35,14 +35,7 @@ import styled from '@emotion/styled';
 import _round from 'lodash/round';
 import _map from 'lodash/map';
 import { Tabs } from 'components/shared/Tabs';
-import {
-  useCallback,
-  ReactNode,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import {
   peptideNaturalAnalogues,
   rnaDnaNaturalAnalogues,
@@ -987,37 +980,10 @@ export const MacromoleculePropertiesWindow = () => {
   const recalculateMacromoleculeProperties =
     useRecalculateMacromoleculeProperties();
   const skipDataFetch = !isMacromoleculesPropertiesWindowOpened;
-  const recalculateMacromoleculePropertiesRef = useRef<
-    (shouldSkip?: boolean) => void
-  >(recalculateMacromoleculeProperties);
-  const debouncedRecalculateMacromoleculePropertiesRef = useRef<
-    ReturnType<typeof debounce> | undefined
-  >(undefined);
-  const debouncedRecalculateMacromoleculeProperties = useCallback(
-    (shouldSkip?: boolean) => {
-      debouncedRecalculateMacromoleculePropertiesRef.current?.(shouldSkip);
-    },
-    [],
+  const debouncedRecalculateMacromoleculeProperties = useDebouncedCallback(
+    recalculateMacromoleculeProperties,
+    500,
   );
-
-  useEffect(() => {
-    debouncedRecalculateMacromoleculePropertiesRef.current = debounce(
-      (shouldSkip?: boolean) => {
-        recalculateMacromoleculePropertiesRef.current(shouldSkip);
-      },
-      500,
-    );
-
-    return () => {
-      debouncedRecalculateMacromoleculePropertiesRef.current?.cancel();
-    };
-  }, []);
-
-  useEffect(() => {
-    recalculateMacromoleculePropertiesRef.current = (shouldSkip?: boolean) => {
-      recalculateMacromoleculeProperties(shouldSkip);
-    };
-  }, [recalculateMacromoleculeProperties]);
 
   useEffect(() => {
     if (recalculatePropertiesHandler) {
@@ -1064,13 +1030,14 @@ export const MacromoleculePropertiesWindow = () => {
   // re-runs the effect above and schedules a debounced call; cancel it so
   // only this immediate calculation actually runs.
   useEffect(() => {
-    debouncedRecalculateMacromoleculePropertiesRef.current?.cancel();
-    recalculateMacromoleculePropertiesRef.current(skipDataFetch);
+    debouncedRecalculateMacromoleculeProperties.cancel();
+    recalculateMacromoleculeProperties(skipDataFetch);
   }, [
     unipositiveIonsMeasurementUnit,
     oligonucleotidesMeasurementUnit,
     skipDataFetch,
     debouncedRecalculateMacromoleculeProperties,
+    recalculateMacromoleculeProperties,
   ]);
 
   // The properties object is re-parsed from the Indigo response on every

--- a/packages/ketcher-macromolecules/src/contexts/RootSizeContext.tsx
+++ b/packages/ketcher-macromolecules/src/contexts/RootSizeContext.tsx
@@ -34,7 +34,10 @@ export const RootSizeProvider = ({
     setSize({ width, height });
   }, [rootRef]);
 
-  const debouncedHandleResize = useDebouncedCallback(handleResize, 100);
+  const {
+    debouncedCallback: debouncedHandleResize,
+    cancel: cancelDebouncedHandleResize,
+  } = useDebouncedCallback(handleResize, 100);
 
   useEffect(() => {
     handleResize();
@@ -45,9 +48,9 @@ export const RootSizeProvider = ({
 
     return () => {
       window.removeEventListener('resize', debouncedHandleResize);
-      debouncedHandleResize.cancel();
+      cancelDebouncedHandleResize();
     };
-  }, [debouncedHandleResize]);
+  }, [cancelDebouncedHandleResize, debouncedHandleResize]);
 
   return (
     <RootSizeContext.Provider value={size}>{children}</RootSizeContext.Provider>

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
@@ -1,9 +1,21 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { debounce, DebouncedFunc } from 'lodash';
 
 export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
   callback: T,
   delay: number,
 ): DebouncedFunc<T> {
-  return useMemo(() => debounce(callback, delay), [callback, delay]);
+  const debouncedCallback = useMemo(
+    () => debounce(callback, delay),
+    [callback, delay],
+  );
+
+  useEffect(
+    () => () => {
+      debouncedCallback.cancel();
+    },
+    [debouncedCallback],
+  );
+
+  return debouncedCallback;
 }

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
@@ -1,21 +1,39 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { debounce, DebouncedFunc } from 'lodash';
+
+type UseDebouncedCallbackResult<T extends (...args: never[]) => unknown> = {
+  debouncedCallback: (...args: Parameters<T>) => void;
+  cancel: () => void;
+};
 
 export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
   callback: T,
   delay: number,
-): DebouncedFunc<T> {
-  const debouncedCallback = useMemo(
-    () => debounce(callback, delay),
-    [callback, delay],
-  );
+): UseDebouncedCallbackResult<T> {
+  const callbackRef = useRef(callback);
+  const debounceInstanceRef = useRef<DebouncedFunc<T> | undefined>(undefined);
 
-  useEffect(
-    () => () => {
-      debouncedCallback.cancel();
-    },
-    [debouncedCallback],
-  );
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
-  return debouncedCallback;
+  useEffect(() => {
+    debounceInstanceRef.current = debounce(
+      (...args: never[]) => callbackRef.current(...args),
+      delay,
+    ) as DebouncedFunc<T>;
+
+    return () => {
+      debounceInstanceRef.current?.cancel();
+      debounceInstanceRef.current = undefined;
+    };
+  }, [delay]);
+
+  const debouncedCallback = useCallback(
+    (...args: Parameters<T>) => debounceInstanceRef.current?.(...args),
+    [],
+  );
+  const cancel = useCallback(() => debounceInstanceRef.current?.cancel(), []);
+
+  return { debouncedCallback, cancel };
 }

--- a/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useDebouncedCallback.ts
@@ -3,6 +3,7 @@ import { debounce, DebouncedFunc } from 'lodash';
 
 type UseDebouncedCallbackResult<T extends (...args: never[]) => unknown> = {
   debouncedCallback: (...args: Parameters<T>) => void;
+  invokeImmediately: (...args: Parameters<T>) => ReturnType<T>;
   cancel: () => void;
 };
 
@@ -33,7 +34,11 @@ export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
     (...args: Parameters<T>) => debounceInstanceRef.current?.(...args),
     [],
   );
+  const invokeImmediately = useCallback(
+    (...args: Parameters<T>) => callbackRef.current(...args) as ReturnType<T>,
+    [],
+  );
   const cancel = useCallback(() => debounceInstanceRef.current?.cancel(), []);
 
-  return { debouncedCallback, cancel };
+  return { debouncedCallback, invokeImmediately, cancel };
 }

--- a/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
+++ b/packages/ketcher-macromolecules/src/hooks/useRecalculateMacromoleculeProperties.ts
@@ -18,6 +18,7 @@ import {
   selectUnipositiveIonsValue,
   setMacromoleculesProperties,
 } from 'state/common';
+import { useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from './stateHooks';
 
 export const useRecalculateMacromoleculeProperties = () => {
@@ -32,85 +33,100 @@ export const useRecalculateMacromoleculeProperties = () => {
   const unipositiveIonsValue = useAppSelector(selectUnipositiveIonsValue);
   const oligonucleotidesValue = useAppSelector(selectOligonucleotidesValue);
 
-  return async (shouldSkip?: boolean) => {
-    if (!editor || shouldSkip) {
-      return;
-    }
+  return useCallback(
+    async (shouldSkip?: boolean) => {
+      if (!editor || shouldSkip) {
+        return;
+      }
 
-    const indigo = IndigoProvider.getIndigo() as StructService;
-    const selectionDrawingEntitiesManager =
-      editor.drawingEntitiesManager.filterSelection();
-    const ketSerializer = new KetSerializer();
-    const hasNoSelection = !selectionDrawingEntitiesManager.hasDrawingEntities;
-    const drawingEntitiesManagerToCalculateProperties =
-      selectionDrawingEntitiesManager.hasDrawingEntities
-        ? selectionDrawingEntitiesManager
-        : editor.drawingEntitiesManager;
-    const chainsCollection = ChainsCollection.fromMonomers([
-      ...drawingEntitiesManagerToCalculateProperties.monomers.values(),
-    ]);
-    const firstMonomer = chainsCollection.firstNode?.monomer;
-    const allowedMonomers = new Set(
-      drawingEntitiesManagerToCalculateProperties.monomers.values(),
-    );
-    const areAllMonomersConnectedByCovalentOrHydrogenBonds =
-      !firstMonomer ||
-      chainsCollection.chains.reduce(
-        (acc: number, chain: Chain) => acc + chain.monomers.length,
-        0,
-      ) <=
-        getAllConnectedMonomersRecursively(firstMonomer, allowedMonomers)
-          .length;
-
-    const hasNoChainsButMultipleFragments =
-      chainsCollection.chains.length === 0 &&
-      [...drawingEntitiesManagerToCalculateProperties.monomers.values()].filter(
-        (monomer) => monomer.monomerItem.props.isMicromoleculeFragment,
-      ).length > 1;
-
-    if (
-      !drawingEntitiesManagerToCalculateProperties.hasDrawingEntities ||
-      !areAllMonomersConnectedByCovalentOrHydrogenBonds ||
-      (hasNoSelection && hasNoChainsButMultipleFragments)
-    ) {
-      dispatch(setMacromoleculesProperties(undefined));
-
-      return;
-    }
-
-    const serializedKet = ketSerializer.serialize(
-      new Struct(),
-      editor.drawingEntitiesManager,
-      undefined,
-      false,
-      true,
-    );
-    const calculateMacromoleculePropertiesResponse =
-      await indigo.calculateMacromoleculeProperties(
-        {
-          struct: serializedKet,
-        },
-        {
-          upc:
-            unipositiveIonsValue /
-            molarMeasurementUnitToNumber[unipositiveIonsMeasurementUnit],
-          nac:
-            oligonucleotidesValue /
-            molarMeasurementUnitToNumber[oligonucleotidesMeasurementUnit],
-        },
+      const indigo = IndigoProvider.getIndigo() as StructService;
+      const selectionDrawingEntitiesManager =
+        editor.drawingEntitiesManager.filterSelection();
+      const ketSerializer = new KetSerializer();
+      const hasNoSelection =
+        !selectionDrawingEntitiesManager.hasDrawingEntities;
+      const drawingEntitiesManagerToCalculateProperties =
+        selectionDrawingEntitiesManager.hasDrawingEntities
+          ? selectionDrawingEntitiesManager
+          : editor.drawingEntitiesManager;
+      const chainsCollection = ChainsCollection.fromMonomers([
+        ...drawingEntitiesManagerToCalculateProperties.monomers.values(),
+      ]);
+      const firstMonomer = chainsCollection.firstNode?.monomer;
+      const allowedMonomers = new Set(
+        drawingEntitiesManagerToCalculateProperties.monomers.values(),
       );
+      const areAllMonomersConnectedByCovalentOrHydrogenBonds =
+        !firstMonomer ||
+        chainsCollection.chains.reduce(
+          (acc: number, chain: Chain) => acc + chain.monomers.length,
+          0,
+        ) <=
+          getAllConnectedMonomersRecursively(firstMonomer, allowedMonomers)
+            .length;
 
-    try {
-      const macromoleculeProperties =
-        calculateMacromoleculePropertiesResponse.properties &&
-        JSON.parse(calculateMacromoleculePropertiesResponse.properties);
+      const hasNoChainsButMultipleFragments =
+        chainsCollection.chains.length === 0 &&
+        [
+          ...drawingEntitiesManagerToCalculateProperties.monomers.values(),
+        ].filter((monomer) => monomer.monomerItem.props.isMicromoleculeFragment)
+          .length > 1;
 
-      notifyRequestCompleted();
-      dispatch(setMacromoleculesProperties(macromoleculeProperties));
-    } catch (e) {
-      KetcherLogger.error('Error during parsing macromolecule properties: ', e);
+      if (
+        !drawingEntitiesManagerToCalculateProperties.hasDrawingEntities ||
+        !areAllMonomersConnectedByCovalentOrHydrogenBonds ||
+        (hasNoSelection && hasNoChainsButMultipleFragments)
+      ) {
+        dispatch(setMacromoleculesProperties(undefined));
 
-      dispatch(setMacromoleculesProperties(undefined));
-    }
-  };
+        return;
+      }
+
+      const serializedKet = ketSerializer.serialize(
+        new Struct(),
+        editor.drawingEntitiesManager,
+        undefined,
+        false,
+        true,
+      );
+      const calculateMacromoleculePropertiesResponse =
+        await indigo.calculateMacromoleculeProperties(
+          {
+            struct: serializedKet,
+          },
+          {
+            upc:
+              unipositiveIonsValue /
+              molarMeasurementUnitToNumber[unipositiveIonsMeasurementUnit],
+            nac:
+              oligonucleotidesValue /
+              molarMeasurementUnitToNumber[oligonucleotidesMeasurementUnit],
+          },
+        );
+
+      try {
+        const macromoleculeProperties =
+          calculateMacromoleculePropertiesResponse.properties &&
+          JSON.parse(calculateMacromoleculePropertiesResponse.properties);
+
+        notifyRequestCompleted();
+        dispatch(setMacromoleculesProperties(macromoleculeProperties));
+      } catch (e) {
+        KetcherLogger.error(
+          'Error during parsing macromolecule properties: ',
+          e,
+        );
+
+        dispatch(setMacromoleculesProperties(undefined));
+      }
+    },
+    [
+      dispatch,
+      editor,
+      oligonucleotidesMeasurementUnit,
+      oligonucleotidesValue,
+      unipositiveIonsMeasurementUnit,
+      unipositiveIonsValue,
+    ],
+  );
 };


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Moved the creation of the debounced macromolecule properties recalculation handler from the render phase to an effect.

Refs are now accessed only inside effects and deferred event handlers. This keeps the component render pure while preserving a single stable debounce instance and ensuring that the latest recalculation callback is used.

Added cleanup to cancel pending debounced calls when the component is unmounted. The obsolete react-hooks/refs and react-hooks/use-memo ESLint suppressions were removed.

The existing macromolecule properties recalculation behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request