### PR TITLE
#11233 - Refactor: Reading from or writing to ref.current during React render problem clean up from packages\ketcher-macromolecules\src\components\DragGhost\DragGhost.tsx file

### DIFF
--- a/packages/ketcher-macromolecules/src/components/DragGhost/DragGhost.tsx
+++ b/packages/ketcher-macromolecules/src/components/DragGhost/DragGhost.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
 import {
   isLibraryItemRnaPreset,
   LibraryItemDragState,
@@ -15,13 +16,12 @@ import { selectEditor } from 'state/common';
 export const DragGhost = () => {
   const editor = useSelector(selectEditor);
 
-  const [{ libraryItemDragData, canvasBBox }, setDragState] = useState<{
-    libraryItemDragData: LibraryItemDragState;
-    canvasBBox: DOMRect | null;
-  }>({ libraryItemDragData: null, canvasBBox: null });
+  const [libraryItemDragData, setLibraryItemDragData] =
+    useState<LibraryItemDragState>(null);
 
   const ghostWrapperRef = useRef<HTMLDivElement>(null);
   const animateRef = useRef<number | null>(null);
+  const canvasBBoxRef = useRef<DOMRect | null>(null);
 
   const transform = useZoomTransform();
 
@@ -31,13 +31,7 @@ export const DragGhost = () => {
     }
 
     const handleLibraryItemDrag = (state: LibraryItemDragState) => {
-      const canvasWrapper = ZoomTool.instance?.canvasWrapper.node();
-
-      setDragState({
-        libraryItemDragData: state,
-        canvasBBox:
-          state && canvasWrapper ? canvasWrapper.getBoundingClientRect() : null,
-      });
+      setLibraryItemDragData(state);
     };
 
     editor.events.setLibraryItemDragState.add(handleLibraryItemDrag);
@@ -47,15 +41,21 @@ export const DragGhost = () => {
     };
   }, [editor]);
 
+  useEffect(() => {
+    if (!ZoomTool.instance || !libraryItemDragData) {
+      return;
+    }
+
+    const canvasWrapper = ZoomTool.instance.canvasWrapper.node();
+    if (!canvasWrapper) {
+      return;
+    }
+
+    canvasBBoxRef.current = canvasWrapper.getBoundingClientRect();
+  }, [libraryItemDragData]);
+
   const leftOffset = editor?.ketcherRootElementBoundingClientRect?.left || 0;
   const topOffset = editor?.ketcherRootElementBoundingClientRect?.top || 0;
-  const dragOverCanvas =
-    canvasBBox &&
-    libraryItemDragData &&
-    libraryItemDragData.position.x + leftOffset >= canvasBBox.left &&
-    libraryItemDragData.position.x + leftOffset <= canvasBBox.right &&
-    libraryItemDragData.position.y + topOffset >= canvasBBox.top &&
-    libraryItemDragData.position.y + topOffset <= canvasBBox.bottom;
 
   useLayoutEffect(() => {
     const element = ghostWrapperRef.current;
@@ -63,9 +63,16 @@ export const DragGhost = () => {
       return;
     }
 
-    animateRef.current = requestAnimationFrame(() => {
-      const { x, y } = libraryItemDragData.position;
+    const { x, y } = libraryItemDragData.position;
+    const canvasBBox = canvasBBoxRef.current;
+    const dragOverCanvas =
+      canvasBBox &&
+      x + leftOffset >= canvasBBox.left &&
+      x + leftOffset <= canvasBBox.right &&
+      y + topOffset >= canvasBBox.top &&
+      y + topOffset <= canvasBBox.bottom;
 
+    animateRef.current = requestAnimationFrame(() => {
       if (dragOverCanvas) {
         const scale = transform.k;
 
@@ -82,7 +89,7 @@ export const DragGhost = () => {
         animateRef.current = null;
       }
     };
-  }, [dragOverCanvas, libraryItemDragData, transform.k]);
+  }, [leftOffset, libraryItemDragData, topOffset, transform.k]);
 
   if (!libraryItemDragData) {
     return null;

--- a/packages/ketcher-macromolecules/src/components/DragGhost/DragGhost.tsx
+++ b/packages/ketcher-macromolecules/src/components/DragGhost/DragGhost.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
-/* eslint-disable react-hooks/refs */
 import {
   isLibraryItemRnaPreset,
   LibraryItemDragState,
@@ -17,12 +15,13 @@ import { selectEditor } from 'state/common';
 export const DragGhost = () => {
   const editor = useSelector(selectEditor);
 
-  const [libraryItemDragData, setLibraryItemDragData] =
-    useState<LibraryItemDragState>(null);
+  const [{ libraryItemDragData, canvasBBox }, setDragState] = useState<{
+    libraryItemDragData: LibraryItemDragState;
+    canvasBBox: DOMRect | null;
+  }>({ libraryItemDragData: null, canvasBBox: null });
 
   const ghostWrapperRef = useRef<HTMLDivElement>(null);
   const animateRef = useRef<number | null>(null);
-  const canvasBBoxRef = useRef<DOMRect | null>(null);
 
   const transform = useZoomTransform();
 
@@ -32,7 +31,13 @@ export const DragGhost = () => {
     }
 
     const handleLibraryItemDrag = (state: LibraryItemDragState) => {
-      setLibraryItemDragData(state);
+      const canvasWrapper = ZoomTool.instance?.canvasWrapper.node();
+
+      setDragState({
+        libraryItemDragData: state,
+        canvasBBox:
+          state && canvasWrapper ? canvasWrapper.getBoundingClientRect() : null,
+      });
     };
 
     editor.events.setLibraryItemDragState.add(handleLibraryItemDrag);
@@ -42,28 +47,15 @@ export const DragGhost = () => {
     };
   }, [editor]);
 
-  useEffect(() => {
-    if (!ZoomTool.instance || !libraryItemDragData) {
-      return;
-    }
-
-    const canvasWrapper = ZoomTool.instance.canvasWrapper.node();
-    if (!canvasWrapper) {
-      return;
-    }
-
-    canvasBBoxRef.current = canvasWrapper.getBoundingClientRect();
-  }, [libraryItemDragData]);
   const leftOffset = editor?.ketcherRootElementBoundingClientRect?.left || 0;
   const topOffset = editor?.ketcherRootElementBoundingClientRect?.top || 0;
   const dragOverCanvas =
-    canvasBBoxRef.current &&
+    canvasBBox &&
     libraryItemDragData &&
-    libraryItemDragData.position.x + leftOffset >= canvasBBoxRef.current.left &&
-    libraryItemDragData.position.x + leftOffset <=
-      canvasBBoxRef.current.right &&
-    libraryItemDragData.position.y + topOffset >= canvasBBoxRef.current.top &&
-    libraryItemDragData.position.y + topOffset <= canvasBBoxRef.current.bottom;
+    libraryItemDragData.position.x + leftOffset >= canvasBBox.left &&
+    libraryItemDragData.position.x + leftOffset <= canvasBBox.right &&
+    libraryItemDragData.position.y + topOffset >= canvasBBox.top &&
+    libraryItemDragData.position.y + topOffset <= canvasBBox.bottom;
 
   useLayoutEffect(() => {
     const element = ghostWrapperRef.current;
@@ -74,7 +66,7 @@ export const DragGhost = () => {
     animateRef.current = requestAnimationFrame(() => {
       const { x, y } = libraryItemDragData.position;
 
-      if (dragOverCanvas && canvasBBoxRef.current) {
+      if (dragOverCanvas) {
         const scale = transform.k;
 
         element.style.transformOrigin = '0 0';


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Replaced the canvas bounding box ref with React state because its value affects the rendered drag ghost position and scale.

The library item drag data and canvas bounding box are now calculated and updated together in the drag event handler. This removes the need for a separate effect and prevents reading ref.current during render.

The DOM element and animation frame refs remain unchanged because they are accessed only inside the layout effect and its cleanup.

The obsolete react-hooks/refs and react-you-might-not-need-an-effect/no-event-handler ESLint suppressions were removed. The existing drag ghost behavior remains unchanged.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request