### PR TITLE
#11311 - Unable to undo Remove Grouping (or Expand monomer) operation in some cases

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/editor/index.js
+++ b/packages/ketcher-react/src/script/ui/state/editor/index.js
@@ -60,7 +60,14 @@ export default function initEditor(dispatch, getState, ketcherId) {
     async (dispatch) => {
       const state = getState();
       const activeTool = state.actionState?.activeTool.tool;
-      if (!activeTool || (activeTool === 'select' && !force)) return;
+      if (!activeTool || (activeTool === 'select' && !force)) {
+        // Even when the active tool doesn't need to be reset (e.g. a
+        // context-menu action like "Remove Grouping"/"Expand Monomer" runs
+        // while the select tool is already active), button states such as
+        // Undo/Redo still need to be refreshed to reflect the new history.
+        updateAction();
+        return;
+      }
       const selectMode = state.toolbar.visibleTools.select;
       const resetOption = state.options.settings.resetToSelect;
       if (resetOption === true || resetOption === activeTool || force === true)


### PR DESCRIPTION
"Remove Grouping" and "Expand Monomer" push a new entry onto the editor's history stack via editor.update(), but resetToSelect() bailed out early whenever the select tool was already active (the common case for a context-menu action) without refreshing the Redux actionState. The Undo/Redo toolbar buttons kept rendering their last-computed disabled flag, leaving Undo visibly stuck disabled even though the action was undoable.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request