### PR TITLE
#346 - Promise failing during benzene rings render

### DIFF
--- a/packages/ketcher-core/__tests__/application/editor/actions/atomMerge.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/atomMerge.test.ts
@@ -76,4 +76,28 @@ describe('fromAtomMerge', () => {
     expect(restoredAttachmentPoints).toHaveLength(1);
     expect(restoredAttachmentPoints[0].atomId).toBe(srcId);
   });
+
+  // Regression test for https://github.com/epam/ketcher/issues/346:
+  // fromAtomMerge must no-op, not throw, when dstId was already removed.
+  it('does not throw and returns an empty Action when dstId no longer exists', () => {
+    const struct = new Struct();
+
+    const srcId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(0, 0), fragment: 0 }),
+    );
+    const dstId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(1, 0), fragment: 0 }),
+    );
+
+    // Simulate dstId having already been removed by a prior merge.
+    struct.atoms.delete(dstId);
+
+    const restruct = { molecule: struct };
+
+    let action;
+    expect(() => {
+      action = fromAtomMerge(restruct as ReStruct, srcId, dstId);
+    }).not.toThrow();
+    expect(action?.operations).toHaveLength(0);
+  });
 });

--- a/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/bond.test.ts
@@ -1,11 +1,15 @@
 import * as utils from 'application/editor/actions/utils';
 
-import { type Action, fromBondAddition } from 'application/editor/actions';
+import {
+  type Action,
+  fromBondAddition,
+  fromBondsMerge,
+} from 'application/editor/actions';
 import { ReStruct, Render } from 'application/render';
 import type { RenderOptions } from 'application/render/render.types';
 import { AtomAdd } from 'application/editor/operations/atom/AtomAdd';
 import { BondAdd } from 'application/editor/operations/bond/BondAdd';
-import { Bond, Struct, Vec2 } from 'domain/entities';
+import { Atom, Bond, Struct, Vec2 } from 'domain/entities';
 
 import { restruct, singleBond } from '../../../mock-data';
 
@@ -132,5 +136,65 @@ describe('atomForNewBond', () => {
 
     expect((tripleResult.pos as Vec2).x).toBeCloseTo(1);
     expect((tripleResult.pos as Vec2).y).toBeCloseTo(0);
+  });
+});
+
+// Regression test for https://github.com/epam/ketcher/issues/346: an
+// earlier pair in the same batch can delete another pair's target atom;
+// fromBondsMerge must resolve to the atom that actually survived.
+describe('fromBondsMerge: chained merges within one batch', () => {
+  function buildReStruct(struct: Struct) {
+    const options = {
+      microModeScale: 20,
+      width: 100,
+      height: 100,
+    } as RenderOptions;
+    const render = new Render(document as unknown as HTMLElement, options);
+    const reStruct = new ReStruct(struct, render);
+    reStruct.assignConnectedComponents();
+    return reStruct;
+  }
+
+  function addAtom(struct: Struct, pos: Vec2) {
+    return struct.atoms.add(new Atom({ label: 'C', pp: pos, fragment: 0 }));
+  }
+
+  function addBond(struct: Struct, begin: number, end: number) {
+    return struct.bonds.add(
+      new Bond({ begin, end, type: Bond.PATTERN.TYPE.SINGLE }),
+    );
+  }
+
+  it('redirects a merge to the surviving atom instead of a stale/deleted one', () => {
+    const struct = new Struct();
+
+    // Pair Y (processed first): A-A2 fuses to B-B2, so A is deleted, B survives.
+    const a = addAtom(struct, new Vec2(0, 0));
+    const a2 = addAtom(struct, new Vec2(1, 0));
+    const b = addAtom(struct, new Vec2(0, 0));
+    const b2 = addAtom(struct, new Vec2(1, 0));
+    const bondYSrc = addBond(struct, a, a2);
+    const bondYDst = addBond(struct, b, b2);
+
+    // Pair X: C-C2 fuses to A-A3 - its target A is the atom pair Y just deleted.
+    const c = addAtom(struct, new Vec2(2, 0));
+    const c2 = addAtom(struct, new Vec2(3, 0));
+    const a3 = addAtom(struct, new Vec2(1, 0));
+    const bondXSrc = addBond(struct, c, c2);
+    const bondXDst = addBond(struct, a, a3);
+
+    const reStruct = buildReStruct(struct);
+
+    const mergeMap = new Map<number, number>([
+      [bondYSrc, bondYDst],
+      [bondXSrc, bondXDst],
+    ]);
+
+    expect(() => fromBondsMerge(reStruct, mergeMap)).not.toThrow();
+
+    // C must have been redirected to the surviving B, not left unmerged.
+    expect(struct.atoms.has(a)).toBe(false);
+    expect(struct.atoms.has(c)).toBe(false);
+    expect(struct.atoms.has(b)).toBe(true);
   });
 });

--- a/packages/ketcher-core/__tests__/application/editor/actions/closelyFusing.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/closelyFusing.test.ts
@@ -1,0 +1,46 @@
+import { fromItemsFuse } from 'application/editor/actions';
+import { ReStruct, Render } from 'application/render';
+import type { RenderOptions } from 'application/render/render.types';
+import { Atom, Struct, Vec2 } from 'domain/entities';
+
+// Regression test for https://github.com/epam/ketcher/issues/346:
+// fromItemsFuse's single-atom merge loop must not crash on a stale dst.
+describe('fromItemsFuse: stale atom-merge target', () => {
+  function buildReStruct(struct: Struct) {
+    const options = {
+      microModeScale: 20,
+      width: 100,
+      height: 100,
+    } as RenderOptions;
+    const render = new Render(document as unknown as HTMLElement, options);
+    const reStruct = new ReStruct(struct, render);
+    reStruct.assignConnectedComponents();
+    return reStruct;
+  }
+
+  function addAtom(struct: Struct, pos: Vec2) {
+    return struct.atoms.add(new Atom({ label: 'C', pp: pos, fragment: 0 }));
+  }
+
+  it('does not throw when items.atoms references an already-deleted dst atom', () => {
+    const struct = new Struct();
+
+    const src = addAtom(struct, new Vec2(0, 0));
+    const dst = addAtom(struct, new Vec2(1, 0));
+
+    // dst already removed by something else in the same batch.
+    struct.atoms.delete(dst);
+
+    const reStruct = buildReStruct(struct);
+
+    const items = {
+      atoms: new Map<number, number>([[src, dst]]),
+      bonds: new Map<number, number>(),
+    };
+
+    expect(() => fromItemsFuse(reStruct, items)).not.toThrow();
+
+    // src is left as-is, not deleted along with a merge that never happened.
+    expect(struct.atoms.has(src)).toBe(true);
+  });
+});

--- a/packages/ketcher-core/src/application/editor/actions/aromaticFusing.ts
+++ b/packages/ketcher-core/src/application/editor/actions/aromaticFusing.ts
@@ -30,7 +30,6 @@ export function fromAromaticTemplateOnBond(
   bid: number,
   _events: unknown,
   simpleFusing: SimpleFusing,
-): Promise<[Action, PasteItems]> {
-  const pasteResult = simpleFusing(restruct, template, bid);
-  return Promise.resolve(pasteResult);
+): [Action, PasteItems] {
+  return simpleFusing(restruct, template, bid);
 }

--- a/packages/ketcher-core/src/application/editor/actions/atomMerge.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atomMerge.ts
@@ -37,6 +37,7 @@ export function fromAtomMerge(
   dstId: number,
 ): Action {
   if (srcId === dstId) return new Action();
+  if (!restruct.molecule.atoms.has(dstId)) return new Action();
 
   const fragAction = new Action();
   mergeFragmentsIfNeeded(fragAction, restruct, srcId, dstId);

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -249,7 +249,9 @@ export function fromBondsMerge(
   });
 
   // Shared vertex atoms fused earlier in this batch may already be deleted;
-  // resolve through prior merges to the atom that actually survived.
+  // resolve through prior merges to the atom that actually survived. Can't
+  // cycle: fromAtomMerge always deletes src and keeps dst, so a resolved id
+  // is never re-inserted as a key once it has appeared as a value below.
   const survivingAtomId = new Map<number, number>();
   const resolveAtomId = (atomId: number): number => {
     let resolved = atomId;

--- a/packages/ketcher-core/src/application/editor/actions/bond.ts
+++ b/packages/ketcher-core/src/application/editor/actions/bond.ts
@@ -248,8 +248,35 @@ export function fromBondsMerge(
     atomPairs.set(bond.end, !params.cross ? bondCI.end : bondCI.begin);
   });
 
+  // Shared vertex atoms fused earlier in this batch may already be deleted;
+  // resolve through prior merges to the atom that actually survived.
+  const survivingAtomId = new Map<number, number>();
+  const resolveAtomId = (atomId: number): number => {
+    let resolved = atomId;
+    let next = survivingAtomId.get(resolved);
+    while (next !== undefined) {
+      resolved = next;
+      next = survivingAtomId.get(resolved);
+    }
+    return resolved;
+  };
+
   atomPairs.forEach((dst, src) => {
-    action = fromAtomMerge(restruct, src, dst).mergeWith(action);
+    const resolvedSrc = resolveAtomId(src);
+    const resolvedDst = resolveAtomId(dst);
+
+    if (
+      resolvedSrc === resolvedDst ||
+      !struct.atoms.has(resolvedSrc) ||
+      !struct.atoms.has(resolvedDst)
+    ) {
+      return;
+    }
+
+    action = fromAtomMerge(restruct, resolvedSrc, resolvedDst).mergeWith(
+      action,
+    );
+    survivingAtomId.set(resolvedSrc, resolvedDst);
   });
 
   return action;

--- a/packages/ketcher-core/src/application/editor/actions/template.ts
+++ b/packages/ketcher-core/src/application/editor/actions/template.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-redeclare */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -268,27 +267,9 @@ export function fromTemplateOnBondAction(
   bid: number,
   events: unknown,
   flip: boolean,
-  force: false,
-  isPreview?: boolean,
-): FromTemplateOnBondResult;
-export function fromTemplateOnBondAction(
-  restruct: ReStruct,
-  template: EditorTemplate,
-  bid: number,
-  events: unknown,
-  flip: boolean,
-  force: true,
-  isPreview?: boolean,
-): Promise<FromTemplateOnBondResult>;
-export function fromTemplateOnBondAction(
-  restruct: ReStruct,
-  template: EditorTemplate,
-  bid: number,
-  events: unknown,
-  flip: boolean,
   force: boolean,
   isPreview = false,
-): FromTemplateOnBondResult | Promise<FromTemplateOnBondResult> {
+): FromTemplateOnBondResult {
   if (!force) return fromTemplateOnBond(restruct, template, bid, flip);
 
   const simpleFusing = (
@@ -296,7 +277,6 @@ export function fromTemplateOnBondAction(
     template: EditorTemplate,
     bid: number,
   ) => fromTemplateOnBond(restruct, template, bid, flip, isPreview);
-  /* aromatic merge (Promise) */
   return fromAromaticTemplateOnBond(
     restruct,
     template,

--- a/packages/ketcher-react/src/script/editor/shared/closest.test.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.test.ts
@@ -1,0 +1,45 @@
+import { Atom, Bond, Render, ReStruct, Struct, Vec2 } from 'ketcher-core';
+import type { RenderOptions } from 'ketcher-core';
+import closest from './closest';
+
+// Regression test for https://github.com/epam/ketcher/issues/346:
+// findCloseMerge (closest.merge) must skip a bond whose atom was already
+// deleted by an earlier merge in the same batch, not throw.
+describe('closest.merge (findCloseMerge): stale bond references', () => {
+  function buildReStruct() {
+    const options = {
+      microModeScale: 20,
+      width: 100,
+      height: 100,
+    } as RenderOptions;
+    const render = new Render(document as unknown as HTMLElement, options);
+    return new ReStruct(new Struct(), render);
+  }
+
+  it('does not throw when a selected bond references an already-deleted atom', () => {
+    const restruct = buildReStruct();
+    const struct = restruct.molecule;
+
+    const beginId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(0, 0), fragment: 0 }),
+    );
+    const endId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(1, 0), fragment: 0 }),
+    );
+    const bondId = struct.bonds.add(
+      new Bond({ begin: beginId, end: endId, type: Bond.PATTERN.TYPE.SINGLE }),
+    );
+
+    // Bond still present, but one of its atoms was already merged away.
+    struct.atoms.delete(endId);
+
+    expect(() =>
+      closest.merge(
+        restruct,
+        { atoms: [], bonds: [bondId] },
+        restruct.render.options,
+        [],
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -648,16 +648,15 @@ function findCloseMerge(
   selected.bonds.forEach((bid) => {
     const bond = struct.bonds.get(bid);
     if (bond) {
-      const beginAtom = getOrThrow(
-        struct.atoms,
-        bond.begin,
-        atomsForBondNotFoundMessage(bid, bond.begin, bond.end),
-      );
-      const endAtom = getOrThrow(
-        struct.atoms,
-        bond.end,
-        atomsForBondNotFoundMessage(bid, bond.begin, bond.end),
-      );
+      const beginAtom = struct.atoms.get(bond.begin);
+      const endAtom = struct.atoms.get(bond.end);
+      if (!beginAtom || !endAtom) {
+        // Same stale-cache scenario as findClosestBond: skip instead of crashing.
+        KetcherLogger.warn(
+          atomsForBondNotFoundMessage(bid, bond.begin, bond.end),
+        );
+        return;
+      }
       pos.bonds.set(bid, Vec2.lc2(beginAtom.pp, 0.5, endAtom.pp, 0.5));
     }
   });

--- a/packages/ketcher-react/src/script/editor/shared/closest.ts
+++ b/packages/ketcher-react/src/script/editor/shared/closest.ts
@@ -28,6 +28,7 @@ import {
   atomsForBondNotFoundMessage,
   entityNotFoundMessage,
   assert,
+  KetcherLogger,
 } from 'ketcher-core';
 import type {
   ClosestItem,
@@ -218,16 +219,15 @@ function findClosestBond(
       return;
     }
 
-    const beginAtom = getOrThrow(
-      restruct.atoms,
-      bond.b.begin,
-      atomsForBondNotFoundMessage(bid, bond.b.begin, bond.b.end),
-    );
-    const endAtom = getOrThrow(
-      restruct.atoms,
-      bond.b.end,
-      atomsForBondNotFoundMessage(bid, bond.b.begin, bond.b.end),
-    );
+    const beginAtom = restruct.atoms.get(bond.b.begin);
+    const endAtom = restruct.atoms.get(bond.b.end);
+    if (!beginAtom || !endAtom) {
+      // visibleBonds is a stale cache mid-batch-edit; skip instead of crashing.
+      KetcherLogger.warn(
+        atomsForBondNotFoundMessage(bid, bond.b.begin, bond.b.end),
+      );
+      return;
+    }
     const p1 = beginAtom.a.pp;
     const p2 = endAtom.a.pp;
 
@@ -245,11 +245,11 @@ function findClosestBond(
       closestBondCenter = bid;
     }
 
-    const hb = getOrThrow(
-      restruct.molecule.halfBonds,
-      bond.b.hb1 as number,
-      `Half-bond ${bond.b.hb1} for bond ${bid} not found`,
-    );
+    const hb = restruct.molecule.halfBonds.get(bond.b.hb1 as number);
+    if (!hb) {
+      KetcherLogger.warn(`Half-bond ${bond.b.hb1} for bond ${bid} not found`);
+      return;
+    }
     const dir = hb.dir;
     const norm = hb.norm;
 

--- a/packages/ketcher-react/src/script/editor/tool/template.ts
+++ b/packages/ketcher-react/src/script/editor/tool/template.ts
@@ -334,7 +334,7 @@ class TemplateTool implements Tool {
           this.editor.event,
           dragCtx.sign1 * dragCtx.sign2 > 0,
           false,
-        ) as [Action, { atoms: number[]; bonds: number[] }];
+        );
 
         dragCtx.action = action;
         this.editor.update(dragCtx.action, true);
@@ -457,20 +457,18 @@ class TemplateTool implements Tool {
     ) {
       dragCtx.action.perform(restruct); // revert drag action
 
-      const promise = fromTemplateOnBondAction(
+      let [action, pasteItems] = fromTemplateOnBondAction(
         restruct,
         this.template,
         ci.id,
         this.editor.event,
         dragCtx.sign1 * dragCtx.sign2 > 0,
         true,
-      ) as Promise<[Action, { atoms: number[]; bonds: number[] }]>;
+      );
 
-      promise.then(([action, pasteItems]) => {
-        const mergeItems = getItemsToFuse(this.editor, pasteItems);
-        action = fromItemsFuse(restruct, mergeItems).mergeWith(action);
-        this.editor.update(action);
-      });
+      const mergeItems = getItemsToFuse(this.editor, pasteItems);
+      action = fromItemsFuse(restruct, mergeItems).mergeWith(action);
+      this.editor.update(action);
       return;
     }
     /* end */
@@ -567,22 +565,18 @@ class TemplateTool implements Tool {
         }
         dragCtx.action = action;
       } else if (ci.map === 'bonds' && !this.isModeFunctionalGroup) {
-        const promise = fromTemplateOnBondAction(
+        let [action, pasteItems] = fromTemplateOnBondAction(
           restruct,
           this.template,
           ci.id,
           this.editor.event,
           dragCtx.sign1 * dragCtx.sign2 > 0,
           true,
-        ) as Promise<[Action, { atoms: number[]; bonds: number[] }]>;
+        );
 
-        promise.then(([action, pasteItems]) => {
-          if (!this.isModeFunctionalGroup) {
-            const mergeItems = getItemsToFuse(this.editor, pasteItems);
-            action = fromItemsFuse(restruct, mergeItems).mergeWith(action);
-            this.editor.update(action);
-          }
-        });
+        const mergeItems = getItemsToFuse(this.editor, pasteItems);
+        action = fromItemsFuse(restruct, mergeItems).mergeWith(action);
+        this.editor.update(action);
 
         return;
       }

--- a/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
+++ b/packages/ketcher-react/src/script/editor/tool/templatePreview.ts
@@ -212,7 +212,7 @@ class TemplatePreview {
       const sign2 = this.template.sign;
       const shouldFlip = sign1 * sign2 > 0;
 
-      const promise = fromTemplateOnBondAction(
+      let [action, pasteItems] = fromTemplateOnBondAction(
         this.restruct,
         this.template,
         ci.id,
@@ -222,14 +222,10 @@ class TemplatePreview {
         true,
       );
 
-      promise.then(([action, pasteItems]) => {
-        if (!this.isModeFunctionalGroup) {
-          const mergeItems = getItemsToFuse(this.editor, pasteItems);
-          action = fromItemsFuse(this.restruct, mergeItems).mergeWith(action);
-          this.editor.update(action, true);
-          this.connectedPreviewAction = action;
-        }
-      });
+      const mergeItems = getItemsToFuse(this.editor, pasteItems);
+      action = fromItemsFuse(this.restruct, mergeItems).mergeWith(action);
+      this.editor.update(action, true);
+      this.connectedPreviewAction = action;
     } else if (ci.map === 'atoms') {
       const angle = getAngleFromEvent(event, ci, this.restruct);
 


### PR DESCRIPTION
Root cause:
When a benzene ring template is dropped directly onto an existing bond, TemplateTool (packages/ketcher-react/src/script/editor/tool/template.ts) calls fromTemplateOnBondAction(..., force: true), which resolves through `fromAromaticTemplateOnBond `(packages/ketcher-core/src/application/editor/actions/aromaticFusing.ts). That function did all of its work synchronously but then wrapped the result in Promise.resolve(...) for no real async reason. As a result, the new ring atoms/bonds were added to restruct immediately, but the fuse/merge cleanup (fromItemsFuse, which merges/removes the duplicate placeholder atoms) and the subsequent editor.update() repaint were deferred to a .then() microtask.

The tool's drag context (dragCtx) is a single mutable field with no generation/sequencing guard. On a burst of very fast clicks, a later click can synchronously revert/replace atoms and bonds via dragCtx.action.perform(restruct) before an earlier click's deferred .then() callback has run its merge cleanup. This leaves a ReBond in restruct.bonds (and therefore in visibleBonds) whose begin/end point to an atom that has already been removed.

The corruption itself is silent until the next mouse move, when the generic hover path `(Editor.findItem → closest.item → findClosestBond)` iterates visibleBonds and calls getOrThrow(restruct.atoms, bond.b.begin, ...), which throws with exactly the reported error — matching the original "Promise failing" symptom in the issue title.

Fix: Removed the redundant Promise wrapping so template placement, merge/fuse cleanup, and repaint happen synchronously in one step per click, closing the race window. On top of that:

- fromAtomMerge and fromBondsMerge now guard against merging into an atom that a prior merge in the same batch already deleted, instead of merging into (or crashing on) a stale id.
- findClosestBond and findCloseMerge no longer throw on a bond referencing a missing atom during a mid-batch edit; they log a warning and skip it instead.
- Added regression tests covering the original race (bond.test.ts, closelyFusing.test.ts) and the two defensive guards (atomMerge.test.ts, closest.test.ts).

All new and existing tests pass, along with type-check and lint on the touched files.

## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

Fixes #346 