### PR TITLE
#10854 - System ignores Display charge option on export to SVG/PNG

### DIFF
--- a/packages/ketcher-core/src/application/ketcher.ts
+++ b/packages/ketcher-core/src/application/ketcher.ts
@@ -784,8 +784,9 @@ export class Ketcher {
     },
   ): Promise<Blob> {
     let meta: string;
+    const outputFormat = options.outputFormat || 'png';
 
-    switch (options.outputFormat) {
+    switch (outputFormat) {
       case 'svg':
         meta = 'image/svg+xml';
         break;
@@ -796,11 +797,35 @@ export class Ketcher {
         options.outputFormat = 'png';
     }
     const serverSettings = this.editor.serverSettings;
-
-    const base64 = await this.structService.generateImageAsBase64(data, {
+    const mergedOptions = {
       ...serverSettings,
       ...options,
-    });
+    };
+
+    // For PNG export with hidden charges, generate SVG first then convert to PNG
+    // This allows us to filter charge symbols from SVG before rasterization
+    const shouldHideCharges = mergedOptions['render-charges-visible'] === false;
+    if (outputFormat === 'png' && shouldHideCharges) {
+      // Generate SVG with charges hidden (post-processing in structService)
+      const svgDataUrl = await this.structService.generateImageAsBase64(data, {
+        ...mergedOptions,
+        outputFormat: 'svg',
+      });
+
+      // Convert SVG to PNG using Canvas API (scale=1 to match SVG dimensions)
+      const { svgToPng } = await import('../utilities/svgToPng');
+      const pngBlob = await svgToPng(
+        'data:image/svg+xml;base64,' + svgDataUrl,
+        1,
+      );
+      return pngBlob;
+    }
+
+    // Standard flow for SVG or PNG without charge filtering
+    const base64 = await this.structService.generateImageAsBase64(
+      data,
+      mergedOptions,
+    );
     const byteCharacters = atob(base64);
     const byteNumbers = new Array(byteCharacters.length);
     for (let i = 0; i < byteCharacters.length; i++) {

--- a/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
+++ b/packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts
@@ -51,6 +51,57 @@ import { KetcherLogger, normalizeError } from 'utilities';
 import { getLabelRenderModeForIndigo } from 'infrastructure/services/helpers';
 import { ketcherProvider } from 'application/ketcherProvider';
 
+/**
+ * Removes charge symbol path elements from Indigo-generated SVG.
+ * Charge symbols are rendered as simple path elements with fill-rule="nonzero"
+ * that appear near the end of the SVG document.
+ *
+ * @param svgDataUrl - SVG data URL with base64 encoding
+ * @returns SVG data URL without charge paths
+ */
+function removeChargePathsFromSvg(svgDataUrl: string): string {
+  // Constants for charge path detection
+  const CHARGE_PATH_DISTANCE_FROM_END = 15; // Lines from end where charge paths typically appear
+  const MAX_CHARGE_PATH_LENGTH = 300; // Max path data length for simple charge symbols
+
+  // Decode SVG from base64 data URL
+  const svgContent = svgDataUrl.replace(/^data:image\/svg\+xml;base64,/, '');
+  const decodedSvg = atob(svgContent);
+
+  const svgLines = decodedSvg.split('\n');
+  const filteredLines: string[] = [];
+
+  for (let i = 0; i < svgLines.length; i++) {
+    const line = svgLines[i];
+
+    // Charge path detection heuristics:
+    // 1. Contains <path> with fill-rule="nonzero"
+    // 2. Is near the end (charge paths are added last by Indigo)
+    // 3. Is a self-closing tag (ends with />)
+    // 4. Has simple path data (charge symbols are geometric shapes: +, -)
+    const isNearEnd = i > svgLines.length - CHARGE_PATH_DISTANCE_FROM_END;
+    const hasPath = line.includes('<path');
+    const hasFillRule = line.includes('fill-rule="nonzero"');
+    const isSelfClosing = line.trim().endsWith('/>');
+
+    const pathMatch = line.match(/d="([^"]+)"/);
+    const isSimplePath =
+      pathMatch && pathMatch[1].length < MAX_CHARGE_PATH_LENGTH;
+
+    const isChargePath =
+      hasPath && hasFillRule && isSelfClosing && isNearEnd && isSimplePath;
+
+    if (!isChargePath) {
+      filteredLines.push(line);
+    }
+  }
+
+  const cleanedSvg = filteredLines.join('\n');
+
+  // Return with data URL prefix
+  return 'data:image/svg+xml;base64,' + btoa(cleanedSvg);
+}
+
 function pollDeferred(process, complete, timeGap, startTimeGap) {
   return new Promise((resolve, reject) => {
     function iterate() {
@@ -450,6 +501,7 @@ export class RemoteStructService implements StructService {
     options?: GenerateImageOptions,
   ): Promise<string> {
     const outputFormat: OutputFormatType = options?.outputFormat ?? 'png';
+    const shouldHideCharges = options?.['render-charges-visible'] === false;
 
     return indigoCall(
       'POST',
@@ -486,7 +538,19 @@ export class RemoteStructService implements StructService {
           : undefined,
       },
       (response) => response.then((resp) => resp.text()),
-    );
+    ).then((result) => {
+      // Post-process SVG output to remove charge labels if needed
+      if (shouldHideCharges && outputFormat === 'svg') {
+        try {
+          return removeChargePathsFromSvg(result);
+        } catch {
+          // Fallback to original output if post-processing fails
+          return result;
+        }
+      }
+
+      return result;
+    });
   }
 
   toggleExplicitHydrogens(

--- a/packages/ketcher-core/src/utilities/index.ts
+++ b/packages/ketcher-core/src/utilities/index.ts
@@ -32,3 +32,4 @@ export * from './dom';
 export * from './getOrThrow';
 export * from './errorMessages';
 export * from './assert';
+export * from './svgToPng';

--- a/packages/ketcher-core/src/utilities/svgToPng.ts
+++ b/packages/ketcher-core/src/utilities/svgToPng.ts
@@ -1,0 +1,76 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+/**
+ * Converts an SVG data URL to a PNG Blob using Canvas API.
+ * This is used when we need to export PNG with filtered/modified SVG content
+ * (e.g., hiding charge symbols while preserving chemical structure).
+ *
+ * @param svgDataUrl - SVG data URL (data:image/svg+xml;base64,...)
+ * @param scale - Scale factor for PNG resolution (default: 2 for better quality)
+ * @returns Promise that resolves to PNG Blob
+ */
+export async function svgToPng(
+  svgDataUrl: string,
+  scale: number = 2,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+
+    img.onload = () => {
+      try {
+        // Create canvas with scaled dimensions for better quality
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width * scale;
+        canvas.height = img.height * scale;
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          reject(new Error('Failed to get canvas 2D context'));
+          return;
+        }
+
+        // Scale context for high-resolution rendering
+        ctx.scale(scale, scale);
+
+        // Draw SVG image onto canvas
+        ctx.drawImage(img, 0, 0);
+
+        // Convert canvas to PNG blob
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              resolve(blob);
+            } else {
+              reject(new Error('Failed to convert canvas to blob'));
+            }
+          },
+          'image/png',
+          1.0, // Maximum quality
+        );
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    img.onerror = () => {
+      reject(new Error('Failed to load SVG image'));
+    };
+
+    // Load SVG data URL into image element
+    img.src = svgDataUrl;
+  });
+}

--- a/packages/ketcher-react/src/script/ui/state/options/index.js
+++ b/packages/ketcher-react/src/script/ui/state/options/index.js
@@ -100,6 +100,7 @@ function getSerilizedServerOptions(options) {
 
   let newOptions = {
     'render-coloring': options.atomColoring,
+    'render-charges-visible': options.showCharge,
     'render-font-size': options.fontsz,
     'render-font-size-unit': options.fontszUnit,
     'render-font-size-sub': options.fontszsub,

--- a/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
+++ b/packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx
@@ -342,6 +342,53 @@ class SaveDialog extends Component<SaveDialogProps, SaveDialogState> {
 
       serverOptions.outputFormat = type;
 
+      // For PNG preview with hidden charges, generate SVG first then convert to PNG
+      const shouldHideCharges =
+        serverOptions['render-charges-visible'] === false;
+      if (type === 'png' && shouldHideCharges) {
+        return server
+          .generateImageAsBase64(structStr, {
+            ...serverOptions,
+            outputFormat: 'svg',
+          } as GenerateImageOptions)
+          .then(async (svgBase64) => {
+            // Import svgToPng utility
+            const { svgToPng } = await import('ketcher-core');
+            // Use scale=1 to match SVG dimensions exactly
+            const pngBlob = await svgToPng(
+              'data:image/svg+xml;base64,' + svgBase64,
+              1,
+            );
+
+            // Convert blob to base64 for preview
+            return new Promise<string>((resolve, reject) => {
+              const reader = new FileReader();
+              reader.onloadend = () => {
+                const result = reader.result as string;
+                // Remove data URL prefix to get just base64
+                const base64 = result.replace(/^data:image\/png;base64,/, '');
+                resolve(base64);
+              };
+              reader.onerror = reject;
+              reader.readAsDataURL(pngBlob);
+            });
+          })
+          .then((base64) => {
+            this.setState({
+              disableControls: false,
+              tabIndex: 0,
+              imageSrc: base64,
+              isLoading: false,
+            });
+          })
+          .catch((e) => {
+            KetcherLogger.error('Save.jsx::SaveDialog::changeType', e);
+            errorHandler(e);
+            this.props.onResetForm(formState);
+            return e;
+          });
+      }
+
       return server
         .generateImageAsBase64(structStr, serverOptions as GenerateImageOptions)
         .then((base64) => {

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts
@@ -50,6 +50,57 @@ const normalizeError = (error: unknown): Error => {
   }
 };
 
+/**
+ * Removes charge symbol path elements from Indigo-generated SVG.
+ * Charge symbols are rendered as simple path elements with fill-rule="nonzero"
+ * that appear near the end of the SVG document.
+ *
+ * @param base64Svg - Base64-encoded SVG string (may include data URL prefix)
+ * @returns Base64-encoded SVG without charge paths
+ */
+function removeChargePathsFromSvg(base64Svg: string): string {
+  // Constants for charge path detection
+  const CHARGE_PATH_DISTANCE_FROM_END = 15; // Lines from end where charge paths typically appear
+  const MAX_CHARGE_PATH_LENGTH = 300; // Max path data length for simple charge symbols
+
+  // Decode SVG from base64
+  const svgContent = base64Svg.replace(/^data:image\/svg\+xml;base64,/, '');
+  const decodedSvg = atob(svgContent);
+
+  const svgLines = decodedSvg.split('\n');
+  const filteredLines = [];
+
+  for (let i = 0; i < svgLines.length; i++) {
+    const line = svgLines[i];
+
+    // Charge path detection heuristics:
+    // 1. Contains <path> with fill-rule="nonzero"
+    // 2. Is near the end (charge paths are added last by Indigo)
+    // 3. Is a self-closing tag (ends with />)
+    // 4. Has simple path data (charge symbols are geometric shapes: +, -)
+    const isNearEnd = i > svgLines.length - CHARGE_PATH_DISTANCE_FROM_END;
+    const hasPath = line.includes('<path');
+    const hasFillRule = line.includes('fill-rule="nonzero"');
+    const isSelfClosing = line.trim().endsWith('/>');
+
+    const pathMatch = line.match(/d="([^"]+)"/);
+    const isSimplePath =
+      pathMatch && pathMatch[1].length < MAX_CHARGE_PATH_LENGTH;
+
+    const isChargePath =
+      hasPath && hasFillRule && isSelfClosing && isNearEnd && isSimplePath;
+
+    if (!isChargePath) {
+      filteredLines.push(line);
+    }
+  }
+
+  const cleanedSvg = filteredLines.join('\n');
+
+  // Return base64 only (wrapper will add data URL prefix)
+  return btoa(cleanedSvg);
+}
+
 type HandlerType = (
   indigo: IndigoModule,
   indigoOptions: IndigoOptions,
@@ -103,10 +154,33 @@ self.onmessage = (e: MessageEvent<InputMessage<CommandData>>) => {
     case Command.GenerateImageAsBase64: {
       const data: GenerateImageCommandData =
         message.data as GenerateImageCommandData;
+
+      const shouldHideCharges =
+        data.options?.['render-charges-visible'] === false;
+
+      // Remove render-charges-visible from options before passing to Indigo
+      // (Indigo doesn't recognize this parameter)
+      const { 'render-charges-visible': _, ...indigoOptions } =
+        data.options || {};
+
       handle(
-        (indigo, indigoOptions) => indigo.render(data.struct, indigoOptions),
+        (indigo, indigoOptions) => {
+          const rendered = indigo.render(data.struct, indigoOptions);
+
+          // Post-process SVG output to remove charge labels if needed
+          if (shouldHideCharges && data.outputFormat === 'svg') {
+            try {
+              return removeChargePathsFromSvg(rendered);
+            } catch {
+              // Fallback to original output if post-processing fails
+              return rendered;
+            }
+          }
+
+          return rendered;
+        },
         {
-          ...data.options,
+          ...indigoOptions,
           'render-output-format': data.outputFormat,
           'render-background-color': data.backgroundColor,
         },

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -885,6 +885,7 @@ class IndigoService implements StructService {
           ? getLabelRenderModeForIndigo(this.ketcherId)
           : undefined,
         'render-coloring': restOptions['render-coloring'],
+        'render-charges-visible': restOptions['render-charges-visible'],
         'render-font-size': restOptions['render-font-size'],
         'render-font-size-unit': restOptions['render-font-size-unit'],
         'render-font-size-sub': restOptions['render-font-size-sub'],


### PR DESCRIPTION
# Fix #10854: System ignores Display charge option on export to SVG/PNG
                                                                                                                                                                                                                                  
  ## 🐛 Problem   
                                                                                                                                                                                                                                  
  The "Display charge" setting in Ketcher Settings → Atoms was being ignored during SVG/PNG export. When users disabled "Display charge" and tried to save a structure (e.g., `[OH3+]`) as SVG or PNG, the charge symbol ('+') was
   still visible in the preview and exported file, even though it was correctly hidden on the canvas.

  **Root Cause:** The Indigo rendering backend does not support the `render-charges-visible` parameter natively. While Ketcher passes this option to Indigo, the backend ignores it and always renders charge symbols in the
  output.

  ## ✅ Solution

  Implemented **client-side post-processing** to remove charge symbols from Indigo-generated images when `render-charges-visible = false`:

  ### 1. SVG Export (Post-processing)
  - Indigo generates SVG with all elements including charges
  - New function `removeChargePathsFromSvg()` parses the SVG and removes charge symbol path elements
  - Charge detection heuristics:
    - Contains `<path>` with `fill-rule="nonzero"`
    - Self-closing tag (`/>`)
    - Located near end of SVG (last 15 lines)
    - Simple path data (< 300 characters)
  - Applied in both `remoteStructService.ts` (HTTP backend) and `indigoWorker.ts` (WASM backend)

  ### 2. PNG Export (SVG → PNG Conversion)
  - Cannot post-process PNG bitmap directly
  - Solution: Generate SVG first (with charges removed via post-processing above), then convert to PNG using Canvas API
  - New utility function `svgToPng()` in `ketcher-core/utilities/`
  - Conversion happens:
    - In `Ketcher.generateImage()` for file downloads
    - In `Save.tsx` for preview rendering
  - Uses `scale=1` to maintain original SVG dimensions

  ## 📁 Files Changed

  ### Core Logic:
  - `packages/ketcher-react/src/script/ui/state/options/index.js`
    - Added `'render-charges-visible': options.showCharge` mapping

  - `packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorker.ts`
    - Added `removeChargePathsFromSvg()` function
    - Post-processing for SVG when `render-charges-visible === false`

  - `packages/ketcher-core/src/infrastructure/services/struct/remoteStructService.ts`
    - Added `removeChargePathsFromSvg()` function (same logic as worker)
    - Post-processing for remote Indigo backend

  ### PNG Conversion:
  - `packages/ketcher-core/src/utilities/svgToPng.ts` (NEW)
    - Canvas-based SVG → PNG conversion utility

  - `packages/ketcher-core/src/application/ketcher.ts`
    - Added SVG→PNG conversion path for `generateImage()` when charges hidden

  - `packages/ketcher-react/src/script/ui/views/modal/components/document/Save/Save.tsx`
    - Added SVG→PNG conversion for PNG preview with hidden charges

  ## 🔒 Regression Safety

  **No impact on existing functionality:**
  - New code paths execute **ONLY** when `render-charges-visible === false`
  - Default behavior (`showCharge = true`) uses standard rendering (unchanged)
  - Fallback to original output on any errors
  - All changes are backwards compatible


  ## ⚠️  Limitations

  1. **PNG Quality:** PNG is generated at original SVG dimensions (no upscaling). For higher resolution exports, users should export SVG.

  2. **Heuristic-based detection:** The charge path detection relies on patterns observed in current Indigo output:
     - Charge symbols appear as `<path>` elements with specific attributes
     - Located near end of SVG document
     - Path data length < 300 characters
     - **Risk:** May break if Indigo changes SVG structure in future versions


  ## 🔮 Future Considerations
  ### Proper Solution: Native Indigo Support

  Since both **Ketcher and Indigo are EPAM open-source projects** under Apache 2.0 license, the team can implement native support directly in Indigo:

  **Benefits of Native Implementation:**
  - ✅ **Better performance** - no client-side post-processing overhead
  - ✅ **More reliable** - no fragile SVG parsing heuristics
  - ✅ **Native PNG support** - no Canvas conversion required
  - ✅ **Cleaner codebase** - simpler, maintainable code
  - ✅ **Benefits all Indigo users** - not just Ketcher

  **Similar parameters to implement:**
  - `render-valence-visible` - control valence number display (e.g., "(III)")
  - `render-radicals-visible` - control radical marker display
  - `render-isotopes-visible` - control isotope label display

  These would follow the existing pattern of Indigo's `render-*` parameters.

  ### Monitoring

  Until native Indigo support is implemented, monitor for Indigo version updates that may change SVG output format. The charge detection heuristics in `removeChargePathsFromSvg()` may need updates if:
  - Different attributes appear on charge path elements
  - Path positioning in SVG changes
  - Path data length/complexity changes


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request