### PR TITLE
#10954 - Refactor: Explicit/implicit Any type clean up from packages/ketcher-core/src/application/editor/actions/atom.ts file

### DIFF
--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -32,6 +32,7 @@ import { fromRGroupFragment, fromUpdateIfThen } from './rgroup';
 import { fromBondStereoUpdate } from './bondStereo';
 
 import { Action } from './action';
+import { isNumber } from 'lodash';
 import { without } from 'lodash/fp';
 import type { Pile } from 'domain/entities/pile';
 import type { Point } from 'domain/entities/vec2';
@@ -165,9 +166,9 @@ export function mergeFragmentsIfNeeded(
 ) {
   const frid = atomGetAttr(restruct, srcId, 'fragment');
   const frid2 = atomGetAttr(restruct, dstId, 'fragment');
-  assert(typeof frid === 'number', `Fragment of atom ${srcId} was not found`);
+  assert(isNumber(frid), `Fragment of atom ${srcId} was not found`);
 
-  if (frid2 !== frid && typeof frid2 === 'number') {
+  if (frid2 !== frid && isNumber(frid2)) {
     const struct = restruct.molecule;
 
     const rgid = RGroup.findRGroupByFragment(struct.rgroups, frid2);

--- a/packages/ketcher-core/src/application/editor/actions/atom.ts
+++ b/packages/ketcher-core/src/application/editor/actions/atom.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
  *
@@ -15,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { Atom } from 'domain/entities/atom';
+import { Atom, type AtomAttributes } from 'domain/entities/atom';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import { RGroup } from 'domain/entities/rgroup';
 import {
@@ -28,26 +27,35 @@ import {
   FragmentDeleteStereoAtom,
   SGroupAtomAdd,
 } from '../operations';
-import { atomGetAttr, atomGetSGroups } from './utils';
+import { type AtomAttributeName, atomGetAttr, atomGetSGroups } from './utils';
 import { fromRGroupFragment, fromUpdateIfThen } from './rgroup';
 import { fromBondStereoUpdate } from './bondStereo';
 
 import { Action } from './action';
 import { without } from 'lodash/fp';
+import type { Pile } from 'domain/entities/pile';
+import type { Point } from 'domain/entities/vec2';
 import type ReStruct from 'application/render/restruct/restruct';
 import { assert } from 'utilities';
 
-export function fromAtomAddition(restruct, pos, atom) {
-  atom = { ...(atom || {}) };
+export function fromAtomAddition(
+  restruct: ReStruct,
+  pos: Point | null,
+  atom?: Partial<AtomAttributes>,
+) {
+  const atomAttrs: Partial<AtomAttributes> = { ...(atom ?? {}) };
   const action = new Action();
-  atom.fragment = (
-    action.addOp(new FragmentAdd().perform(restruct)) as FragmentAdd
-  ).frid;
 
-  const aid = (
-    action.addOp(new AtomAdd(atom, pos).perform(restruct)) as AtomAdd
-  ).data.aid;
-  action.addOp(new CalcImplicitH([aid as number]).perform(restruct));
+  const fragmentAdd = new FragmentAdd();
+  action.addOp(fragmentAdd.perform(restruct));
+  assert(fragmentAdd.frid !== null, 'Fragment was not added');
+  atomAttrs.fragment = fragmentAdd.frid;
+
+  const atomAdd = new AtomAdd(atomAttrs, pos ?? undefined);
+  action.addOp(atomAdd.perform(restruct));
+  const { aid } = atomAdd.data;
+  assert(aid !== null, 'Atom was not added');
+  action.addOp(new CalcImplicitH([aid]).perform(restruct));
 
   return action;
 }
@@ -55,23 +63,27 @@ export function fromAtomAddition(restruct, pos, atom) {
 export function fromAtomsAttrs(
   restruct: ReStruct,
   ids: Array<number> | number,
-  attrs: any,
+  attrs: Partial<AtomAttributes> | null | undefined,
   reset: boolean | null,
 ) {
   const action = new Action();
   const aids = Array.isArray(ids) ? ids : [ids];
+  const atomAttrs = attrs ?? {};
+  // Object.keys is typed as string[]; Atom.attrlist is keyed by atom attribute names
+  const attrNames = Object.keys(Atom.attrlist) as AtomAttributeName[];
 
   aids.forEach((atomId) => {
-    Object.keys(Atom.attrlist).forEach((key) => {
-      if (key === 'attachmentPoints' && !(key in attrs)) return;
-      if (!(key in attrs) && !reset) return;
+    attrNames.forEach((key) => {
+      if (key === 'attachmentPoints' && !(key in atomAttrs)) return;
+      if (!(key in atomAttrs) && !reset) return;
 
-      const value = key in attrs ? attrs[key] : Atom.attrGetDefault(key);
+      const value =
+        key in atomAttrs ? atomAttrs[key] : Atom.attrGetDefault(key);
 
       switch (key) {
         case 'stereoLabel':
         case 'stereoParity':
-          if (key in attrs && value) {
+          if (key in atomAttrs && value) {
             action.addOp(new AtomAttr(atomId, key, value).perform(restruct));
           }
           break;
@@ -83,10 +95,10 @@ export function fromAtomsAttrs(
 
     if (
       !reset &&
-      'label' in attrs &&
-      attrs.label !== null &&
-      attrs.label !== 'L#' &&
-      !('atomList' in attrs)
+      'label' in atomAttrs &&
+      atomAttrs.label !== null &&
+      atomAttrs.label !== 'L#' &&
+      !('atomList' in atomAttrs)
     ) {
       action.addOp(new AtomAttr(atomId, 'atomList', null).perform(restruct));
     }
@@ -117,11 +129,16 @@ export function fromAtomsAttrs(
 
 export { fromStereoAtomAttrs } from './bondStereo';
 
-export function fromAtomsFragmentAttr(restruct, aids, newfrid) {
+export function fromAtomsFragmentAttr(
+  restruct: ReStruct,
+  aids: number[] | Pile<number>,
+  newfrid: number,
+) {
   const action = new Action();
 
   aids.forEach((aid) => {
     const atom = restruct.molecule.atoms.get(aid);
+    assert(atom !== undefined, `Atom ${aid} was not found`);
     const sgroup = restruct.molecule.getGroupFromAtomId(aid);
     const oldfrid = atom.fragment;
 
@@ -140,11 +157,17 @@ export function fromAtomsFragmentAttr(restruct, aids, newfrid) {
   return action.perform(restruct);
 }
 
-export function mergeFragmentsIfNeeded(action, restruct, srcId, dstId) {
-  const frid = atomGetAttr(restruct, srcId, 'fragment') as number;
+export function mergeFragmentsIfNeeded(
+  action: Action,
+  restruct: ReStruct,
+  srcId: number,
+  dstId: number,
+) {
+  const frid = atomGetAttr(restruct, srcId, 'fragment');
   const frid2 = atomGetAttr(restruct, dstId, 'fragment');
+  assert(typeof frid === 'number', `Fragment of atom ${srcId} was not found`);
 
-  if (frid2 !== frid && typeof frid === 'number' && typeof frid2 === 'number') {
+  if (frid2 !== frid && typeof frid2 === 'number') {
     const struct = restruct.molecule;
 
     const rgid = RGroup.findRGroupByFragment(struct.rgroups, frid2);
@@ -156,7 +179,7 @@ export function mergeFragmentsIfNeeded(action, restruct, srcId, dstId) {
 
     const fridAtoms = struct.getFragmentIds(frid);
 
-    const atomsToNewFrag: Array<any> = [];
+    const atomsToNewFrag: number[] = [];
     struct.atoms.forEach((atom, aid) => {
       if (atom.fragment === frid2) atomsToNewFrag.push(aid);
     });
@@ -174,26 +197,35 @@ export function mergeFragmentsIfNeeded(action, restruct, srcId, dstId) {
   return frid;
 }
 
-export function mergeSgroups(action, restruct, srcAtoms, dstAtom) {
+export function mergeSgroups(
+  action: Action,
+  restruct: ReStruct,
+  srcAtoms: number[] | Pile<number>,
+  dstAtom: number,
+) {
   const sgroups = atomGetSGroups(restruct, dstAtom);
 
   sgroups.forEach((sid) => {
     const sgroup = restruct.molecule.sgroups.get(sid);
+    assert(sgroup !== undefined, `S-group ${sid} was not found`);
+    // A missing context matches none of the not-expanded ones, so it must not
+    // skip the s-group here
+    const context = sgroup.data.context ?? '';
     const notExpandedContexts = ['Atom', 'Bond', 'Group'];
-    if (
-      sgroup.type === 'DAT' &&
-      notExpandedContexts.includes(sgroup.data.context)
-    ) {
+    if (sgroup.type === 'DAT' && notExpandedContexts.includes(context)) {
       return;
     }
-    const atomsToSgroup: any = without(sgroup.atoms, srcAtoms);
+    // `without` operates on arrays only. A Pile reaching here yields no atoms,
+    // which is the existing behaviour of the fragment merge path.
+    const srcAtomList = Array.isArray(srcAtoms) ? srcAtoms : [];
+    const atomsToSgroup = without(sgroup.atoms, srcAtomList);
     atomsToSgroup.forEach((aid) =>
       action.addOp(new SGroupAtomAdd(sid, aid).perform(restruct)),
     );
   });
 }
 
-export function checkAtomValence(restruct, atomId) {
+export function checkAtomValence(restruct: ReStruct, atomId: number) {
   const action = new Action();
 
   if (!restruct.atoms.has(atomId)) return action;


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?

Removes the file-level `no-explicit-any` suppression and types the three explicit `any`s plus the five untyped signatures, all from existing types: `ReStruct`, `Point`, `Partial<AtomAttributes>`, `Pile<number>`, `Action`, `AtomAttributeName`.

The `as` casts are replaced by narrowing rather than moved around, per the previous review. `FragmentAdd.frid` and `AtomAdd.data.aid` are nullable, so the operations are held in locals and asserted after `perform()`; `execute()` always assigns both, so those asserts can't fire.

Two spots needed care to keep behaviour identical:

- **S-group context** — a missing `context` matched none of the not-expanded ones and fell through, so it reads with an empty-string fallback. An early return would have inverted that and skipped every s-group without one.
- **`mergeSgroups`** gets arrays from bond/template but a `Pile` (a `Set`) from `mergeFragmentsIfNeeded`, and lodash `without` returns `[]` for a `Set` — so that path adds no atoms today. The array case is selected explicitly and the `Pile` case keeps producing nothing, with a comment. Worth raising separately as a bug rather than fixing it silently here.

One deliberate delta: asserting `frid` turns a silent skip into a throw, but only for a non-existent atom id — `Atom.fragment` is `number` defaulting to `-1`, so it's always a number for a real atom. That's the premise the review stated, and it's what lets the cast go.

### Verification

`tsc` — **0 errors in ketcher-core, ketcher-react and ketcher-standalone** (`fromAtomsAttrs` alone has 40 call sites across both); macromolecules unchanged at its 13 pre-existing errors. eslint/prettier clean, restoring an `any` makes the rule fire again, ketcher-core suite passes at **822 tests**, ketcher-react identical to master.



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request