### PR TITLE
#3515 - Uncaught TypeError: Cannot read properties of undefined (reading eventBus) in react

### DIFF
--- a/packages/ketcher-react/src/hooks/useSubscribtionOnEvents.ts
+++ b/packages/ketcher-react/src/hooks/useSubscribtionOnEvents.ts
@@ -19,6 +19,7 @@ import { indigoVerification } from '../script/ui/state/request';
 import {
   type Ketcher,
   KetcherAsyncEvents,
+  KetcherLogger,
   ketcherProvider,
 } from 'ketcher-core';
 import { useEffect } from 'react';
@@ -65,14 +66,33 @@ export const useSubscriptionOnEvents = () => {
       );
     };
 
+    // Instance may already be removed from the provider (fast mount/unmount, duo mode) - #3515, #7568.
+    const getKetcherSafely = () => {
+      try {
+        return ketcherProvider.getKetcher(ketcherId);
+      } catch (error) {
+        KetcherLogger.error(
+          `Failed to get ketcher instance with id ${ketcherId}`,
+          error,
+        );
+        return undefined;
+      }
+    };
+
     const subscribeOnInit = () => {
-      subscribe(ketcherProvider.getKetcher(ketcherId));
+      const ketcher = getKetcherSafely();
+      if (ketcher) {
+        subscribe(ketcher);
+      }
     };
 
     const initEventName = ketcherInitEventName(ketcherId);
     window.addEventListener(initEventName, subscribeOnInit);
     return () => {
-      unsubscribe(ketcherProvider.getKetcher(ketcherId));
+      const ketcher = getKetcherSafely();
+      if (ketcher) {
+        unsubscribe(ketcher);
+      }
       window.removeEventListener(initEventName, subscribeOnInit);
     };
   }, [ketcherId, dispatch]);


### PR DESCRIPTION
**Problem**

Uncaught TypeError: Cannot read properties of undefined (reading 'eventBus') could be thrown from useSubscriptionOnEvents in ketcher-react. Same root cause as #3515 / #7568, but in a spot that wasn't covered by the earlier fix.

**Root cause**

ketcherProvider.getKetcher(id) throws if the instance for that id was already removed (or not yet added) from the provider's map. `useSubscribtionOnEvents.ts` called it unguarded in subscribeOnInit and in the effect's cleanup — under a race (fast mount/unmount, duo mode) the instance can be gone by the time these run, crashing the app. useLoading/useLayoutMode in ketcher-macromolecules had the identical issue, already fixed in #7583 with a try/catch; this hook was missed.

**Fix**

Wrap `getKetcher `calls in a `getKetcherSafely()` helper (try/catch + KetcherLogger.error, mirrors the pattern already used in useLoading/useLayoutMode), and skip subscribe/unsubscribe when no instance is found instead of throwing.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

Fixes  #3515 