### PR TITLE
#5565 - vite build error

### DIFF
--- a/packages/ketcher-core/src/application/render/raphael-ext.ts
+++ b/packages/ketcher-core/src/application/render/raphael-ext.ts
@@ -21,8 +21,14 @@ import type { RaphaelStatic } from 'raphael';
 
 type RaphaelModule = RaphaelStatic | { default: RaphaelStatic };
 
-const raphaelModule: RaphaelModule | undefined =
-  typeof window !== 'undefined' ? require('raphael') : undefined;
+// require() is unavailable in strict-ESM bundler output (e.g. Vite), so
+// guard against it the same way we guard against a missing `window` (SSR)
+const canRequireRaphael =
+  typeof window !== 'undefined' && typeof require !== 'undefined';
+
+const raphaelModule: RaphaelModule | undefined = canRequireRaphael
+  ? require('raphael')
+  : undefined;
 
 // Some environments (vite, webpack etc) might resolve this import differently
 // this is a workaround to make it work in all environments


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
###Uncaught ReferenceError: require is not defined                                                                        
                                                                                                                                     
  Root cause: raphael-ext.ts loads Raphael conditionally with typeof window !== 'undefined' ? require('raphael') : undefined — the window check exists to keep this SSR-safe (Raphael touches DOM globals at import time and crashes under Node). But the runtime require() call itself has no browser equivalent, and strict-ESM bundler output (Vite/Rollup) doesn't provide a require global, so it throws and aborts the whole bundle.        
Fix: added a second guard, typeof require !== 'undefined', so the module degrades to undefined instead of crashing when require isn't available

Issue - [#5565](https://github.com/epam/ketcher/issues/5565)

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [X] PR name follows the pattern `#1234 – issue name`
- [X] branch name doesn't contain '#'
- [X] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request