### PR TITLE
#2350  - Access Ketcher iframe via JavaScript, .ketcher undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ function App() {
 }
 ```
 
+### Accessing Ketcher embedded via IFrame
+
+When you embed the ready-to-run standalone application as an `IFrame` (rather than using
+`ketcher-react` as a component library), Ketcher initializes **asynchronously** inside the
+frame (loading the Indigo service/WASM, etc.). Because of this, `window.ketcher` inside the
+frame is only assigned once initialization finishes — reading
+`iframeEl.contentWindow.ketcher` right after the frame's `load` event (or immediately after
+inserting the `<iframe>`) will typically still be `undefined`.
+
+To reliably know when the embedded Ketcher is ready, listen for the `init` message that the
+standalone application posts to its parent window once `onInit` has fired, instead of polling
+`contentWindow.ketcher`:
+
+```javascript
+const iframeEl = document.getElementById('ifKetcher');
+
+window.addEventListener('message', (event) => {
+  if (event.source !== iframeEl.contentWindow) return;
+  if (event.data?.eventType === 'init') {
+    const ketcher = iframeEl.contentWindow.ketcher;
+    // ketcher is now guaranteed to be initialized
+  }
+});
+```
+
 ## FAQ
 
 ### How to use react component library


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Summary

- Document how to reliably detect when Ketcher embedded via IFrame (standalone build) has finished initializing.
- Clarifies that window.ketcher inside the frame is set asynchronously (after the Indigo service/WASM finishes loading) via the onInit callback, so reading iframeEl.contentWindow.ketcher right after the frame's load event is a race and often returns undefined.
- Adds a documented pattern using the existing postMessage({ eventType: 'init' }) signal (already sent by the standalone app after onInit) as the correct way for a host page to know when it's safe to access contentWindow.ketcher.

Why

Addresses the confusion reported in #2350, where a user embedding the standalone package via IFrame got undefined when accessing contentWindow.ketcher immediately after loading the frame. The init postMessage mechanism already exists in the standalone app (added in #1250) and solves this, but it was never documented for the IFrame embedding use case — this was a documentation gap, not a code bug, so no functional changes are included.

Fix

- README.md: new "Accessing Ketcher embedded via IFrame" subsection under "Basic Setup" with an example of listening for the init message before reading contentWindow.ketcher.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [x] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

Fixes #2350 