### PR TITLE
Fix stale ketcher.html reference in DEVNOTES.md

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -224,7 +224,7 @@ server {
   # see here https://lifescience.opensource.epam.com/indigo/service/index.html
   location / {
     root /srv/www;
-    index ketcher.html;
+    index index.html;
     try_files $uri $uri/ @indigoservice;
   }
 
@@ -247,7 +247,7 @@ Run
 docker-compose up -d
 ```
 
-Service with Ketcher will be run under localhost:8080/ketcher.html
+Service with Ketcher will be run under localhost:8080
 
 ## Custom Buttons
 


### PR DESCRIPTION
## Summary

Closes #1774

The reporter on #1774 was frustrated by the "Simple server" / Docker-Compose setup instructions in root `DEVNOTES.md` being confusing and, per their report, not working.

Investigation (see notes for this cluster) found:
- The two *external* demo-server URLs the reporter quoted (`lifescience.opensource.epam.com` and a raw IP `52.32.91.31`) are infrastructure we don't control from this repo, so they're out of scope here.
- The linked Indigo service install doc (`https://lifescience.opensource.epam.com/indigo/service/index.html`) currently returns HTTP 200 — not broken.
- The dev/build split described (Vite for `dev:*`, `react-app-rewired` for `start:*`/`build`) still matches `example/package.json` — accurate as written.
- One concrete, demonstrably wrong thing in the doc: the sample nginx config's `index ketcher.html;` directive and the "Service with Ketcher will be run under localhost:8080/ketcher.html" line both reference `ketcher.html`, but the actual production build output (via `example/vite.config.js`, `template: 'public/index.html'`) is `index.html`. Following the doc as written would 404 against a real build output directory, which lines up with the reporter's "it never works" complaint.

Fixed both references to point at `index.html`.

## Notes for reviewer
- The two external demo-server URLs from the issue are not addressable from this repo and were intentionally left alone.
- No other inaccuracies were found in the "Build instructions" / "Indigo service" / "Simple server" sections after a full read-through.

## Test plan
- [x] Read DEVNOTES.md end-to-end against current `example/package.json` scripts and `example/vite.config.js` build output naming
- [x] Confirmed build template is `public/index.html`, not `ketcher.html`