### PR TITLE
#7901 - Document the removed CDN bundle; flag stale wiki link for maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ At this moment Ketcher can be embedded into your application in two ways:
 - as ready-to-run application (to find desired version please look at Assets block of [releases](https://github.com/epam/ketcher/releases)). The application can be injected as IFrame or a separate page.
 - as a [react component library](https://www.npmjs.com/package/ketcher-react)
 
+> **Note:** Ketcher no longer publishes a single UMD `ketcher.min.js`/`.css` bundle, so loading it
+> via a CDN `<script>`/`<link>` tag (as shown in some older, third-party guides) is not supported.
+> Use one of the two methods above instead.
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #7901

The reporter followed an old Developer Manual snippet that loaded Ketcher via a CDN `<script>`/`<link>` tag pointing at `https://cdn.jsdelivr.net/npm/ketcher@2.1.0/dist/ketcher.min.js` (+ matching `.css`), using a legacy `ketcherFrame.contentWindow.ketcher` iframe pattern. Both files are gone.

**Investigation** (full repo + wiki history search, see notes):
- No `jsdelivr`, `ketcher.min`, or `ketcher@2.1.0` reference exists anywhere in `epam/ketcher` (current or full history, all branches).
- No such reference exists in the full history of `epam/ketcher.wiki` either.
- No package under `packages/*` publishes a UMD/single-bundle `ketcher.min.js`-style artifact today — only `dist/index.js` (CJS) and `dist/index.modern.js` (ESM). The old single-package `ketcher` CDN pattern is fully obsolete, not just link-rotted, so the literal broken link the reporter quoted cannot be "fixed" — it needs to be replaced with the current, supported installation methods.

**Fix applied in this repo:**
- `README.md` — added a short note under "Installation and usage" clarifying that the old single-file CDN UMD bundle is no longer published/supported, and pointing at the two currently-supported methods (ready-to-run application release asset, or the `ketcher-react` component library).

**Not fixable from this repo — needs a maintainer to apply directly to the wiki:**
The GitHub wiki (`github.com/epam/ketcher.wiki.git`) is a separate git repo with no PR/review mechanism, so I did not push to it directly. While tracing where a modern-day reader would land on the same stale-link problem, I found a live instance of the same bug shape still present today:
- Repo: `epam/ketcher.wiki`
- File: `_Sidebar.md`
- Current: `[Ketcher editor overview](https://github.com/epam/ketcher/blob/v2.12.0-rc.2/documentation/help.md)` — pinned to an old release-candidate tag.
- Needed: repoint to `https://github.com/epam/ketcher/blob/master/documentation/help.md` (the file exists identically on `master`).

A maintainer with wiki write access should apply that one-line edit directly on the wiki.

## Open questions
- None — the wiki fix is well-defined; it just cannot be delivered as a PR given the wiki's lack of a review mechanism.

## Test plan
- [x] Verified `README.md` renders correctly (Markdown note formatting)
- [x] Confirmed no other file in the main repo references the old CDN URL/version
- [ ] Maintainer to manually apply the `_Sidebar.md` fix on the wiki