### PR TITLE
#7011 – SVG export does not respect "Display carbon explicitly" option

### DIFF
--- a/packages/ketcher-core/src/infrastructure/services/__tests__/helpers.test.ts
+++ b/packages/ketcher-core/src/infrastructure/services/__tests__/helpers.test.ts
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { ShowHydrogenLabels } from 'application/render';
+import { ketcherProvider } from 'application/ketcherProvider';
+import { getLabelRenderModeForIndigo } from '../helpers';
+
+jest.mock('application/ketcherProvider', () => ({
+  ketcherProvider: {
+    getKetcher: jest.fn(),
+  },
+}));
+
+const KETCHER_ID = 'test-id';
+
+function mockEditorOptions(
+  carbonExplicitly: boolean,
+  showHydrogenLabels: ShowHydrogenLabels,
+) {
+  (ketcherProvider.getKetcher as jest.Mock).mockReturnValue({
+    editor: {
+      options: () => ({ carbonExplicitly, showHydrogenLabels }),
+    },
+  });
+}
+
+describe('getLabelRenderModeForIndigo', () => {
+  describe('carbonExplicitly: true', () => {
+    it('returns "all" regardless of showHydrogenLabels', () => {
+      const hydrogenLabelModes = [
+        ShowHydrogenLabels.Off,
+        ShowHydrogenLabels.Hetero,
+        ShowHydrogenLabels.Terminal,
+        ShowHydrogenLabels.TerminalAndHetero,
+        ShowHydrogenLabels.On,
+      ];
+
+      for (const mode of hydrogenLabelModes) {
+        mockEditorOptions(true, mode);
+        expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('all');
+      }
+    });
+  });
+
+  describe('carbonExplicitly: false', () => {
+    it('maps Off → "hetero"', () => {
+      mockEditorOptions(false, ShowHydrogenLabels.Off);
+      expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('hetero');
+    });
+
+    it('maps Hetero → "hetero"', () => {
+      mockEditorOptions(false, ShowHydrogenLabels.Hetero);
+      expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('hetero');
+    });
+
+    it('maps Terminal → "terminal-hetero"', () => {
+      mockEditorOptions(false, ShowHydrogenLabels.Terminal);
+      expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('terminal-hetero');
+    });
+
+    it('maps TerminalAndHetero → "terminal-hetero"', () => {
+      mockEditorOptions(false, ShowHydrogenLabels.TerminalAndHetero);
+      expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('terminal-hetero');
+    });
+
+    it('maps On → "all"', () => {
+      mockEditorOptions(false, ShowHydrogenLabels.On);
+      expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('all');
+    });
+
+    it('falls back to "none" for an unknown showHydrogenLabels value', () => {
+      mockEditorOptions(false, 'unknown-value' as ShowHydrogenLabels);
+      expect(getLabelRenderModeForIndigo(KETCHER_ID)).toBe('none');
+    });
+  });
+});

--- a/packages/ketcher-core/src/infrastructure/services/helpers.ts
+++ b/packages/ketcher-core/src/infrastructure/services/helpers.ts
@@ -11,6 +11,14 @@ enum IndigoShowHydrogenLabelsMode {
 export function getLabelRenderModeForIndigo(ketcherId: string) {
   // Terminal does not supported by indigo so TERMINAL_HETERO used
   // Off removing all labels in indigo so HETERO used
+  const editorOptions = ketcherProvider.getKetcher(ketcherId).editor.options();
+
+  // carbonExplicitly requires all atom labels (including internal C) to be visible.
+  // Indigo's only mode that shows internal carbons is 'all'.
+  if (editorOptions.carbonExplicitly) {
+    return IndigoShowHydrogenLabelsMode.ALL;
+  }
+
   const renderModeMapping = {
     [ShowHydrogenLabels.Off]: IndigoShowHydrogenLabelsMode.HETERO,
     [ShowHydrogenLabels.Hetero]: IndigoShowHydrogenLabelsMode.HETERO,
@@ -21,8 +29,7 @@ export function getLabelRenderModeForIndigo(ketcherId: string) {
   };
 
   return (
-    renderModeMapping[
-      ketcherProvider.getKetcher(ketcherId).editor.options().showHydrogenLabels
-    ] || IndigoShowHydrogenLabelsMode.OFF
+    renderModeMapping[editorOptions.showHydrogenLabels] ||
+    IndigoShowHydrogenLabelsMode.OFF
   );
 }


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
Updated the Indigo label render mode to respect the "Display carbon explicitly" setting during SVG and PNG export.

When the setting is enabled, all carbon labels are now shown in the image preview and exported file. Existing hydrogen label behavior remains unchanged when the setting is disabled.

Added unit tests covering all hydrogen label modes with the explicit carbon setting enabled and disabled.

### Verification

The SVG preview now respects the "Display carbon explicitly" setting.


https://github.com/user-attachments/assets/8dbb0fa1-bca9-4e43-ad18-ac5e928d87a5



Closes #7011


## Check list
- [x] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request