### PR TITLE
Fix #11312 #11314: expand monomer and recompute valence on Remove Grouping/Abbreviation

### DIFF
--- a/ketcher-autotests/tests/specs/Bugs/ketcher-3.19.0-bugs.spec.ts
+++ b/ketcher-autotests/tests/specs/Bugs/ketcher-3.19.0-bugs.spec.ts
@@ -1,19 +1,50 @@
 import { Page, test, expect } from '@fixtures';
 import {
   clickInTheMiddleOfTheCanvas,
+  MacroFileType,
   openFileAndAddToCanvasAsNewProjectMacro,
   pasteFromClipboardAndAddToCanvas,
   pasteFromClipboardAndOpenAsNewProject,
+  pasteFromClipboardAndOpenAsNewProjectMacro,
 } from '@utils';
 
 import { CommonTopLeftToolbar } from '@tests/pages/common/CommonTopLeftToolbar';
 import { CommonTopRightToolbar } from '@tests/pages/common/CommonTopRightToolbar';
+import { ContextMenu } from '@tests/pages/common/ContextMenu';
 import { SaveStructureDialog } from '@tests/pages/common/SaveStructureDialog';
+import { MonomerOnMicroOption } from '@tests/pages/constants/contextMenu/Constants';
 import { MoleculesFileFormatType } from '@tests/pages/constants/fileFormats/microFileFormats';
 import { ErrorMessageDialog } from '@tests/pages/common/ErrorMessageDialog';
 import { getAtomLocator } from '@utils/canvas/atoms/getAtomLocator/getAtomLocator';
+import { getAbbreviationLocator } from '@utils/canvas/s-group-signes/getAbbreviationLocator';
 
 let page: Page;
+
+type AtomState = {
+  id: number;
+  label: string;
+  implicitH: number;
+  badConn: boolean;
+  sgroupCount: number;
+};
+
+type BondState = { id: number; begin: number; end: number; type: number };
+
+async function getBondPixelLength(
+  page: Page,
+  bond: { begin: number; end: number },
+) {
+  const bondLocator = page.locator(
+    `[data-testid="bond"][data-fromatomid="${bond.begin}"][data-toatomid="${bond.end}"]`,
+  );
+  const box = await bondLocator.boundingBox();
+  if (!box) {
+    throw new Error(
+      `Expected bond ${bond.begin}-${bond.end} to be visible on canvas`,
+    );
+  }
+  return Math.hypot(box.width, box.height);
+}
 
 test.describe('Ketcher bugs in 3.19.0', () => {
   test.beforeAll(async ({ initMoleculesCanvas }) => {
@@ -93,5 +124,113 @@ test.describe('Ketcher bugs in 3.19.0', () => {
     await clickInTheMiddleOfTheCanvas(page);
     expect(await ErrorMessageDialog(page).isVisible()).toBe(false);
     await expect(getAtomLocator(page, { atomLabel: 'P' })).toHaveCount(1);
+  });
+
+  test('Case 3: "Remove Grouping" expands a collapsed monomer before removing its group', async ({
+    FlexCanvas: _,
+  }) => {
+    /*
+     * Test case: https://github.com/epam/ketcher/issues/11312
+     * Description: "Remove Grouping" deleted a monomer's S-group without
+     * recomputing implicit-hydrogen/valence state on the freed atoms, so the
+     * exposed carbonyl carbon kept a stale valence-error flag (red underline),
+     * the nitrogen rendered as "N" instead of "NH", and the resulting stray
+     * label shortened the bond to a still-collapsed neighboring monomer.
+     * Scenario:
+     * 1. Go to Macromolecules mode
+     * 2. Load from HELM: PEPTIDE1{A.A.A}$$$$V2.0
+     * 3. Switch to Molecules mode
+     * 4. Right-click the center monomer and select "Remove Grouping"
+     * 5. Verify the exposed atoms carry no stale valence-error flag, the
+     *    nitrogen shows its implicit hydrogen, and the bond to each
+     *    still-collapsed neighbor isn't clipped short
+     */
+    await pasteFromClipboardAndOpenAsNewProjectMacro(
+      page,
+      MacroFileType.HELM,
+      'PEPTIDE1{A.A.A}$$$$V2.0',
+    );
+    await CommonTopRightToolbar(page).turnOnMicromoleculesEditor();
+
+    const remainingAbbreviations = getAbbreviationLocator(page, { name: 'A' });
+
+    await ContextMenu(page, remainingAbbreviations.nth(1)).click(
+      MonomerOnMicroOption.RemoveGrouping,
+    );
+
+    // The two outer monomers stay collapsed; only the center one is expanded.
+    await expect(remainingAbbreviations).toHaveCount(2);
+
+    const { atoms, bonds } = await page.evaluate(() => {
+      const molecule = window.ketcher.editor.render.ctab.molecule;
+      const atomEntries = Array.from(molecule.atoms.entries()).map(
+        ([id, atom]) => ({
+          id,
+          label: atom.label,
+          implicitH: atom.implicitH,
+          badConn: atom.badConn,
+          sgroupCount: atom.sgs.size,
+        }),
+      );
+      const bondEntries = Array.from(molecule.bonds.entries()).map(
+        ([id, bond]) => ({
+          id,
+          begin: bond.begin,
+          end: bond.end,
+          type: bond.type,
+        }),
+      );
+      return { atoms: atomEntries, bonds: bondEntries };
+    });
+
+    // The exposed alanine's own atoms are the ones no longer inside any S-group.
+    const exposedAtoms = atoms.filter(
+      (atom: AtomState) => atom.sgroupCount === 0,
+    );
+    expect(exposedAtoms).toHaveLength(5); // N, C-alpha, C(=O), O, CH3
+
+    // None of the just-exposed atoms should be left with a stale
+    // valence-error flag. (Atoms belonging to the still-collapsed sibling
+    // monomers are out of scope: a collapsed abbreviation's internal atoms
+    // carry an intentionally unresolved placeholder structure - e.g. the
+    // leaving group from its own peptide bond - until that monomer is itself
+    // expanded, which this action does not do for its neighbors.)
+    const exposedAtomsWithBadConn = exposedAtoms.filter(
+      (atom: AtomState) => atom.badConn,
+    );
+    expect(exposedAtomsWithBadConn).toEqual([]);
+
+    const exposedNitrogenAtoms = exposedAtoms.filter(
+      (atom) => atom.label === 'N',
+    );
+    expect(exposedNitrogenAtoms).toHaveLength(1);
+    expect(exposedNitrogenAtoms[0].implicitH).toBe(1);
+    await expect(getAtomLocator(page, { atomLabel: 'N' })).toHaveCount(1);
+
+    // The bond(s) crossing into a still-collapsed neighbor shouldn't be
+    // clipped shorter than an ordinary bond inside the exposed monomer.
+    const exposedIds = new Set(exposedAtoms.map((atom) => atom.id));
+    const crossMonomerBonds = bonds.filter(
+      (bond: BondState) =>
+        exposedIds.has(bond.begin) !== exposedIds.has(bond.end),
+    );
+    const siblingBond = bonds.find(
+      (bond: BondState) =>
+        exposedIds.has(bond.begin) &&
+        exposedIds.has(bond.end) &&
+        bond.type === 1,
+    );
+    expect(crossMonomerBonds.length).toBeGreaterThan(0);
+    if (!siblingBond) {
+      throw new Error(
+        'Expected to find a sibling single bond inside the exposed monomer',
+      );
+    }
+
+    const siblingLength = await getBondPixelLength(page, siblingBond);
+    for (const bond of crossMonomerBonds) {
+      const length = await getBondPixelLength(page, bond);
+      expect(length).toBeGreaterThan(siblingLength * 0.7);
+    }
   });
 });

--- a/packages/ketcher-core/__tests__/application/editor/actions/sgroup.test.ts
+++ b/packages/ketcher-core/__tests__/application/editor/actions/sgroup.test.ts
@@ -233,3 +233,90 @@ describe('setExpandMonomerSGroup', () => {
     expect(moleculeNodes[0].fragment?.bonds.size).toBe(1);
   });
 });
+
+describe('fromSgroupDeletion', () => {
+  const buildCollapsedMonomerWithLeavingAtom = () => {
+    const struct = new Struct();
+    const attachmentAtomId = struct.atoms.add(
+      new Atom({ label: 'C', pp: new Vec2(0, 0) }),
+    );
+    const leaveAtomId = struct.atoms.add(
+      new Atom({ label: 'Cl', pp: new Vec2(1, 0) }),
+    );
+    const bondId = struct.bonds.add(
+      new Bond({
+        begin: attachmentAtomId,
+        end: leaveAtomId,
+        type: Bond.PATTERN.TYPE.SINGLE,
+      }),
+    );
+    struct.bondInitHalfBonds(bondId);
+    struct.initNeighbors();
+
+    const sgroupId = createMonomerSGroup(struct, attachmentAtomId);
+    const sgroup = struct.sgroups.get(sgroupId);
+    if (sgroup instanceof MonomerMicromolecule) {
+      sgroup.data.expanded = false;
+      sgroup.addAttachmentPoint(
+        new SGroupAttachmentPoint(attachmentAtomId, leaveAtomId, undefined, 1),
+      );
+    }
+
+    const options = {
+      scale: 40,
+      width: 100,
+      height: 100,
+    } as unknown as RenderOptions;
+    const render = new Render(document as unknown as HTMLElement, options);
+    const restruct = new ReStruct(struct, render);
+
+    return { struct, restruct, sgroupId, attachmentAtomId, leaveAtomId };
+  };
+
+  it('expands a still-collapsed monomer before removing its S-group, so the leaving atom keeps its real label instead of a generic cap (#11312)', () => {
+    const { struct, restruct, sgroupId, leaveAtomId } =
+      buildCollapsedMonomerWithLeavingAtom();
+
+    fromSgroupDeletion(restruct, sgroupId);
+
+    // Before the fix, a still-collapsed monomer's leaving atom was relabeled
+    // with a generic MonomerCaps fallback ('H'), discarding its real
+    // chemistry and layout. The fix expands the monomer first (mirroring
+    // "Expand monomer"), so the exposed leaving atom keeps its real label and
+    // only its rglabel is cleared.
+    expect(struct.atoms.get(leaveAtomId)?.label).toBe('Cl');
+    expect(struct.atoms.get(leaveAtomId)?.rglabel).toBeNull();
+  });
+
+  it('recomputes implicit hydrogens/valence on the exposed attachment atom after removing a collapsed monomer grouping (#11314)', () => {
+    const { struct, restruct, sgroupId, attachmentAtomId } =
+      buildCollapsedMonomerWithLeavingAtom();
+
+    // Seed a stale/incorrect implicitH value, as if it had been computed
+    // while the monomer was still collapsed and never recalculated.
+    const attachmentAtom = struct.atoms.get(attachmentAtomId);
+    if (attachmentAtom) {
+      attachmentAtom.implicitH = 99;
+    }
+
+    fromSgroupDeletion(restruct, sgroupId);
+
+    expect(struct.atoms.get(attachmentAtomId)?.implicitH).not.toBe(99);
+    expect(struct.atoms.get(attachmentAtomId)?.badConn).toBe(false);
+  });
+
+  it('does not expand a monomer whose props are unresolved before removing its S-group', () => {
+    const { struct, restruct, sgroupId, leaveAtomId } =
+      buildCollapsedMonomerWithLeavingAtom();
+    const sgroup = struct.sgroups.get(sgroupId);
+    if (sgroup instanceof MonomerMicromolecule) {
+      sgroup.monomer.monomerItem.props.unresolved = true;
+    }
+
+    fromSgroupDeletion(restruct, sgroupId);
+
+    // Expansion is skipped for an unresolved monomer, so the leaving atom
+    // still goes through the generic MonomerCaps fallback ('H').
+    expect(struct.atoms.get(leaveAtomId)?.label).toBe('H');
+  });
+});

--- a/packages/ketcher-core/src/application/editor/actions/sgroup.ts
+++ b/packages/ketcher-core/src/application/editor/actions/sgroup.ts
@@ -43,13 +43,18 @@ import { atomGetAttr, atomGetDegree, atomGetSGroups } from './utils';
 import { Action } from './action';
 import { SgContexts } from '../shared/constants';
 import { uniq } from 'lodash/fp';
-import { fromAtomsAttrs, mergeFragmentsIfNeeded } from './atom';
+import {
+  checkAtomValence,
+  fromAtomsAttrs,
+  mergeFragmentsIfNeeded,
+} from './atom';
 import {
   SGroupAttachmentPointAdd,
   SGroupAttachmentPointRemove,
 } from 'application/editor/operations/sgroup/sgroupAttachmentPoints';
 import type Restruct from 'application/render/restruct/restruct';
 import { assert } from 'utilities';
+import { AmbiguousMonomer } from 'domain/entities/AmbiguousMonomer';
 import { MonomerMicromolecule } from 'domain/entities/monomerMicromolecule';
 import { isNumber } from 'lodash';
 import { getAttachmentPointStereoBond } from 'domain/helpers/getAttachmentPointStereoBond';
@@ -579,6 +584,25 @@ export function fromSgroupDeletion(restruct: Restruct, id, needPerform = true) {
   const struct = restruct.molecule;
 
   const sG = restruct.sgroups.get(id)?.item;
+
+  // Mirror "Remove Abbreviation" / spec 1.1.4 (#7864): expand a still-collapsed
+  // monomer (via the same pass "Expand monomer" uses) before tearing down its
+  // S-group, so the newly-exposed atoms are correctly repositioned relative to
+  // neighbors and cross-monomer stereo bonds are resolved (#11312).
+  // setExpandMonomerSGroup performs its ops eagerly (unlike the rest of this
+  // function's deferred `action`), so only run it when we're actually going to
+  // apply this action - a needPerform=false caller must not have restruct
+  // touched before it performs the action itself.
+  let expandAction: Action | undefined;
+  if (
+    needPerform &&
+    sG instanceof MonomerMicromolecule &&
+    !(sG.monomer instanceof AmbiguousMonomer) &&
+    !sG.monomer?.monomerItem?.props?.unresolved
+  ) {
+    expandAction = setExpandMonomerSGroup(restruct, id, { expanded: true });
+  }
+
   const atoms = SGroup.getAtoms(struct, sG);
   const atomsSet = new Set(atoms);
   const outsideConnections: Array<readonly [number, number]> = [];
@@ -638,7 +662,12 @@ export function fromSgroupDeletion(restruct: Restruct, id, needPerform = true) {
 
   action.addOp(new SGroupDelete(id));
 
-  // After SGroup is deleted, resolve leaving groups on plain structure
+  // After SGroup is deleted, resolve leaving groups on plain structure.
+  // In the common case the monomer was just force-expanded above, so
+  // `isExpanded` is true here and the `else` branch below is unreachable;
+  // it still runs for: a needPerform=false caller (removeSgroupIfNeeded),
+  // an ambiguous/unresolved monomer (expand is skipped for those), or as a
+  // defensive fallback if expansion above didn't happen for another reason.
   if (sG instanceof MonomerMicromolecule) {
     const isExpanded = sG.isExpanded();
     const monomerCaps = sG.monomer?.monomerItem?.props?.MonomerCaps ?? {};
@@ -704,8 +733,32 @@ export function fromSgroupDeletion(restruct: Restruct, id, needPerform = true) {
   if (needPerform) {
     action = action.perform(restruct);
 
+    if (expandAction) {
+      action = expandAction.mergeWith(action);
+    }
+
     outsideConnections.forEach(([atomId, neighborAtomId]) => {
       mergeFragmentsIfNeeded(action, restruct, atomId, neighborAtomId);
+    });
+
+    // The SGroup's leaving-group atoms/bonds were removed above, which changes
+    // the real explicit-bond count on its former attachment atoms. Their
+    // cached implicitH/badConn (see Struct.calcImplicitHydrogen) were computed
+    // while the group was still collapsed and are never recalculated
+    // automatically, so recompute them now to avoid a stale valence-error
+    // warning or wrong hydrogen count on the exposed atoms (#11314; the
+    // companion layout fix - expanding the monomer before deletion - is the
+    // setExpandMonomerSGroup(...) call above, which addresses #11312).
+    // Neighboring atoms across a cross-monomer bond (still inside their own,
+    // possibly still-collapsed, S-group) are recomputed too: the expand step
+    // above can replace their connecting bond (delete+re-add, to fix its
+    // stereo flag) without touching the neighbor's own cached valence.
+    const atomsToRecheckValence = new Set(atoms);
+    outsideConnections.forEach(([, neighborAtomId]) => {
+      atomsToRecheckValence.add(neighborAtomId);
+    });
+    atomsToRecheckValence.forEach((atomId) => {
+      action = checkAtomValence(restruct, atomId).mergeWith(action);
     });
   }
 

--- a/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRemoveGrouping.ts
+++ b/packages/ketcher-react/src/script/ui/views/components/ContextMenu/hooks/useRemoveGrouping.ts
@@ -13,9 +13,13 @@ type Params = ItemEventParams<MacromoleculeContextMenuProps>;
  * Returns a handler that removes the S-group grouping for each monomer in the
  * context (mirrors `useFunctionalGroupRemove` but typed for macromolecule props).
  *
- * Per the spec (1.1.4), if a collapsed monomer's abbreviation is deleted the
- * underlying `fromSgroupDeletion` action already expands the monomer atoms
- * before removing the S-group, so no extra step is needed here.
+ * Per the spec (1.1.4, #7864), "Remove Grouping" behaves like "Remove
+ * Abbreviation": `fromSgroupDeletion` calls
+ * `setExpandMonomerSGroup(..., { expanded: true })` internally for
+ * `MonomerMicromolecule` s-groups before removing the wrapper, so a
+ * still-collapsed monomer is expanded/repositioned (#11312) and its exposed
+ * atoms' valence is recomputed (#11314) as part of this single call - no
+ * extra step is needed here.
  */
 const useRemoveGrouping = () => {
   const { ketcherId } = useAppContext();


### PR DESCRIPTION
…uping/Abbreviation

"Remove Grouping"/"Remove Abbreviation" deleted a monomer's S-group without expanding it first, so exposed atoms kept stale layout and a valence-error flag from the collapsed representation (#11312, #11314). fromSgroupDeletion now force-expands the monomer before tearing down its S-group and recomputes implicit-hydrogen/valence state on the freed atoms and their cross-monomer neighbors.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request