### PR TITLE
#4218 - Cannot read properties of null

### DIFF
--- a/packages/ketcher-react/src/script/ui/App/initApp.tsx
+++ b/packages/ketcher-react/src/script/ui/App/initApp.tsx
@@ -27,7 +27,7 @@ import { Provider } from 'react-redux';
 import type { Root } from 'react-dom/client';
 import createStore, { setServer } from '../state';
 import { initKeydownListener, removeKeydownListener } from '../state/hotkeys';
-import { initResize } from '../state/toolbar';
+import { initResize, removeResizeListener } from '../state/toolbar';
 import { initMouseListener, removeMouseListeners } from '../state/mouse';
 
 function initApp(
@@ -85,6 +85,7 @@ function initApp(
   return () => {
     store.dispatch(removeKeydownListener(element));
     store.dispatch(removeMouseListeners(element));
+    removeResizeListener();
   };
 }
 

--- a/packages/ketcher-react/src/script/ui/state/toolbar/index.js
+++ b/packages/ketcher-react/src/script/ui/state/toolbar/index.js
@@ -47,15 +47,25 @@ function updateVisibleTools(visibleTool, activeTool) {
   );
 }
 
+let resizeListener = null;
+
 export function initResize() {
   return function (dispatch, getState) {
-    const onResize = throttle(250, () => {
+    resizeListener = throttle(250, () => {
       const state = getState();
+      if (!state.editor) return;
       state.editor.render.update();
       dispatch({ type: 'CLEAR_VISIBLE', data: state.actionState.activeTool });
     });
-    addEventListener('resize', onResize);
+    addEventListener('resize', resizeListener);
   };
+}
+
+export function removeResizeListener() {
+  if (resizeListener) {
+    removeEventListener('resize', resizeListener);
+    resizeListener = null;
+  }
 }
 
 /* REDUCER */

--- a/packages/ketcher-react/src/script/ui/state/toolbar/index.test.js
+++ b/packages/ketcher-react/src/script/ui/state/toolbar/index.test.js
@@ -1,0 +1,53 @@
+import { initResize, removeResizeListener } from './index';
+
+describe('initResize', () => {
+  afterEach(() => {
+    removeResizeListener();
+  });
+
+  // Regression test for https://github.com/epam/ketcher/issues/4218:
+  // the resize handler ran before the editor was set in the store and threw
+  // "Cannot read properties of null (reading 'render')".
+  it('should not throw when a resize event fires before state.editor is set', () => {
+    const dispatch = jest.fn();
+    const getState = jest.fn(() => ({ editor: null }));
+
+    initResize()(dispatch, getState);
+
+    expect(() => window.dispatchEvent(new Event('resize'))).not.toThrow();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('should update the editor render and clear the active tool on resize', () => {
+    const update = jest.fn();
+    const dispatch = jest.fn();
+    const getState = jest.fn(() => ({
+      editor: { render: { update } },
+      actionState: { activeTool: 'select' },
+    }));
+
+    initResize()(dispatch, getState);
+    window.dispatchEvent(new Event('resize'));
+
+    expect(update).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'CLEAR_VISIBLE',
+      data: 'select',
+    });
+  });
+
+  it('should stop reacting to resize after removeResizeListener is called', () => {
+    const update = jest.fn();
+    const dispatch = jest.fn();
+    const getState = jest.fn(() => ({
+      editor: { render: { update } },
+      actionState: { activeTool: 'select' },
+    }));
+
+    initResize()(dispatch, getState);
+    removeResizeListener();
+    window.dispatchEvent(new Event('resize'));
+
+    expect(update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**What was wrong**

Ketcher would occasionally throw TypeError: Cannot read properties of null (reading 'render') when a window resize event fired shortly after the editor was mounted.

**Root cause**

initResize() (toolbar/index.js) registers a window resize listener synchronously when the redux store is created, before the core editor object exists and state.editor is populated (via the INIT action). The throttled resize handler accessed state.editor.render.update() with no null-check, so any resize event landing before INIT fired crashed.

A related defect made this worse: initApp.tsx's unmount cleanup removed the keydown and mouse listeners but never removed the resize listener, so every mount/unmount cycle leaked one window resize listener permanently.

**Fix**

- toolbar/index.js: guard the handler with if (!state.editor) return; before touching state.editor.render, and expose removeResizeListener().
- initApp.tsx: call removeResizeListener() in the unmount cleanup alongside the existing keydown/mouse cleanup, so the listener no longer leaks.
- Added toolbar/index.test.js: verifies no throw/dispatch when state.editor is null, correct render.update() + CLEAR_VISIBLE dispatch when it's set, and that removeResizeListener() actually detaches the handler.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request

Fixes #4218 