### PR TITLE
#4657 Implement a method to destroy web workers created by IndigoService (standaloneStructService) in standalone mode

### DIFF
--- a/packages/ketcher-core/src/domain/services/struct/structService.types.ts
+++ b/packages/ketcher-core/src/domain/services/struct/structService.types.ts
@@ -229,4 +229,5 @@ export interface StructService {
     options?: StructServiceOptions,
   ) => Promise<CalculateMacromoleculePropertiesResult>;
   destroy?: () => void;
+  terminateWorker?: () => void;
 }

--- a/packages/ketcher-react/src/script/api.ts
+++ b/packages/ketcher-react/src/script/api.ts
@@ -53,6 +53,7 @@ function createApi(
     calculateMacromoleculeProperties:
       structService.calculateMacromoleculeProperties.bind(structService),
     destroy: structService.destroy?.bind(structService),
+    terminateWorker: structService.terminateWorker?.bind(structService),
   });
 }
 

--- a/packages/ketcher-react/src/script/index.ts
+++ b/packages/ketcher-react/src/script/index.ts
@@ -53,7 +53,7 @@ async function buildKetcherAsync({
   const ketcher = await builder.build();
   structService.addKetcherId(ketcher.id);
 
-  const { cleanup, setServer } = await builder.appendUiAsync(
+  const { cleanup: uiCleanup, setServer } = await builder.appendUiAsync(
     prevKetcherId,
     ketcher.id,
     element,
@@ -64,6 +64,11 @@ async function buildKetcherAsync({
     togglerComponent,
     customButtons,
   );
+
+  const cleanup = () => {
+    uiCleanup?.();
+    structService.destroy?.();
+  };
 
   return { ketcher, cleanup, builder, setServer };
 }

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorkerImports/useOffMainThreadPlugin.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorkerImports/useOffMainThreadPlugin.ts
@@ -13,3 +13,8 @@ export function getIndigoWorker(): Worker {
   }
   return _indigoWorker;
 }
+
+export function terminateIndigoWorker(): void {
+  _indigoWorker?.terminate();
+  _indigoWorker = null;
+}

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorkerImports/useWasmLoader.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/indigoWorkerImports/useWasmLoader.ts
@@ -12,3 +12,8 @@ export function getIndigoWorker(): Worker {
   }
   return _indigoWorker;
 }
+
+export function terminateIndigoWorker(): void {
+  _indigoWorker?.terminate();
+  _indigoWorker = null;
+}

--- a/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
+++ b/packages/ketcher-standalone/src/infrastructure/services/struct/standaloneStructService.ts
@@ -77,7 +77,10 @@ import {
   STRUCT_SERVICE_NO_RENDER_INITIALIZED_EVENT,
   DEFAULT_WORKER_TIMEOUT,
 } from './constants';
-import { getIndigoWorker } from '_indigo-worker-import-alias_';
+import {
+  getIndigoWorker,
+  terminateIndigoWorker,
+} from '_indigo-worker-import-alias_';
 
 interface KeyValuePair {
   [key: string]: number | string | boolean | object;
@@ -1005,7 +1008,11 @@ class IndigoService implements StructService {
 
   public destroy() {
     this.worker.removeEventListener('message', this.messageHandler);
-    this.worker.terminate();
+  }
+
+  public terminateWorker() {
+    this.worker.removeEventListener('message', this.messageHandler);
+    terminateIndigoWorker();
   }
 }
 


### PR DESCRIPTION
…s destroyed

- Split destroy() from terminateWorker() in IndigoService: destroy() now only removes the message event listener (preventing listener leaks on editor unmount/remount), while terminateWorker() also terminates and resets the module-level singleton worker so it can be recreated cleanly.
- Export terminateIndigoWorker() from both worker loader modules (useWasmLoader and useOffMainThreadPlugin) to terminate and null-out the singleton.
- Add terminateWorker? to StructService interface and expose it via api.ts.
- Call structService.destroy() as part of the editor cleanup in buildKetcherAsync so event listeners are removed whenever the MicromoleculesEditor component unmounts.

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [ ] PR name follows the pattern `#1234 – issue name`
- [ ] branch name doesn't contain '#'
- [ ] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [ ] reviewers are notified about the pull request