### PR TITLE
#2637-Import error

### DIFF
--- a/packages/ketcher-react/README.md
+++ b/packages/ketcher-react/README.md
@@ -14,6 +14,13 @@ The ketcher-react package contains only the functionality necessary to define co
 
 ## Installation
 
+### Requirements
+
+- **React**: 18.2.0 or higher (React 19 is also supported)
+- **Node.js**: 24.14.1 or higher
+
+### Install
+
 The ketcher-react library is available as an [NPM](https://www.npmjs.com/) package. Install it either with NPM:
 
 ```sh
@@ -34,7 +41,7 @@ import { RemoteStructServiceProvider } from 'ketcher-core'
 const structServiceProvider = new RemoteStructServiceProvider(
   process.env.REACT_APP_API_PATH!,
   {
-    'custom header': 'value' // optionally you can add custom headers object 
+    'custom header': 'value' // optionally you can add custom headers object
   }
 )
 
@@ -81,3 +88,108 @@ const MyComponent = () => {
 
 You can find the latest version of Miew-React [here](https://github.com/epam/miew/tree/master/packages/miew-react).
 The last checked version - [0.12.0](https://www.npmjs.com/package/miew-react).
+
+## Troubleshooting
+
+### "Can't resolve 'react/jsx-runtime'" or module resolution errors
+
+Ketcher requires **React 18.2.0 or higher** (or React 19.x). If you see errors like:
+
+```
+Module not found: Error: Can't resolve 'react/jsx-runtime'
+Can't import the named export 'Children' from non EcmaScript module
+```
+
+**Solution 1: Update React version**
+
+Make sure you have the correct React version installed:
+
+```sh
+npm install react@^18.2.0 react-dom@^18.2.0
+```
+
+**Solution 2: Check your bundler configuration**
+
+If you're still seeing the "Can't import the named export" error after updating React, you may need to update your webpack or build tool configuration:
+
+For **webpack 5**, ensure you have:
+
+```javascript
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.m?js$/,
+        resolve: {
+          fullySpecified: false,
+        },
+      },
+    ],
+  },
+};
+```
+
+For **Create React App**, you may need to upgrade to the latest version:
+
+```sh
+npm install react-scripts@latest
+```
+
+For **Vite**, the default configuration should work. If you encounter issues, ensure you're using Vite 4+ with the React plugin properly configured.
+
+### Editor appears but templates/icons are missing
+
+Make sure you've correctly set `staticResourcesUrl` and that the Ketcher static assets are accessible:
+
+```jsx
+// For Vite
+staticResourcesUrl={import.meta.env.BASE_URL}
+
+// For Create React App
+staticResourcesUrl={process.env.PUBLIC_URL}
+
+// Or provide absolute path
+staticResourcesUrl="/ketcher-assets"
+```
+
+### "Cannot find module 'ketcher-standalone'"
+
+Make sure you've installed the standalone package:
+
+```sh
+npm install ketcher-standalone
+```
+
+### TypeScript errors
+
+Install type definitions:
+
+```sh
+npm install --save-dev @types/react @types/react-dom
+```
+
+### Editor is blank or not visible
+
+Ensure the editor container has a defined height:
+
+```jsx
+<div style={{ height: '100vh', width: '100%' }}>
+  <Editor {...props} />
+</div>
+```
+
+### CSS styles not applied
+
+Make sure you import the CSS file:
+
+```jsx
+import 'ketcher-react/dist/index.css';
+```
+
+## Examples
+
+For complete working examples, see:
+
+- [Basic example](https://github.com/epam/ketcher/tree/master/example) - Full-featured example with both standalone and remote modes
+- [Main README](https://github.com/epam/ketcher/blob/master/README.md) - Additional usage examples and API documentation


### PR DESCRIPTION
Fix: Add React version requirements and module resolution troubleshooting to ketcher-react README                                                                                                                               
                                                                                                                                                                                                                                  
Summary

This PR addresses common integration errors encountered by developers when installing and using ketcher-react by adding clear requirements documentation and comprehensive troubleshooting for module resolution issues.

Problem
Users frequently encounter cryptic errors when integrating ketcher-react:

Module not found: Error: Can't resolve 'react/jsx-runtime'
Can't import the named export 'Children' from non EcmaScript module

These errors occur because:
  1. Missing Requirements Section: README didn't specify React 18.2.0+ and Node.js 24.14.1+ are required
  2. No Troubleshooting Documentation: Users had no guidance when facing module resolution issues
  3. Hidden Root Cause: ketcher-react is pre-compiled with modern JSX runtime (react/jsx-runtime), which requires React 18+, but this wasn't documented

Changes
  1. Added Requirements Section 📋

  Added clear requirements before installation instructions:

  ### Requirements
  - **React**: 18.2.0 or higher (React 19 is also supported)
  - **Node.js**: 24.14.1 or higher

  Benefits:
  - Fail fast approach - users see requirements before attempting installation
  - Matches peerDependencies and engines in package.json
  - Prevents incompatible version installations

  2. Added Module Resolution Troubleshooting 🔧

New troubleshooting section addressing the most common error:

Solution 1: Update React version
  - Direct command: npm install react@^18.2.0 react-dom@^18.2.0
  - Explains React 18+ is required for jsx-runtime

Solution 2: Bundler configuration
  - Webpack 5: ESM/CJS interop fix (fullySpecified: false)
  - Create React App: Upgrade command (react-scripts@latest)
  - Vite: Confirmation that default configuration works

3. Enhanced Troubleshooting Section 🛠️

Added solutions for 5 additional common issues:
  - Missing templates/icons (staticResourcesUrl configuration)
  - Module not found for ketcher-standalone
  - TypeScript type definition errors
  - Blank/invisible editor (container height)
  - CSS not applied (missing import)

4. Added Examples Section 🔗

  - Links to complete working examples in repository
  - References to API documentation in main README

Technical Background

Why these errors happen:

  1. jsx-runtime error:
    - ketcher-react/dist/index.js contains: import { jsx } from 'react/jsx-runtime'
    - This is compiled output from Rollup build process
    - React 17 and older don't export react/jsx-runtime module
    - Upgrading to React 18+ resolves this
  2. Named export error:
    - react-contexify dependency uses ESM format (.mjs)
    - Older webpack configurations don't handle ESM/CJS interop correctly
    - Webpack 5 with proper config resolves this


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request