### PR TITLE
#9693 - RNA Builder: Default preset name changes unexpectedly after switching phosphate picker from 3' to 5' 

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/RnaEditorExpanded.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable react-you-might-not-need-an-effect/no-event-handler, react-you-might-not-need-an-effect/no-chain-state-updates */
+/* eslint-disable react-you-might-not-need-an-effect/no-event-handler */
 /* eslint-disable react-hooks/set-state-in-effect */
 /****************************************************************************
  * Copyright 2021 EPAM Systems
@@ -281,28 +281,16 @@ export const RnaEditorExpanded = ({
         dispatch(setSequenceSelection(updatedSequenceSelection));
       } else {
         const currentPreset = updatePresetMonomerGroup();
-        const resolvedPhosphatePosition =
-          resolvePhosphatePosition(currentPreset);
         let presetFullName = newPreset?.name;
 
         if (!currentPreset.editedName) {
-          presetFullName = selectPresetFullName({
-            ...currentPreset,
-            connections: buildRnaPresetConnections(
-              currentPreset,
-              resolvedPhosphatePosition,
-            ),
-          });
+          presetFullName = selectPresetFullName(currentPreset);
         }
 
         setNewPreset({ ...currentPreset, name: presetFullName });
       }
     }
-  }, [
-    activePresetMonomerGroup?.groupItem,
-    isSequenceEditInRNABuilderMode,
-    selectedPhosphatePosition,
-  ]);
+  }, [activePresetMonomerGroup?.groupItem, isSequenceEditInRNABuilderMode]);
 
   const scrollToActiveItemInLibrary = (selectedGroup, selectedMonomer) => {
     if (selectedGroup === RnaBuilderPresetsItem.Presets) {

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.test.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.test.ts
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * Copyright 2021 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import { buildRnaPresetConnections } from 'ketcher-core';
+import { selectPresetFullName } from './rnaBuilderSlice';
+
+const presetMonomers = {
+  sugar: { label: '5formD', props: { id: 'sugar-template-id' } } as never,
+  base: { label: 'baA', props: { id: 'base-template-id' } } as never,
+  phosphate: { label: 'cm', props: { id: 'phosphate-template-id' } } as never,
+};
+
+describe('selectPresetFullName', () => {
+  it("appends the phosphate for a preset with the phosphate on 3'", () => {
+    expect(
+      selectPresetFullName({
+        ...presetMonomers,
+        connections: buildRnaPresetConnections(presetMonomers, 'right'),
+      }),
+    ).toBe('5formD(baA)cm');
+  });
+
+  it("keeps the same name when the phosphate is moved to 5'", () => {
+    expect(
+      selectPresetFullName({
+        ...presetMonomers,
+        connections: buildRnaPresetConnections(presetMonomers, 'left'),
+      }),
+    ).toBe('5formD(baA)cm');
+  });
+});

--- a/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
+++ b/packages/ketcher-macromolecules/src/state/rna-builder/rnaBuilderSlice.ts
@@ -447,9 +447,6 @@ export const selectPresetFullName = (preset: IRnaPreset): string => {
   const base = preset.base?.label ?? preset.base?.props.MonomerName ?? '';
   const phosphate =
     preset.phosphate?.label ?? preset.phosphate?.props.MonomerName ?? '';
-  const phosphatePosition = getRnaPresetPhosphatePosition(
-    preset as RnaPresetWithOptionalFields,
-  );
   let fullName = sugar;
 
   if (sugar && phosphate) {
@@ -460,11 +457,11 @@ export const selectPresetFullName = (preset: IRnaPreset): string => {
     fullName += base;
   }
 
+  // The phosphate is always appended, whatever position the picker holds:
+  // prefixing it for 5' leaves no cue where the phosphate label ends and the
+  // sugar label begins, so the name would become ambiguous (#9693).
   if (phosphate) {
-    fullName =
-      phosphatePosition === 'left'
-        ? `${phosphate}${fullName}`
-        : `${fullName}${phosphate}`;
+    fullName += phosphate;
   }
 
   return fullName;


### PR DESCRIPTION

<img width="959" height="530" alt="left" src="https://github.com/user-attachments/assets/1a0e3c8b-953a-48ca-8ec7-d55a8e68e5f7" />
<img width="959" height="530" alt="2222" src="https://github.com/user-attachments/assets/de69fca3-71d4-44b4-8bb5-441b61fc5a35" />


The generated preset name placed the phosphate before the sugar for a 5' phosphate, so switching the position picker rewrote a name the user had already seen. Phosphate position no longer affects the name — the phosphate is always appended, giving sugar(base)phosphate in both orientations.

Building the connections at the call site only served to derive that position for the name, so it is removed together with the effect's position trigger. The saved preset still takes its connections from the picker, so the 5'/3' geometry is unchanged.

Why this shape

The reordering was never part of the #9120 requirements, and the rationale for reverting it is ambiguity: in cm5formD(baA) there is no cue where the phosphate label ends and the sugar label begins.

Deliberate trade-off: a 3' and a 5' preset built from the same monomers now propose the same default name, so the second hits the existing unique-name check and needs a manual rename.

## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request