### PR TITLE
#9690 - RNA Builder: Monomers remain grayed out after canceling preset creation

### DIFF
--- a/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/RnaElements.tsx
+++ b/packages/ketcher-macromolecules/src/components/monomerLibrary/RnaBuilder/RnaElementsView/RnaElements.tsx
@@ -54,6 +54,22 @@ export const RnaElements = ({
   );
 
   const [newPreset, setNewPreset] = useState(activePreset);
+  // The RNA builder is reset through redux, which cannot reach this local copy
+  // of the preset being built. Re-syncing it whenever the active preset or the
+  // edit mode changes keeps a cancelled preset's monomers from constraining the
+  // library the next time a group is expanded (#9690).
+  const [prevBuilderState, setPrevBuilderState] = useState({
+    activePreset,
+    isEditMode,
+  });
+
+  if (
+    prevBuilderState.activePreset !== activePreset ||
+    prevBuilderState.isEditMode !== isEditMode
+  ) {
+    setPrevBuilderState({ activePreset, isEditMode });
+    setNewPreset(activePreset);
+  }
 
   useEffect(() => {
     if (!isEditMode) {


### PR DESCRIPTION

<img width="959" height="496" alt="aaaaaa" src="https://github.com/user-attachments/assets/123455bb-2f8b-47ba-977c-45cbde6e0b0a" />
<img width="958" height="496" alt="bbbbbbbbbbb" src="https://github.com/user-attachments/assets/82c133d5-4644-4151-9331-042346024032" />
What changed

RnaElements keeps a local copy of the preset being built, and that copy is the only input to the validation recalculation performed when a library group is expanded. The RNA builder is reset through redux, which cannot reach component state, so the monomers of a cancelled preset kept constraining the library: after cancelling a preset whose sugar has no R3 and starting a new one, every base stayed grayed out.

The copy is now re-synced with the active preset whenever the active preset or the edit mode changes.

Why both keys

Cancelling an empty preset dispatches setActivePreset(presets[0]), so activePreset changes. Cancelling while editing a saved preset takes the other branch and only leaves edit mode, leaving activePreset untouched. Keying on activePreset alone would leave that second path broken.

Written as a render-time adjustment rather than an effect: react-hooks/set-state-in-effect is error for this file, which carries no eslint-disable, and this matches the pattern already used in RnaEditor.tsx and RnaElementsAccordionView.tsx.

How it was verified

Reproduced and fixed in the browser using temporary logging, since removed. On master, after cancelling a dier preset and starting a new one, the accordion recalculated from a stale copy still holding sugar: 'dier' — dier carries only R2, so every base was disabled. With the fix the same step reports sugar: undefined and the bases are enabled.

Full ketcher-macromolecules gate green: prettier, stylelint, eslint, types, 36 suites / 158 tests.

Note for reviewers: the defect only appears in the accordion layout. useIsCompactView switches to a tabs view below 720px height, and that view never receives the local copy.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request