### PR TITLE
#10953, #2999 - Merge repeated V2000 M-property lines and allow >2 SRU cross-bonds

### DIFF
--- a/packages/ketcher-core/src/domain/serializers/mol/__tests__/common.prepareSruForSaving.test.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/__tests__/common.prepareSruForSaving.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import { MolSerializer } from '../molSerializer';
+import common from '../common';
+
+/**
+ * `*—C—C(—*)—C—*`: an SRU covering the three carbons, so three bonds cross its
+ * brackets. Two-cross-bond and zero-cross-bond variants are derived from it by
+ * changing the `M  SAL` line only.
+ */
+const sruMolfile = (sal: string): string =>
+  [
+    'star-atom SRU',
+    '  Ketcher',
+    '',
+    '  6  5  0  0  0  0            999 V2000',
+    '    0.0000    0.0000    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0',
+    '    1.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0',
+    '    2.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0',
+    '    3.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0',
+    '    4.0000    0.0000    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0',
+    '    2.0000   -1.0000    0.0000 *   0  0  0  0  0  0  0  0  0  0  0  0',
+    '  1  2  1  0  0  0  0',
+    '  2  3  1  0  0  0  0',
+    '  3  4  1  0  0  0  0',
+    '  4  5  1  0  0  0  0',
+    '  3  6  1  0  0  0  0',
+    'M  STY  1   1 SRU',
+    'M  SLB  1   1   1',
+    'M  SCN  1   1 HT ',
+    'M  SMT   1 n',
+    sal,
+    'M  END',
+  ].join('\n');
+
+/** SRU = the three carbons; bonds 1, 4 and 5 cross the brackets. */
+const threeCrossBonds = sruMolfile('M  SAL   1  3   2   3   4');
+/** SRU = two carbons plus one star; bonds 1 and 4 cross the brackets. */
+const twoCrossBonds = sruMolfile('M  SAL   1  4   2   3   4   6');
+/** SRU = the whole molecule; nothing crosses the brackets. */
+const zeroCrossBonds = sruMolfile('M  SAL   1  6   1   2   3   4   5   6');
+
+const getSru = (molfile: string) => {
+  const struct = new MolSerializer().deserialize(molfile);
+  const sgroup = struct.sgroups.get(0);
+  expect(sgroup!.type).toBe('SRU');
+  return { struct, sgroup: sgroup! };
+};
+
+describe('prepareSruForSaving', () => {
+  it('collects three crossing bonds instead of throwing', () => {
+    const { struct, sgroup } = getSru(threeCrossBonds);
+
+    expect(() => common.prepareForSaving.SRU(sgroup, struct)).not.toThrow();
+    expect(sgroup.bonds).toEqual([0, 3, 4]);
+  });
+
+  it('still collects exactly two crossing bonds', () => {
+    const { struct, sgroup } = getSru(twoCrossBonds);
+
+    common.prepareForSaving.SRU(sgroup, struct);
+    expect(sgroup.bonds).toEqual([0, 3]);
+  });
+
+  it('collects no crossing bonds when the whole molecule is inside the brackets', () => {
+    const { struct, sgroup } = getSru(zeroCrossBonds);
+
+    common.prepareForSaving.SRU(sgroup, struct);
+    expect(sgroup.bonds).toEqual([]);
+  });
+
+  it('is used for COP as well', () => {
+    const { struct, sgroup } = getSru(threeCrossBonds);
+
+    expect(() => common.prepareForSaving.COP(sgroup, struct)).not.toThrow();
+    expect(sgroup.bonds).toEqual([0, 3, 4]);
+  });
+});
+
+describe('SRU molfile export', () => {
+  beforeAll(() => {
+    // `SGroup.bracketPos` falls back to `window.ketcher.editor.render` when no
+    // render is passed; jest only provides an empty `ketcher` global.
+    (window as unknown as Record<string, unknown>).ketcher = {
+      editor: {
+        render: {
+          ctab: { getRGroupAttachmentPointsVBoxByAtomIds: () => null },
+        },
+      },
+    };
+  });
+
+  it('writes an SBL line listing all three crossing bonds', () => {
+    const struct = new MolSerializer().deserialize(threeCrossBonds);
+
+    const molfile = new MolSerializer().serialize(struct);
+
+    expect(molfile).toContain('M  SBL   1  3   1   4   5');
+  });
+
+  it('writes an SBL line for two crossing bonds', () => {
+    const struct = new MolSerializer().deserialize(twoCrossBonds);
+
+    const molfile = new MolSerializer().serialize(struct);
+
+    expect(molfile).toContain('M  SBL   1  2   1   4');
+  });
+
+  it('writes no SBL line when nothing crosses the brackets', () => {
+    const struct = new MolSerializer().deserialize(zeroCrossBonds);
+
+    const molfile = new MolSerializer().serialize(struct);
+
+    expect(molfile).not.toContain('M  SBL');
+  });
+});

--- a/packages/ketcher-core/src/domain/serializers/mol/__tests__/v2000.test.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/__tests__/v2000.test.ts
@@ -451,6 +451,57 @@ describe('parseCTabV2000', () => {
       expect(struct.atoms.get(1)!.isotope).toBe(11);
     });
 
+    // A property block holds at most 8 entries per line, so writers continue it on
+    // further `M  XXX` lines. Every line must be merged, not just the first one.
+    it('should parse isotopes spread over several M  ISO lines', () => {
+      const atomLine =
+        '   14.0000   -3.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0';
+      const lines = [
+        ...Array.from({ length: 10 }, () => atomLine),
+        'M  ISO  8   1   2   2   2   3   2   4   2   5   2   6   2   7   2   8   2',
+        'M  ISO  2   9   2  10   2',
+      ];
+
+      const struct = molParsers.parseCTabV2000(lines, createCountsLine(10));
+
+      for (let atomId = 0; atomId < 10; atomId++) {
+        expect(struct.atoms.get(atomId)!.isotope).toBe(2);
+      }
+    });
+
+    it('should parse charges spread over several M  CHG lines', () => {
+      const atomLine =
+        '   14.0000   -3.0000    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0';
+      const lines = [
+        ...Array.from({ length: 9 }, () => atomLine),
+        'M  CHG  8   1   1   2   1   3   1   4   1   5   1   6   1   7   1   8   1',
+        'M  CHG  1   9  -1',
+      ];
+
+      const struct = molParsers.parseCTabV2000(lines, createCountsLine(9));
+
+      for (let atomId = 0; atomId < 8; atomId++) {
+        expect(struct.atoms.get(atomId)!.charge).toBe(1);
+      }
+      expect(struct.atoms.get(8)!.charge).toBe(-1);
+    });
+
+    it('should let a later property line override an earlier value for the same atom', () => {
+      const atomLine =
+        '   14.0000   -3.0000    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0';
+      const lines = [
+        atomLine,
+        atomLine,
+        'M  CHG  2   1   1   2   1',
+        'M  CHG  1   2   3',
+      ];
+
+      const struct = molParsers.parseCTabV2000(lines, createCountsLine(2));
+
+      expect(struct.atoms.get(0)!.charge).toBe(1);
+      expect(struct.atoms.get(1)!.charge).toBe(3);
+    });
+
     it('should parse ringBondCount', () => {
       const lines = [
         '   14.0000   -3.0000    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0',

--- a/packages/ketcher-core/src/domain/serializers/mol/common.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/common.ts
@@ -24,11 +24,6 @@ import type { Mapping } from './mol.types';
 import utils from './utils';
 import v2000 from './v2000';
 
-interface SGroupSavingError extends Error {
-  id: number;
-  'error-type': string;
-}
-
 function getAtom(mol: Struct, id: number): Atom {
   const atom = mol.atoms.get(id);
   if (!atom) {
@@ -93,6 +88,15 @@ const prepareForSaving: Record<string, (sgroup: SGroup, mol: Struct) => void> =
     queryComponent: prepareQueryComponentForSaving,
   };
 
+/**
+ * Collects the bonds crossing the SRU brackets into `sgroup.bonds`, which is what
+ * the `M  SBL` line is written from.
+ *
+ * Any number of crossing bonds is supported: `makeAtomBondLines` wraps `SBL` at 15
+ * ids per line and `SGroup.getBracketParameters` has a branch that draws one bracket
+ * per crossing bond. Only MUL genuinely needs exactly two crossing bonds, and that
+ * constraint lives in `SGroup.prepareMulForSaving`.
+ */
 function prepareSruForSaving(sgroup: SGroup, mol: Struct): void {
   const xBonds: number[] = [];
   mol.bonds.forEach((bond, bid) => {
@@ -105,14 +109,6 @@ function prepareSruForSaving(sgroup: SGroup, mol: Struct): void {
       xBonds.push(bid);
     }
   });
-  if (xBonds.length !== 0 && xBonds.length !== 2) {
-    const error = new Error(
-      'Unsupported cross-bonds number',
-    ) as SGroupSavingError;
-    error.id = sgroup.id;
-    error['error-type'] = 'cross-bond-number';
-    throw error;
-  }
   sgroup.bonds = xBonds;
 }
 

--- a/packages/ketcher-core/src/domain/serializers/mol/common.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/common.ts
@@ -80,51 +80,29 @@ function parseRxn(
 const prepareForSaving: Record<string, (sgroup: SGroup, mol: Struct) => void> =
   {
     MUL: SGroup.prepareMulForSaving,
-    SRU: prepareSruForSaving,
-    SUP: prepareSupForSaving,
+    // SRU, SUP and COP all serialise the bonds crossing their brackets the same way
+    SRU: prepareCrossBondsForSaving,
+    SUP: prepareCrossBondsForSaving,
+    COP: prepareCrossBondsForSaving,
     DAT: prepareDatForSaving,
     GEN: prepareGenForSaving,
-    COP: prepareCopForSaving,
     queryComponent: prepareQueryComponentForSaving,
   };
 
 /**
- * Collects the bonds crossing the SRU brackets into `sgroup.bonds`, which is what
- * the `M  SBL` line is written from.
+ * Collects the bonds crossing the s-group's brackets into `sgroup.bonds`, which is
+ * what the `M  SBL` line is written from.
  *
  * Any number of crossing bonds is supported: `makeAtomBondLines` wraps `SBL` at 15
  * ids per line and `SGroup.getBracketParameters` has a branch that draws one bracket
  * per crossing bond. Only MUL genuinely needs exactly two crossing bonds, and that
  * constraint lives in `SGroup.prepareMulForSaving`.
  */
-function prepareSruForSaving(sgroup: SGroup, mol: Struct): void {
+function prepareCrossBondsForSaving(sgroup: SGroup, mol: Struct): void {
   const xBonds: number[] = [];
   mol.bonds.forEach((bond, bid) => {
     const a1 = getAtom(mol, bond.begin);
     const a2 = getAtom(mol, bond.end);
-    if (
-      (a1.sgs.has(sgroup.id) && !a2.sgs.has(sgroup.id)) ||
-      (a2.sgs.has(sgroup.id) && !a1.sgs.has(sgroup.id))
-    ) {
-      xBonds.push(bid);
-    }
-  });
-  sgroup.bonds = xBonds;
-}
-
-function prepareCopForSaving(sgroup: SGroup, mol: Struct): void {
-  // Same cross-bond computation as SRU.
-  prepareSruForSaving(sgroup, mol);
-}
-
-function prepareSupForSaving(sgroup: SGroup, mol: Struct): void {
-  // This code is also used for GroupSru and should be moved into a separate common method
-  // It seems that such code should be used for any sgroup by this this should be checked
-  const xBonds: number[] = [];
-  mol.bonds.forEach((bond, bid) => {
-    const a1 = getAtom(mol, bond.begin);
-    const a2 = getAtom(mol, bond.end);
-
     if (
       (a1.sgs.has(sgroup.id) && !a2.sgs.has(sgroup.id)) ||
       (a2.sgs.has(sgroup.id) && !a1.sgs.has(sgroup.id))

--- a/packages/ketcher-core/src/domain/serializers/mol/v2000.ts
+++ b/packages/ketcher-core/src/domain/serializers/mol/v2000.ts
@@ -152,6 +152,10 @@ function handleAliasProperty(
 
 /**
  * Handles simple atom property types (CHG, RAD, ISO, RBC, UNS, APO)
+ *
+ * A property block may be spread over several `M  XXX` lines: the writer emits at
+ * most 8 entries per line, so every subsequent line must be merged into the pool
+ * built from the previous ones (last value wins for a repeated atom).
  */
 function handleSimpleAtomProperty(
   propName: string,
@@ -159,7 +163,16 @@ function handleSimpleAtomProperty(
   props: MPropertyProps,
 ): void {
   if (!props.get(propName)) {
-    props.set(propName, sGroup.readKeyValuePairs(propertyData, false));
+    props.set(propName, new Pool<string | number | AtomList>());
+  }
+  const pool = props.get(propName);
+  if (!pool) {
+    return;
+  }
+
+  const values = sGroup.readKeyValuePairs(propertyData, false);
+  for (const [atomId, value] of values) {
+    pool.set(atomId, value);
   }
 }
 


### PR DESCRIPTION
Closes #10953
Closes #2999

Two independent V2000 serializer bugs that meet in one small diff under `packages/ketcher-core/src/domain/serializers/mol/`.

## #10953 — only the first `M  XXX` property line was read

`handleSimpleAtomProperty` (`v2000.ts`) was guarded by `if (!props.get(propName))`, so the pool built from the first property line was never added to. A V2000 property block holds at most 8 entries per line and continues on further lines, so everything past the first 8 was silently dropped — the reporter's 10 isotopes became 8.

The helper now merges every line into the same pool (last value wins for a repeated atom).

**This was never ISO-only.** The same helper backs six property types, and all six had the bug:

| `M  XXX` | property |
| --- | --- |
| `CHG` | `charge` |
| `RAD` | `radical` |
| `ISO` | `isotope` |
| `RBC` | `ringBondCount` |
| `UNS` | `unsaturatedAtom` |
| `APO` | `attachmentPoints` |

So any structure with more than 8 charged atoms or 8 radicals was equally lossy on re-read. The writer (`writeAtomPropList`) already splits at 8 entries per line and is unchanged; this makes the reader symmetric with it.

## #2999 — SRU export aborted for more than 2 cross-bonds

`prepareSruForSaving` (`common.ts`) threw `Unsupported cross-bonds number` whenever the SRU had a cross-bond count other than 0 or 2. With `MolSerializer`'s default `ignoreErrors: false` this made `ketcher.getMolfile()` throw outright for the whole structure; with `ignoreErrors: true` the s-group was silently deleted from the output.

The throw is removed. `SBL` is now emitted for however many bonds cross the brackets. Nothing downstream needed exactly 2: `makeAtomBondLines` already wraps `SBL` at 15 ids per line, and `SGroup.getBracketParameters` already has a branch that draws one bracket per cross-bond. `prepareSupForSaving` computed the identical array with no throw, which is standing proof the >2 case serialises fine. **`SGroup.prepareMulForSaving` is deliberately untouched** — MUL geometry genuinely needs the two crossing bonds, and `sgroup.test.ts` asserts on its messages.

### Scope note: the reported symptom is partly already fixed on master

Worth flagging honestly. Probing the three cases:

| case | cross-bonds | on master today |
| --- | --- | --- |
| stars **outside** the brackets | 2 | already correct, `M  SBL` emitted — **not a bug** |
| stars **inside** the brackets | 0 | no `SBL` line, which is correct per spec (nothing crosses) |
| star on a branch | 3 | **`Error: Unsupported cross-bonds number`, whole export fails** |

So the 2.11-era symptom in the issue body is gone; what remains is the collaborator's follow-up case, and that is what this PR targets. A 0-cross-bond SRU still emits no `SBL`, which is intended — `SBL` is the list of *crossing* bonds, and `M  SBL   1  0` would be wrong.

The issue also notes that "Save as…" and `getMolfile()` use different exporters. That difference is the Indigo path (`formatterFactory` routes non-query, in-limit V2000 to the local formatter, everything else to the server). **This PR does not touch the Indigo path** and makes no claim about it.

## Refactor folded in

Removing the throw left `prepareSruForSaving` byte-identical to `prepareSupForSaving`, which already carried a TODO asking for exactly this extraction ("This code is also used for GroupSru and should be moved into a separate common method"). Both, plus `prepareCopForSaving` which already delegated, are now one `prepareCrossBondsForSaving`. Behaviour for SUP and COP is unchanged.

The `SGroupSavingError` interface and its `'error-type': 'cross-bond-number'` tag went with the throw. Confirmed no consumer anywhere in `packages/*/src` (only stale compiled copies under `dist/`).

## Tests

- `v2000.test.ts` — three new cases beside the existing isotope test: isotopes across two `M  ISO` lines, charges across two `M  CHG` lines, and a later line overriding an earlier value for the same atom.
- `common.prepareSruForSaving.test.ts` (new) — 0 / 2 / 3 cross-bond SRUs, asserted both at the `prepareCrossBondsForSaving` level and end-to-end through `MolSerializer` on the emitted `M  SBL` line, plus the COP delegation.

All six new tests were confirmed red against the unfixed code (3 fail without the `v2000.ts` change, 3 without the `common.ts` change).

`npm test --workspace=packages/ketcher-core` is fully green — prettier, eslint, tsc, circular-dependency check and all 854 unit tests. **No existing expectation moved.**

## Did existing expectations move?

Answering the question raised during exploration, as honestly as I can from what I was able to run.

**Unit tests: no.** Nothing in the ketcher-core suite changed expectation.

**Playwright e2e: not run** (needs Docker/browsers, and per `CLAUDE.md` e2e authoring is gated on asking first). Static analysis of `ketcher-autotests/tests/test-data/`:

- For #2999, no currently-passing golden can change: any structure that hit the throw was failing export outright, so it cannot have a passing golden. The one real exposure is tests running with `ignoreErrors: true`, where such an s-group was previously **deleted** and is now kept — those molfiles would gain `M  STY/SAL/SBL/SDI` lines. Canvas screenshots for >2-cross-bond SRUs also change, since `getBracketParameters` draws one bracket per cross-bond. Worth a look at the SRU-Polymer and `3227-Introducing-Copolymer-S-group-type` specs and their `-snapshots/`.
- For #10953, no `.mol` in `test-data` has multiple `M  ISO` lines, so isotopes are churn-free. There **are** files with multi-line blocks of the other properties — 5 `CHG`, 12 `RAD`, 6 `RBC`, 3 `UNS`, 8 `APO` (e.g. `Molfiles-V2000/ferrocene-radical-8-expected.mol`, which has 2 `M  CHG` and 4 `M  RAD` lines). These are *expected-export* goldens produced by the writer, which was always correct, so the goldens themselves are right and should not need regenerating. The change is that opening one of these files now yields the full set of charges/radicals rather than the first 8. Any test that opens such a file and re-exports it gets strictly more correct output; if a golden had captured the previously-truncated output it would move, but I did not find one. **This is the part a reviewer should confirm with a real e2e run** — it is the one place I could not verify by execution.

## Open question — #4223 is NOT addressed by this PR

#4223 (absolute double bond) was claimed with this batch on the assumption it was a counts-line serializer fix. Exploration found the root cause upstream in the editor stereo model: `StereoValidator.isCorrectStereoCenter` returns false unless `bond.stereo > 0`, so a Marvin-style `1 2 2 0` double bond never becomes a stereo atom, `enhancedStereoFlag` stays undefined, and `molfile.ts:310` writes `ccc = 0`. Making the chiral flag reflect absolute double-bond stereo is a feature spanning the stereo model, and the flag is column 5 of every V2000 counts line — 88 `*expected*.mol` fixtures and 931 `verifyFileExport` sites, plus `ignore-chiral-flag.spec.ts` snapshots. It also cannot be caught by unit tests as they stand, because the helper `createCountsLine` pins the flag to 1. Scope needs confirming before implementation; #4223 was left unimplemented here and should be un-assigned or re-scoped.

No closing keyword is attached to #4223. This PR is a **draft** because of this open question.

## Open findings

- **Adjacent latent bug, deliberately not folded in.** `packages/ketcher-react/src/script/ui/state/server/index.js:67` compares `fr.enhancedStereoFlag === 'abs'` while `StereoFlag.Abs === 'ABS'`, so that chiral-flag structure check never fires. Unrelated to these two issues; flagging rather than silently fixing. Worth its own ticket.
- **Read/write asymmetry around double bonds and enhanced stereo**, noted while reading and left alone: `parseCTabV2000` stamps a `stereoLabel` on the begin atom of any `bond.stereo` bond *including* doubles, while `Fragment.updateStereoAtom` explicitly excludes doubles from the stereo-atom set. Part of the #4223 scope question above.
- **Property-pool boilerplate is duplicated** across `handleAliasProperty`, `handleSimpleAtomProperty`, `handleSubstitutionProperty` and `handleRGroupProperty` — each repeats the same "get pool, create if absent, narrow" preamble. I kept the new code matching the existing sibling shape rather than extracting a fifth variation; a `getOrCreatePool` helper would be a nice follow-up but is out of scope here.

## Bypassed checks

None. The `precommit` hook (lint-staged + prettier) ran normally on both commits; nothing was bypassed.

Two pre-existing environment gaps had to be worked around **locally only**, with no committed change:

1. `ketcher-core` jest runs die on a missing `@babel/plugin-transform-runtime`. Installed with `npm i --no-save`.
2. `src/domain/serializers/ket/compiledSchema` is generated, not checked in. Produced with the existing `npm run ajv --workspace=packages/ketcher-core`.

`git status` was verified clean of dependency and `node_modules` changes before both commits — `package.json` and the lockfile are untouched.

## Memory bank

Not updated, per `CLAUDE.md`: the memory bank is updated when a change is archived, not mid-change. If this lands, `.memory-bank/modules/serialization.md` (the MOL subsection) is the file that wants the note about multi-line `M` property blocks and n-cross-bond SRU export.
