### PR TITLE
#9104 – The Nucleotide Phosphate becomes broken or separates if the Sugar part is moved slightly beforehand

### DIFF
--- a/packages/ketcher-react/src/script/editor/Editor.ts
+++ b/packages/ketcher-react/src/script/editor/Editor.ts
@@ -1080,6 +1080,10 @@ class Editor implements KetcherEditor {
       this.potentialLeavingAtomsForManualAssignment = [];
     }
 
+    // Each wizard session builds fresh mappings; stale entries from prior
+    // sessions cause incorrect AP lookup in reconcileExternalBonds.
+    this.selectedToOriginalAtomsIdMap.clear();
+
     /*
      * Upon cloning the structure each entity gets a new id thus losing the mapping between the new and original one
      * Original atom ids can be retrieved from the selection data (do not confuse with the selected struct) by index:


### PR DESCRIPTION
## How the feature works? / How did you fix the issue?
The atom ID mapping used by the Create Monomer wizard was retained between consecutive wizard sessions. Stale entries could cause an incorrect attachment-point lookup and the Sugar–Phosphate bond to be removed.

The mapping is now cleared when a new wizard session starts, ensuring that attachment points are reconciled using only the current selection.

The issue was manually verified three times using the SMARTS structure and the original reproduction steps. The Phosphate remained connected after moving the Sugar.

closes #9104 

## Manual verification:

https://github.com/user-attachments/assets/8e8073f4-5ee6-46f1-b792-e41db3574a46


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [ ] task status changed to "Code review"
- [x] reviewers are notified about the pull request