### PR TITLE
#2178 - Selection is freezing if the user's cursor goes beyond the canvas on left or right side of canvas

### DIFF
--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -157,6 +157,7 @@ class SelectTool implements Tool {
 
     if (!ci) {
       onSelectionStart(event, this.editor, this.#lassoHelper);
+      this.handleMoveCloseToEdgeOfCanvas();
       return;
     }
 

--- a/packages/ketcher-react/src/script/editor/tool/select/select.ts
+++ b/packages/ketcher-react/src/script/editor/tool/select/select.ts
@@ -156,6 +156,7 @@ class SelectTool implements Tool {
     );
 
     if (!ci) {
+      this.previousMouseMoveEvent = event;
       onSelectionStart(event, this.editor, this.#lassoHelper);
       this.handleMoveCloseToEdgeOfCanvas();
       return;


### PR DESCRIPTION
…as-on-left-or-right-side-of-canvas

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


https://github.com/user-attachments/assets/84279189-9630-4476-be66-bf346a0b9fb1



## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request