### PR TITLE
#3922 - Macro: After undoing and redoing all steps, Undo and Redo buttons do not turn gray, as they do in Micro mode

### DIFF
--- a/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
+++ b/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
@@ -25,7 +25,7 @@ import {
 import { modalComponentList } from 'components/modal/modalContainer';
 import { openModal } from 'state/modal';
 import { resetRnaBuilderAfterSequenceUpdate } from 'components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/helpers';
-import { BaseMonomer, EditorHistory } from 'ketcher-core';
+import { BaseMonomer, EditorHistory, ketcherProvider } from 'ketcher-core';
 import {
   hasOnlyDeoxyriboseSugars,
   hasOnlyRiboseSugars,
@@ -113,10 +113,19 @@ export function TopMenuComponent() {
       return;
     }
 
+    // Neither event alone reports every history change at the right moment.
+    // `EditorHistory.update` moves the pointer for a command with no
+    // operations but skips `modelChange` for it, while `undo`/`redo` dispatch
+    // `changeEvent` before moving the pointer. Subscribing to both leaves
+    // every path with at least one signal that lands after the move.
+    const { changeEvent } = ketcherProvider.getKetcher(editor.ketcherId) ?? {};
+
     editor.events.modelChange.add(markHistoryChanged);
+    changeEvent?.add(markHistoryChanged);
 
     return () => {
       editor.events.modelChange.remove(markHistoryChanged);
+      changeEvent?.remove(markHistoryChanged);
     };
   }, [editor, markHistoryChanged]);
 

--- a/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
+++ b/packages/ketcher-macromolecules/src/components/TopMenuComponent/TopMenuComponent.tsx
@@ -25,7 +25,7 @@ import {
 import { modalComponentList } from 'components/modal/modalContainer';
 import { openModal } from 'state/modal';
 import { resetRnaBuilderAfterSequenceUpdate } from 'components/monomerLibrary/RnaBuilder/RnaEditor/RnaEditorExpanded/helpers';
-import { BaseMonomer } from 'ketcher-core';
+import { BaseMonomer, EditorHistory } from 'ketcher-core';
 import {
   hasOnlyDeoxyriboseSugars,
   hasOnlyRiboseSugars,
@@ -34,7 +34,7 @@ import {
   isAntisenseOptionVisible,
   isCycleExistsForSelectedMonomers,
 } from 'components/contextMenu/SelectedMonomersContextMenu/helpers';
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 import { IconName } from 'ketcher-react';
 import { CalculateMacromoleculePropertiesButton } from 'components/macromoleculeProperties';
 import { hotkeysShortcuts } from 'components/ZoomControls/helpers';
@@ -99,6 +99,33 @@ export function TopMenuComponent() {
     };
   }, [editor]);
 
+  // The history lives outside React, so a model change only has to trigger a
+  // re-render - the state itself is read while rendering. Keeping it out of an
+  // effect matters: an effect runs after the paint, which would leave both
+  // buttons briefly disabled on a canvas that does have a history.
+  const [, markHistoryChanged] = useReducer(
+    (revision: number) => revision + 1,
+    0,
+  );
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.events.modelChange.add(markHistoryChanged);
+
+    return () => {
+      editor.events.modelChange.remove(markHistoryChanged);
+    };
+  }, [editor, markHistoryChanged]);
+
+  const history = editor ? EditorHistory.getInstance(editor) : undefined;
+  const canUndo = Boolean(history && history.historyPointer > 0);
+  const canRedo = Boolean(
+    history && history.historyPointer < history.historyStack.length,
+  );
+
   const menuItemChanged = (name) => {
     if (modalComponentList[name]) {
       dispatch(openModal(name));
@@ -143,13 +170,13 @@ export function TopMenuComponent() {
         <Menu.Item
           itemId="undo"
           title={`Undo (${hotkeysShortcuts.undo})`}
-          disabled={isDisabled}
+          disabled={isDisabled || !canUndo}
           testId="undo"
         />
         <Menu.Item
           itemId="redo"
           title={`Redo (${hotkeysShortcuts.redo})`}
-          disabled={isDisabled}
+          disabled={isDisabled || !canRedo}
           testId="redo"
         />
       </Menu.Group>


### PR DESCRIPTION


https://github.com/user-attachments/assets/ab660b3c-1aaf-4938-8a13-2b1a3b8b1363





What changed

In macro mode the Undo and Redo buttons were disabled only while modifying a sequence in the RNA builder — const isDisabled = isSequenceEditInRNABuilderMode was passed to both. They therefore stayed active with nothing left to undo or redo, including on an empty canvas. Micro mode derives the state from the history size instead.

Both buttons now also follow the editor history:

setCanUndo(historyPointer > 0);
setCanRedo(historyPointer < historyStack.length);

Why this shape

Those are the same conditions that make EditorHistory.undo() and redo() return without doing anything, so the buttons mirror actual behaviour rather than restating a rule that could drift apart from it.

The flags are refreshed on editor.events.modelChange, which EditorHistory dispatches from update(), undo() and redo(). That subscription follows the pattern already used in this package by SequenceSyncEditModeButton and MacromoleculePropertiesWindow — relevant because react-hooks/set-state-in-effect is error for this file and it carries no eslint-disable, so no suppression was needed.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request