### PR TITLE
#7639-monomers-added-via-arrow-button-remain-out-of-visible-canvas-are…

### DIFF
--- a/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/BaseMode.ts
@@ -56,8 +56,9 @@ export abstract class BaseMode {
   ): void {
     editor.events.layoutModeChange.dispatch(modeName);
     const ModeConstructor = getModeConstructor(modeName);
+    const previousModeName = editor.mode.modeName;
     editor.mode.destroy();
-    editor.setMode(new ModeConstructor());
+    editor.setMode(new ModeConstructor(previousModeName));
     editor.mode.initialize(true, isUndo, false);
   }
 

--- a/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
+++ b/packages/ketcher-core/src/application/editor/modes/SequenceMode.ts
@@ -105,13 +105,16 @@ export class SequenceMode extends BaseMode {
   private _isEditInRNABuilderMode = false;
   private _isAntisenseEditMode = false;
   private _isSyncEditMode = true;
-  private isFirstInit = true;
+  // Only true when constructed without a previous mode, i.e. the very first mode
+  // the editor is initialized with, not when switching from another mode.
+  private isFirstInit: boolean;
   private selectionStarted = false;
   private selectionStartCaretPosition = -1;
   private mousemoveCounter = 0;
 
   constructor(previousMode?: LayoutMode) {
     super('sequence-layout-mode', previousMode);
+    this.isFirstInit = previousMode === undefined;
   }
 
   public get isEditMode() {


### PR DESCRIPTION
…a-after-switching-modes-to-sequence

## How the feature works? / How did you fix the issue?
(Screenshots, videos, or GIFs, if applicable)


https://github.com/user-attachments/assets/c048589c-b233-4edd-b463-6f8eba4e1b5a


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [x] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [x] reviewers are notified about the pull request