### PR TITLE
#1916 - Redux devtool is not tracking the app's store 

### DIFF
--- a/packages/ketcher-react/src/script/ui/state/index.js
+++ b/packages/ketcher-react/src/script/ui/state/index.js
@@ -112,6 +112,40 @@ function getRootReducer(setEditor) {
   };
 }
 
+// The store keeps live objects that are circular and very large: the editor
+// (its renderer holds DOM nodes), the struct service, and the parsed template
+// libraries. DevTools serialises the whole state after every action and keeps
+// a copy per action for time travel, which hangs the tab on a graph that size,
+// so these are replaced on the way out. Everything else stays inspectable, and
+// `templates` keeps its small fields - only the struct library is dropped.
+const NOT_SERIALIZED = '<not serialized>';
+
+function sanitizeForDevTools(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const sanitized = { ...value };
+
+  ['editor', 'server', 'functionalGroups', 'saltsAndSolvents'].forEach(
+    (key) => {
+      if (key in sanitized) {
+        sanitized[key] = NOT_SERIALIZED;
+      }
+    },
+  );
+
+  if (sanitized.templates?.lib) {
+    sanitized.templates = { ...sanitized.templates, lib: NOT_SERIALIZED };
+  }
+
+  if (sanitized.lib) {
+    sanitized.lib = NOT_SERIALIZED;
+  }
+
+  return sanitized;
+}
+
 export default function (options, server, setEditor) {
   const { buttons = {}, customButtons, ...restOptions } = options;
 
@@ -148,7 +182,10 @@ export default function (options, server, setEditor) {
   // builds collapse this to plain `compose`.
   const composeEnhancers =
     (process.env.NODE_ENV !== 'production' &&
-      globalThis.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
+      globalThis.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__?.({
+        stateSanitizer: sanitizeForDevTools,
+        actionSanitizer: sanitizeForDevTools,
+      })) ||
     compose;
 
   return createStore(

--- a/packages/ketcher-react/src/script/ui/state/index.js
+++ b/packages/ketcher-react/src/script/ui/state/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  ***************************************************************************/
 
-import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 import { load, onAction } from './shared';
 import optionsReducer, { initOptionsState } from './options';
 import templatesReducer, { initTmplsState } from './templates';
@@ -139,7 +139,23 @@ export default function (options, server, setEditor) {
   }
 
   const rootReducer = getRootReducer(setEditor);
-  return createStore(rootReducer, initState, applyMiddleware(...middleware));
+  // The Redux DevTools extension only sees stores created with its enhancer,
+  // which this store never used. Reading the global instead of depending on
+  // `@redux-devtools/extension` keeps it a development-only concern: rollup
+  // externalises every entry of `dependencies`, so a package added here would
+  // become a runtime dependency of every ketcher-react consumer. The
+  // `process.env.NODE_ENV` value is inlined at build time, so production
+  // builds collapse this to plain `compose`.
+  const composeEnhancers =
+    (process.env.NODE_ENV !== 'production' &&
+      globalThis.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
+    compose;
+
+  return createStore(
+    rootReducer,
+    initState,
+    composeEnhancers(applyMiddleware(...middleware)),
+  );
 }
 
 export function setServer(server) {


### PR DESCRIPTION
The molecules store was created with createStore(rootReducer, initState, applyMiddleware(...)) and no enhancer, so the Redux DevTools extension never registered it — the panel showed only the initial action. The macromolecules store is built with RTK configureStore, which registers itself, which is why only micro mode was affected.

This composes the extension's enhancer when it is present, leaving the store unchanged otherwise.

Reading the extension's global instead of depending on @redux-devtools/extension is deliberate. rollup.config.mjs runs peerDepsExternal({ includeDependencies: true }), so every entry of dependencies is externalised rather than bundled — adding the package there would turn a devtools-only convenience into a runtime dependency for every consumer of the published ketcher-react. Happy to switch to the library if reviewers prefer it; it's a one-line change.

There is no production cost: process.env.NODE_ENV is inlined at build time, so production builds collapse the expression to plain compose. This mirrors the redux-logger guard directly above it.

Verified:
- Redux DevTools now shows the molecules store with a live action stream (APP_OPTIONS, UPDATE, TMPL_INIT, FG_INIT, …), state diffs and time travel; previously "No store found for the inspected page".
- npm run test green across all four packages; npm run test:types clean across all workspaces.
- No behaviour change on the canvas, so no screenshot baselines are affected.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request