### PR TITLE
#11466 - After this bond between two phosphates, the "Select Attachment Points" dialog should not be opened it

### DIFF
--- a/packages/ketcher-core/src/domain/entities/Phosphate.ts
+++ b/packages/ketcher-core/src/domain/entities/Phosphate.ts
@@ -56,10 +56,6 @@ export class Phosphate extends BaseMonomer {
       return self.unUsedAttachmentPointsNamesList[0];
     }
 
-    // If other monomer is not a Sugar, we want to open modal
-    if (!isSugarOrAmbiguousSugar(otherMonomer)) {
-      return;
-    }
     // If we chose a specific AP on other monomer, we want to determine the correct AP on this one
     if (potentialPointOnOther) {
       if (
@@ -75,6 +71,13 @@ export class Phosphate extends BaseMonomer {
       } else {
         return;
       }
+    }
+
+    // Without a chosen AP on the other monomer, only a sugar leaves one
+    // sensible bond: between two phosphates R2-R1, R1-R1 and R2-R2 are all
+    // possible, so the user has to be asked (#3808).
+    if (!isSugarOrAmbiguousSugar(otherMonomer)) {
+      return;
     }
 
     if (

--- a/packages/ketcher-core/src/domain/entities/__tests__/phosphate.test.ts
+++ b/packages/ketcher-core/src/domain/entities/__tests__/phosphate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for Phosphate.getValidSourcePoint.
+ *
+ * The method decides whether a bond can be resolved without asking the user:
+ * returning an attachment point creates the bond straight away, while
+ * returning undefined makes the caller open the "Select Attachment Points"
+ * dialog (see LibraryItemDragDropHandler).
+ *
+ * Two requirements meet here and must stay separated:
+ *   - #3808  two free phosphates connected centre-to-centre can bond R2-R1,
+ *            R1-R1 or R2-R2, so the user has to choose.
+ *   - #11466 dropping a phosphate onto one specific free attachment point
+ *            leaves a single possible bond, so no dialog.
+ *
+ * What tells them apart is whether an attachment point has been chosen on the
+ * other monomer. Only stub the properties the method actually reads.
+ */
+import { Phosphate } from 'domain/entities/Phosphate';
+import type { BaseMonomer } from 'domain/entities/BaseMonomer';
+import { AttachmentPointName } from 'domain/types';
+import { KetMonomerClass } from 'application/formatters';
+
+type MonomerStub = {
+  freeAttachmentPoints?: AttachmentPointName[];
+  potentialSecondAttachmentPointForBond?: AttachmentPointName | null;
+  chosenFirstAttachmentPointForBond?: AttachmentPointName | null;
+  monomerClass?: KetMonomerClass;
+};
+
+function makeMonomer({
+  freeAttachmentPoints = [AttachmentPointName.R1, AttachmentPointName.R2],
+  potentialSecondAttachmentPointForBond = null,
+  chosenFirstAttachmentPointForBond = null,
+  monomerClass = KetMonomerClass.Phosphate,
+}: MonomerStub = {}): BaseMonomer {
+  return {
+    monomerItem: { props: { MonomerClass: monomerClass } },
+    chosenFirstAttachmentPointForBond,
+    potentialSecondAttachmentPointForBond,
+    unUsedAttachmentPointsNamesList: freeAttachmentPoints,
+    isAttachmentPointExistAndFree: (attachmentPoint: AttachmentPointName) =>
+      freeAttachmentPoints.includes(attachmentPoint),
+  } as unknown as BaseMonomer;
+}
+
+function makePhosphate(options: MonomerStub = {}): Phosphate {
+  const stub = makeMonomer(options);
+  Object.setPrototypeOf(stub, Phosphate.prototype);
+  return stub as Phosphate;
+}
+
+describe('Phosphate.getValidSourcePoint', () => {
+  it('resolves R1 when the other phosphate already has R2 chosen (#11466)', () => {
+    const droppedPhosphate = makePhosphate();
+    const presetPhosphate = makeMonomer({
+      freeAttachmentPoints: [AttachmentPointName.R2],
+      potentialSecondAttachmentPointForBond: AttachmentPointName.R2,
+    });
+
+    expect(droppedPhosphate.getValidSourcePoint(presetPhosphate)).toBe(
+      AttachmentPointName.R1,
+    );
+  });
+
+  it('still asks the user for two free phosphates with no chosen point (#3808)', () => {
+    const leftPhosphate = makePhosphate();
+    const rightPhosphate = makeMonomer();
+
+    expect(leftPhosphate.getValidSourcePoint(rightPhosphate)).toBeUndefined();
+  });
+
+  it('resolves R1 against a sugar with a free R2, as before', () => {
+    const phosphate = makePhosphate();
+    const sugar = makeMonomer({
+      monomerClass: KetMonomerClass.Sugar,
+      freeAttachmentPoints: [AttachmentPointName.R2],
+    });
+
+    expect(phosphate.getValidSourcePoint(sugar)).toBe(AttachmentPointName.R1);
+  });
+
+  it('asks the user when the chosen point on the other monomer has no counterpart', () => {
+    const phosphate = makePhosphate({
+      freeAttachmentPoints: [AttachmentPointName.R2, AttachmentPointName.R3],
+    });
+    const otherPhosphate = makeMonomer({
+      freeAttachmentPoints: [AttachmentPointName.R2],
+      potentialSecondAttachmentPointForBond: AttachmentPointName.R2,
+    });
+
+    expect(phosphate.getValidSourcePoint(otherPhosphate)).toBeUndefined();
+  });
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/bd5842a9-7142-4984-8122-b64e39b66142

Dropping a phosphate from the library onto the free attachment point of a preset's phosphate opened the "Select Attachment Points" dialog, even though the drop had already fixed the point on the target and only one bond remained possible.

Phosphate.getValidPoint returned early for any partner that is not a sugar, before reaching the branch that resolves this monomer's attachment point from the one already chosen on the other. Moving that guard below the branch lets a chosen point be honoured whatever the partner is. The drag-drop path opens the dialog exactly when getValidSourcePoint returns nothing (LibraryItemDragDropHandler), so that early return was the whole cause.

The guard still applies where it originally mattered: with no point chosen on the other monomer, two phosphates can bond R2-R1, R1-R1 or R2-R2, so the user must pick — the #3808 rule that connection-rules-for-phosphate-monomers.spec.ts covers. The two cases are separated by whether potentialSecondAttachmentPointForBond is set, and DrawingEntitiesManager only sets it when a specific attachment point is hovered or dropped on. Centre-to-centre never sets it, so that path is unchanged.

Per requirement #7926: "Because there is only one possible bond between two phosphates, the 'Select Attachment Points' dialog doesn't open."

Scope is Phosphate only — no sibling monomer class carries this guard. Sibling issue #11467 is a different path and is deliberately not addressed here.


## Check list
- [ ] unit-tests written
- [ ] e2e-tests written
- [ ] documentation updated
- [x] PR name follows the pattern `#1234 – issue name`
- [x] branch name doesn't contain '#'
- [x] PR is linked with the issue
- [ ] base branch (master or release/xx) is correct
- [x] task status changed to "Code review"
- [ ] reviewers are notified about the pull request